### PR TITLE
feat: Add stereo width effect

### DIFF
--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -5,7 +5,7 @@ import { gainTransform, timeVariant, toTimeVariant } from './automation.js'
 import { createAudioGraphBuilder, type AudioGraphBuilder } from './builder.js'
 import { dbToGain, DEFAULT_ROOT_NOTE } from './constants.js'
 import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
-import type { BiquadNode, DelayNode, GainNode, IdentityNode, Node, PanNode, ReverbNode, SampleNode } from './nodes.js'
+import type { BiquadNode, DelayNode, GainNode, IdentityNode, Node, PanNode, ReverbNode, SampleNode, WidthNode } from './nodes.js'
 
 type Builder = AudioGraphBuilder<Node>
 
@@ -150,6 +150,13 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         frequency: effect.frequency,
         // TODO configurable rolloff
         rolloffPerOctave: numeric('db', 12)
+      }))
+    }
+
+    case 'width': {
+      return toSubGraph(builder.addNode<WidthNode>('width', {
+        // TODO time variant
+        width: numeric(undefined, Math.max(0, Math.min(1, effect.width.value)))
       }))
     }
 

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -8,6 +8,7 @@ export interface NodeTypeMap {
   readonly gain: GainNode
   readonly pan: PanNode
   readonly biquad: BiquadNode
+  readonly width: WidthNode
   readonly delay: DelayNode
   readonly reverb: ReverbNode
   readonly sample: SampleNode
@@ -34,6 +35,11 @@ export interface BiquadNode extends AnyNode {
   readonly filterType: 'lowpass' | 'highpass'
   readonly frequency: Numeric<'hz'>
   readonly rolloffPerOctave: Numeric<'db'>
+}
+
+export interface WidthNode extends AnyNode {
+  readonly type: 'width'
+  readonly width: Numeric<undefined>
 }
 
 export interface DelayNode extends AnyNode {

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -402,6 +402,18 @@ describe('lowering.ts', () => {
       })
     })
 
