### PR TITLE
fix: Generate reverb impulse without audio context

### DIFF
--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -1,9 +1,8 @@
 import type { BiquadNode, DelayNode, GainNode, IdentityNode, PanNode, ReverbNode } from '@audiograph'
-import type { Numeric } from '@utility'
-import { mulberry32, xmur3 } from '@utility'
-import { automate } from './automation.js'
 import type { Transport } from '../transport/transport.js'
+import { automate } from './automation.js'
 import type { Instance } from './instance.js'
+import { generateReverbImpulseResponse } from './noise.js'
 
 export function createIdentityInstance (node: IdentityNode, transport: Transport): Instance {
   return toInstance(transport.ctx.createGain())
@@ -37,10 +36,19 @@ export function createDelayInstance (node: DelayNode, transport: Transport): Ins
 }
 
 export function createReverbInstance (node: ReverbNode, transport: Transport): Instance {
-  const audioNode = transport.ctx.createConvolver()
-  const promise = generateReverbImpulseResponse(transport.ctx, node.decay).then((buffer) => {
+  const { ctx } = transport
+
+  const audioNode = ctx.createConvolver()
+
+  const promise = generateReverbImpulseResponse({
+    createBuffer: (options) => new AudioBuffer(options),
+    numberOfChannels: ctx.destination.channelCount,
+    sampleRate: ctx.sampleRate,
+    decay: node.decay
+  }).then((buffer) => {
     audioNode.buffer = buffer
   })
+
   return toInstance(audioNode, promise)
 }
 
@@ -53,59 +61,4 @@ function toInstance (node: AudioNode, loaded = Promise.resolve()): Instance {
       node.disconnect()
     }
   }
-}
-
-function generateReverbImpulseResponse (ctx: BaseAudioContext, decay: Numeric<'s'>): Promise<AudioBuffer> {
-  const channels = 2
-
-  // buffer length must be non-zero
-  const samples = Math.max(1, Math.floor(ctx.sampleRate * decay.value))
-
-  const renderer = new OfflineAudioContext(channels, samples, ctx.sampleRate)
-
-  const noise = renderer.createBufferSource()
-  noise.buffer = createNoiseBuffer(renderer, channels)
-  noise.loop = true
-
-  const decayGain = renderer.createGain()
-  decayGain.gain.setValueAtTime(1.0, 0)
-
-  // value must be > 0 to avoid exponentialRampToValueAtTime error
-  decayGain.gain.exponentialRampToValueAtTime(0.001, decay.value)
-
-  noise.connect(decayGain)
-  decayGain.connect(renderer.destination)
-
-  noise.start(0)
-
-  return renderer.startRendering()
-}
-
-// 2 seconds at 44.1kHz
-const noiseSamples = 44_100 * 2
-
-// decorrelated noise buffers per channel
-const noiseCache: Array<Float32Array<ArrayBuffer>> = []
-
-function createNoiseBuffer (ctx: BaseAudioContext, channels: number): AudioBuffer {
-  while (noiseCache.length < channels) {
-    const channel = noiseCache.length
-    const seed = xmur3(`cadence webaudio noise channel ${channel}`)()
-    const rng = mulberry32(seed)
-
-    // generate white noise
-    const data = new Float32Array(noiseSamples)
-    for (let i = 0; i < noiseSamples; ++i) {
-      data[i] = rng() * 2 - 1
-    }
-
-    noiseCache.push(data)
-  }
-
-  const buffer = ctx.createBuffer(channels, noiseSamples, ctx.sampleRate)
-  for (let channel = 0; channel < channels; ++channel) {
-    buffer.copyToChannel(noiseCache[channel], channel)
-  }
-
-  return buffer
 }

--- a/packages/webaudio/src/graph/noise.ts
+++ b/packages/webaudio/src/graph/noise.ts
@@ -1,0 +1,72 @@
+import { mulberry32, xmur3, type Numeric } from '@utility'
+
+type CreateAudioBuffer = (options: AudioBufferOptions) => AudioBuffer
+
+// Target decay of the noise envelope is -60 dB (RT60)
+const reverbDecayDb = 60
+const reverbDecayTarget = Math.pow(10, -reverbDecayDb / 20)
+
+export function generateReverbImpulseResponse (options: {
+  readonly createBuffer: CreateAudioBuffer
+  readonly numberOfChannels: number
+  readonly sampleRate: number
+  readonly decay: Numeric<'s'>
+}): Promise<AudioBuffer> {
+  const { sampleRate, numberOfChannels, decay, createBuffer } = options
+
+  // buffer length must be non-zero
+  const length = Math.max(1, Math.floor(sampleRate * decay.value))
+
+  const noise = createNoiseBuffer({ numberOfChannels, sampleRate, createBuffer })
+  const ir = createBuffer({ length, numberOfChannels, sampleRate })
+
+  const exponentScale = length > 1 ? Math.log(reverbDecayTarget) / (length - 1) : 0
+
+  for (let channel = 0; channel < numberOfChannels; ++channel) {
+    const input = noise.getChannelData(channel)
+    const output = ir.getChannelData(channel)
+
+    for (let i = 0; i < length; ++i) {
+      output[i] = input[i % input.length] * Math.exp(exponentScale * i)
+    }
+  }
+
+  return Promise.resolve(ir)
+}
+
+// 2 seconds at 44.1kHz
+const noiseSamples = 44_100 * 2
+
+// decorrelated noise buffers per channel
+const noiseCache: Array<Float32Array<ArrayBuffer>> = []
+
+function createNoiseBuffer (options: {
+  readonly createBuffer: CreateAudioBuffer
+  readonly numberOfChannels: number
+  readonly sampleRate: number
+}): AudioBuffer {
+  const { sampleRate, numberOfChannels, createBuffer } = options
+
+  while (noiseCache.length < numberOfChannels) {
+    const channel = noiseCache.length
+    const seed = xmur3(`cadence webaudio noise channel ${channel}`)()
+    const rng = mulberry32(seed)
+
+    // generate white noise
+    const data = new Float32Array(noiseSamples)
+    for (let i = 0; i < noiseSamples; ++i) {
+      data[i] = rng() * 2 - 1
+    }
+
+    noiseCache.push(data)
+  }
+
+  const length = noiseSamples
+  const buffer = createBuffer({ length, numberOfChannels, sampleRate })
+
+  for (let channel = 0; channel < numberOfChannels; ++channel) {
+    buffer.copyToChannel(noiseCache[channel], channel)
+  }
+
+  return buffer
+}

