### PR TITLE
feat: Add support for multi-segment curves

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -39,7 +39,7 @@ track (120.bpm) {
     snare << snare_pattern
     synth << arp_intro
 
-    automate synth.gain as curve [lin(-60.db, 0.db)]
+    automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]
   }
 
   part main (8.bars) {

--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -1,11 +1,13 @@
-import { ast, type SourceRange } from '@ast'
+import type { SourceRange } from '@ast'
+import { ast } from '@ast'
 import type { Unit } from '@utility'
 import { busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from './common.js'
 import { curveParameterCounts } from './curves.js'
 import { CompileError } from './error.js'
 import { getStandardModule, standardLibraryModuleNames } from './modules.js'
 import type { PropertySchema, PropertySpec } from './schema.js'
-import { BusType, CurveType, EffectType, FunctionType, InstrumentType, ModuleType, NumberType, ParameterType, PartType, PatternType, StringType, type ModuleValue, type Type } from './types.js'
+import type { ModuleValue, Type } from './types.js'
+import { BusType, CurveType, EffectType, FunctionType, InstrumentType, ModuleType, NumberType, ParameterType, PartType, PatternType, StringType } from './types.js'
 import { isSyntaxUnit, toBaseUnit } from './units.js'
 
 export function check (program: ast.Program): readonly CompileError[] {
@@ -590,13 +592,31 @@ function checkCurve (context: Context, curve: ast.Curve): Checked<Type> {
     errors.push(new CompileError('Curve interpolation is not supported yet', child.range))
   }
 
-  if (segments.length !== 1) {
-    // TODO Support zero or multiple segments
-    errors.push(new CompileError('Curve must have exactly one segment', curve.range))
+  if (segments.length === 0) {
+    errors.push(new CompileError('Curve must have at least one segment', curve.range))
     return { errors }
   }
 
-  const segment = segments[0]
+  const segmentChecks = segments.map((segment) => checkCurveSegment(context, segment))
+  errors.push(...segmentChecks.flatMap((c) => c.errors))
+
+  if (errors.length > 0) {
+    return { errors }
+  }
+
+  const firstUnit = segmentChecks[0].result
+
+  for (let i = 1; i < segmentChecks.length; ++i) {
+    if (segmentChecks[i].result !== firstUnit) {
+      errors.push(new CompileError('Curve segments must have the same unit', segments[i].range))
+    }
+  }
+
+  return { errors, result: CurveType.with(firstUnit) }
+}
+
+function checkCurveSegment (context: Context, segment: ast.CurveSegment): Checked<Unit> {
+  const errors: CompileError[] = []
 
   const expectedParameters = curveParameterCounts.get(segment.curveType)
   if (expectedParameters == null) {
@@ -631,14 +651,12 @@ function checkCurve (context: Context, curve: ast.Curve): Checked<Type> {
   }
 
   const firstUnit = units[0]
-  const result = CurveType.with(firstUnit)
-
   const expected = NumberType.with(firstUnit)
   for (let i = 1; i < units.length; ++i) {
     errors.push(...checkType([expected], NumberType.with(units[i]), segment.parameters[i].range))
   }
 
-  return { errors, result: errors.length > 0 ? undefined : result }
+  return { errors, result: firstUnit }
 }
 
 function checkUnaryExpression (operator: ast.UnaryOperator, argument: Type, range: SourceRange): Checked<Type> {

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -1,30 +1,41 @@
 import type { AutomationPoint } from '@core'
 import type { Numeric, Unit } from '@utility'
+import { numeric } from '@utility'
 
-const CURVE_HOLD = 'hold'
-const CURVE_LINEAR = 'lin'
+const SEGMENT_TYPE_HOLD = 'hold'
+const SEGMENT_TYPE_LINEAR = 'lin'
 
-export type Curve<U extends Unit> = HoldCurve<U> | LinearCurve<U>
+export interface Curve<U extends Unit> {
+  readonly unit: U
+  readonly segments: ReadonlyArray<CurveSegment<U>>
+}
 
-export interface HoldCurve<U extends Unit> {
-  readonly type: typeof CURVE_HOLD
+export type CurveSegment<U extends Unit> = HoldCurveSegment<U> | LinearCurveSegment<U>
+
+export interface HoldCurveSegment<U extends Unit> {
+  readonly type: typeof SEGMENT_TYPE_HOLD
   readonly unit: U
   readonly value: Numeric<U>
 }
 
-export interface LinearCurve<U extends Unit> {
-  readonly type: typeof CURVE_LINEAR
+export interface LinearCurveSegment<U extends Unit> {
+  readonly type: typeof SEGMENT_TYPE_LINEAR
   readonly unit: U
   readonly start: Numeric<U>
   readonly end: Numeric<U>
 }
 
 export const curveParameterCounts = new Map<string, number>([
-  [CURVE_HOLD, 1],
-  [CURVE_LINEAR, 2]
+  [SEGMENT_TYPE_HOLD, 1],
+  [SEGMENT_TYPE_LINEAR, 2]
 ])
 
-export function createCurve<U extends Unit> (type: string, parameters: ReadonlyArray<Numeric<U>>): Curve<U> | undefined {
+export function createCurve<U extends Unit> (segments: ReadonlyArray<CurveSegment<U>>): Curve<U> {
+  const unit = segments.at(0)?.unit as U
+  return { unit, segments }
+}
+
+export function createCurveSegment<U extends Unit> (type: string, parameters: ReadonlyArray<Numeric<U>>): CurveSegment<U> {
   if (curveParameterCounts.get(type) !== parameters.length) {
     throw new Error('Invalid curve parameters')
   }
@@ -32,14 +43,14 @@ export function createCurve<U extends Unit> (type: string, parameters: ReadonlyA
   const unit = parameters.at(0)?.unit as U
 
   switch (type) {
-    case CURVE_HOLD: {
+    case SEGMENT_TYPE_HOLD: {
       const [value] = parameters
-      return { type: CURVE_HOLD, unit, value }
+      return { type, unit, value }
     }
 
-    case CURVE_LINEAR: {
+    case SEGMENT_TYPE_LINEAR: {
       const [start, end] = parameters
-      return { type: CURVE_LINEAR, unit, start, end }
+      return { type, unit, start, end }
     }
 
     default:
@@ -48,17 +59,45 @@ export function createCurve<U extends Unit> (type: string, parameters: ReadonlyA
 }
 
 export function renderCurvePoints<U extends Unit> (curve: Curve<U>, timeStart: Numeric<'beats'>, timeEnd: Numeric<'beats'>): ReadonlyArray<AutomationPoint<U>> {
-  switch (curve.type) {
-    case CURVE_HOLD:
-      return [
-        { time: timeStart, value: curve.value, curve: 'step' },
-        { time: timeEnd, value: curve.value, curve: 'step' }
-      ]
-
-    case CURVE_LINEAR:
-      return [
-        { time: timeStart, value: curve.start, curve: 'step' },
-        { time: timeEnd, value: curve.end, curve: 'linear' }
-      ]
+  const segments = curve.segments
+  if (segments.length === 0) {
+    throw new Error('Invalid curve: no segments')
   }
+
+  const totalDuration = timeEnd.value - timeStart.value
+  const segmentDuration = totalDuration / segments.length
+
+  const points: Array<AutomationPoint<U>> = []
+
+  for (let i = 0; i < segments.length; ++i) {
+    const segment = segments[i]
+
+    points.push({
+      time: numeric('beats', timeStart.value + segmentDuration * i),
+      value: segment.type === SEGMENT_TYPE_LINEAR ? segment.start : segment.value,
+      curve: 'step'
+    }, {
+      time: numeric('beats', i === segments.length - 1 ? timeEnd.value : timeStart.value + segmentDuration * (i + 1)),
+      value: segment.type === SEGMENT_TYPE_LINEAR ? segment.end : segment.value,
+      curve: segment.type === SEGMENT_TYPE_LINEAR ? 'linear' : 'step'
+    })
+  }
+
+  return simplifyCurvePoints(points)
+}
+
+function simplifyCurvePoints<U extends Unit> (points: ReadonlyArray<AutomationPoint<U>>): ReadonlyArray<AutomationPoint<U>> {
+  // Note: This assumes exact floating point equality, which works since the start/end times are calculated
+  // using the same formula.
+
+  const simplified: Array<AutomationPoint<U>> = []
+
+  for (const point of points) {
+    const previous = simplified.at(-1)
+    if (previous == null || point.time.value !== previous.time.value || point.value.value !== previous.value.value) {
+      simplified.push(point)
+    }
+  }
+
+  return simplified
 }

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -4,7 +4,7 @@ import { concatPatterns, createParallelPattern, createSerialPattern, mergePatter
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
 import { busSchema, partSchema, stepSchema, trackSchema } from './common.js'
-import { createCurve, renderCurvePoints } from './curves.js'
+import { createCurve, createCurveSegment, renderCurvePoints } from './curves.js'
 import { CompileError } from './error.js'
 import { getStandardModule } from './modules.js'
 import type { InferSchema, PropertySchema } from './schema.js'
@@ -225,21 +225,6 @@ function generatePart (context: Context, part: ast.PartStatement, startTime: Num
   return { name, length, routings }
 }
 
-function generateCurve (context: Context, curve: ast.Curve): CurveValue {
-  const segments = curve.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
-  assert(segments.length === 1)
-
-  const segment = segments[0]
-
-  const parameters = segment.parameters.map((point) => {
-    return NumberType.cast(resolve(context, point)).data
-  })
-
-  return CurveType.of(
-    nonNull(createCurve(segment.curveType, parameters))
-  )
-}
-
 function generateMixer (context: Context, mixer: ast.MixerStatement): Mixer {
   const mixerContext = createLocalScope(context)
 
@@ -448,6 +433,25 @@ function generateStep (context: Context, expression: ast.Step): Step {
   }
 
   return { value, length, ...parameters }
+}
+
+function generateCurve (context: Context, curve: ast.Curve): CurveValue {
+  const segments = curve.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
+  const otherChildren = curve.children.filter((c) => c.type !== 'CurveSegment')
+  assert(segments.length > 0)
+  assert(otherChildren.length === 0)
+
+  const generatedSegments = segments.map((segment) => {
+    const parameters = segment.parameters.map((point) => {
+      return NumberType.cast(resolve(context, point)).data
+    })
+
+    return nonNull(createCurveSegment(segment.curveType, parameters))
+  })
+
+  return CurveType.of(
+    createCurve(generatedSegments)
+  )
 }
 
 function computeUnaryExpression (operator: ast.UnaryOperator, argument: Value): Value {

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -341,6 +341,90 @@ describe('compiler/generator.ts', () => {
     ])
   })
 
+  it('should allocate equal time to multiple curve segments', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['instruments'] })
+        })
+      ],
+      children: [
+        ast.make('Assignment', RANGE, {
+          key: ast.make('Identifier', RANGE, { name: 'synth' }),
+          value: ast.make('Call', RANGE, {
+            callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+            arguments: [
+              ast.make('String', RANGE, { parts: ['synth.wav'] })
+            ]
+          })
+        }),
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 4 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                    property: ast.make('Identifier', RANGE, { name: 'gain' })
+                  }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -30 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ]
+                      }),
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -30 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: 0 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ]
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+
+    assert.strictEqual(result.automations.size, 1)
+    const automation = [...result.automations.values()][0]
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 8), value: numeric('db', -30), curve: 'linear' },
+      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+    ])
+  })
+
   it('should support buses as sources in mixer', () => {
     const program = ast.make('Program', RANGE, {
       imports: [],

--- a/packages/language/test/compiler/types.test.ts
+++ b/packages/language/test/compiler/types.test.ts
@@ -199,10 +199,15 @@ describe('compiler/types.ts', () => {
 
     it('should identify curve values correctly', () => {
       const value = CurveType.of({
-        type: 'lin',
         unit: 'db',
-        start: numeric('db', -6),
-        end: numeric('db', 0)
+        segments: [
+          {
+            type: 'lin',
+            unit: 'db',
+            start: numeric('db', -6),
+            end: numeric('db', 0)
+          }
+        ]
       })
       assert.strictEqual(CurveType.is(value), true)
       assert.strictEqual(CurveType.with('db').is(value), true)
@@ -627,17 +632,27 @@ describe('compiler/types.ts', () => {
     describe('of()', () => {
       it('should narrow type correctly', () => {
         const curve1 = CurveType.of({
-          type: 'lin',
           unit: undefined,
-          start: numeric(undefined, 0),
-          end: numeric(undefined, 1)
+          segments: [
+            {
+              type: 'lin',
+              unit: undefined,
+              start: numeric(undefined, 0),
+              end: numeric(undefined, 1)
+            }
+          ]
         })
         expectTypeEquals<CurveValue<undefined>, typeof curve1>()
 
         const curve2 = CurveType.of({
-          type: 'hold',
           unit: 'db',
-          value: numeric('db', -6)
+          segments: [
+            {
+              type: 'hold',
+              unit: 'db',
+              value: numeric('db', -6)
+            }
+          ]
         })
         expectTypeEquals<CurveValue<'db'>, typeof curve2>()
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -641,6 +641,10 @@ describe('parser/parser.ts', () => {
       { name: '=' },
       { name: 'word', text: 'curve' },
       { name: '[' },
+      { name: 'word', text: 'hold' },
+      { name: '(' },
+      { name: 'number', text: '0' },
+      { name: ')' },
       { name: 'word', text: 'lin' },
       { name: '(' },
       { name: 'number', text: '0' },
@@ -662,6 +666,13 @@ describe('parser/parser.ts', () => {
             value: {
               type: 'Curve',
               children: [
+                {
+                  type: 'CurveSegment',
+                  curveType: 'hold',
+                  parameters: [
+                    { type: 'Number', value: 0 }
+                  ]
+                },
                 {
                   type: 'CurveSegment',
                   curveType: 'lin',


### PR DESCRIPTION
It is now possible to specify a sequence of segments for a curve, each of which will be allotted an equal portion of the total duration of the curve. Example:

```
automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]
```