### PR TITLE
feat: Support multiple pattern assignments

### DIFF
--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -1,18 +1,8 @@
 import { createLexer } from 'leac'
 
 export const lex = createLexer([
-  { name: 'space', regex: /[ \t]+/, discard: true },
-  { name: 'digit', regex: /[0-9]/ },
-  { name: 'char', regex: /[a-zA-Z]/ },
-  { name: '[' },
-  { name: ']' },
-  { name: '(' },
-  { name: ')' },
-  { name: '=' },
-  { name: '.' },
-  { name: ':' },
-  { name: '*' },
-  { name: '/' },
-  { name: '+' },
-  { name: '-' }
+  { name: 'space', regex: /[ \t\n\r]+/, discard: true },
+  { name: 'identifier', regex: /[a-zA-Z_][a-zA-Z_0-9]*/ },
+  { name: 'pattern', regex: /\[[ \t\n\rx-]*\]/ },
+  { name: '=' }
 ])

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -2,22 +2,50 @@ import { Token } from 'leac'
 import * as p from 'peberminta'
 import { lex } from './lexer.js'
 
+type PatternItem = 'rest' | 'hit'
+type Pattern = PatternItem[]
+
+interface Assignment {
+  key: string
+  value: Pattern
+}
+
+interface Program {
+  patterns: Record<string, Pattern>
+}
+
 function literal (name: string): p.Parser<Token, unknown, true> {
   return p.token((t) => t.name === name ? true : undefined)
 }
 
-type PatternItem = 'rest' | 'hit'
-type Pattern = PatternItem[]
-
-const patternChar_: p.Parser<Token, unknown, PatternItem> = p.eitherOr(
-  p.token((t) => t.name === '-' ? 'rest' : undefined),
-  p.token((t) => t.name === 'char' ? 'hit' : undefined)
+const patternLiteral_: p.Parser<Token, unknown, Pattern> = p.map(
+  p.token((t) => t.name === 'pattern' ? t.text : undefined),
+  (text) => {
+    return text.slice(1, -1).replace(/\s/g, '').split('').map((char) => {
+      return char === '-' ? 'rest' : 'hit'
+    })
+  }
 )
 
-const patternLiteral_: p.Parser<Token, unknown, PatternItem[]> = p.middle(
-  literal('['),
-  p.many(patternChar_),
-  literal(']')
+const identifier_: p.Parser<Token, unknown, string> = p.token((t) => t.name === 'identifier' ? t.text : undefined)
+
+const assignment_: p.Parser<Token, unknown, Assignment> = p.abc(
+  identifier_,
+  literal('='),
+  patternLiteral_,
+  (key, _eq, value) => ({ key, value })
+)
+
+const program_: p.Parser<Token, unknown, Program> = p.map(
+  p.many(assignment_),
+  (assignments) => {
+    const patterns: Record<string, Pattern> = {}
+    for (const assignment of assignments) {
+      patterns[assignment.key] = assignment.value
+    }
+
+    return { patterns }
+  }
 )
 
 export type ParseResult = {
@@ -25,7 +53,7 @@ export type ParseResult = {
   value: undefined
 } | {
   complete: true
-  value: Pattern
+  value: Program
 }
 
 export function parse (input: string): ParseResult {
@@ -37,7 +65,7 @@ export function parse (input: string): ParseResult {
     }
   }
 
-  const value = p.tryParse(patternLiteral_, lexerResult.tokens, {})
+  const value = p.tryParse(program_, lexerResult.tokens, {})
   if (value == null) {
     return {
       complete: false,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,12 +5,26 @@ import { Editor } from './components/Editor.js'
 import { parse } from '../language/parser.js'
 import clsx from 'clsx'
 
-const INITIAL_CODE = '[x--- x--- x--- x--x]'
+const initialCode = `
+kick  = [x--- x--- x--- x---]
+snare = [---- x--- ---- x---]
+hat   = [--x- --x- --x- --x-]
+tom   = [---- -x-- ---- ---x]
+`.trimStart()
 
-const demo = createAudioDemo()
+const instruments = {
+  kick: 'https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/house/000_BD.wav',
+  snare: 'https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808sd/SD0010.WAV',
+  hat: 'https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808oh/OH00.WAV',
+  tom: 'https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808mt/MT10.WAV'
+}
+
+const demo = createAudioDemo({
+  instruments
+})
 
 export const App: FunctionComponent = () => {
-  const [code, setCode] = useState(INITIAL_CODE)
+  const [code, setCode] = useState(initialCode)
 
   const parseResult = useMemo(() => {
     return parse(code)
@@ -18,7 +32,7 @@ export const App: FunctionComponent = () => {
 
   useEffect(() => {
     if (parseResult.complete) {
-      demo.setPattern(parseResult.value)
+      demo.setProgram(parseResult.value)
     }
   }, [parseResult])
 


### PR DESCRIPTION
Updates the demo to handle multiple instruments and patterns using a new Program structure. The lexer and parser are refactored to support pattern assignments. The demo includes hardcoded samples for kick, snare, hat, and tom. These are programmed simply by assigning patterns to the respective name. (This is not the final design.)