### PR TITLE
feat: Add language support to editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@codemirror/state": "6.5.2",
         "@codemirror/theme-one-dark": "6.1.3",
         "@codemirror/view": "6.38.4",
+        "@lezer/highlight": "1.2.1",
+        "@lezer/lr": "1.4.2",
         "clsx": "2.1.1",
         "codemirror": "6.0.2",
         "leac": "0.7.0",
@@ -25,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/compat": "1.4.0",
+        "@lezer/generator": "1.8.0",
         "@meyfa/eslint-config": "9.0.0",
         "@tailwindcss/vite": "4.1.14",
         "@types/react": "19.2.0",
@@ -1288,6 +1291,20 @@
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
       "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
       "license": "MIT"
+    },
+    "node_modules/@lezer/generator": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.8.0.tgz",
+      "integrity": "sha512-/SF4EDWowPqV1jOgoGSGTIFsE7Ezdr7ZYxyihl5eMKVO5tlnpIhFcDavgm1hHY5GEonoOAEnJ0CU0x+tvuAuUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.1.0",
+        "@lezer/lr": "^1.3.0"
+      },
+      "bin": {
+        "lezer-generator": "src/lezer-generator.cjs"
+      }
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/compat": "1.4.0",
+    "@lezer/generator": "1.8.0",
     "@meyfa/eslint-config": "9.0.0",
     "@tailwindcss/vite": "4.1.14",
     "@types/react": "19.2.0",
@@ -41,6 +42,8 @@
     "@codemirror/state": "6.5.2",
     "@codemirror/theme-one-dark": "6.1.3",
     "@codemirror/view": "6.38.4",
+    "@lezer/highlight": "1.2.1",
+    "@lezer/lr": "1.4.2",
     "clsx": "2.1.1",
     "codemirror": "6.0.2",
     "leac": "0.7.0",

--- a/src/editor/cadence.grammar
+++ b/src/editor/cadence.grammar
@@ -1,0 +1,73 @@
+@tokens {
+  space { @whitespace+ }
+
+  Comment { "#" ![\n]* }
+
+  identifier { $[a-zA-Z_] $[a-zA-Z_0-9]* }
+
+  number { $[0-9]+ ("." $[0-9]+)? }
+  string { "\"" (!["\\] | "\\" (![.] | $[.]))* "\"" }
+  pattern { "[" $[ \t\n\rx-]* "]" }
+
+  "="
+  ":"
+  "{" "}"
+  "(" ")"
+  ","
+
+  "<<"
+}
+
+@skip { space | Comment }
+
+@detectDelim
+
+@top Program {
+  (Assignment | Routing | NamedBlock)*
+}
+
+Property {
+  PropertyName ":" Literal
+}
+
+PropertyName { identifier }
+
+Literal {
+  NumberLiteral | StringLiteral | PatternLiteral
+}
+
+NumberLiteral { number }
+StringLiteral { string }
+PatternLiteral { pattern }
+
+Assignment {
+  AssignmentName "=" (Literal | Call | VariableReference)
+}
+
+AssignmentName { identifier }
+
+VariableReference { identifier }
+
+Call {
+  Callee "(" (Property ("," Property)*)? ")"
+}
+
+Callee { identifier }
+
+Routing {
+  RoutingTarget "<<" (PatternLiteral | VariableReference)
+}
+
+RoutingTarget { identifier }
+
+NamedBlock {
+  BlockName Block
+}
+
+BlockName { identifier }
+
+Block {
+  "{"
+  (Property)*
+  "}"
+}

--- a/src/editor/grammar.d.ts
+++ b/src/editor/grammar.d.ts
@@ -1,0 +1,4 @@
+declare module '*.grammar' {
+  import { LRParser } from '@lezer/lr'
+  export const parser: LRParser
+}

--- a/src/editor/language-support.ts
+++ b/src/editor/language-support.ts
@@ -1,0 +1,46 @@
+import { parser } from './cadence.grammar'
+import { foldNodeProp, foldInside, LRLanguage, LanguageSupport } from '@codemirror/language'
+import { styleTags, tags as t } from '@lezer/highlight'
+
+const parserWithMetadata = parser.configure({
+  props: [
+    styleTags({
+      Comment: t.comment,
+
+      NumberLiteral: t.number,
+      StringLiteral: t.string,
+      PatternLiteral: t.string,
+
+      '=': t.definitionOperator,
+      ':': t.separator,
+      '{ }': t.brace,
+      '( )': t.paren,
+      ',': t.separator,
+
+      '<<': t.operator,
+
+      BlockName: t.keyword,
+      AssignmentName: t.definition(t.variableName),
+      VariableReference: t.variableName,
+      Callee: t.function(t.name),
+      RoutingTarget: t.variableName
+    }),
+
+    foldNodeProp.add({
+      Block: foldInside
+    })
+  ]
+})
+
+export const cadenceLanguage = LRLanguage.define({
+  parser: parserWithMetadata,
+  languageData: {
+    commentTokens: {
+      line: '#'
+    }
+  }
+})
+
+export function cadenceLanguageSupport (): LanguageSupport {
+  return new LanguageSupport(cadenceLanguage)
+}

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -6,9 +6,9 @@ export const lex = createLexer([
   { name: 'comment', regex: /#[^\n]*/, discard: true },
 
   { name: 'identifier', regex: /[a-zA-Z_][a-zA-Z_0-9]*/ },
+
   { name: 'number', regex: /[0-9]+(\.[0-9]+)?/ },
   { name: 'string', regex: /"([^"\\]|\\.)*"/ },
-
   { name: 'pattern', regex: /\[[ \t\n\rx-]*\]/ },
 
   { name: '=' },

--- a/src/ui/components/Editor.tsx
+++ b/src/ui/components/Editor.tsx
@@ -1,8 +1,11 @@
+import './Editor.css'
 import { EditorState } from '@codemirror/state'
 import { EditorView, basicSetup } from 'codemirror'
 import { FunctionComponent, useEffect, useRef } from 'react'
 import { oneDark } from '@codemirror/theme-one-dark'
-import './Editor.css'
+import { cadenceLanguageSupport } from '../../editor/language-support.js'
+import { keymap } from '@codemirror/view'
+import { indentWithTab } from '@codemirror/commands'
 
 export const Editor: FunctionComponent<{
   value: string
@@ -33,7 +36,13 @@ export const Editor: FunctionComponent<{
       extensions: [
         basicSetup,
         EditorState.tabSize.of(2),
+        keymap.of([
+          indentWithTab,
+          // Disable browser save dialog, improving UX for users accustomed to regularly pressing Ctrl+S
+          { key: 'Ctrl-s', run: () => true }
+        ]),
         oneDark,
+        cadenceLanguageSupport(),
         updateListener
       ]
     })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { lezer } from '@lezer/generator/rollup'
 
 export default defineConfig({
   plugins: [
     react(),
-    tailwindcss()
+    tailwindcss(),
+    lezer()
   ],
   build: {
     outDir: 'dist'


### PR DESCRIPTION
Introduces a custom Lezer grammar, which enables syntax highlighting for the Cadence language.

Lezer grammars are particularly suited for integration with CodeMirror language support but are not suitable for our primary parsing task. Conversely, the main parser cannot easily be used language support. Hence, there have to be two language definitions.