+    it('should handle width', () => {
+      const graph = createAudioGraph(createProgramWithEffect({
+        type: 'width',
+        width: numeric(undefined, 0.75)
+      }))
+      assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
+        id: 2 as NodeId,
+        type: 'width',
+        width: numeric(undefined, 0.75)
+      })
+    })
+
     it('should handle delay', () => {
       const graph = createAudioGraph(createProgramWithEffect({
         type: 'delay',

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -134,6 +134,7 @@ export type Effect =
   PanEffect |
   LowpassEffect |
   HighpassEffect |
+  WidthEffect |
   DelayEffect |
   ReverbEffect
 
@@ -155,6 +156,11 @@ export interface LowpassEffect {
 export interface HighpassEffect {
   readonly type: 'highpass'
   readonly frequency: Numeric<'hz'>
+}
+
+export interface WidthEffect {
+  readonly type: 'width'
+  readonly width: Numeric<undefined>
 }
 
 export interface DelayEffect {

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -31,6 +31,10 @@ const highpass = createEffectConstructor('highpass', [
   { name: 'frequency', type: NumberType.with('hz'), required: true }
 ])
 
+const width = createEffectConstructor('width', [
+  { name: 'width', type: NumberType.with(undefined), required: true }
+])
+
 const delay = createEffectConstructor('delay', [
   { name: 'mix', type: NumberType.with(undefined), required: true },
   { name: 'time', type: NumberType.with('beats'), required: true },
@@ -50,6 +54,7 @@ export const effectsModule = ModuleType.of({
     ['pan', pan],
     ['lowpass', lowpass],
     ['highpass', highpass],
+    ['width', width],
     ['delay', delay],
     ['reverb', reverb]
   ])

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -86,6 +86,23 @@ describe('compiler/modules/effects.ts', () => {
     })
   })
 
+  describe('width', () => {
+    const width = effects.exports.get('width')
+    assert.ok(width != null && FunctionType.is(width))
+
+    it('should create width effect', () => {
+      const context = createFunctionContext()
+      const result = width.data.invoke(context, {
+        width: numeric(undefined, 0.8)
+      })
+
+      assert.deepStrictEqual(result.data, {
+        type: 'width',
+        width: numeric(undefined, 0.8)
+      })
+    })
+  })
+
   describe('delay', () => {
     const delay = effects.exports.get('delay')
     assert.ok(delay != null && FunctionType.is(delay))

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -1,4 +1,4 @@
-import type { BiquadNode, DelayNode, GainNode, IdentityNode, PanNode, ReverbNode } from '@audiograph'
+import type { BiquadNode, DelayNode, GainNode, IdentityNode, PanNode, ReverbNode, WidthNode } from '@audiograph'
 import type { Transport } from '../transport/transport.js'
 import { automate } from './automation.js'
 import type { Instance } from './instance.js'
@@ -27,6 +27,62 @@ export function createBiquadInstance (node: BiquadNode, transport: Transport): I
   audioNode.frequency.value = node.frequency.value
   audioNode.Q.value = -node.rolloffPerOctave.value
   return toInstance(audioNode)
+}
+
+export function createWidthInstance (node: WidthNode, transport: Transport): Instance {
+  const { ctx } = transport
+
+  // Upmix to stereo if necessary
+  const input = ctx.createGain()
+  input.channelCount = 2
+  input.channelCountMode = 'explicit'
+  input.channelInterpretation = 'speakers'
+
+  const splitter = ctx.createChannelSplitter(2)
+
+  const merger = ctx.createChannelMerger(2)
+
+  const directGain = (1 + node.width.value) / 2
+  const crossGain = (1 - node.width.value) / 2
+
+  const leftDirect = ctx.createGain()
+  leftDirect.gain.value = directGain
+
+  const leftCross = ctx.createGain()
+  leftCross.gain.value = crossGain
+
+  const rightCross = ctx.createGain()
+  rightCross.gain.value = crossGain
+
+  const rightDirect = ctx.createGain()
+  rightDirect.gain.value = directGain
+
+  input.connect(splitter)
+
+  splitter.connect(leftDirect, 0)
+  splitter.connect(leftCross, 1)
+  splitter.connect(rightCross, 0)
+  splitter.connect(rightDirect, 1)
+
+  leftDirect.connect(merger, 0, 0)
+  leftCross.connect(merger, 0, 0)
+  rightCross.connect(merger, 0, 1)
+  rightDirect.connect(merger, 0, 1)
+
+  return {
+    input,
+    output: merger,
+    loaded: Promise.resolve(),
+    dispose: () => {
+      input.disconnect()
+      splitter.disconnect()
+      leftDirect.disconnect()
+      leftCross.disconnect()
+      rightCross.disconnect()
+      rightDirect.disconnect()
+      merger.disconnect()
+    }
+  }
 }
 
 export function createDelayInstance (node: DelayNode, transport: Transport): Instance {

--- a/packages/webaudio/src/graph/factory.ts
+++ b/packages/webaudio/src/graph/factory.ts
@@ -1,9 +1,9 @@
 import type { Node } from '@audiograph'
 import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
-import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance } from './effect.js'
-import { createSampleInstance } from './sample.js'
+import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance, createWidthInstance } from './effect.js'
 import type { Instance } from './instance.js'
+import { createSampleInstance } from './sample.js'
 
 const factories = Object.freeze({
   identity: createIdentityInstance,
@@ -11,6 +11,7 @@ const factories = Object.freeze({
   gain: createGainInstance,
   pan: createPanInstance,
   biquad: createBiquadInstance,
+  width: createWidthInstance,
   delay: createDelayInstance,
   reverb: createReverbInstance,
 


### PR DESCRIPTION
This patch adds an effect `fx.width(width: number)` that adjusts the stereo width of the signal. A width of 0 effectively sums left and right to mono, while a width of 1 leaves the signal unchanged. If the input is already mono, the width effect has no effect.