### PR TITLE
fix: Support expressions for section length

### DIFF
--- a/src/core/audio-demo.ts
+++ b/src/core/audio-demo.ts
@@ -91,20 +91,21 @@ export function createAudioDemo (options: {
     ]))
 
     for (const section of program.track?.sections ?? []) {
-      if (!Number.isSafeInteger(section.length.value) || section.length.value <= 0) {
+      const lengthValue = resolveExpression(section.length, program)
+      if (lengthValue == null || lengthValue.type !== 'NumberLiteral') {
         // TODO error handling - invalid section length
         continue
       }
 
       let sectionLengthSteps: number
 
-      switch (section.length.unit) {
+      switch (lengthValue.unit) {
         case 'bars':
-          sectionLengthSteps = section.length.value * STEPS_PER_BAR
+          sectionLengthSteps = lengthValue.value * STEPS_PER_BAR
           break
 
         case 'beats':
-          sectionLengthSteps = section.length.value * STEPS_PER_BEAT
+          sectionLengthSteps = lengthValue.value * STEPS_PER_BEAT
           break
 
         default:

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -86,7 +86,7 @@ export interface TrackStatement extends ASTNode {
 export interface SectionStatement extends ASTNode {
   readonly type: 'SectionStatement'
   readonly name: Identifier
-  readonly length: NumberLiteral
+  readonly length: Expression
   readonly routings: readonly Routing[]
 }
 

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -185,7 +185,7 @@ const routing_: p.Parser<Token, unknown, ast.Routing> = p.abc(
 
 const sectionStatement_: p.Parser<Token, unknown, ast.SectionStatement> = p.abc(
   combine2(keyword('section'), identifier_),
-  combine2(keyword('for'), numberLiteral_),
+  combine2(keyword('for'), expression_),
   combine3(
     literal('{'),
     p.many(routing_),


### PR DESCRIPTION
The editor grammar already supported this, and it was always the intention to allow variable names and other expressions as section lengths. Now the parser is caught up as well.