### PR TITLE
fix: Use empty source+layout state while loading

### DIFF
--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -16,7 +16,6 @@ import { playbackModule } from './modules/playback/index.js'
 import { problemsModule } from './modules/problems/index.js'
 import { settingsModule } from './modules/settings/index.js'
 import { viewModule } from './modules/view/index.js'
-import { appPersistenceDefaults } from './persistence/persistence.js'
 import { ProjectSourceProvider } from './project-source/ProjectSourceContext.js'
 import { applyThemeSetting } from './theme.js'
 
@@ -62,8 +61,8 @@ const root = createRoot(container)
 root.render(
   <StrictMode>
     <CacheProvider value={emotionCache}>
-      <CommonProvider persistenceEngine={persistenceEngine} initialLayout={appPersistenceDefaults.layout} modules={modules}>
-        <ProjectSourceProvider initialState={appPersistenceDefaults.source}>
+      <CommonProvider persistenceEngine={persistenceEngine} modules={modules}>
+        <ProjectSourceProvider>
           <CompilationProvider compileOptions={compileOptions}>
             <App />
             <DialogHost />

--- a/packages/app/src/persistence/persistence.ts
+++ b/packages/app/src/persistence/persistence.ts
@@ -7,11 +7,6 @@ import { useProjectSource, useProjectSourceDispatch } from '../project-source/Pr
 import { createProjectSourceState, type ProjectSourceState } from '../project-source/model.js'
 import { dockLayoutSchema } from './layout.js'
 
-export const appPersistenceDefaults = {
-  layout: defaultLayout,
-  source: createProjectSourceState(demoCode)
-}
-
 const layoutDomain: PersistenceDomain<DockLayout> = {
   key: 'app.layout',
   fallbackValue: defaultLayout,

--- a/packages/app/src/project-source/ProjectSourceContext.tsx
+++ b/packages/app/src/project-source/ProjectSourceContext.tsx
@@ -11,10 +11,8 @@ export type ProjectSourceDispatch = Dispatch<SetStateAction<ProjectSourceState>>
 const ProjectSourceContext = createContext<ProjectSourceState | undefined>(undefined)
 const ProjectSourceDispatchContext = createContext<ProjectSourceDispatch | undefined>(undefined)
 
-export const ProjectSourceProvider: FunctionComponent<PropsWithChildren<{
-  initialState?: ProjectSourceState
-}>> = ({ children, initialState = createProjectSourceState() }) => {
-  const [state, dispatch] = useReducer(projectSourceReducer, initialState)
+export const ProjectSourceProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const [state, dispatch] = useReducer(projectSourceReducer, createProjectSourceState())
 
   return (
     <ProjectSourceContext value={state}>

--- a/packages/editor/src/layout/components/LayoutContext.tsx
+++ b/packages/editor/src/layout/components/LayoutContext.tsx
@@ -15,10 +15,8 @@ export type LayoutDispatch = Dispatch<SetStateAction<DockLayout>>
 export const LayoutContext = createContext<DockLayout | undefined>(undefined)
 export const LayoutDispatchContext = createContext<Dispatch<SetStateAction<DockLayout>> | undefined>(undefined)
 
-export const LayoutProvider: FunctionComponent<PropsWithChildren<{
-  initialLayout?: DockLayout
-}>> = ({ children, initialLayout = initialLayoutState }) => {
-  const [state, dispatch] = useReducer(layoutReducer, initialLayout)
+export const LayoutProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const [state, dispatch] = useReducer(layoutReducer, initialLayoutState)
 
   return (
     <LayoutContext value={state}>

--- a/packages/editor/src/provider/CommonProvider.tsx
+++ b/packages/editor/src/provider/CommonProvider.tsx
@@ -3,22 +3,20 @@ import { CommandRegistryProvider } from '../commands/components/CommandRegistryC
 import { MenuProvider } from '../commands/components/MenuContext.js'
 import { DialogProvider } from '../dialogs/components/DialogContext.js'
 import { LayoutProvider } from '../layout/components/LayoutContext.js'
-import type { DockLayout } from '../layout/types.js'
 import { ModuleProvider } from '../modules/components/ModuleContext.js'
 import type { Module } from '../modules/types.js'
 import { NotificationProvider } from '../notifications/components/NotificationContext.js'
-import { ProblemProvider } from '../problems/components/ProblemContext.js'
 import { PersistenceProvider } from '../persistence/components/PersistenceContext.js'
 import type { PersistenceEngine } from '../persistence/engine.js'
+import { ProblemProvider } from '../problems/components/ProblemContext.js'
 
 export const CommonProvider: FunctionComponent<PropsWithChildren<{
   persistenceEngine: PersistenceEngine
-  initialLayout?: DockLayout
   modules: readonly Module[]
-}>> = ({ children, persistenceEngine, initialLayout, modules }) => {
+}>> = ({ children, persistenceEngine, modules }) => {
   return (
     <PersistenceProvider engine={persistenceEngine}>
-      <LayoutProvider initialLayout={initialLayout}>
+      <LayoutProvider>
         <DialogProvider>
           <NotificationProvider>
             <CommandRegistryProvider>


### PR DESCRIPTION
Loading of defaults for initial visitors is already handled via the persistence domains' fallback values. Having initial state in contexts causes the app to load with that state before switching to the persisted state, which can lead, for example, to the timeline or mixer graph showing the default program for a moment.