### PR TITLE
refactor: Use scheduler also in offline transport

### DIFF
--- a/packages/webaudio/src/transport/scheduler.ts
+++ b/packages/webaudio/src/transport/scheduler.ts
@@ -1,26 +1,5 @@
-import { insertSorted, type Numeric } from '@utility'
-
-export interface SchedulerOptions {
-  /**
-   * Time source for the scheduler (e.g. AudioContext.currentTime).
-   */
-  readonly now: () => number
-
-  /**
-   * Scheduler tick frequency.
-   */
-  readonly tickInterval: Numeric<'s'>
-
-  /**
-   * How far ahead (from transport time) callbacks may run.
-   */
-  readonly scheduleAheadTime: Numeric<'s'>
-
-  readonly timers?: {
-    readonly setInterval: typeof globalThis.setInterval
-    readonly clearInterval: typeof globalThis.clearInterval
-  }
-}
+import type { Numeric } from '@utility'
+import { insertSorted } from '@utility'
 
 export interface Scheduler {
   /**
@@ -48,14 +27,29 @@ export interface Scheduler {
   readonly flush: () => void
 }
 
-interface ScheduledEvent {
-  readonly time: number
-  readonly callback: (time: number) => void
+export interface RealtimeSchedulerOptions {
+  /**
+   * Time source for the scheduler (e.g. AudioContext.currentTime).
+   */
+  readonly now: () => number
+
+  /**
+   * Scheduler tick frequency.
+   */
+  readonly tickInterval: Numeric<'s'>
+
+  /**
+   * How far ahead (from transport time) callbacks may run.
+   */
+  readonly scheduleAheadTime: Numeric<'s'>
+
+  readonly timers?: {
+    readonly setInterval: typeof globalThis.setInterval
+    readonly clearInterval: typeof globalThis.clearInterval
+  }
 }
 
