### PR TITLE
feat: Add support for binary expressions

### DIFF
--- a/src/editor/cadence.grammar
+++ b/src/editor/cadence.grammar
@@ -9,13 +9,15 @@
   string { "\"" (!["\\] | "\\" (![.] | $[.]))* "\"" }
   pattern { "[" $[ \t\n\rx-]* "]" }
 
-  "="
-  ":"
   "{" "}"
   "(" ")"
   ","
 
+  "="
+  ":"
   "<<"
+
+  "+"
 }
 
 @skip { space | Comment }
@@ -23,6 +25,10 @@
 @detectDelim
 
 kw<term> { @specialize[@name={term}]<word, term> }
+
+@precedence {
+  plus @left
+}
 
 @top Program {
   (Assignment | TrackStatement)*
@@ -32,6 +38,9 @@ unit {
   @specialize<word, "bpm" | "bars" | "beats" | "s" | "ms" | "hz" | "db">
 }
 
+VariableDefinition { word }
+VariableName { word }
+
 NumberLiteral { number unit? }
 StringLiteral { string }
 PatternLiteral { pattern }
@@ -40,19 +49,24 @@ Literal {
   NumberLiteral | StringLiteral | PatternLiteral
 }
 
-VariableDefinition { word }
-VariableName { word }
+expression {
+  Literal | Call | VariableName | BinaryExpression
+}
+
+BinaryExpression {
+  expression !plus "+" expression
+}
 
 Property {
   PropertyName { word }
   ":"
-  Literal
+  expression
 }
 
 Assignment {
   VariableDefinition
   "="
-  (Literal | Call | VariableName)
+  expression
 }
 
 Call {
@@ -75,7 +89,7 @@ TrackStatement {
 
 SectionStatement {
   kw<"section"> VariableDefinition
-  kw<"for"> NumberLiteral
+  kw<"for"> expression
   SectionBlock {
     "{" (Routing)* "}"
   }

--- a/src/editor/language-support.ts
+++ b/src/editor/language-support.ts
@@ -11,13 +11,15 @@ const parserWithMetadata = parser.configure({
       StringLiteral: t.string,
       PatternLiteral: t.string,
 
-      '=': t.definitionOperator,
-      ':': t.separator,
       '{ }': t.brace,
       '( )': t.paren,
       ',': t.separator,
 
+      '=': t.definitionOperator,
+      ':': t.separator,
       '<<': t.operator,
+
+      '+': t.arithmeticOperator,
 
       'track section for': t.keyword,
 

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -32,12 +32,26 @@ export interface PatternLiteral extends ASTNode {
 
 export type Literal = NumberLiteral | StringLiteral | PatternLiteral
 
+export type Value = Literal | Call | Identifier
+
+export const binaryOperators = ['+'] as const
+export type BinaryOperator = typeof binaryOperators[number]
+
+export interface BinaryExpression extends ASTNode {
+  readonly type: 'BinaryExpression'
+  readonly operator: BinaryOperator
+  readonly left: Expression
+  readonly right: Expression
+}
+
+export type Expression = Value | BinaryExpression
+
 // Composite Types
 
 export interface Property extends ASTNode {
   readonly type: 'Property'
   readonly key: Identifier
-  readonly value: Literal
+  readonly value: Expression
 }
 
 export interface Call extends ASTNode {
@@ -49,7 +63,7 @@ export interface Call extends ASTNode {
 export interface Assignment extends ASTNode {
   readonly type: 'Assignment'
   readonly key: Identifier
-  readonly value: Literal | Call
+  readonly value: Expression
 }
 
 export interface Routing extends ASTNode {

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -11,13 +11,15 @@ export const lex = createLexer([
   { name: 'string', regex: /"([^"\\]|\\.)*"/ },
   { name: 'pattern', regex: /\[[ \t\n\rx-]*\]/ },
 
-  { name: '=' },
-  { name: ':' },
   { name: '{' },
   { name: '}' },
   { name: '(' },
   { name: ')' },
   { name: ',' },
 
-  { name: '<<' }
+  { name: '=' },
+  { name: ':' },
+  { name: '<<' },
+
+  { name: '+' }
 ])

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -10,10 +10,12 @@ const initialCode = `
 
 # Define samples to use in the track.
 
-kick  = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/house/000_BD.wav")
-snare = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808sd/SD0010.WAV")
-hat   = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808oh/OH00.WAV")
-tom   = sample(url: "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/808mt/MT10.WAV")
+sample_collection = "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/"
+
+kick  = sample(url: sample_collection + "house/000_BD.wav")
+snare = sample(url: sample_collection + "808sd/SD0010.WAV")
+hat   = sample(url: sample_collection + "808oh/OH00.WAV")
+tom   = sample(url: sample_collection + "808mt/MT10.WAV")
 
 # Define patterns using a simple step sequencer syntax where 'x' is a hit and '-' is a rest.
 # Patterns are 16th notes by default, and can be any length.
@@ -25,7 +27,7 @@ track {
   tempo: 128 bpm
 
   # Sections play in sequence.
-  # Patterns will loop to fill the section length.
+  # Patterns will loop to fill the section length, specified in bars or beats.
 
   section intro for 4 bars {
     kick  << kick_pattern


### PR DESCRIPTION
This patch introduces binary expressions (currently supporting '+') to the language, allowing variables and properties to be defined using expressions such as concatenation and arithmetic. The grammar, lexer, parser, and AST are updated to support binary expressions, and the audio demo logic now resolves and computes these expressions.