### PR TITLE
feat!: Treat curve as a first-class value

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -39,7 +39,7 @@ track (120.bpm) {
     snare << snare_pattern
     synth << arp_intro
 
-    automate synth.gain as linear(-60.db, 0.db)
+    automate synth.gain as curve [lin(-60.db, 0.db)]
   }
 
   part main (8.bars) {

--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -38,6 +38,17 @@ export interface Pattern extends ASTNode {
   readonly children: ReadonlyArray<Step | Expression>
 }
 
+export interface CurveSegment extends ASTNode {
+  readonly type: 'CurveSegment'
+  readonly curveType: string
+  readonly parameters: readonly Expression[]
+}
+
+export interface Curve extends ASTNode {
+  readonly type: 'Curve'
+  readonly children: ReadonlyArray<CurveSegment | Expression>
+}
+
 // Imports
 
 export interface UseStatement extends ASTNode {
@@ -83,7 +94,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Number | String | Pattern | Identifier
+export type Value = Identifier | Number | String | Pattern | Curve
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -146,13 +157,7 @@ export interface EffectStatement extends ASTNode {
 export interface AutomateStatement extends ASTNode {
   readonly type: 'AutomateStatement'
   readonly target: Expression
-  readonly curve: Curve
-}
-
-export interface Curve extends ASTNode {
-  readonly type: 'Curve'
-  readonly curveType: string
-  readonly parameters: readonly Expression[]
+  readonly curve: Expression
 }
 
 // Root Type
@@ -184,8 +189,12 @@ export interface NodeByType {
 
   Number: Number
   String: String
+
   Step: Step
   Pattern: Pattern
+
+  CurveSegment: CurveSegment
+  Curve: Curve
 
   UseStatement: UseStatement
 
@@ -204,7 +213,6 @@ export interface NodeByType {
   BusStatement: BusStatement
   EffectStatement: EffectStatement
   AutomateStatement: AutomateStatement
-  Curve: Curve
 
   Program: Program
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -93,13 +93,24 @@ step {
   (word | "-") ("(" argumentList? ")")? (":" primary)?
 }
 
+Curve {
+  kw<"curve">
+  "["
+  (curveSegment | interpolationExpression)*
+  "]"
+}
+
+curveSegment {
+  CurveType { word } ("(" argumentList? ")")?
+}
+
 argumentList {
   (Property | expression)
   ("," (Property | expression))*
 }
 
 primary {
-  "(" expression ")" | Number | String | Pattern | Call | VariableName
+  "(" expression ")" | Number | String | Pattern | Curve | Call | VariableName
 }
 
 Call {

--- a/packages/language-support/src/language-support.ts
+++ b/packages/language-support/src/language-support.ts
@@ -10,6 +10,7 @@ const parserWithMetadata = parser.configure({
       Number: t.number,
       String: t.string,
       Pattern: t.special(t.string),
+      CurveType: t.function(t.name),
 
       keyword: t.keyword,
       unit: t.number,

--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -255,60 +255,17 @@ function checkAutomation (context: Context, automation: ast.AutomateStatement): 
     errors.push(...checkType([ParameterType], targetCheck.result, automation.target.range))
   }
 
-  const curveCheck = checkCurve(context, automation.curve)
+  const curveCheck = checkExpression(context, automation.curve)
   errors.push(...curveCheck.errors)
 
   if (targetCheck.result != null && curveCheck.result != null) {
     const { unit } = ParameterType.detail(targetCheck.result)
     errors.push(...checkType([CurveType.with(unit)], curveCheck.result, automation.curve.range))
+  } else if (curveCheck.result != null) {
+    errors.push(...checkType([CurveType], curveCheck.result, automation.curve.range))
   }
 
   return errors
-}
-
-function checkCurve (context: Context, curve: ast.Curve): Checked<Type> {
-  const expectedParameters = curveParameterCounts.get(curve.curveType)
-  if (expectedParameters == null) {
-    return { errors: [new CompileError(`Unknown curve type "${curve.curveType}"`, curve.range)] }
-  }
-
-  if (curve.parameters.length !== expectedParameters) {
-    const message = `Expected ${expectedParameters} ${expectedParameters === 1 ? 'parameter' : 'parameters'} for ${curve.curveType} curve, got ${curve.parameters.length}`
-    return { errors: [new CompileError(message, curve.range)] }
-  }
-
-  const errors: CompileError[] = []
-  const units: Array<Unit | undefined> = []
-
-  for (const point of curve.parameters) {
-    const pointCheck = checkExpression(context, point)
-    errors.push(...pointCheck.errors)
-
-    if (pointCheck.result != null) {
-      const typeErrors = checkType([NumberType], pointCheck.result, point.range)
-      errors.push(...typeErrors)
-
-      const generics = typeErrors.length === 0
-        ? NumberType.detail(pointCheck.result)
-        : undefined
-
-      units.push(generics?.unit)
-    }
-  }
-
-  if (errors.length > 0) {
-    return { errors }
-  }
-
-  const firstUnit = units[0]
-  const result = CurveType.with(firstUnit)
-
-  const expected = NumberType.with(firstUnit)
-  for (let i = 1; i < units.length; ++i) {
-    errors.push(...checkType([expected], NumberType.with(units[i]), curve.parameters[i].range))
-  }
-
-  return { errors, result: errors.length > 0 ? undefined : result }
 }
 
 function checkMixers (context: Context, mixers: readonly ast.MixerStatement[]): readonly CompileError[] {
@@ -514,11 +471,11 @@ function checkExpression (context: Context, expression: ast.Expression): Checked
     }
 
     case 'Pattern': {
-      const errors = checkPattern(context, expression)
-      if (errors.length > 0) {
-        return { errors }
-      }
-      return { errors: [], result: PatternType }
+      return checkPattern(context, expression)
+    }
+
+    case 'Curve': {
+      return checkCurve(context, expression)
     }
 
     case 'Identifier': {
@@ -583,7 +540,7 @@ function checkExpression (context: Context, expression: ast.Expression): Checked
   }
 }
 
-function checkPattern (context: Context, pattern: ast.Pattern): readonly CompileError[] {
+function checkPattern (context: Context, pattern: ast.Pattern): Checked<Type> {
   const errors: CompileError[] = []
 
   for (const item of pattern.children) {
@@ -600,7 +557,7 @@ function checkPattern (context: Context, pattern: ast.Pattern): readonly Compile
     }
   }
 
-  return errors
+  return { errors, result: errors.length > 0 ? undefined : PatternType }
 }
 
 function checkStep (context: Context, step: ast.Step): readonly CompileError[] {
@@ -620,6 +577,68 @@ function checkStep (context: Context, step: ast.Step): readonly CompileError[] {
   errors.push(...parametersCheck.errors)
 
   return errors
+}
+
+function checkCurve (context: Context, curve: ast.Curve): Checked<Type> {
+  const errors: CompileError[] = []
+
+  const segments = curve.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
+  const otherChildren = curve.children.filter((c) => c.type !== 'CurveSegment')
+
+  for (const child of otherChildren) {
+    // TODO Add support for interpolation in curves
+    errors.push(new CompileError('Curve interpolation is not supported yet', child.range))
+  }
+
+  if (segments.length !== 1) {
+    // TODO Support zero or multiple segments
+    errors.push(new CompileError('Curve must have exactly one segment', curve.range))
+    return { errors }
+  }
+
+  const segment = segments[0]
+
+  const expectedParameters = curveParameterCounts.get(segment.curveType)
+  if (expectedParameters == null) {
+    return { errors: [new CompileError(`Unknown curve type "${segment.curveType}"`, segment.range)] }
+  }
+
+  if (segment.parameters.length !== expectedParameters) {
+    const message = `Expected ${expectedParameters} ${expectedParameters === 1 ? 'parameter' : 'parameters'} for ${segment.curveType} curve, got ${segment.parameters.length}`
+    return { errors: [new CompileError(message, segment.range)] }
+  }
+
+  const units: Array<Unit | undefined> = []
+
+  for (const point of segment.parameters) {
+    const pointCheck = checkExpression(context, point)
+    errors.push(...pointCheck.errors)
+
+    if (pointCheck.result != null) {
+      const typeErrors = checkType([NumberType], pointCheck.result, point.range)
+      errors.push(...typeErrors)
+
+      const generics = typeErrors.length === 0
+        ? NumberType.detail(pointCheck.result)
+        : undefined
+
+      units.push(generics?.unit)
+    }
+  }
+
+  if (errors.length > 0) {
+    return { errors }
+  }
+
+  const firstUnit = units[0]
+  const result = CurveType.with(firstUnit)
+
+  const expected = NumberType.with(firstUnit)
+  for (let i = 1; i < units.length; ++i) {
+    errors.push(...checkType([expected], NumberType.with(units[i]), segment.parameters[i].range))
+  }
+
+  return { errors, result: errors.length > 0 ? undefined : result }
 }
 
 function checkUnaryExpression (operator: ast.UnaryOperator, argument: Type, range: SourceRange): Checked<Type> {

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -1,24 +1,27 @@
 import type { AutomationPoint } from '@core'
 import type { Numeric, Unit } from '@utility'
 
+const CURVE_HOLD = 'hold'
+const CURVE_LINEAR = 'lin'
+
 export type Curve<U extends Unit> = HoldCurve<U> | LinearCurve<U>
 
 export interface HoldCurve<U extends Unit> {
-  readonly type: 'hold'
+  readonly type: typeof CURVE_HOLD
   readonly unit: U
   readonly value: Numeric<U>
 }
 
 export interface LinearCurve<U extends Unit> {
-  readonly type: 'linear'
+  readonly type: typeof CURVE_LINEAR
   readonly unit: U
   readonly start: Numeric<U>
   readonly end: Numeric<U>
 }
 
 export const curveParameterCounts = new Map<string, number>([
-  ['hold', 1],
-  ['linear', 2]
+  [CURVE_HOLD, 1],
+  [CURVE_LINEAR, 2]
 ])
 
 export function createCurve<U extends Unit> (type: string, parameters: ReadonlyArray<Numeric<U>>): Curve<U> | undefined {
@@ -29,14 +32,14 @@ export function createCurve<U extends Unit> (type: string, parameters: ReadonlyA
   const unit = parameters.at(0)?.unit as U
 
   switch (type) {
-    case 'hold': {
+    case CURVE_HOLD: {
       const [value] = parameters
-      return { type: 'hold', unit, value }
+      return { type: CURVE_HOLD, unit, value }
     }
 
-    case 'linear': {
+    case CURVE_LINEAR: {
       const [start, end] = parameters
-      return { type: 'linear', unit, start, end }
+      return { type: CURVE_LINEAR, unit, start, end }
     }
 
     default:
@@ -46,13 +49,13 @@ export function createCurve<U extends Unit> (type: string, parameters: ReadonlyA
 
 export function renderCurvePoints<U extends Unit> (curve: Curve<U>, timeStart: Numeric<'beats'>, timeEnd: Numeric<'beats'>): ReadonlyArray<AutomationPoint<U>> {
   switch (curve.type) {
-    case 'hold':
+    case CURVE_HOLD:
       return [
         { time: timeStart, value: curve.value, curve: 'step' },
         { time: timeEnd, value: curve.value, curve: 'step' }
       ]
 
-    case 'linear':
+    case CURVE_LINEAR:
       return [
         { time: timeStart, value: curve.start, curve: 'step' },
         { time: timeEnd, value: curve.end, curve: 'linear' }

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -1,12 +1,15 @@
 import { ast } from '@ast'
-import { concatPatterns, createParallelPattern, createSerialPattern, mergePatterns, multiplyPattern, type Automation, type Bus, type BusId, type Instrument, type InstrumentId, type InstrumentRouting, type Mixer, type MixerRouting, type ParameterId, type Part, type Pattern, type Program, type Step, type Track } from '@core'
-import { numeric, type Numeric, type Unit } from '@utility'
+import type { Automation, Bus, BusId, Instrument, InstrumentId, InstrumentRouting, Mixer, MixerRouting, ParameterId, Part, Pattern, Program, Step, Track } from '@core'
+import { concatPatterns, createParallelPattern, createSerialPattern, mergePatterns, multiplyPattern } from '@core'
+import type { Numeric, Unit } from '@utility'
+import { numeric } from '@utility'
 import { busSchema, partSchema, stepSchema, trackSchema } from './common.js'
 import { createCurve, renderCurvePoints } from './curves.js'
 import { CompileError } from './error.js'
 import { getStandardModule } from './modules.js'
 import type { InferSchema, PropertySchema } from './schema.js'
-import { BusType, CurveType, EffectType, FunctionType, InstrumentType, NumberType, ParameterType, PartType, PatternType, StringType, type CurveValue, type PatternValue, type StringValue, type Type, type Value } from './types.js'
+import type { CurveValue, PatternValue, StringValue, Type, Value } from './types.js'
+import { BusType, CurveType, EffectType, FunctionType, InstrumentType, NumberType, ParameterType, PartType, PatternType, StringType } from './types.js'
 import { isSyntaxUnit, toNumberValue } from './units.js'
 
 export interface GenerateOptions {
@@ -204,7 +207,7 @@ function generatePart (context: Context, part: ast.PartStatement, startTime: Num
 
   for (const automation of part.automations) {
     const target = ParameterType.cast(resolve(context, automation.target))
-    const curve = generateCurve(context, automation.curve)
+    const curve = CurveType.cast(resolve(context, automation.curve))
 
     const rendered = renderCurvePoints(curve.data, startTime, endTime)
     const existing = context.top.automations.get(target.data.id)
@@ -223,12 +226,17 @@ function generatePart (context: Context, part: ast.PartStatement, startTime: Num
 }
 
 function generateCurve (context: Context, curve: ast.Curve): CurveValue {
-  const parameters = curve.parameters.map((point) => {
+  const segments = curve.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
+  assert(segments.length === 1)
+
+  const segment = segments[0]
+
+  const parameters = segment.parameters.map((point) => {
     return NumberType.cast(resolve(context, point)).data
   })
 
   return CurveType.of(
-    nonNull(createCurve(curve.curveType, parameters))
+    nonNull(createCurve(segment.curveType, parameters))
   )
 }
 
@@ -329,6 +337,9 @@ function resolve (context: Context, expression: ast.Expression): Value {
 
     case 'Pattern':
       return generatePattern(context, expression)
+
+    case 'Curve':
+      return generateCurve(context, expression)
 
     case 'Identifier': {
       let current: Context | undefined = context

--- a/packages/language/src/parser/constants.ts
+++ b/packages/language/src/parser/constants.ts
@@ -7,7 +7,8 @@ export const keywords = Object.freeze([
   'mixer',
   'bus',
   'effect',
-  'automate'
+  'automate',
+  'curve'
 ] as const)
 
 export type Keyword = (typeof keywords)[number]

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -306,15 +306,57 @@ const parallelPattern_: p.Parser<Token, unknown, ast.Pattern> = p.abc(
   }
 )
 
-const value_: p.Parser<Token, unknown, ast.Value> = p.eitherOr(
-  p.eitherOr(
-    p.eitherOr(
-      number_,
-      string_
+const curveSegment_: p.Parser<Token, unknown, ast.CurveSegment> = p.ab(
+  p.token((t) => t.name === 'word' ? t : undefined),
+  p.option(
+    combine3(
+      literal('('),
+      p.sepBy(
+        p.recursive(() => optionalExpression_),
+        literal(',')
+      ),
+      expectLiteral(')')
     ),
-    serialPattern_
+    undefined
   ),
-  identifier_
+  (curveTypeToken, callTail) => {
+    const curveType = curveTypeToken.text
+    const parameters = callTail == null ? [] : callTail[1]
+
+    const range = callTail == null
+      ? getSourceRange(curveTypeToken)
+      : combineSourceRanges(curveTypeToken, callTail[2])
+
+    return ast.make('CurveSegment', range, { curveType, parameters })
+  }
+)
+
+const curve_: p.Parser<Token, unknown, ast.Curve> = p.ab(
+  keyword('curve'),
+  combine3(
+    expectLiteral('['),
+    p.many(
+      p.eitherOr(curveSegment_, patternInterpolation_)
+    ),
+    expectLiteral(']')
+  ),
+  (_curve, [_l, children, _r]) => {
+    return ast.make('Curve', combineSourceRanges(_curve, _r), { children })
+  }
+)
+
+const value_: p.Parser<Token, unknown, ast.Value> = p.eitherOr(
+  identifier_,
+  p.eitherOr(
+    number_,
+    p.eitherOr(
+      string_,
+      p.eitherOr(
+        serialPattern_,
+        curve_
+      )
+    )
+  )
 )
 
 const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
@@ -482,31 +524,6 @@ const routing_: p.Parser<Token, unknown, ast.Routing> = p.abc(
   }
 )
 
-const curve_: p.Parser<Token, unknown, ast.Curve> = p.ab(
-  p.token((t) => t.name === 'word' ? t : undefined),
-  p.option(
-    combine3(
-      literal('('),
-      p.sepBy(
-        optionalExpression_,
-        literal(',')
-      ),
-      expectLiteral(')')
-    ),
-    undefined
-  ),
-  (curveTypeToken, callTail) => {
-    const curveType = curveTypeToken.text
-    const parameters = callTail == null ? [] : callTail[1]
-
-    const range = callTail == null
-      ? getSourceRange(curveTypeToken)
-      : combineSourceRanges(curveTypeToken, callTail[2])
-
-    return ast.make('Curve', range, { curveType, parameters })
-  }
-)
-
 const automateStatement_: p.Parser<Token, unknown, ast.AutomateStatement> = p.ab(
   combine2(
     keyword('automate'),
@@ -514,7 +531,7 @@ const automateStatement_: p.Parser<Token, unknown, ast.AutomateStatement> = p.ab
   ),
   combine2(
     expect(keyword('as'), 'keyword "as"'),
-    curve_
+    expression_
   ),
   ([_automate, target], [_as, curve]) => {
     return ast.make('AutomateStatement', combineSourceRanges(_automate, curve), { target, curve })

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -250,6 +250,71 @@ describe('compiler/checker.ts', () => {
       })
       assert.deepStrictEqual(check(program), [])
     })
+
+    it('should accept curve automation with lin curve type', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          // synth = sample("synth.wav")
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'synth' }),
+            value: ast.make('Call', RANGE, {
+              callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+              arguments: [
+                ast.make('String', RANGE, { parts: ['synth.wav'] })
+              ]
+            })
+          }),
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  // (4.bars)
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'lin',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -60 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            }),
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: 0 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ]
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [])
+    })
   })
 
   describe('invalid', () => {

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -269,6 +269,78 @@ describe('compiler/generator.ts', () => {
     assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 0))
   })
 
+  it('should generate automation points for a lin curve', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['instruments'] })
+        })
+      ],
+      children: [
+        // synth = sample("synth.wav")
+        ast.make('Assignment', RANGE, {
+          key: ast.make('Identifier', RANGE, { name: 'synth' }),
+          value: ast.make('Call', RANGE, {
+            callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+            arguments: [
+              ast.make('String', RANGE, { parts: ['synth.wav'] })
+            ]
+          })
+        }),
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                // (4.bars)
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 4 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                    property: ast.make('Identifier', RANGE, { name: 'gain' })
+                  }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: 0 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ]
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+
+    assert.strictEqual(result.automations.size, 1)
+    const automation = [...result.automations.values()][0]
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+    ])
+  })
+
   it('should support buses as sources in mixer', () => {
     const program = ast.make('Program', RANGE, {
       imports: [],

--- a/packages/language/test/compiler/types.test.ts
+++ b/packages/language/test/compiler/types.test.ts
@@ -199,7 +199,7 @@ describe('compiler/types.ts', () => {
 
     it('should identify curve values correctly', () => {
       const value = CurveType.of({
-        type: 'linear',
+        type: 'lin',
         unit: 'db',
         start: numeric('db', -6),
         end: numeric('db', 0)
@@ -627,7 +627,7 @@ describe('compiler/types.ts', () => {
     describe('of()', () => {
       it('should narrow type correctly', () => {
         const curve1 = CurveType.of({
-          type: 'linear',
+          type: 'lin',
           unit: undefined,
           start: numeric(undefined, 0),
           end: numeric(undefined, 1)

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -635,6 +635,49 @@ describe('parser/parser.ts', () => {
     }
   })
 
+  it('should parse curve expressions', () => {
+    const result = parse(makeTokens([
+      { name: 'word', text: 'foo' },
+      { name: '=' },
+      { name: 'word', text: 'curve' },
+      { name: '[' },
+      { name: 'word', text: 'lin' },
+      { name: '(' },
+      { name: 'number', text: '0' },
+      { name: ',' },
+      { name: 'number', text: '1' },
+      { name: ')' },
+      { name: ']' }
+    ]))
+
+    assert.deepStrictEqual(stripRanges(result), {
+      complete: true,
+      value: {
+        type: 'Program',
+        imports: [],
+        children: [
+          {
+            type: 'Assignment',
+            key: { type: 'Identifier', name: 'foo' },
+            value: {
+              type: 'Curve',
+              children: [
+                {
+                  type: 'CurveSegment',
+                  curveType: 'lin',
+                  parameters: [
+                    { type: 'Number', value: 0 },
+                    { type: 'Number', value: 1 }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    })
+  })
+
   it('should parse property access with function calls', () => {
     // x = object.method1().method2()
     const nonParenthesized = makeTokens([


### PR DESCRIPTION
This patch introduces a new syntax for curves, allowing them to be defined and manipulated as first-class values, such as assignment to variables:

```
my_curve = curve [lin(-60.db, 0.db)]

// later:
automate synth.gain as my_curve
```

The automation syntax is now more verbose, which will be resolved in a future patch. Similarly, creating curves with multiple segments needs additional implementation work.

BREAKING CHANGE: `curve` keyword added; automation syntax changed.