-const compareByTime = (a: ScheduledEvent, b: ScheduledEvent): number => a.time - b.time
-
-export function createScheduler (options: SchedulerOptions): Scheduler {
+export function createRealtimeScheduler (options: RealtimeSchedulerOptions): Scheduler {
   const { now, tickInterval, scheduleAheadTime } = options
 
   const timers = options.timers ?? {
@@ -63,36 +57,25 @@ export function createScheduler (options: SchedulerOptions): Scheduler {
     clearInterval: globalThis.clearInterval.bind(globalThis)
   }
 
-  const scheduled: ScheduledEvent[] = []
-  let sorted = false
+  const queue = createScheduledEventQueue()
 
   let interval: ReturnType<typeof globalThis.setInterval> | undefined
   let offsetTime = 0
   let started = false
 
   const flush = () => {
-    if (!started) {
-      return
+    if (started) {
+      queue.flushBefore(now() - offsetTime + scheduleAheadTime.value, offsetTime)
     }
-
-    if (!sorted) {
-      scheduled.sort(compareByTime)
-      sorted = true
-    }
-
-    flushBefore(scheduled, now() - offsetTime + scheduleAheadTime.value, offsetTime)
   }
 
   const start = (newOffsetTime: number) => {
-    if (started) {
-      return
+    if (!started) {
+      started = true
+      offsetTime = newOffsetTime
+      flush()
+      interval = timers.setInterval(flush, tickInterval.value * 1000)
     }
-
-    started = true
-    offsetTime = newOffsetTime
-
-    flush()
-    interval = timers.setInterval(flush, tickInterval.value * 1000)
   }
 
   const stop = () => {
@@ -100,26 +83,14 @@ export function createScheduler (options: SchedulerOptions): Scheduler {
       timers.clearInterval(interval)
       interval = undefined
     }
+
+    started = false
   }
 
   const schedule = (time: number, callback: (time: number) => void) => {
-    const event: ScheduledEvent = { time, callback }
-
-    if (!started) {
-      // Keep pre-start scheduling cheap: push and sort once on start.
-      scheduled.push(event)
-      sorted = false
-      return
-    }
-
-    if (!sorted) {
-      scheduled.push(event)
-    } else {
-      insertSorted(scheduled, event, compareByTime)
-    }
-
+    queue.schedule({ time, callback })
     // If the event is near, try scheduling it without waiting for the next tick.
-    if (time <= now() - offsetTime + scheduleAheadTime.value) {
+    if (started && time <= now() - offsetTime + scheduleAheadTime.value) {
       flush()
     }
   }
@@ -127,17 +98,99 @@ export function createScheduler (options: SchedulerOptions): Scheduler {
   return { start, stop, schedule, flush }
 }
 
-function flushBefore (array: ScheduledEvent[], threshold: number, offsetTime: number): void {
-  let flushed = 0
+export function createImmediateScheduler (): Scheduler {
+  const queue = createScheduledEventQueue()
 
-  for (const event of array) {
-    if (event.time > threshold) {
-      break
+  let offsetTime = 0
+  let started = false
+
+  const flush = () => {
+    if (started) {
+      queue.flushAll(offsetTime)
     }
-
-    event.callback(event.time + offsetTime)
-    ++flushed
   }
 
-  array.splice(0, flushed)
+  const start = (newOffsetTime: number) => {
+    if (!started) {
+      started = true
+      offsetTime = newOffsetTime
+      flush()
+    }
+  }
+
+  const stop = () => {
+    started = false
+  }
+
+  const schedule = (time: number, callback: (time: number) => void) => {
+    queue.schedule({ time, callback })
+    if (started) {
+      flush()
+    }
+  }
+
+  return { start, stop, schedule, flush }
+}
+
+interface ScheduledEventQueue {
+  readonly schedule: (event: ScheduledEvent) => void
+  readonly flushAll: (offsetTime: number) => void
+  readonly flushBefore: (threshold: number, offsetTime: number) => void
+}
+
+interface ScheduledEvent {
+  readonly time: number
+  readonly callback: (time: number) => void
+}
+
+const compareByTime = (a: ScheduledEvent, b: ScheduledEvent): number => a.time - b.time
+
+function createScheduledEventQueue (): ScheduledEventQueue {
+  const scheduled: ScheduledEvent[] = []
+  let sorted = false
+
+  const ensureSorted = () => {
+    if (!sorted) {
+      scheduled.sort(compareByTime)
+      sorted = true
+    }
+  }
+
+  const schedule: ScheduledEventQueue['schedule'] = (event) => {
+    if (!sorted) {
+      scheduled.push(event)
+      return
+    }
+
+    insertSorted(scheduled, event, compareByTime)
+  }
+
+  const flushAll: ScheduledEventQueue['flushAll'] = (offsetTime) => {
+    ensureSorted()
+
+    for (const event of scheduled) {
+      event.callback(event.time + offsetTime)
+    }
+
+    scheduled.splice(0, scheduled.length)
+  }
+
+  const flushBefore: ScheduledEventQueue['flushBefore'] = (threshold, offsetTime) => {
+    ensureSorted()
+
+    let flushed = 0
+
+    for (const event of scheduled) {
+      if (event.time > threshold) {
+        break
+      }
+
+      event.callback(event.time + offsetTime)
+      ++flushed
+    }
+
+    scheduled.splice(0, flushed)
+  }
+
+  return { schedule, flushAll, flushBefore }
 }

--- a/packages/webaudio/src/transport/transport.ts
+++ b/packages/webaudio/src/transport/transport.ts
@@ -1,7 +1,8 @@
-import { DisposeStack, MutableObservable, numeric, type Numeric, type Observable } from '@utility'
+import type { Numeric, Observable } from '@utility'
+import { DisposeStack, MutableObservable, numeric } from '@utility'
 import { createIntervalTimeTracker } from '../time-tracker/interval.js'
 import { createWorkletTimeTracker } from '../time-tracker/worklet.js'
-import { createScheduler } from './scheduler.js'
+import { createImmediateScheduler, createRealtimeScheduler } from './scheduler.js'
 
 export interface OfflineTransportOptions {
   readonly duration: Numeric<'s'>
@@ -55,14 +56,14 @@ export function createOnlineTransport (): OnlineTransport {
 
   const time = new MutableObservable(numeric('s', 0))
 
-  const scheduler = createScheduler({
+  const scheduler = createRealtimeScheduler({
     now: () => ctx.currentTime,
     tickInterval: TICK_INTERVAL,
     scheduleAheadTime: SCHEDULE_AHEAD_TIME
   })
   disposeStack.push(() => scheduler.stop())
 
-  const start = async (position: Numeric<'s'>) => {
+  const start: OnlineTransport['start'] = async (position) => {
     if (started) {
       return
     }
@@ -91,11 +92,11 @@ export function createOnlineTransport (): OnlineTransport {
     disposeStack.push(tracker.time.subscribe((value) => time.set(value)))
   }
 
-  const dispose = () => {
+  const dispose: OnlineTransport['dispose'] = () => {
     disposeStack.dispose()
   }
 
-  const schedule: Transport['schedule'] = (time, callback) => {
+  const schedule: OnlineTransport['schedule'] = (time, callback) => {
     scheduler.schedule(time, callback)
   }
 
@@ -114,18 +115,15 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
 
   const output = ctx.createGain()
   output.connect(ctx.destination)
+  disposeStack.push(() => output.disconnect())
 
   const time = new MutableObservable<Numeric<'s'> | undefined>(undefined)
 
-  const callbacks: Array<{
-    readonly time: number
-    readonly callback: (time: number) => void
-  }> = []
+  const scheduler = createImmediateScheduler()
+  disposeStack.push(() => scheduler.stop())
 
-  const render = async () => {
-    callbacks.sort((a, b) => a.time - b.time)
-    callbacks.forEach(({ time, callback }) => callback(time))
-    callbacks.splice(0, callbacks.length)
+  const render: OfflineTransport['render'] = async () => {
+    scheduler.start(0)
 
     try {
       const tracker = await createWorkletTimeTracker(ctx, output, {
@@ -147,7 +145,7 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
   }
 
   const schedule: Transport['schedule'] = (time, callback) => {
-    callbacks.push({ time, callback })
+    scheduler.schedule(time, callback)
   }
 
   return { ctx, output, time, render, schedule }

--- a/packages/webaudio/test-browser/transport/transport.test.ts
+++ b/packages/webaudio/test-browser/transport/transport.test.ts
@@ -1,0 +1,26 @@
+import { numeric } from '@utility'
+import { describe, expect, it } from 'vitest'
+import { createOfflineTransport } from '../../src/transport/transport.js'
+
+describe('transport/transport.ts', () => {
+  describe('createOfflineTransport', () => {
+    it('uses the immediate scheduler during offline rendering', async () => {
+      const transport = createOfflineTransport({
+        duration: numeric('s', 3),
+        channels: 2,
+        sampleRate: 44_100
+      })
+
+      const calls: number[] = []
+      transport.schedule(2, (time) => calls.push(time))
+      transport.schedule(1, (time) => calls.push(time))
+
+      const buffer = await transport.render()
+
+      expect(calls).toEqual([1, 2])
+      expect(buffer.length).toBe(132_300)
+      expect(buffer.numberOfChannels).toBe(2)
+      expect(buffer.sampleRate).toBe(44_100)
+    })
+  })
+})

--- a/packages/webaudio/test/transport/scheduler.test.ts
+++ b/packages/webaudio/test/transport/scheduler.test.ts
@@ -1,121 +1,231 @@
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { createScheduler } from '../../src/transport/scheduler.js'
+import { createImmediateScheduler, createRealtimeScheduler } from '../../src/transport/scheduler.js'
 
 type SetInterval = typeof globalThis.setInterval
 type ClearInterval = typeof globalThis.clearInterval
 
 describe('transport/scheduler.ts', () => {
-  it('runs callbacks shortly before their target time', () => {
-    let nowSeconds = 10
+  describe('createRealtimeScheduler', () => {
+    it('runs callbacks shortly before their target time', () => {
+      let nowSeconds = 10
 
-    let intervalCallback: (() => void) | undefined
+      let intervalCallback: (() => void) | undefined
 
-    const scheduler = createScheduler({
-      now: () => nowSeconds,
-      tickInterval: numeric('s', 0.01),
-      scheduleAheadTime: numeric('s', 0.05),
+      const scheduler = createRealtimeScheduler({
+        now: () => nowSeconds,
+        tickInterval: numeric('s', 0.01),
+        scheduleAheadTime: numeric('s', 0.05),
 
-      timers: {
-        setInterval: ((handler: unknown) => {
-          intervalCallback = () => typeof handler === 'function' ? handler() : {}
-          return 1
-        }) as SetInterval,
+        timers: {
+          setInterval: ((handler: unknown) => {
+            intervalCallback = () => typeof handler === 'function' ? handler() : {}
+            return 1
+          }) as SetInterval,
 
-        clearInterval: (() => {
-          intervalCallback = undefined
-        }) as ClearInterval
-      }
+          clearInterval: (() => {
+            intervalCallback = undefined
+          }) as ClearInterval
+        }
+      })
+
+      scheduler.start(10)
+
+      let called = false
+      let callNow: number | undefined
+      let targetTime: number | undefined
+
+      scheduler.schedule(1, (time) => {
+        called = true
+        callNow = nowSeconds
+        targetTime = time
+      })
+
+      // Not yet within the schedule-ahead window
+      nowSeconds = 10.9
+      intervalCallback?.()
+      assert.strictEqual(called, false)
+
+      // Enter the window: transportNow=0.96, threshold=1.01 -> event time 1 runs
+      nowSeconds = 10.96
+      intervalCallback?.()
+
+      assert.strictEqual(called, true)
+      assert.strictEqual(targetTime, 11)
+      assert.ok(callNow != null && callNow < targetTime)
     })
 
-    scheduler.start(10)
+    it('executes past events immediately on start', () => {
+      const nowSeconds = 10
 
-    let called = false
-    let callNow: number | undefined
-    let targetTime: number | undefined
+      const scheduler = createRealtimeScheduler({
+        now: () => nowSeconds,
+        tickInterval: numeric('s', 0.01),
+        scheduleAheadTime: numeric('s', 0.05),
 
-    scheduler.schedule(1, (time) => {
-      called = true
-      callNow = nowSeconds
-      targetTime = time
+        timers: {
+          setInterval: (() => 1) as unknown as SetInterval,
+          clearInterval: (() => {}) as ClearInterval
+        }
+      })
+
+      let called = false
+      let targetTime = undefined
+
+      scheduler.schedule(-0.5, (time) => {
+        called = true
+        targetTime = time
+      })
+
+      scheduler.start(10)
+
+      assert.strictEqual(called, true)
+      assert.strictEqual(targetTime, 9.5)
     })
 
-    // Not yet within the schedule-ahead window
-    nowSeconds = 10.9
-    intervalCallback?.()
-    assert.strictEqual(called, false)
+    it('preserves chronological callback order', () => {
+      let nowSeconds = 10
 
-    // Enter the window: transportNow=0.96, threshold=1.01 -> event time 1 runs
-    nowSeconds = 10.96
-    intervalCallback?.()
+      let intervalCallback: (() => void) | undefined
 
-    assert.strictEqual(called, true)
-    assert.strictEqual(targetTime, 11)
-    assert.ok(callNow != null && callNow < targetTime)
+      const scheduler = createRealtimeScheduler({
+        now: () => nowSeconds,
+        tickInterval: numeric('s', 0.01),
+        scheduleAheadTime: numeric('s', 0.05),
+
+        timers: {
+          setInterval: ((handler: unknown) => {
+            intervalCallback = () => typeof handler === 'function' ? handler() : {}
+            return 1
+          }) as SetInterval,
+
+          clearInterval: (() => {
+            intervalCallback = undefined
+          }) as ClearInterval
+        }
+      })
+
+      // Schedule out of order before start
+      const calls: number[] = []
+      scheduler.schedule(2, (time) => calls.push(time))
+      scheduler.schedule(1, (time) => calls.push(time))
+
+      scheduler.start(10)
+
+      // Move time until both are within the window
+      nowSeconds = 11.96 // transportNow=1.96 -> threshold=2.01
+      intervalCallback?.()
+
+      assert.deepStrictEqual(calls, [11, 12])
+    })
+
+    it('preserves chronological callback order for events scheduled after start', () => {
+      let nowSeconds = 10
+
+      let intervalCallback: (() => void) | undefined
+
+      const scheduler = createRealtimeScheduler({
+        now: () => nowSeconds,
+        tickInterval: numeric('s', 0.01),
+        scheduleAheadTime: numeric('s', 0.05),
+
+        timers: {
+          setInterval: ((handler: unknown) => {
+            intervalCallback = () => typeof handler === 'function' ? handler() : {}
+            return 1
+          }) as SetInterval,
+
+          clearInterval: (() => {
+            intervalCallback = undefined
+          }) as ClearInterval
+        }
+      })
+
+      const calls: number[] = []
+
+      scheduler.start(10)
+      scheduler.schedule(2, (time) => calls.push(time))
+      scheduler.schedule(1, (time) => calls.push(time))
+
+      nowSeconds = 11.96
+      intervalCallback?.()
+
+      assert.deepStrictEqual(calls, [11, 12])
+    })
+
+    it('does not run callbacks after stop', () => {
+      let nowSeconds = 10
+
+      let intervalCallback: (() => void) | undefined
+
+      const scheduler = createRealtimeScheduler({
+        now: () => nowSeconds,
+        tickInterval: numeric('s', 0.01),
+        scheduleAheadTime: numeric('s', 0.05),
+
+        timers: {
+          setInterval: ((handler: unknown) => {
+            intervalCallback = () => typeof handler === 'function' ? handler() : {}
+            return 1
+          }) as SetInterval,
+
+          clearInterval: (() => {
+            intervalCallback = undefined
+          }) as ClearInterval
+        }
+      })
+
+      const calls: number[] = []
+
+      scheduler.start(10)
+      scheduler.stop()
+
+      nowSeconds = 10.96
+      scheduler.schedule(1, (time) => calls.push(time))
+      scheduler.flush()
+      intervalCallback?.()
+
+      assert.deepStrictEqual(calls, [])
+    })
   })
 
-  it('executes past events immediately on start', () => {
-    const nowSeconds = 10
+  describe('createImmediateScheduler', () => {
+    it('flushes all scheduled callbacks immediately on start', () => {
+      const scheduler = createImmediateScheduler()
 
-    const scheduler = createScheduler({
-      now: () => nowSeconds,
-      tickInterval: numeric('s', 0.01),
-      scheduleAheadTime: numeric('s', 0.05),
+      const calls: number[] = []
+      scheduler.schedule(2, (time) => calls.push(time))
+      scheduler.schedule(1, (time) => calls.push(time))
 
-      timers: {
-        setInterval: (() => 1) as unknown as SetInterval,
-        clearInterval: (() => {}) as ClearInterval
-      }
+      scheduler.start(10)
+
+      assert.deepStrictEqual(calls, [11, 12])
     })
 
-    let called = false
-    let targetTime = undefined
+    it('runs callbacks immediately after start', () => {
+      const scheduler = createImmediateScheduler()
 
-    scheduler.schedule(-0.5, (time) => {
-      called = true
-      targetTime = time
+      const calls: number[] = []
+      scheduler.start(10)
+
+      scheduler.schedule(2, (time) => calls.push(time))
+      scheduler.schedule(1, (time) => calls.push(time))
+
+      assert.deepStrictEqual(calls, [12, 11])
     })
 
-    scheduler.start(10)
+    it('does not run callbacks after stop', () => {
+      const scheduler = createImmediateScheduler()
 
-    assert.strictEqual(called, true)
-    assert.strictEqual(targetTime, 9.5)
-  })
+      const calls: number[] = []
+      scheduler.start(10)
+      scheduler.stop()
 
-  it('preserves chronological callback order', () => {
-    let nowSeconds = 10
+      scheduler.schedule(1, (time) => calls.push(time))
+      scheduler.flush()
 
-    let intervalCallback: (() => void) | undefined
-
-    const scheduler = createScheduler({
-      now: () => nowSeconds,
-      tickInterval: numeric('s', 0.01),
-      scheduleAheadTime: numeric('s', 0.05),
-
-      timers: {
-        setInterval: ((handler: unknown) => {
-          intervalCallback = () => typeof handler === 'function' ? handler() : {}
-          return 1
-        }) as SetInterval,
-
-        clearInterval: (() => {
-          intervalCallback = undefined
-        }) as ClearInterval
-      }
+      assert.deepStrictEqual(calls, [])
     })
-
-    // Schedule out of order before start
-    const calls: number[] = []
-    scheduler.schedule(2, (time) => calls.push(time))
-    scheduler.schedule(1, (time) => calls.push(time))
-
-    scheduler.start(10)
-
-    // Move time until both are within the window
-    nowSeconds = 11.96 // transportNow=1.96 -> threshold=2.01
-    intervalCallback?.()
-
-    assert.deepStrictEqual(calls, [11, 12])
   })
 })

--- a/packages/webaudio/vitest.config.ts
+++ b/packages/webaudio/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       enabled: true,
       headless: true,
       provider: playwright(),
+      screenshotFailures: false,
       instances: [
         {
           browser: 'chromium'


### PR DESCRIPTION
This patch refactors the scheduler to work either realtime via timers, or offline by running all scheduled events immediately. This allows us to reuse the scheduler for the offline transport, which previously had to do its own scheduling.

Tests are added for the updated scheduler, as well as a browser test for the offline transport.