### PR TITLE
fix: Improve "open file" reliability

### DIFF
--- a/packages/app/src/modules/editor/index.ts
+++ b/packages/app/src/modules/editor/index.ts
@@ -1,20 +1,26 @@
 import type { CommandId, MenuId, MenuSectionId, Module, ModuleId, PanelId } from '@editor'
 import { activateTabOfType, getProjectFileContent, setProjectFileContent, useDialogService, useLatestRef, useLayout, useLayoutDispatch, useProjectSource, useProjectSourceDispatch, useProvideProblems, useRegisterCommand } from '@editor'
-import { numeric } from '@utility'
 import type { FunctionComponent } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
 import { TRACK_FILE_PATH } from '../../persistence/constants.js'
-import { openTextFile, saveTextFile } from '../../utilities/files.js'
+import { openFiles, readFileAsText, saveTextFile } from '../../utilities/files.js'
 import { getFocusedEditorCaret } from './caret.js'
 import { EditorPanel } from './components/EditorPanel.js'
 import { LoadDemoDialog } from './components/LoadDemoDialog.js'
 import { ResetProjectSettingsCard } from './components/ResetProjectSettingsCard.js'
-import { getEditorPanelProps, type EditorPanelProps } from './panel-props.js'
+import type { EditorPanelProps } from './panel-props.js'
+import { getEditorPanelProps } from './panel-props.js'
 import { EditorProvider, useEditor, useEditorDispatch } from './provider.js'
 
 const DEFAULT_FILENAME = TRACK_FILE_PATH
-const FILE_ACCEPT = '.cadence,text/plain'
-const FILE_OPEN_TIMEOUT = numeric('s', 5)
+const FILE_TYPES = [
+  {
+    description: 'Cadence files',
+    accept: {
+      'text/plain': ['.cadence']
+    }
+  }
+]
 
 const moduleId = 'editor' as ModuleId
 export const editorPanelId = `${moduleId}.editor` as PanelId
@@ -62,9 +68,8 @@ const GlobalHooks: FunctionComponent = () => {
       'Ctrl+O'
     ],
     run: () => {
-      openTextFile({
-        accept: FILE_ACCEPT,
-        signal: AbortSignal.timeout(FILE_OPEN_TIMEOUT.value * 1000)
+      openFiles({ types: FILE_TYPES }).then(async (files) => {
+        return files.length > 0 ? await readFileAsText(files[0]) : undefined
       }).then((content) => {
         if (content != null) {
           editorRef.current.sourceDispatch((state) => setProjectFileContent(state, TRACK_FILE_PATH, content))
@@ -74,7 +79,7 @@ const GlobalHooks: FunctionComponent = () => {
           }))
         }
       }).catch(() => {
-      // ignore errors
+        // ignore errors
       })
     }
   }), [])

--- a/packages/app/src/utilities/files.ts
+++ b/packages/app/src/utilities/files.ts
@@ -23,47 +23,100 @@ export function saveTextFile (options: SaveOptions<string>): void {
   })
 }
 
-export async function openTextFile (options: {
-  readonly accept: string
-  readonly signal?: AbortSignal
-}): Promise<string | undefined> {
-  return new Promise((resolve, reject) => {
+interface OpenFilePickerOptions {
+  readonly excludeAcceptAllOption?: boolean
+  readonly multiple?: boolean
+  readonly types?: ReadonlyArray<{
+    readonly description?: string
+    readonly accept: Record<string, readonly string[]>
+  }>
+}
+
+type ShowOpenFilePicker = (options?: OpenFilePickerOptions) => Promise<FileSystemFileHandle[]>
+
+export async function openFiles (options?: OpenFilePickerOptions): Promise<File[]> {
+  try {
+    if ('showOpenFilePicker' in window && typeof window.showOpenFilePicker === 'function') {
+      const showOpenFilePicker = window.showOpenFilePicker as ShowOpenFilePicker
+      const handles = await showOpenFilePicker(options)
+      return await Promise.all(handles.map((handle) => handle.getFile()))
+    }
+
+    return await showOpenFilePickerFallback(options)
+  } catch (error) {
+    // "Thrown if the user dismisses the prompt without making a selection [...]."
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return []
+    }
+
+    throw error
+  }
+}
+
+async function showOpenFilePickerFallback (options?: OpenFilePickerOptions): Promise<File[]> {
+  const multiple = options?.multiple ?? false
+
+  const accept = options?.types?.flatMap((type) => {
+    // input accept attribute is a comma-separated list of both MIME types and file extensions.
+    return Object.entries(type.accept).flat()
+  }).join(',') ?? ''
+
+  return new Promise<File[]>((resolve, reject) => {
     const input = document.createElement('input')
+
     input.type = 'file'
-    input.accept = options.accept
     input.style.display = 'none'
 
-    const onChange = () => {
-      const file = input.files?.[0]
-      if (file == null) {
-        resolve(undefined)
-        cleanup()
-        return
-      }
+    input.multiple = multiple
+    input.accept = accept
 
-      readFileAsText(file).then(resolve, reject).finally(cleanup)
-    }
-
-    const onAbort = () => {
-      cleanup()
-      resolve(undefined)
-    }
+    let settled = false
 
     const cleanup = () => {
       input.removeEventListener('change', onChange)
-      options.signal?.removeEventListener('abort', onAbort)
-      document.body.removeChild(input)
+      window.removeEventListener('focus', onFocusReturn)
+      input.remove()
+
+      setTimeout(() => {
+        if (!settled) {
+          reject(new DOMException('User cancelled file picker', 'AbortError'))
+        }
+      }, 0)
     }
 
-    input.addEventListener('change', onChange)
-    options.signal?.addEventListener('abort', onAbort)
+    const onChange = () => {
+      settled = true
+
+      const files = Array.from(input.files ?? [])
+      cleanup()
+
+      if (files.length === 0) {
+        reject(new DOMException('No file selected', 'AbortError'))
+        return
+      }
+
+      resolve(files)
+    }
+
+    // Some browsers never fire change if user cancels.
+    // Use focus return heuristic as fallback signal.
+    const onFocusReturn = () => {
+      setTimeout(() => {
+        if (!settled && (input.files == null || input.files.length === 0)) {
+          cleanup()
+        }
+      }, 500)
+    }
+
+    input.addEventListener('change', onChange, { once: true })
+    window.addEventListener('focus', onFocusReturn, { once: true })
 
     document.body.appendChild(input)
     input.click()
   })
 }
 
-function readFileAsText (file: File): Promise<string> {
+export async function readFileAsText (file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
 


### PR DESCRIPTION
First, we attempt to use the native `showOpenFilePicker` API, which is ideal for this but is not supported in all browsers. If that fails, we fall back to using a hidden file input like before, but with better reliability. In particular, a timeout is no longer needed to ensure cleanup of the input element. Instead, we primarily rely on the `change` event, and fall back to focus returning to the document to determine if the file picker was dismissed.