--- a/packages/webaudio/test/graph/noise.test.ts
+++ b/packages/webaudio/test/graph/noise.test.ts
@@ -1,0 +1,111 @@
+import { numeric } from '@utility'
+import { describe, it } from 'node:test'
+import { generateReverbImpulseResponse } from '../../src/graph/noise.js'
+import assert from 'node:assert'
+
+class MockAudioBuffer {
+  readonly length: number
+  readonly numberOfChannels: number
+  readonly sampleRate: number
+  private channels: Float32Array[]
+
+  constructor (options: AudioBufferOptions) {
+    this.length = options.length
+    this.numberOfChannels = options.numberOfChannels ?? 1
+    this.sampleRate = options.sampleRate
+
+    this.channels = Array.from({ length: this.numberOfChannels }, () => new Float32Array(this.length))
+  }
+
+  copyToChannel (source: Float32Array, channelNumber: number, startInChannel = 0): void {
+    const channel = this.channels.at(channelNumber)
+    if (channel == null) {
+      throw new Error()
+    }
+
+    channel.set(source.subarray(0, source.length), startInChannel)
+  }
+
+  getChannelData (channelNumber: number): Float32Array {
+    const channel = this.channels.at(channelNumber)
+    if (channel == null) {
+      throw new Error()
+    }
+    return channel
+  }
+}
+
+describe('graph/noise.ts', () => {
+  describe('generateReverbImpulseResponse', () => {
+    it('generates an impulse response with the expected properties', async () => {
+      const sampleRate = 44_100
+      const decay = numeric('s', 1.5)
+
+      const ir = await generateReverbImpulseResponse({
+        createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
+        numberOfChannels: 4,
+        sampleRate,
+        decay
+      })
+
+      const expectedLength = Math.max(1, Math.floor(sampleRate * decay.value))
+      assert.strictEqual(ir.length, expectedLength, `Expected impulse response length to be ${expectedLength}, but got ${ir.length}`)
+
+      assert.strictEqual(ir.numberOfChannels, 4)
+      assert.strictEqual(ir.sampleRate, sampleRate)
+    })
+
+    it('generates an impulse response with a decaying envelope', async () => {
+      const sampleRate = 44_100
+      const decay = numeric('s', 2)
+
+      const ir = await generateReverbImpulseResponse({
+        createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
+        numberOfChannels: 1,
+        sampleRate,
+        decay
+      })
+
+      const channelData = ir.getChannelData(0)
+
+      // Compute average value for first and second half
+      const firstHalfAvg = channelData.slice(0, channelData.length / 2).reduce((sum, value) => sum + Math.abs(value), 0) / (channelData.length / 2)
+      const secondHalfAvg = channelData.slice(channelData.length / 2).reduce((sum, value) => sum + Math.abs(value), 0) / (channelData.length / 2)
+
+      // The average amplitude in the second half should be significantly lower than the first half due to the decay
+      assert(secondHalfAvg < firstHalfAvg * 0.1, `Expected second half average (${secondHalfAvg}) to be less than 10% of first half average (${firstHalfAvg})`)
+    })
+
+    it('generates different noise for different channels', async () => {
+      const sampleRate = 44_100
+      const decay = numeric('s', 1)
+
+      const ir = await generateReverbImpulseResponse({
+        createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
+        numberOfChannels: 2,
+        sampleRate,
+        decay
+      })
+
+      const channelData1 = ir.getChannelData(0)
+      const channelData2 = ir.getChannelData(1)
+
+      // The two channels should not be identical
+      assert.notDeepStrictEqual(channelData1, channelData2, 'Expected different noise patterns for different channels')
+    })
+
+    it('handles long decay times without errors', async () => {
+      const sampleRate = 44_100
+      const decay = numeric('s', 30)
+
+      const ir = await generateReverbImpulseResponse({
+        createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
+        numberOfChannels: 1,
+        sampleRate,
+        decay
+      })
+
+      assert.strictEqual(ir.length, Math.max(1, Math.floor(sampleRate * decay.value)))
+    })
+  })
+})


### PR DESCRIPTION
This patch reimplements the `generateReverbImpulseResponse` function to generate the noise source + envelope directly, without instantiating an OfflineAudioContext. Besides being simpler, this makes the function testable.