### PR TITLE
fix: Use focused tab for editor caret position

### DIFF
--- a/packages/app/src/components/tab/StyledTabTitle.tsx
+++ b/packages/app/src/components/tab/StyledTabTitle.tsx
@@ -42,10 +42,10 @@ export const StyledTabTitle: FunctionComponent<TabTitleProps> = ({ tab, state, o
     >
       {macOS && closeButton}
 
-      <TitleComponent panelProps={tab.component.props} />
+      <TitleComponent panelProps={tab.component.props} tabId={tab.id} />
 
       <div className='px-1 py-0.5 text-xs leading-none bg-error-surface text-error-content border border-error-frame rounded empty:hidden'>
-        <NotificationsComponent panelProps={tab.component.props} />
+        <NotificationsComponent panelProps={tab.component.props} tabId={tab.id} />
       </div>
 
       {!macOS && closeButton}

--- a/packages/app/src/modules/editor/caret.ts
+++ b/packages/app/src/modules/editor/caret.ts
@@ -1,0 +1,26 @@
+import type { DockLayout, EditorLocation, PanelId } from '@editor'
+import { findFocusedTab } from '@editor'
+import { getEditorPanelProps } from './panel-props.js'
+import type { EditorState } from './provider.js'
+
+export function getFocusedEditorFilePath (layout: DockLayout, panelId: PanelId): string | undefined {
+  const tab = findFocusedTab(layout)
+  if (tab?.component.type !== panelId) {
+    return undefined
+  }
+
+  try {
+    return getEditorPanelProps(tab.component.props).filePath
+  } catch {
+    return undefined
+  }
+}
+
+export function getFocusedEditorCaret (
+  layout: DockLayout,
+  panelId: PanelId,
+  carets: EditorState['carets']
+): EditorLocation | undefined {
+  const tab = findFocusedTab(layout)
+  return tab?.component.type === panelId ? carets[tab.id] : undefined
+}

--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -15,7 +15,7 @@ import { cadenceDarkTheme, cadenceLightTheme } from '../theme.js'
 const indent = '  ' // 2 spaces
 const lintDelay = numeric('s', 0.25)
 
-export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps }) => {
+export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }) => {
   const { filePath } = getEditorPanelProps(panelProps)
   const editorDispatch = useEditorDispatch()
   const source = useProjectSource()
@@ -33,10 +33,10 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps }) => {
       ...prev,
       carets: {
         ...prev.carets,
-        [filePath]: caret
+        [tabId]: caret
       }
     }))
-  }, [editorDispatch, filePath])
+  }, [editorDispatch, tabId])
 
   const viewDispatchRef = useRef<EditorViewDispatch | undefined>(undefined)
 

