### PR TITLE
feat: Include file path in range errors

### DIFF
--- a/packages/app/src/compilation/compiler.ts
+++ b/packages/app/src/compilation/compiler.ts
@@ -55,9 +55,10 @@ export interface CompileResult {
 }
 
 export function compileSource (source: ProjectSource, compileOptions: CompileOptions): CompileResult {
-  const code = getProjectFileContent(source, TRACK_FILE_PATH) ?? ''
+  const entrypointPath = TRACK_FILE_PATH
+  const code = getProjectFileContent(source, entrypointPath) ?? ''
 
-  const lexResult = safeLex(code)
+  const lexResult = safeLex(code, entrypointPath)
   if (!lexResult.complete) {
     return { errors: unwrapError(lexResult.error) }
   }

--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -6,7 +6,6 @@ import { cadenceLanguageSupport } from '@language-support'
 import { useCallback, useMemo, type FunctionComponent } from 'react'
 import { useCompilationState } from '../../../compilation/CompilationContext.js'
 import { getCspNonce } from '../../../csp.js'
-import { TRACK_FILE_PATH } from '../../../persistence/constants.js'
 import { useEffectiveTheme } from '../../../theme.js'
 import { getEditorPanelProps } from '../panel-props.js'
 import { useEditorDispatch } from '../provider.js'
@@ -47,10 +46,9 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
 
   const { result: { errors } } = useCompilationState()
   const diagnostics = useMemo(() => {
-    if (filePath !== TRACK_FILE_PATH) {
-      return []
-    }
-    return errors.map((error) => convertError(error.message, error.range))
+    return errors
+      .filter((error) => error.range?.filePath === filePath)
+      .map((error) => convertError(error.message, error.range))
   }, [errors, filePath])
 
   return (

--- a/packages/app/src/modules/problems/ProblemsPanel.tsx
+++ b/packages/app/src/modules/problems/ProblemsPanel.tsx
@@ -1,3 +1,4 @@
+import type { SourceRange } from '@ast'
 import type { PanelProps } from '@editor'
 import { useProblems } from '@editor'
 import { RangeError } from '@language'
@@ -16,13 +17,17 @@ export const ProblemsPanel: FunctionComponent<PanelProps> = () => {
           </div>
         )}
 
-        {problems.map((problem, index) => (
+        {problems.map(({ error, label }, index) => (
           <div key={index}>
             <span className='text-content-100'>
-              {`${problem.label}:`}
+              {`${label}: `}
             </span>
-            {' '}
-            {formatError(problem.error)}
+            {error.message}
+            {error instanceof RangeError && error.range != null && (
+              <span className='text-content-100 text-sm'>
+                {` (${stringifyRange(error.range)})`}
+              </span>
+            )}
           </div>
         ))}
       </div>
@@ -30,11 +35,16 @@ export const ProblemsPanel: FunctionComponent<PanelProps> = () => {
   )
 }
 
-function formatError (error: Error): string {
-  const range = error instanceof RangeError ? error.range : undefined
-  if (range == null) {
-    return error.message
+function stringifyRange (range: SourceRange, maxPathLength = 32): string {
+  const { filePath, line, column } = range
+
+  if (filePath != null) {
+    const fileName = filePath.split('/').at(-1) ?? filePath
+    const truncatedFileName = fileName.length > maxPathLength
+      ? fileName.slice(0, maxPathLength) + '…'
+      : fileName
+    return `${truncatedFileName}: Ln ${line}, Col ${column}`
   }
 
-  return `${error.message} at line ${range.line}, column ${range.column}`
+  return `Ln ${line}, Col ${column}`
 }

--- a/packages/ast/src/range.ts
+++ b/packages/ast/src/range.ts
@@ -5,6 +5,7 @@ interface Token {
   readonly len: number
   readonly line: number
   readonly column: number
+  readonly filePath?: string
 }
 
 export interface SourceRange {
@@ -12,6 +13,7 @@ export interface SourceRange {
   readonly length: number
   readonly line: number
   readonly column: number
+  readonly filePath?: string
 }
 
 type Locatable = Token | ast.ASTNode
@@ -25,11 +27,14 @@ export function getSourceRange (item: Locatable): SourceRange {
     return item.range
   }
 
+  const filePath = item.filePath
+
   return {
     offset: item.offset,
     length: item.len,
     line: item.line,
-    column: item.column
+    column: item.column,
+    ...(filePath == null ? {} : { filePath })
   }
 }
 
@@ -41,6 +46,11 @@ export function combineSourceRanges (...items: Locatable[]): SourceRange {
   const ranges = items.map(getSourceRange)
   const first = ranges.reduce((min, range) => (range.offset < min.offset ? range : min), ranges[0])
   const end = Math.max(...ranges.map((range) => range.offset + range.length))
+  const filePath = ranges[0].filePath
+
+  if (ranges.some((range) => range.filePath !== filePath)) {
+    throw new Error('Cannot combine source ranges from different files')
+  }
 
   return {
     offset: first.offset,
@@ -48,10 +58,15 @@ export function combineSourceRanges (...items: Locatable[]): SourceRange {
 
     // This assumes that smaller offset means smaller line/column.
     line: first.line,
-    column: first.column
+    column: first.column,
+    ...(filePath == null ? {} : { filePath })
   }
 }
 
 export function areSourceRangesEqual (a: SourceRange, b: SourceRange): boolean {
-  return a.offset === b.offset && a.length === b.length && a.line === b.line && a.column === b.column
+  return a.offset === b.offset &&
+    a.length === b.length &&
+    a.line === b.line &&
+    a.column === b.column &&
+    a.filePath === b.filePath
 }

--- a/packages/ast/test/range.test.ts
+++ b/packages/ast/test/range.test.ts
@@ -17,6 +17,12 @@ describe('ast/range.ts', () => {
       assert.deepStrictEqual(range, { offset: 5, length: 3, line: 2, column: 10 })
     })
 
+    it('should include the file path from a token', () => {
+      const token = { offset: 5, len: 3, line: 2, column: 10, filePath: 'track.cadence' } as any
+      const range = getSourceRange(token)
+      assert.deepStrictEqual(range, { offset: 5, length: 3, line: 2, column: 10, filePath: 'track.cadence' })
+    })
+
     it('should extract source range from an AST node', () => {
       const node = { range: { offset: 8, length: 4, line: 3, column: 15 } } as any
       const range = getSourceRange(node)
@@ -26,12 +32,19 @@ describe('ast/range.ts', () => {
 
   describe('combineSourceRanges()', () => {
     it('should combine ranges of multiple items', () => {
-      const item1 = { offset: 5, len: 3, line: 2, column: 10 } as any
-      const item2 = { offset: 8, len: 4, line: 3, column: 15 } as any
-      const item3 = { offset: 12, len: 2, line: 4, column: 5 } as any
+      const item1 = { offset: 5, len: 3, line: 2, column: 10, filePath: 'track.cadence' } as any
+      const item2 = { offset: 8, len: 4, line: 3, column: 15, filePath: 'track.cadence' } as any
+      const item3 = { offset: 12, len: 2, line: 4, column: 5, filePath: 'track.cadence' } as any
 
       const combinedRange = combineSourceRanges(item1, item2, item3)
-      assert.deepStrictEqual(combinedRange, { offset: 5, length: 9, line: 2, column: 10 })
+      assert.deepStrictEqual(combinedRange, { offset: 5, length: 9, line: 2, column: 10, filePath: 'track.cadence' })
+    })
+
+    it('should reject combining ranges from different files', () => {
+      const item1 = { offset: 5, len: 3, line: 2, column: 10, filePath: 'track-a.cadence' } as any
+      const item2 = { offset: 8, len: 4, line: 3, column: 15, filePath: 'track-b.cadence' } as any
+
+      assert.throws(() => combineSourceRanges(item1, item2), /different files/)
     })
 
     it('should return empty range when no items are provided', () => {
@@ -42,14 +55,20 @@ describe('ast/range.ts', () => {
 
   describe('areSourceRangesEqual()', () => {
     it('should return true for identical source ranges', () => {
-      const range1: SourceRange = { offset: 5, length: 3, line: 2, column: 10 }
-      const range2: SourceRange = { offset: 5, length: 3, line: 2, column: 10 }
+      const range1: SourceRange = { offset: 5, length: 3, line: 2, column: 10, filePath: 'track.cadence' }
+      const range2: SourceRange = { offset: 5, length: 3, line: 2, column: 10, filePath: 'track.cadence' }
       assert.deepStrictEqual(range1, range2)
     })
 
     it('should return false for different source ranges', () => {
-      const range1: SourceRange = { offset: 5, length: 3, line: 2, column: 10 }
-      const range2: SourceRange = { offset: 8, length: 4, line: 3, column: 15 }
+      const range1: SourceRange = { offset: 5, length: 3, line: 2, column: 10, filePath: 'track.cadence' }
+      const range2: SourceRange = { offset: 8, length: 4, line: 3, column: 15, filePath: 'track.cadence' }
+      assert.notDeepStrictEqual(range1, range2)
+    })
+
+    it('should return false for ranges with different file paths', () => {
+      const range1: SourceRange = { offset: 5, length: 3, line: 2, column: 10, filePath: 'track-a.cadence' }
+      const range2: SourceRange = { offset: 5, length: 3, line: 2, column: 10, filePath: 'track-b.cadence' }
       assert.notDeepStrictEqual(range1, range2)
     })
   })

--- a/packages/language/src/lexer/lexer.ts
+++ b/packages/language/src/lexer/lexer.ts
@@ -71,7 +71,7 @@ const mainLexer = createLexer([
 
 export type LexResult = Result<Token[], LexError>
 
-export function lex (input: string): LexResult {
+export function lex (input: string, filePath?: string): LexResult {
   function getLineAndColumn (offset: number): Pick<SourceRange, 'line' | 'column'> {
     const lines = input.slice(0, offset).split(/(?:\r\n|\r|\n)/)
     const line = lines.length
@@ -88,10 +88,14 @@ export function lex (input: string): LexResult {
       error: new LexError(`Unexpected input "${context}"`, {
         offset: lexerResult.offset,
         length: 1,
+        filePath,
         ...getLineAndColumn(lexerResult.offset)
       })
     }
   }
 
-  return { complete: true, value: lexerResult.tokens }
+  return {
+    complete: true,
+    value: lexerResult.tokens.map((token) => ({ ...token, filePath }))
+  }
 }

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -166,7 +166,8 @@ function splitStepsFromWordToken (text: string, tokenRange: SourceRange): readon
       offset: tokenRange.offset + offset,
       line: tokenRange.line,
       column: tokenRange.column + offset,
-      length: stepValue.length
+      length: stepValue.length,
+      filePath: tokenRange.filePath
     }
 
     if (!isStepValue(stepValue)) {

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -139,11 +139,18 @@ describe('lexer/lexer.ts', () => {
   })
 
   it('should handle invalid input', () => {
-    const result = lex('foo = 42 $')
+    const result = lex('foo = 42 $', 'track.cadence')
     assert.strictEqual(result.complete, false)
     assert.strictEqual(result.error.name, 'LexError')
     assert.strictEqual(result.error.message, 'Unexpected input "$"')
-    assert.deepStrictEqual(result.error.range, { offset: 9, length: 1, line: 1, column: 10 })
+    assert.deepStrictEqual(result.error.range, { offset: 9, length: 1, line: 1, column: 10, filePath: 'track.cadence' })
+    assert.strictEqual(result.error.range.filePath, 'track.cadence')
+  })
+
+  it('should annotate tokens with the source file path', () => {
+    const result = lex('foo = 42', 'track.cadence')
+    assert.strictEqual(result.complete, true)
+    assert.strictEqual((result.value[0] as any)?.filePath, 'track.cadence')
   })
 
   it('should ignore whitespace and comments', () => {

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -6,7 +6,7 @@ import { parse } from '../../src/parser/parser.js'
 /**
  * Helper function to create an array of tokens with automatically assigned source ranges
  */
-function makeTokens (tokens: ReadonlyArray<Readonly<{ name: string, text?: string }>>): Token[] {
+function makeTokens (tokens: ReadonlyArray<Readonly<{ name: string, text?: string }>>, filePath?: string): Token[] {
   let offset = 0
 
   return tokens.map(({ name, text }) => {
@@ -18,6 +18,7 @@ function makeTokens (tokens: ReadonlyArray<Readonly<{ name: string, text?: strin
       len: tokenText.length,
       line: 1,
       column: offset + 1,
+      filePath,
       state: ''
     }
 
@@ -549,6 +550,27 @@ describe('parser/parser.ts', () => {
         ]
       }
     })
+  })
+
+  it('should preserve file paths in split pattern step ranges', () => {
+    const result = parse(makeTokens([
+      { name: 'word', text: 'pattern' },
+      { name: '=' },
+      { name: '[' },
+      { name: 'word', text: 'xx' },
+      { name: ':' },
+      { name: 'number', text: '1' },
+      { name: ']' }
+    ], 'track.cadence'))
+
+    if (!result.complete) {
+      assert.fail(`Expected parse to succeed, got: ${result.error.message}`)
+    }
+
+    const assignment = result.value.children[0]
+    assert.strictEqual(assignment.type, 'Assignment')
+    assert.strictEqual(assignment.value.type, 'Pattern')
+    assert.strictEqual(assignment.value.children[1]?.range.filePath, 'track.cadence')
   })
 
   it('should parse property access expressions', () => {


### PR DESCRIPTION
The path of the file that was being lexed/parsed/compiled is now part of the range information included in errors. This is foundational work for supporting multiple source files at some point.