### PR TITLE
feat: Add unit support for number literals

### DIFF
--- a/src/core/audio-demo.ts
+++ b/src/core/audio-demo.ts
@@ -37,7 +37,7 @@ export function createAudioDemo (options: {
     let tempo = options.defaultTempo
 
     const tempoProperty = findProperty(program.track?.properties ?? [], 'tempo')
-    if (tempoProperty?.type === 'NumberLiteral') {
+    if (tempoProperty?.type === 'NumberLiteral' && tempoProperty.unit === 'bpm') {
       const { value } = tempoProperty
       if (Number.isFinite(value) && value > 1 && value <= 400) {
         tempo = value
@@ -163,7 +163,6 @@ function findProperty (properties: readonly ast.Property[], key: string): ast.Pr
   return properties.find((prop) => prop.key.name === key)?.value
 }
 
-function resolveIdentifierToValue (program: ast.Program, key: string): ast.Literal | ast.Call | undefined {
-  const assignment = program.assignments.find((a) => a.key.name === key)
-  return assignment?.value
+function resolveIdentifierToValue (program: ast.Program, key: string): ast.Assignment['value'] | undefined {
+  return program.assignments.find((a) => a.key.name === key)?.value
 }

--- a/src/editor/cadence.grammar
+++ b/src/editor/cadence.grammar
@@ -3,7 +3,7 @@
 
   Comment { "#" ![\n]* }
 
-  identifier { $[a-zA-Z_] $[a-zA-Z_0-9]* }
+  word { $[a-zA-Z_] $[a-zA-Z_0-9]* }
 
   number { $[0-9]+ ("." $[0-9]+)? }
   string { "\"" (!["\\] | "\\" (![.] | $[.]))* "\"" }
@@ -26,45 +26,49 @@
   (Assignment | Routing | NamedBlock)*
 }
 
-Property {
-  PropertyName ":" Literal
+unit {
+  @specialize<word, "bpm" | "bar" | "bars" | "beat" | "beats" | "s" | "ms" | "hz" | "db">
 }
 
-PropertyName { identifier }
+NumberLiteral { number unit? }
+StringLiteral { string }
+PatternLiteral { pattern }
 
 Literal {
   NumberLiteral | StringLiteral | PatternLiteral
 }
 
-NumberLiteral { number }
-StringLiteral { string }
-PatternLiteral { pattern }
+Property {
+  PropertyName ":" Literal
+}
+
+PropertyName { word }
 
 Assignment {
   AssignmentName "=" (Literal | Call | VariableReference)
 }
 
-AssignmentName { identifier }
+AssignmentName { word }
 
-VariableReference { identifier }
+VariableReference { word }
 
 Call {
   Callee "(" (Property ("," Property)*)? ")"
 }
 
-Callee { identifier }
+Callee { word }
 
 Routing {
   RoutingTarget "<<" (PatternLiteral | VariableReference)
 }
 
-RoutingTarget { identifier }
+RoutingTarget { word }
 
 NamedBlock {
   BlockName Block
 }
 
-BlockName { identifier }
+BlockName { word }
 
 Block {
   "{"

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -4,6 +4,9 @@ export interface ASTNode {
 
 // Basic Types
 
+export const units = ['bpm', 'bar', 'bars', 'beat', 'beats', 's', 'ms', 'hz', 'db'] as const
+export type Unit = typeof units[number]
+
 export interface Identifier extends ASTNode {
   readonly type: 'Identifier'
   readonly name: string
@@ -12,6 +15,7 @@ export interface Identifier extends ASTNode {
 export interface NumberLiteral extends ASTNode {
   readonly type: 'NumberLiteral'
   readonly value: number
+  readonly unit?: Unit
 }
 
 export interface StringLiteral extends ASTNode {

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -5,7 +5,7 @@ export const lex = createLexer([
 
   { name: 'comment', regex: /#[^\n]*/, discard: true },
 
-  { name: 'identifier', regex: /[a-zA-Z_][a-zA-Z_0-9]*/ },
+  { name: 'word', regex: /[a-zA-Z_][a-zA-Z_0-9]*/ },
 
   { name: 'number', regex: /[0-9]+(\.[0-9]+)?/ },
   { name: 'string', regex: /"([^"\\]|\\.)*"/ },

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -8,13 +8,27 @@ function literal (name: string): p.Parser<Token, unknown, true> {
 }
 
 const identifier_: p.Parser<Token, unknown, ast.Identifier> = p.map(
-  p.token((t) => t.name === 'identifier' ? t.text : undefined),
+  p.token((t) => t.name === 'word' ? t.text : undefined),
   (name) => ({ type: 'Identifier', name })
 )
 
-const numberLiteral_: p.Parser<Token, unknown, ast.NumberLiteral> = p.map(
-  p.token((t) => t.name === 'number' ? t.text : undefined),
-  (text) => ({ type: 'NumberLiteral', value: Number.parseFloat(text) })
+const unit_: p.Parser<Token, unknown, ast.Unit> = p.token((t) => {
+  if (t.name === 'word' && ast.units.includes(t.text as ast.Unit)) {
+    return t.text as ast.Unit
+  }
+  return undefined
+})
+
+const numberLiteral_: p.Parser<Token, unknown, ast.NumberLiteral> = p.choice(
+  p.ab(
+    p.token((t) => t.name === 'number' ? t.text : undefined),
+    unit_,
+    (text, unit) => ({ type: 'NumberLiteral', value: Number.parseFloat(text), unit })
+  ),
+  p.map(
+    p.token((t) => t.name === 'number' ? t.text : undefined),
+    (text) => ({ type: 'NumberLiteral', value: Number.parseFloat(text) })
+  )
 )
 
 const stringLiteral_: p.Parser<Token, unknown, ast.StringLiteral> = p.map(
@@ -77,7 +91,7 @@ const routing_: p.Parser<Token, unknown, ast.Routing> = p.abc(
 )
 
 const trackBlock_: p.Parser<Token, unknown, ast.Track> = p.right(
-  p.token((t) => t.name === 'identifier' && t.text === 'track' ? true : undefined),
+  p.token((t) => t.name === 'word' && t.text === 'track' ? true : undefined),
   p.middle(
     literal('{'),
     p.map(

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -10,7 +10,7 @@ const initialCode = `
 # Use 'x' for a hit and '-' for a rest.
 
 track {
-  tempo: 128
+  tempo: 128 bpm
 }
 
 kick  = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/house/000_BD.wav")


### PR DESCRIPTION
Extends the language grammar, lexer, AST, and parser to support units (such as 'bpm', 'bar', 'beat') for number literals.