--- a/packages/app/src/modules/editor/components/LoadDemoDialog.tsx
+++ b/packages/app/src/modules/editor/components/LoadDemoDialog.tsx
@@ -18,10 +18,7 @@ export const LoadDemoDialog: FunctionComponent<DialogComponentProps & {
     sourceDispatch((state) => setProjectFileContent(state, TRACK_FILE_PATH, demoCode))
     editorDispatch((state) => ({
       ...state,
-      carets: {
-        ...state.carets,
-        [TRACK_FILE_PATH]: undefined
-      }
+      carets: {}
     }))
     layoutDispatch((layout) => activateTabOfType(layout, editorPanelId, () => ({
       type: editorPanelId,

--- a/packages/app/src/modules/editor/index.ts
+++ b/packages/app/src/modules/editor/index.ts
@@ -1,5 +1,5 @@
 import type { CommandId, MenuId, MenuSectionId, Module, ModuleId, PanelId } from '@editor'
-import { activateTabOfType, useDialogService, useLayoutDispatch, useProvideProblems, useRegisterCommand } from '@editor'
+import { activateTabOfType, useDialogService, useLayout, useLayoutDispatch, useProvideProblems, useRegisterCommand } from '@editor'
 import { numeric } from '@utility'
 import { useEffect, useRef, type FunctionComponent } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
@@ -7,6 +7,7 @@ import { useProjectSource, useProjectSourceDispatch } from '../../project-source
 import { getProjectFileContent, setProjectFileContent, TRACK_FILE_PATH } from '../../project-source/model.js'
 import { openTextFile, saveTextFile } from '../../utilities/files.js'
 import { EditorPanel } from './components/EditorPanel.js'
+import { getFocusedEditorCaret } from './caret.js'
 import { LoadDemoDialog } from './components/LoadDemoDialog.js'
 import { getEditorPanelProps, type EditorPanelProps } from './panel-props.js'
 import { EditorProvider, useEditor, useEditorDispatch } from './provider.js'
@@ -78,10 +79,7 @@ const GlobalHooks: FunctionComponent = () => {
           editorRef.current.sourceDispatch((state) => setProjectFileContent(state, TRACK_FILE_PATH, content))
           editorRef.current.editorDispatch((state) => ({
             ...state,
-            carets: {
-              ...state.carets,
-              [TRACK_FILE_PATH]: undefined
-            }
+            carets: {}
           }))
         }
       }).catch(() => {
@@ -175,8 +173,9 @@ export const editorModule: Module = {
         commandId: viewEditorId,
         position: 'end',
         Label: () => {
+          const layout = useLayout()
           const editor = useEditor()
-          const caret = editor.carets[TRACK_FILE_PATH]
+          const caret = getFocusedEditorCaret(layout, editorPanelId, editor.carets)
           return `Ln ${caret?.line ?? '-'}, Col ${caret?.column ?? '-'}`
         }
       }

--- a/packages/app/src/modules/editor/provider.tsx
+++ b/packages/app/src/modules/editor/provider.tsx
@@ -1,9 +1,9 @@
-import type { EditorLocation } from '@editor'
+import type { EditorLocation, TabId } from '@editor'
 import { useSafeContext } from '@editor'
 import { createContext, useReducer, type Dispatch, type FunctionComponent, type PropsWithChildren, type SetStateAction } from 'react'
 
 export interface EditorState {
-  readonly carets: Readonly<Record<string, EditorLocation | undefined>>
+  readonly carets: Readonly<Record<TabId, EditorLocation | undefined>>
 }
 
 const initialEditorState: EditorState = {

--- a/packages/app/test/modules/editor/caret.test.ts
+++ b/packages/app/test/modules/editor/caret.test.ts
@@ -1,0 +1,101 @@
+import type { DockLayout, LayoutNodeId, PanelId, TabId } from '@editor'
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { getFocusedEditorCaret, getFocusedEditorFilePath } from '../../../src/modules/editor/caret.js'
+
+const testEditorPanelId = 'editor.editor' as PanelId
+const testMixerPanelId = 'mixer.mixer' as PanelId
+
+const firstEditorTabId = 'editor-a' as TabId
+const secondEditorTabId = 'editor-b' as TabId
+const mixerTabId = 'mixer' as TabId
+
+function createLayout (focusedTabId?: TabId): DockLayout {
+  return {
+    main: {
+      id: 'main-pane' as LayoutNodeId,
+      type: 'pane',
+      tabs: [
+        {
+          id: firstEditorTabId,
+          component: {
+            type: testEditorPanelId,
+            props: { filePath: 'track.cadence' }
+          }
+        },
+        {
+          id: secondEditorTabId,
+          component: {
+            type: testEditorPanelId,
+            props: { filePath: 'track.cadence' }
+          }
+        },
+        {
+          id: mixerTabId,
+          component: {
+            type: testMixerPanelId
+          }
+        }
+      ],
+      activeTabId: firstEditorTabId
+    },
+    focusedTabId
+  }
+}
+
+describe('modules/editor/caret.ts', () => {
+  it('returns the caret for the focused editor tab instance', () => {
+    const carets = {
+      [firstEditorTabId]: { line: 1, column: 2 },
+      [secondEditorTabId]: { line: 10, column: 20 }
+    }
+
+    assert.deepStrictEqual(
+      getFocusedEditorCaret(createLayout(firstEditorTabId), testEditorPanelId, carets),
+      { line: 1, column: 2 }
+    )
+
+    assert.deepStrictEqual(
+      getFocusedEditorCaret(createLayout(secondEditorTabId), testEditorPanelId, carets),
+      { line: 10, column: 20 }
+    )
+  })
+
+  it('returns no caret when the focused tab is not an editor', () => {
+    const carets = {
+      [firstEditorTabId]: { line: 1, column: 2 }
+    }
+
+    assert.strictEqual(getFocusedEditorCaret(createLayout(mixerTabId), testEditorPanelId, carets), undefined)
+  })
+
+  it('returns no caret when no tab is focused', () => {
+    const carets = {
+      [firstEditorTabId]: { line: 1, column: 2 }
+    }
+
+    assert.strictEqual(getFocusedEditorCaret(createLayout(), testEditorPanelId, carets), undefined)
+  })
+
+  it('fails safely when focused editor props are invalid', () => {
+    const layout: DockLayout = {
+      main: {
+        id: 'main-pane' as LayoutNodeId,
+        type: 'pane',
+        tabs: [
+          {
+            id: firstEditorTabId,
+            component: {
+              type: testEditorPanelId,
+              props: { wrong: true }
+            }
+          }
+        ],
+        activeTabId: firstEditorTabId
+      },
+      focusedTabId: firstEditorTabId
+    }
+
+    assert.strictEqual(getFocusedEditorFilePath(layout, testEditorPanelId), undefined)
+  })
+})

--- a/packages/editor/src/layout/algorithms/find.ts
+++ b/packages/editor/src/layout/algorithms/find.ts
@@ -43,6 +43,12 @@ export function findTab (layout: DockLayout, predicate: (tab: Tab) => boolean): 
   return layout.main != null ? findInNode(layout.main) : undefined
 }
 
+export function findFocusedTab (layout: DockLayout): Tab | undefined {
+  return layout.focusedTabId != null
+    ? findTab(layout, (tab) => tab.id === layout.focusedTabId)
+    : undefined
+}
+
 export function findTabByComponentType (layout: DockLayout, componentType: string): Tab | undefined {
   return findTab(layout, (tab) => tab.component.type === componentType)
 }

--- a/packages/editor/src/layout/components/TabContent.tsx
+++ b/packages/editor/src/layout/components/TabContent.tsx
@@ -43,7 +43,7 @@ export const TabContent: FunctionComponent<TabContentProps & {
       <PanelErrorBoundary FallbackComponent={FallbackComponent}>
         {panel == null
           ? `Unknown tab type: ${tab.component.type}`
-          : <panel.Panel panelProps={tab.component.props} />}
+          : <panel.Panel panelProps={tab.component.props} tabId={tab.id} />}
       </PanelErrorBoundary>
     </TabPanel>
   )

--- a/packages/editor/src/modules/types.ts
+++ b/packages/editor/src/modules/types.ts
@@ -2,7 +2,7 @@ import type { Brand } from '@utility'
 import type { ComponentType, PropsWithChildren, ReactNode } from 'react'
 import type { CommandId } from '../commands/commands.js'
 import type { MenuItemDefinition, MenuSectionDefinition } from '../commands/menus.js'
-import type { SerializedComponent } from '../layout/types.js'
+import type { SerializedComponent, TabId } from '../layout/types.js'
 
 export type ModuleRenderFn<P = {}, T extends ReactNode = ReactNode> = (props: P) => T
 export type ModuleProviderComponent = ComponentType<PropsWithChildren>
@@ -39,6 +39,7 @@ export interface Panel {
 
 export interface PanelProps {
   readonly panelProps: SerializedComponent['props']
+  readonly tabId: TabId
 }
 
 export interface HeaderInsert {

--- a/packages/editor/test/layout/algorithms/find.test.ts
+++ b/packages/editor/test/layout/algorithms/find.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { findNode, findNodeById, findPane, findPaneById, findPaneByTabId, findTab, findTabByComponentType } from '../../../src/layout/algorithms/find.js'
+import { findFocusedTab, findNode, findNodeById, findPane, findPaneById, findPaneByTabId, findTab, findTabByComponentType } from '../../../src/layout/algorithms/find.js'
 import { pane1Id, pane2Id, pane3Id, tab2Id, tab3Id, tab4Id, testLayout } from './fixtures.js'
 
 describe('layout/algorithms/find.ts', () => {
@@ -43,6 +43,13 @@ describe('layout/algorithms/find.ts', () => {
     it('should find a tab by predicate', () => {
       const tab = findTab(testLayout, (tab) => tab.id === tab2Id)
       assert.strictEqual(tab?.id, tab2Id)
+    })
+  })
+
+  describe('findFocusedTab', () => {
+    it('should find the focused tab', () => {
+      const tab = findFocusedTab(testLayout)
+      assert.strictEqual(tab?.id, testLayout.focusedTabId)
     })
   })
 


### PR DESCRIPTION
The caret position displayed in the footer will now be based on which tab is focused, rather than always using the editor tab for the primary file (TRACK_FILE_PATH).