### PR TITLE
feat: Implement sections (track arrangement)

### DIFF
--- a/src/editor/cadence.grammar
+++ b/src/editor/cadence.grammar
@@ -22,12 +22,14 @@
 
 @detectDelim
 
+kw<term> { @specialize[@name={term}]<word, term> }
+
 @top Program {
-  (Assignment | Routing | NamedBlock)*
+  (Assignment | TrackStatement)*
 }
 
 unit {
-  @specialize<word, "bpm" | "bar" | "bars" | "beat" | "beats" | "s" | "ms" | "hz" | "db">
+  @specialize<word, "bpm" | "bars" | "beats" | "s" | "ms" | "hz" | "db">
 }
 
 NumberLiteral { number unit? }
@@ -38,40 +40,43 @@ Literal {
   NumberLiteral | StringLiteral | PatternLiteral
 }
 
-Property {
-  PropertyName ":" Literal
-}
+VariableDefinition { word }
+VariableName { word }
 
-PropertyName { word }
+Property {
+  PropertyName { word }
+  ":"
+  Literal
+}
 
 Assignment {
-  AssignmentName "=" (Literal | Call | VariableReference)
+  VariableDefinition
+  "="
+  (Literal | Call | VariableName)
 }
-
-AssignmentName { word }
-
-VariableReference { word }
 
 Call {
-  Callee "(" (Property ("," Property)*)? ")"
+  Callee { word }
+  "(" (Property ("," Property)*)? ")"
 }
-
-Callee { word }
 
 Routing {
-  RoutingTarget "<<" (PatternLiteral | VariableReference)
+  VariableName
+  "<<"
+  (PatternLiteral | VariableName)
 }
 
-RoutingTarget { word }
-
-NamedBlock {
-  BlockName Block
+TrackStatement {
+  kw<"track">
+  TrackBlock {
+    "{" (Property | SectionStatement)* "}"
+  }
 }
 
-BlockName { word }
-
-Block {
-  "{"
-  (Property)*
-  "}"
+SectionStatement {
+  kw<"section"> VariableDefinition
+  kw<"for"> NumberLiteral
+  SectionBlock {
+    "{" (Routing)* "}"
+  }
 }

--- a/src/editor/language-support.ts
+++ b/src/editor/language-support.ts
@@ -19,11 +19,12 @@ const parserWithMetadata = parser.configure({
 
       '<<': t.operator,
 
-      BlockName: t.keyword,
-      AssignmentName: t.definition(t.variableName),
-      VariableReference: t.variableName,
-      Callee: t.function(t.name),
-      RoutingTarget: t.variableName
+      'track section for': t.keyword,
+
+      VariableDefinition: t.definition(t.variableName),
+      VariableName: t.variableName,
+
+      Callee: t.function(t.name)
     }),
 
     foldNodeProp.add({

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -4,7 +4,7 @@ export interface ASTNode {
 
 // Basic Types
 
-export const units = ['bpm', 'bar', 'bars', 'beat', 'beats', 's', 'ms', 'hz', 'db'] as const
+export const units = ['bpm', 'bars', 'beats', 's', 'ms', 'hz', 'db'] as const
 export type Unit = typeof units[number]
 
 export interface Identifier extends ASTNode {
@@ -60,16 +60,23 @@ export interface Routing extends ASTNode {
 
 // Domain Types
 
-export interface Track extends ASTNode {
-  readonly type: 'Track'
+export interface TrackStatement extends ASTNode {
+  readonly type: 'TrackStatement'
   readonly properties: readonly Property[]
+  readonly sections: readonly SectionStatement[]
+}
+
+export interface SectionStatement extends ASTNode {
+  readonly type: 'SectionStatement'
+  readonly name: Identifier
+  readonly length: NumberLiteral
+  readonly routings: readonly Routing[]
 }
 
 // Root Type
 
 export interface Program extends ASTNode {
   readonly type: 'Program'
-  readonly track?: Track
+  readonly track?: TrackStatement
   readonly assignments: readonly Assignment[]
-  readonly routings: readonly Routing[]
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,26 +6,44 @@ import { parse } from '../language/parser.js'
 import clsx from 'clsx'
 
 const initialCode = `
-# Press Play to start the demo. Edit the code to create your own patterns.
-# Use 'x' for a hit and '-' for a rest.
+# Press Play to start the demo.
 
-track {
-  tempo: 128 bpm
-}
+# Define samples to use in the track.
 
 kick  = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/house/000_BD.wav")
 snare = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808sd/SD0010.WAV")
 hat   = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808oh/OH00.WAV")
 tom   = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808mt/MT10.WAV")
 
-kick  << [x-x- x--- x--- x---]
-snare << [---- x--- ---- x---]
-hat   << [--x- --x- --x- --x-]
+# Define patterns using a simple step sequencer syntax where 'x' is a hit and '-' is a rest.
+# Patterns are 16th notes by default, and can be any length.
 
-# You can also define patterns and reuse them.
+kick_pattern  = [x-x- x--- x--- x---]
+snare_pattern = [---- x---]
 
-tom_pattern = [---- -x-- ---- ---x]
-tom   << tom_pattern
+track {
+  tempo: 128 bpm
+
+  # Sections play in sequence.
+  # Patterns will loop to fill the section length.
+
+  section intro for 4 bars {
+    kick  << kick_pattern
+    snare << snare_pattern
+  }
+
+  section main for 8 bars {
+    kick  << kick_pattern
+    snare << snare_pattern
+    hat   << [--x- --x- --x- --x-]
+    tom   << [---- -x-- ---- ---x]
+  }
+
+  section outro for 4 bars {
+    snare << snare_pattern
+    tom   << [---- -x-- ---- ---x]
+  }
+}
 `.trimStart()
 
 const demo = createAudioDemo({


### PR DESCRIPTION
Replaces the old global routing syntax with 'section' statements contained inside the 'track' block. Sections are named and have a defined length, looping any pattern within to fit.