### PR TITLE
fix: Choose tab drop side based on mouse position

### DIFF
--- a/packages/editor/src/layout/algorithms/mutate.ts
+++ b/packages/editor/src/layout/algorithms/mutate.ts
@@ -1,7 +1,9 @@
-import { insertAt, move, randomId, removeAt } from '@utility'
+import { insertAt, randomId, removeAt } from '@utility'
 import type { DockLayout, LayoutNode, LayoutNodeId, PaneNode, SerializedComponent, Tab, TabId } from '../types.js'
 import { findNodeById, findPaneById, findPaneByTabId, findTabByComponentType } from './find.js'
 import { updateNodesInLayout } from './internal.js'
+
+type TabInsertionPosition = 'before' | 'after'
 
 export function transformNode (layout: DockLayout, nodeId: LayoutNodeId, fn: (node: LayoutNode) => LayoutNode): DockLayout {
   const node = findNodeById(layout, nodeId)
@@ -147,24 +149,73 @@ export function moveTabIntoPane (layout: DockLayout, tabId: TabId, targetNodeId:
   ]), { focusTabId: tabId })
 }
 
-export function moveTabBetweenPanes (layout: DockLayout, tabId: TabId, beforeTabId: TabId): DockLayout {
+export function moveTabBetweenPanes (
+  layout: DockLayout,
+  tabId: TabId,
+  targetTabId: TabId,
+  position: TabInsertionPosition = 'before'
+): DockLayout {
   const sourcePane = findPaneByTabId(layout, tabId)
-  const targetPane = findPaneByTabId(layout, beforeTabId)
+  const targetPane = findPaneByTabId(layout, targetTabId)
   if (sourcePane == null || targetPane == null) {
     return layout
   }
 
-  // We know for sure that both tabs exist in their panes
+  const targetTabIndex = targetPane.tabs.findIndex((tab) => tab.id === targetTabId)
+
+  return moveTabToPaneIndex(layout, tabId, targetPane.id, targetTabIndex + (position === 'after' ? 1 : 0))
+}
+
+export function moveTabToPaneEnd (layout: DockLayout, tabId: TabId, targetNodeId: LayoutNodeId): DockLayout {
+  const targetPane = findPaneById(layout, targetNodeId)
+  if (targetPane == null) {
+    return layout
+  }
+
+  return moveTabToPaneIndex(layout, tabId, targetPane.id, targetPane.tabs.length)
+}
+
+export function activateTabOfType (layout: DockLayout, type: string, create: () => SerializedComponent): DockLayout {
+  const tab = findTabByComponentType(layout, type)
+
+  // If no such tab exists, create one
+  if (tab == null) {
+    return createTab(layout, create())
+  }
+
+  return activateTabInPane(layout, tab.id)
+}
+
+export function updateFocusedTab (layout: DockLayout, tabId: TabId): DockLayout {
+  return updateNodesInLayout(layout, new Map(), { focusTabId: tabId })
+}
+
+function moveTabToPaneIndex (layout: DockLayout, tabId: TabId, targetNodeId: LayoutNodeId, targetIndex: number): DockLayout {
+  const sourcePane = findPaneByTabId(layout, tabId)
+  const targetPane = findPaneById(layout, targetNodeId)
+  if (sourcePane == null || targetPane == null) {
+    return layout
+  }
+
   const tabIndex = sourcePane.tabs.findIndex((tab) => tab.id === tabId)
-  const beforeTabIndex = targetPane.tabs.findIndex((tab) => tab.id === beforeTabId)
+  if (tabIndex === -1) {
+    return layout
+  }
+
+  const tab = sourcePane.tabs[tabIndex]
+  const targetTabCount = targetPane.tabs.length
+  const normalizedTargetIndex = Math.max(0, Math.min(targetIndex, targetTabCount))
 
   if (sourcePane === targetPane) {
+    const adjustedTargetIndex = normalizedTargetIndex > tabIndex ? normalizedTargetIndex - 1 : normalizedTargetIndex
+    const remainingTabs = removeAt(sourcePane.tabs, tabIndex)
+
     return updateNodesInLayout(layout, new Map([
       [
         sourcePane.id,
         {
           ...sourcePane,
-          tabs: move([...sourcePane.tabs], tabIndex, beforeTabIndex),
+          tabs: insertAt(remainingTabs, adjustedTargetIndex, tab),
           activeTabId: tabId
         }
       ]
@@ -183,26 +234,11 @@ export function moveTabBetweenPanes (layout: DockLayout, tabId: TabId, beforeTab
       targetPane.id,
       {
         ...targetPane,
-        tabs: insertAt(targetPane.tabs, beforeTabIndex, sourcePane.tabs[tabIndex]),
+        tabs: insertAt(targetPane.tabs, normalizedTargetIndex, tab),
         activeTabId: tabId
       }
     ]
   ]), { focusTabId: tabId })
-}
-
-export function activateTabOfType (layout: DockLayout, type: string, create: () => SerializedComponent): DockLayout {
-  const tab = findTabByComponentType(layout, type)
-
-  // If no such tab exists, create one
-  if (tab == null) {
-    return createTab(layout, create())
-  }
-
-  return activateTabInPane(layout, tab.id)
-}
-
-export function updateFocusedTab (layout: DockLayout, tabId: TabId): DockLayout {
-  return updateNodesInLayout(layout, new Map(), { focusTabId: tabId })
 }
 
 export type SplitPlacement = 'north' | 'south' | 'east' | 'west'

--- a/packages/editor/src/layout/components/DockLayoutView.tsx
+++ b/packages/editor/src/layout/components/DockLayoutView.tsx
@@ -1,15 +1,15 @@
-import { DndContext, DragOverlay, MouseSensor, pointerWithin, useSensor, useSensors, type CollisionDetection, type DragEndEvent, type DragStartEvent, type Modifier } from '@dnd-kit/core'
+import { DndContext, DragOverlay, MouseSensor, pointerWithin, useSensor, useSensors, type CollisionDetection, type DragEndEvent, type DragOverEvent, type DragStartEvent, type Modifier } from '@dnd-kit/core'
 import { getEventCoordinates } from '@dnd-kit/utilities'
 import { useCallback, useState, type ComponentType, type FunctionComponent } from 'react'
 import type { FallbackProps } from 'react-error-boundary'
 import { findPaneById, findPaneByTabId } from '../algorithms/find.js'
-import { moveTabBetweenPanes, moveTabIntoPane, moveTabToSplit } from '../algorithms/mutate.js'
+import { moveTabBetweenPanes, moveTabIntoPane, moveTabToPaneEnd, moveTabToSplit } from '../algorithms/mutate.js'
 import type { DockLayout, Tab, TabId } from '../types.js'
 import type { LayoutDispatch } from './LayoutContext.js'
 import { LayoutNodeView } from './LayoutNodeView.js'
 import { PanelErrorBoundary } from './PanelErrorBoundary.js'
 import { parsePaneNodeDropTarget } from './PaneNodeView.js'
-import { PanelTabTitle, type TabTitleProps } from './TabTitle.js'
+import { PanelTabTitle, parseTabDropTarget, type TabTitleProps } from './TabTitle.js'
 
 const DRAGGED_TAB_OPACITY = 0.6
 
@@ -72,6 +72,7 @@ const InternalDockLayoutView: FunctionComponent<DockLayoutViewProps> = ({
   className
 }) => {
   const [draggedTab, setDraggedTab] = useState<Tab | undefined>(undefined)
+  const [currentDropTargetId, setCurrentDropTargetId] = useState<string | undefined>(undefined)
 
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: {
@@ -81,37 +82,44 @@ const InternalDockLayoutView: FunctionComponent<DockLayoutViewProps> = ({
 
   const sensors = useSensors(mouseSensor)
 
-  // Custom collision detection to treat tab-lists as the last tab in their pane.
   const collisionDetection: CollisionDetection = useCallback((args) => {
     const collisions = pointerWithin(args)
     if (collisions.length === 0) {
       return collisions
     }
 
-    const firstCollision = collisions[0]
-    const dropTarget = parsePaneNodeDropTarget(firstCollision.id.toString())
-    if (dropTarget == null || dropTarget.target !== 'tab-list') {
-      return collisions
+    const tabDropCollision = collisions.find((collision) => parseTabDropTarget(collision.id.toString()) != null)
+    if (tabDropCollision != null) {
+      return [tabDropCollision]
     }
 
-    const tabId = findPaneById(layout, dropTarget.nodeId)?.tabs.at(-1)?.id
-    if (tabId == null) {
-      return collisions
+    const tabListCollision = collisions.find((collision) => {
+      const dropTarget = parsePaneNodeDropTarget(collision.id.toString())
+      return dropTarget?.target === 'tab-list'
+    })
+    if (tabListCollision != null) {
+      return [tabListCollision]
     }
 
-    return [{ ...firstCollision, id: tabId }]
-  }, [layout])
+    return collisions
+  }, [])
 
   const onDragStart = useCallback(({ active }: DragStartEvent) => {
     const activeId = active.id.toString() as TabId
     const sourcePane = findPaneByTabId(layout, activeId)
     setDraggedTab(sourcePane?.tabs.find((tab) => tab.id === activeId))
+    setCurrentDropTargetId(undefined)
   }, [layout])
+
+  const onDragOver = useCallback(({ over }: DragOverEvent) => {
+    setCurrentDropTargetId(over?.id.toString())
+  }, [])
 
   const finalizeDrag = useCallback(() => {
     // Delay resetting drag state as HeadlessUI may still mess with focus during the same tick
     queueMicrotask(() => {
       setDraggedTab(undefined)
+      setCurrentDropTargetId(undefined)
     })
   }, [])
 
@@ -122,14 +130,25 @@ const InternalDockLayoutView: FunctionComponent<DockLayoutViewProps> = ({
       }
 
       const activeId = active.id.toString() as TabId
+      const tabDropTarget = parseTabDropTarget(over.id.toString())
+
+      if (tabDropTarget != null) {
+        return moveTabBetweenPanes(layout, activeId, tabDropTarget.tabId, tabDropTarget.position)
+      }
 
       const dropTarget = parsePaneNodeDropTarget(over.id.toString())
       const overPane = dropTarget != null ? findPaneById(layout, dropTarget.nodeId) : undefined
 
       if (dropTarget != null && overPane != null) {
-        return dropTarget.target === 'center' || dropTarget.target === 'tab-list'
-          ? moveTabIntoPane(layout, activeId, overPane.id)
-          : moveTabToSplit(layout, activeId, overPane.id, dropTarget.target)
+        if (dropTarget.target === 'center') {
+          return moveTabIntoPane(layout, activeId, overPane.id)
+        }
+
+        if (dropTarget.target === 'tab-list') {
+          return moveTabToPaneEnd(layout, activeId, overPane.id)
+        }
+
+        return moveTabToSplit(layout, activeId, overPane.id, dropTarget.target)
       }
 
       return moveTabBetweenPanes(layout, activeId, over.id.toString() as TabId)
@@ -143,6 +162,7 @@ const InternalDockLayoutView: FunctionComponent<DockLayoutViewProps> = ({
       collisionDetection={collisionDetection}
       sensors={sensors}
       onDragStart={onDragStart}
+      onDragOver={onDragOver}
       onDragCancel={finalizeDrag}
       onDragEnd={onDragEnd}
     >
@@ -157,6 +177,7 @@ const InternalDockLayoutView: FunctionComponent<DockLayoutViewProps> = ({
             styles={styles}
             node={layout.main}
             focusedTabId={layout.focusedTabId}
+            currentDropTargetId={currentDropTargetId}
             dispatch={draggedTab != null ? undefined : dispatch}
           />
         )}

--- a/packages/editor/src/layout/components/LayoutNodeView.tsx
+++ b/packages/editor/src/layout/components/LayoutNodeView.tsx
@@ -13,6 +13,7 @@ export interface LayoutNodeViewProps<TNode extends LayoutNode = LayoutNode> {
   readonly styles: DockLayoutStyles
   readonly node: TNode
   readonly focusedTabId?: TabId
+  readonly currentDropTargetId?: string
   readonly dispatch?: LayoutDispatch
 }
 

--- a/packages/editor/src/layout/components/PaneNodeView.tsx
+++ b/packages/editor/src/layout/components/PaneNodeView.tsx
@@ -1,13 +1,13 @@
 import { useDroppable } from '@dnd-kit/core'
 import { horizontalListSortingStrategy, SortableContext } from '@dnd-kit/sortable'
 import { TabGroup, TabList, TabPanels } from '@headlessui/react'
-import { useCallback, type CSSProperties, type FunctionComponent, type PropsWithChildren } from 'react'
+import { useCallback, useRef, type CSSProperties, type FunctionComponent, type PropsWithChildren } from 'react'
 import { removeTabFromPane, transformNode, updateFocusedTab } from '../algorithms/mutate.js'
 import type { LayoutNodeId, PaneNode, TabId } from '../types.js'
 import type { DockLayoutStyles } from './DockLayoutView.js'
 import type { LayoutNodeViewProps } from './LayoutNodeView.js'
 import { TabContent } from './TabContent.js'
-import { TabTitle } from './TabTitle.js'
+import { parseTabDropTarget, TabTitle } from './TabTitle.js'
 
 const paneNodeDropZones = ['north', 'south', 'east', 'west', 'center'] as const
 type PaneNodeDropZone = typeof paneNodeDropZones[number]
@@ -35,9 +35,15 @@ export const PaneNodeView: FunctionComponent<LayoutNodeViewProps<PaneNode>> = ({
   styles,
   node,
   focusedTabId,
+  currentDropTargetId,
   dispatch
 }) => {
   const { id: nodeId, tabs, activeTabId } = node
+  const tabDropTarget = currentDropTargetId != null ? parseTabDropTarget(currentDropTargetId) : undefined
+  const paneDropTarget = currentDropTargetId != null ? parsePaneNodeDropTarget(currentDropTargetId) : undefined
+  const tabListElementRef = useRef<HTMLDivElement | null>(null)
+  const endDropAreaElementRef = useRef<HTMLDivElement | null>(null)
+  const tabElementsRef = useRef(new Map<TabId, HTMLDivElement>())
 
   const onTabFocus = useCallback((id: TabId) => {
     dispatch?.((layout) => updateFocusedTab(layout, id))
@@ -62,19 +68,51 @@ export const PaneNodeView: FunctionComponent<LayoutNodeViewProps<PaneNode>> = ({
     dispatch?.((layout) => removeTabFromPane(layout, id))
   }, [dispatch])
 
+  const setTabListElement = useCallback((element: HTMLDivElement | null) => {
+    tabListElementRef.current = element
+  }, [])
+
+  const setTabElement = useCallback((tabId: TabId, element: HTMLDivElement | null) => {
+    if (element == null) {
+      tabElementsRef.current.delete(tabId)
+      return
+    }
+
+    tabElementsRef.current.set(tabId, element)
+  }, [])
+
+  const setEndDropAreaElement = useCallback((element: HTMLDivElement | null) => {
+    endDropAreaElementRef.current = element
+  }, [])
+
+  const dropIndicatorOffset = getDropIndicatorOffset(
+    node.id,
+    tabDropTarget,
+    paneDropTarget,
+    tabListElementRef.current,
+    tabElementsRef.current,
+    endDropAreaElementRef.current
+  )
+
   return (
     <TabGroup
       selectedIndex={selectedIndex}
       onChange={onSelectionChange}
       style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
     >
-      <TabListDroppable node={node} styles={styles}>
+      <TabListDroppable
+        node={node}
+        styles={styles}
+        dropIndicatorOffset={dropIndicatorOffset}
+        onElementRef={setTabListElement}
+        onEndDropAreaElementRef={setEndDropAreaElement}
+      >
         <SortableContext items={tabs.map((tab) => tab.id)} strategy={horizontalListSortingStrategy}>
           {tabs.map((tab) => (
             <TabTitle
               key={tab.id}
               TabTitleComponent={TabTitleComponent}
-              dropIndicatorColor={styles.dropIndicatorColor}
+              onElementRef={setTabElement}
               tab={tab}
               state={tab.id === focusedTabId ? 'focused' : tab.id === activeTabId ? 'active' : 'inactive'}
               onTabFocus={() => onTabFocus(tab.id)}
@@ -100,14 +138,13 @@ export const PaneNodeView: FunctionComponent<LayoutNodeViewProps<PaneNode>> = ({
 const TabListDroppable: FunctionComponent<PropsWithChildren<{
   node: PaneNode
   styles: DockLayoutStyles
-}>> = ({ children, node, styles }) => {
-  const { setNodeRef } = useDroppable({
-    id: getPaneNodeDropTargetId(node, 'tab-list')
-  })
-
+  dropIndicatorOffset?: number
+  onElementRef: (element: HTMLDivElement | null) => void
+  onEndDropAreaElementRef: (element: HTMLDivElement | null) => void
+}>> = ({ children, node, styles, dropIndicatorOffset, onElementRef, onEndDropAreaElementRef }) => {
   return (
     <TabList
-      ref={setNodeRef}
+      ref={onElementRef}
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -117,8 +154,85 @@ const TabListDroppable: FunctionComponent<PropsWithChildren<{
       }}
     >
       {children}
+      <TabListEndDropArea node={node} onElementRef={onEndDropAreaElementRef} />
+      <TabDropIndicator dropIndicatorColor={styles.dropIndicatorColor} offset={dropIndicatorOffset} />
     </TabList>
   )
+}
+
+const TabListEndDropArea: FunctionComponent<{
+  node: PaneNode
+  onElementRef: (element: HTMLDivElement | null) => void
+}> = ({ node, onElementRef }) => {
+  const { setNodeRef } = useDroppable({
+    id: getPaneNodeDropTargetId(node, 'tab-list')
+  })
+
+  const setElementRef = useCallback((element: HTMLDivElement | null) => {
+    setNodeRef(element)
+    onElementRef(element)
+  }, [onElementRef, setNodeRef])
+
+  return (
+    <div
+      ref={setElementRef}
+      style={{ position: 'relative', flex: 1, alignSelf: 'stretch', minWidth: '1rem' }}
+    />
+  )
+}
+
+const TabDropIndicator: FunctionComponent<{
+  dropIndicatorColor: string
+  offset?: number
+}> = ({ dropIndicatorColor, offset }) => {
+  return (
+    <div
+      style={{
+        display: offset != null ? 'block' : 'none',
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        left: offset != null ? `${offset}px` : undefined,
+        width: '0.125rem',
+        transform: 'translateX(-50%)',
+        backgroundColor: dropIndicatorColor,
+        pointerEvents: 'none'
+      }}
+    />
+  )
+}
+
+function getDropIndicatorOffset (
+  nodeId: LayoutNodeId,
+  tabDropTarget: ReturnType<typeof parseTabDropTarget>,
+  paneDropTarget: ReturnType<typeof parsePaneNodeDropTarget>,
+  tabListElement: HTMLDivElement | null,
+  tabElements: ReadonlyMap<TabId, HTMLDivElement>,
+  endDropAreaElement: HTMLDivElement | null
+): number | undefined {
+  if (tabListElement == null) {
+    return undefined
+  }
+
+  const tabListRect = tabListElement.getBoundingClientRect()
+
+  if (tabDropTarget != null) {
+    const tabElement = tabElements.get(tabDropTarget.tabId)
+    if (tabElement == null) {
+      return undefined
+    }
+
+    const tabRect = tabElement.getBoundingClientRect()
+    return tabDropTarget.position === 'before'
+      ? tabRect.left - tabListRect.left
+      : tabRect.right - tabListRect.left
+  }
+
+  if (paneDropTarget?.nodeId === nodeId && paneDropTarget.target === 'tab-list' && endDropAreaElement != null) {
+    return endDropAreaElement.getBoundingClientRect().left - tabListRect.left
+  }
+
+  return undefined
 }
 
 const TabPanelsDroppable: FunctionComponent<PropsWithChildren<{

--- a/packages/editor/src/layout/components/TabTitle.tsx
+++ b/packages/editor/src/layout/components/TabTitle.tsx
@@ -1,14 +1,30 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { Tab as HUITab } from '@headlessui/react'
+import { useDroppable } from '@dnd-kit/core'
 import React, { useCallback, type ComponentType, type FunctionComponent } from 'react'
 import type { ModuleRenderFn, PanelId, PanelProps } from '../../modules/types.js'
-import type { Tab } from '../types.js'
+import type { Tab, TabId } from '../types.js'
 import { usePanelById } from './panel-lookup.js'
 import { ErrorBoundary } from 'react-error-boundary'
 
 const MOUSE_BUTTON_MIDDLE = 1
 
 type TabTitleState = 'inactive' | 'active' | 'focused' | 'dragging'
+type TabDropPosition = 'before' | 'after'
+
+function getTabDropTargetId (tab: Tab, position: TabDropPosition): string {
+  return `${tab.id}:${position}`
+}
+
+export interface TabDropTargetInfo {
+  readonly tabId: Tab['id']
+  readonly position: TabDropPosition
+}
+
+export function parseTabDropTarget (id: string): TabDropTargetInfo | undefined {
+  const [tabId, position] = id.split(':') as [Tab['id'], string]
+  return position === 'before' || position === 'after' ? { tabId, position } : undefined
+}
 
 export interface TabTitleProps {
   readonly TitleComponent: ModuleRenderFn<PanelProps, string>
@@ -63,24 +79,28 @@ export const TabTitle: FunctionComponent<{
   tab: Tab
   state: TabTitleState
   onClose: () => void
-  dropIndicatorColor: string
+  onElementRef?: (tabId: TabId, element: HTMLDivElement | null) => void
   onTabFocus?: () => void
 }> = ({
   TabTitleComponent,
-  dropIndicatorColor,
   tab,
   state,
   onClose,
+  onElementRef,
   onTabFocus
 }) => {
-  const { attributes, listeners, setNodeRef, transform, isDragging, isOver, isSorting } = useSortable({ id: tab.id })
+  const { attributes, listeners, setNodeRef, isSorting } = useSortable({ id: tab.id })
+  const { setNodeRef: setBeforeDropRef } = useDroppable({ id: getTabDropTargetId(tab, 'before') })
+  const { setNodeRef: setAfterDropRef } = useDroppable({ id: getTabDropTargetId(tab, 'after') })
   const panel = usePanelById(tab.component.type as PanelId)
 
   const disabled = isSorting || state === 'dragging'
   const resolvedOnClose = panel?.closeable === true ? onClose : undefined
 
-  const showDropIndicator = isOver && !isDragging
-  const dropIndicatorOnRightSide = showDropIndicator && (transform?.x ?? 0) < 0
+  const setElementRef = useCallback((element: HTMLDivElement | null) => {
+    setNodeRef(element)
+    onElementRef?.(tab.id, element)
+  }, [onElementRef, setNodeRef, tab.id])
 
   const onMouseDown = useCallback((event: React.MouseEvent) => {
     if (event.button === MOUSE_BUTTON_MIDDLE) {
@@ -119,12 +139,21 @@ export const TabTitle: FunctionComponent<{
   return (
     <HUITab
       as='div'
-      ref={setNodeRef}
+      ref={setElementRef}
       {...attributes}
       {...listeners}
       onFocusCapture={disabled ? undefined : onTabFocus}
       style={{ position: 'relative', outline: 'none', pointerEvents: disabled ? 'none' : undefined }}
     >
+      <div
+        ref={setBeforeDropRef}
+        style={{ position: 'absolute', inset: 0, right: '50%', pointerEvents: 'none' }}
+      />
+      <div
+        ref={setAfterDropRef}
+        style={{ position: 'absolute', inset: 0, left: '50%', pointerEvents: 'none' }}
+      />
+
       <div onMouseDown={onMouseDown} onMouseUp={onMouseUp}>
         <PanelTabTitle
           TabTitleComponent={TabTitleComponent}
@@ -133,19 +162,6 @@ export const TabTitle: FunctionComponent<{
           onClose={resolvedOnClose}
         />
       </div>
-
-      <div
-        style={{
-          display: showDropIndicator ? 'block' : 'none',
-          position: 'absolute',
-          top: 0,
-          bottom: 0,
-          left: dropIndicatorOnRightSide ? undefined : 0,
-          right: dropIndicatorOnRightSide ? 0 : undefined,
-          width: '0.125rem',
-          backgroundColor: dropIndicatorColor
-        }}
-      />
     </HUITab>
   )
 }

--- a/packages/editor/test/layout/algorithms/mutate.test.ts
+++ b/packages/editor/test/layout/algorithms/mutate.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { findPaneById, findPaneByTabId, findTabByComponentType } from '../../../src/layout/algorithms/find.js'
-import { activateTabInPane, activateTabOfType, createTab, moveTabBetweenPanes, moveTabIntoPane, moveTabToSplit, removeTabFromPane, transformNode, updateFocusedTab } from '../../../src/layout/algorithms/mutate.js'
+import { activateTabInPane, activateTabOfType, createTab, moveTabBetweenPanes, moveTabIntoPane, moveTabToPaneEnd, moveTabToSplit, removeTabFromPane, transformNode, updateFocusedTab } from '../../../src/layout/algorithms/mutate.js'
 import type { DockLayout, LayoutNodeId, PaneNode, SplitNode } from '../../../src/layout/types.js'
 import { pane1Id, pane2Id, pane3Id, tab1Id, tab2Id, tab3Id, tab4Id, testLayout } from './fixtures.js'
 
@@ -88,6 +88,38 @@ describe('layout/algorithms/mutate.ts', () => {
       assert.deepStrictEqual(getPane(updated, pane1Id).tabs.map((tab) => tab.id), [tab1Id])
       assert.deepStrictEqual(getPane(updated, pane3Id).tabs.map((tab) => tab.id), [tab2Id, tab4Id])
       assert.strictEqual(getPane(updated, pane3Id).activeTabId, tab2Id)
+    })
+
+    it('can insert a tab after another tab in the same pane', () => {
+      const updated = moveTabBetweenPanes(testLayout, tab1Id, tab2Id, 'after')
+
+      assert.deepStrictEqual(getPane(updated, pane1Id).tabs.map((tab) => tab.id), [tab2Id, tab1Id])
+      assert.strictEqual(getPane(updated, pane1Id).activeTabId, tab1Id)
+    })
+
+    it('can insert a tab after another tab in a different pane', () => {
+      const updated = moveTabBetweenPanes(testLayout, tab2Id, tab3Id, 'after')
+
+      assert.deepStrictEqual(getPane(updated, pane1Id).tabs.map((tab) => tab.id), [tab1Id])
+      assert.deepStrictEqual(getPane(updated, pane2Id).tabs.map((tab) => tab.id), [tab3Id, tab2Id])
+      assert.strictEqual(getPane(updated, pane2Id).activeTabId, tab2Id)
+    })
+  })
+
+  describe('moveTabToPaneEnd', () => {
+    it('moves a tab to the end of another pane', () => {
+      const updated = moveTabToPaneEnd(testLayout, tab2Id, pane2Id)
+
+      assert.deepStrictEqual(getPane(updated, pane1Id).tabs.map((tab) => tab.id), [tab1Id])
+      assert.deepStrictEqual(getPane(updated, pane2Id).tabs.map((tab) => tab.id), [tab3Id, tab2Id])
+      assert.strictEqual(getPane(updated, pane2Id).activeTabId, tab2Id)
+    })
+
+    it('moves a tab to the end of its own pane', () => {
+      const updated = moveTabToPaneEnd(testLayout, tab1Id, pane1Id)
+
+      assert.deepStrictEqual(getPane(updated, pane1Id).tabs.map((tab) => tab.id), [tab2Id, tab1Id])
+      assert.strictEqual(getPane(updated, pane1Id).activeTabId, tab1Id)
     })
   })
 


### PR DESCRIPTION
By taking mouse position into account when determining where a dragged tab should be inserted (before or after the target tab), we can provide a more intuitive drag-and-drop experience. Insertion should occur before the hovered tab if the mouse is in its left half, and after when in the right half. When hovering the empty space at the end of the tab list, tabs should be inserted at the end.

Further, this patch reworks the insertion indicator such that it exists only once per tab list, and is positioned dynamically based on the current drop target and position; ensuring it matches.