### PR TITLE
feat: Add "Go to definition" to language support

### DIFF
--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -1,14 +1,16 @@
 import type { SourceRange } from '@ast'
 import type { Diagnostic } from '@codemirror/lint'
+import type { EditorView } from '@codemirror/view'
 import type { EditorLocation, PanelProps } from '@editor'
 import { Editor, getProjectFileContent, setProjectFileContent, useProjectSource, useProjectSourceDispatch } from '@editor'
 import { cadenceLanguageSupport } from '@language-support'
-import { useCallback, useMemo, type FunctionComponent } from 'react'
+import type { FunctionComponent } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useCompilationState } from '../../../compilation/CompilationContext.js'
 import { getCspNonce } from '../../../csp.js'
 import { useEffectiveTheme } from '../../../theme.js'
 import { getEditorPanelProps } from '../panel-props.js'
-import { useEditorDispatch } from '../provider.js'
+import { useEditorDispatch, useEditorRuntime } from '../provider.js'
 import { cadenceDarkTheme, cadenceLightTheme } from '../theme.js'
 
 const indent = '  ' // 2 spaces
@@ -37,6 +39,12 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
   }, [filePath, sourceDispatch])
 
   const editorDispatch = useEditorDispatch()
+  const editorRuntime = useEditorRuntime()
+
+  const onEditorViewChange = useCallback((view: EditorView | undefined) => {
+    editorRuntime.viewRef.current = view
+  }, [editorRuntime])
+
   const onLocationChange = useCallback((caret: EditorLocation | undefined) => {
     editorDispatch((prev) => ({ ...prev, carets: { ...prev.carets, [tabId]: caret } }))
   }, [editorDispatch, tabId])
@@ -61,6 +69,7 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
       cspNonce={getCspNonce()}
       className='relative h-full overflow-hidden'
       onChange={onChange}
+      onEditorViewChange={onEditorViewChange}
       onLocationChange={onLocationChange}
     />
   )

--- a/packages/app/src/modules/editor/index.ts
+++ b/packages/app/src/modules/editor/index.ts
@@ -1,5 +1,8 @@
+import { syntaxTree } from '@codemirror/language'
+import { EditorSelection } from '@codemirror/state'
 import type { CommandId, MenuId, MenuSectionId, Module, ModuleId, PanelId } from '@editor'
 import { activateTabOfType, getProjectFileContent, setProjectFileContent, useDialogService, useLatestRef, useLayout, useLayoutDispatch, useProjectSource, useProjectSourceDispatch, useProvideProblems, useRegisterCommand } from '@editor'
+import { goToDefinitionInTree } from '@language-support'
 import type { FunctionComponent } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
 import { TRACK_FILE_PATH } from '../../persistence/constants.js'
@@ -10,7 +13,7 @@ import { LoadDemoDialog } from './components/LoadDemoDialog.js'
 import { ResetProjectSettingsCard } from './components/ResetProjectSettingsCard.js'
 import type { EditorPanelProps } from './panel-props.js'
 import { getEditorPanelProps } from './panel-props.js'
-import { EditorProvider, useEditor, useEditorDispatch } from './provider.js'
+import { EditorProvider, useEditor, useEditorDispatch, useEditorRuntime } from './provider.js'
 
 const DEFAULT_FILENAME = TRACK_FILE_PATH
 const FILE_TYPES = [
@@ -33,6 +36,7 @@ const viewEditorId = `${moduleId}.view.editor` as CommandId
 const fileOpenId = `${moduleId}.file.open` as CommandId
 const fileSaveId = `${moduleId}.file.save` as CommandId
 const loadDemoId = `${moduleId}.load-demo` as CommandId
+const goToDefinitionId = `${moduleId}.go-to-definition` as CommandId
 
 const GlobalHooks: FunctionComponent = () => {
   const layoutDispatch = useLayoutDispatch()
@@ -41,11 +45,13 @@ const GlobalHooks: FunctionComponent = () => {
   const source = useProjectSource()
   const sourceDispatch = useProjectSourceDispatch()
   const editorDispatch = useEditorDispatch()
+  const editorRuntime = useEditorRuntime()
 
   const editorRef = useLatestRef({
     source,
     sourceDispatch,
-    editorDispatch
+    editorDispatch,
+    editorRuntime
   })
 
   const { result: { errors } } = useCompilationState()
@@ -105,6 +111,33 @@ const GlobalHooks: FunctionComponent = () => {
       showDialog(LoadDemoDialog, { editorPanelId })
     }
   }), [showDialog])
+
+  useRegisterCommand(() => ({
+    id: goToDefinitionId,
+    label: 'Go to definition',
+    keyboardShortcuts: [
+      'F12'
+    ],
+    run: () => {
+      const runtime = editorRef.current.editorRuntime
+      const view = runtime.viewRef.current
+      if (view == null) {
+        return
+      }
+
+      const tree = syntaxTree(view.state)
+      const caret = view.state.selection.main.head
+      const target = goToDefinitionInTree(tree, view.state.doc, caret)
+      if (target == null) {
+        view.focus()
+        return
+      }
+
+      const selection = EditorSelection.single(target.from)
+      view.dispatch({ selection, scrollIntoView: true })
+      view.focus()
+    }
+  }), [])
 
   useProvideProblems(moduleId, 'Compiler', errors)
 

--- a/packages/app/src/modules/editor/provider.tsx
+++ b/packages/app/src/modules/editor/provider.tsx
@@ -1,9 +1,15 @@
+import type { EditorView } from '@codemirror/view'
 import type { EditorLocation, TabId } from '@editor'
 import { useSafeContext } from '@editor'
-import { createContext, useReducer, type Dispatch, type FunctionComponent, type PropsWithChildren, type SetStateAction } from 'react'
+import type { Dispatch, FunctionComponent, PropsWithChildren, RefObject, SetStateAction } from 'react'
+import { createContext, useReducer, useRef } from 'react'
 
 export interface EditorState {
   readonly carets: Readonly<Record<TabId, EditorLocation | undefined>>
+}
+
+export interface EditorRuntimeState {
+  readonly viewRef: RefObject<EditorView | undefined>
 }
 
 const initialEditorState: EditorState = {
@@ -18,14 +24,18 @@ export type EditorDispatch = Dispatch<SetStateAction<EditorState>>
 
 const EditorContext = createContext<EditorState | undefined>(undefined)
 const EditorDispatchContext = createContext<EditorDispatch | undefined>(undefined)
+const EditorRuntimeContext = createContext<EditorRuntimeState | undefined>(undefined)
 
 export const EditorProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const [state, dispatch] = useReducer(editorReducer, initialEditorState)
+  const viewRef = useRef<EditorView | undefined>(undefined)
 
   return (
     <EditorContext value={state}>
       <EditorDispatchContext value={dispatch}>
-        {children}
+        <EditorRuntimeContext value={{ viewRef }}>
+          {children}
+        </EditorRuntimeContext>
       </EditorDispatchContext>
     </EditorContext>
   )
@@ -37,4 +47,8 @@ export function useEditor (): EditorState {
 
 export function useEditorDispatch (): EditorDispatch {
   return useSafeContext(EditorDispatchContext, 'EditorDispatchContext')
+}
+
+export function useEditorRuntime (): EditorRuntimeState {
+  return useSafeContext(EditorRuntimeContext, 'EditorRuntimeContext')
 }

--- a/packages/editor/src/editor/components/Editor.tsx
+++ b/packages/editor/src/editor/components/Editor.tsx
@@ -1,5 +1,6 @@
 import type { Diagnostic } from '@codemirror/lint'
 import type { Extension } from '@codemirror/state'
+import type { EditorView } from '@codemirror/view'
 import { FunctionComponent, useCallback, useEffect, useRef } from 'react'
 import { useLatestRef } from '../../hooks/latest-ref.js'
 import { createCadenceEditor, type CadenceEditorHandle } from '../handle.js'
@@ -13,18 +14,21 @@ export const Editor: FunctionComponent<{
   diagnostics?: readonly Diagnostic[]
   cspNonce?: string
   className?: string
+  onEditorViewChange?: (view: EditorView | undefined) => void
   onChange: (document: string) => void
   onLocationChange?: (location: EditorLocation | undefined) => void
 }> = ({ document, indent, theme, extensions, diagnostics, cspNonce, className, ...props }) => {
   const handleRef = useRef<CadenceEditorHandle>(null)
   const onChange = useLatestRef(props.onChange)
   const onLocationChange = useLatestRef(props.onLocationChange)
+  const onEditorViewChange = useLatestRef(props.onEditorViewChange)
 
   // Initialize editor
   const initialize = useCallback((container: HTMLDivElement | null) => {
     if (container == null) {
       handleRef.current?.destroy()
       handleRef.current = null
+      onEditorViewChange.current?.(undefined)
       return
     }
 
@@ -38,6 +42,8 @@ export const Editor: FunctionComponent<{
       onChange: (...args) => onChange.current(...args),
       onLocationChange: (...args) => onLocationChange.current?.(...args)
     })
+
+    onEditorViewChange.current?.(handleRef.current.view)
   }, []) // Run only once
 
   // Update editor if props change

--- a/packages/language-support/src/go-to-definition.ts
+++ b/packages/language-support/src/go-to-definition.ts
@@ -1,0 +1,413 @@
+import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
+import type { LRParser } from '@lezer/lr'
+
+export interface GoToDefinitionResult {
+  readonly name: string
+  readonly from: number
+  readonly to: number
+}
+
+interface TextLike {
+  readonly length: number
+  readonly sliceString: (from: number, to?: number) => string
+}
+
+interface WordRange {
+  readonly from: number
+  readonly to: number
+}
+
+const IDENTIFIER_KINDS = [
+  'VariableName',
+  'Callee',
+  'MemberAccess',
+  'PropertyName',
+  'VariableDefinition',
+  'UseAlias'
+] as const
+type IdentifierKind = typeof IDENTIFIER_KINDS[number]
+
+interface IdentifierAt {
+  readonly kind: IdentifierKind | undefined
+  readonly name: string
+  readonly from: number
+  readonly to: number
+  readonly node?: SyntaxNode
+}
+
+interface DefinitionIndex {
+  readonly globalAssignments: ReadonlyMap<string, GoToDefinitionResult>
+  readonly globalUseAliases: ReadonlyMap<string, GoToDefinitionResult>
+  readonly tracks: ReadonlyMap<string, TrackScope>
+  readonly mixers: ReadonlyMap<string, MixerScope>
+}
+
+interface TrackScope {
+  readonly key: string
+  readonly from: number
+  readonly to: number
+  readonly parts: ReadonlyMap<string, GoToDefinitionResult>
+}
+
+interface MixerScope {
+  readonly key: string
+  readonly from: number
+  readonly to: number
+  readonly buses: ReadonlyMap<string, GoToDefinitionResult>
+}
+
+interface WritableTrackScope extends TrackScope {
+  readonly parts: Map<string, GoToDefinitionResult>
+}
+
+interface WritableMixerScope extends MixerScope {
+  readonly buses: Map<string, GoToDefinitionResult>
+}
+
+function isIdentifierKind (value: string): value is IdentifierKind {
+  return IDENTIFIER_KINDS.includes(value as IdentifierKind)
+}
+
+const WORD_REGEXP = /[a-zA-Z_0-9#]/
+
+function isWordChar (char: string): boolean {
+  return char.length === 1 && WORD_REGEXP.test(char)
+}
+
+function charAt (document: TextLike, index: number): string {
+  return index >= 0 && index < document.length ? document.sliceString(index, index + 1) : ''
+}
+
+function getWordRangeAt (document: TextLike, position: number): WordRange | undefined {
+  if (position < 0 || position > document.length) {
+    return undefined
+  }
+
+  // Prefer the character under the cursor; fall back to the left neighbor.
+  const right = charAt(document, position)
+  const left = charAt(document, position - 1)
+  const anchor = isWordChar(right) ? position : (isWordChar(left) ? position - 1 : undefined)
+  if (anchor == null) {
+    return undefined
+  }
+
+  let from = anchor
+  while (from > 0 && isWordChar(charAt(document, from - 1))) {
+    --from
+  }
+
+  let to = anchor + 1
+  while (to < document.length && isWordChar(charAt(document, to))) {
+    ++to
+  }
+
+  return { from, to }
+}
+
+function scopeKey (typeName: string, from: number, to: number): string {
+  return `${typeName}:${from}:${to}`
+}
+
+function findIdentifierAt (tree: Tree, document: TextLike, position: number): IdentifierAt | undefined {
+  const maxDepth = 8
+  let node = tree.resolveInner(position, -1)
+
+  // Climb to a meaningful identifier wrapper node.
+  for (let depth = 0; depth < maxDepth && node.parent != null; ++depth) {
+    if (isIdentifierKind(node.type.name)) {
+      const text = document.sliceString(node.from, node.to)
+      return { kind: node.type.name, name: text, from: node.from, to: node.to, node }
+    }
+    node = node.parent
+  }
+
+  const range = getWordRangeAt(document, position)
+  if (range == null) {
+    return undefined
+  }
+
+  return {
+    kind: undefined,
+    name: document.sliceString(range.from, range.to),
+    from: range.from,
+    to: range.to
+  }
+}
+
+function findEnclosingScopeKey (node: SyntaxNode | undefined, scopeTypeName: 'TrackStatement' | 'MixerStatement'): string | undefined {
+  for (let current = node; current != null; current = current.parent ?? undefined) {
+    if (current.type.name === scopeTypeName) {
+      return scopeKey(current.type.name, current.from, current.to)
+    }
+  }
+  return undefined
+}
+
+function isWhitespace (char: string): boolean {
+  return char === ' ' || char === '\t' || char === '\n' || char === '\r'
+}
+
+function skipWhitespaceLeft (document: TextLike, position: number): number {
+  for (let pos = position; pos > 0; --pos) {
+    if (!isWhitespace(charAt(document, pos - 1))) {
+      return pos
+    }
+  }
+  return 0
+}
+
+function charBeforeNonWhitespace (document: TextLike, position: number): { readonly index: number, readonly char: string } | undefined {
+  for (let pos = position; pos > 0; --pos) {
+    const char = charAt(document, pos - 1)
+    if (!isWhitespace(char)) {
+      return { index: pos - 1, char }
+    }
+  }
+  return undefined
+}
+
+function findAccessChainRootBefore (document: TextLike, memberFrom: number): WordRange | undefined {
+  // Find the '.' token directly preceding the member name (skipping whitespace).
+  const dot = charBeforeNonWhitespace(document, memberFrom)
+  if (dot == null || dot.char !== '.') {
+    return undefined
+  }
+
+  let root: WordRange | undefined
+  let currentDotIndex = dot.index
+
+  while (currentDotIndex >= 0) {
+    // Find the identifier immediately to the left of the dot.
+    const wordEnd = skipWhitespaceLeft(document, currentDotIndex)
+    const range = getWordRangeAt(document, wordEnd)
+    if (range == null) {
+      break
+    }
+
+    root = range
+
+    // Continue walking left if this is a chained access: <ident> . <ident> . <member>
+    const beforeWord = charBeforeNonWhitespace(document, range.from)
+    if (beforeWord == null || beforeWord.char !== '.') {
+      break
+    }
+
+    currentDotIndex = beforeWord.index
+  }
+
+  return root
+}
+
+function buildDefinitionIndex (tree: Tree, document: TextLike): DefinitionIndex {
+  const globalAssignments = new Map<string, GoToDefinitionResult>()
+  const globalUseAliases = new Map<string, GoToDefinitionResult>()
+
+  const tracks = new Map<string, TrackScope>()
+  const mixers = new Map<string, MixerScope>()
+
+  const cursor = tree.cursor()
+
+  const walk = (
+    cursor: TreeCursor,
+    parentType: string | undefined,
+    trackScope: WritableTrackScope | undefined,
+    mixerScope: WritableMixerScope | undefined,
+    assignmentHasEquals: boolean
+  ): void => {
+    const typeName = cursor.type.name
+    const from = cursor.from
+    const to = cursor.to
+
+    const nextParentType = typeName
+
+    let nextTrackScope = trackScope
+    let nextMixerScope = mixerScope
+    let nextAssignmentHasEquals = assignmentHasEquals
+
+    switch (typeName) {
+      case 'TrackStatement': {
+        const key = scopeKey(typeName, from, to)
+        const scope = { key, from, to, parts: new Map<string, GoToDefinitionResult>() }
+        tracks.set(key, scope)
+        nextTrackScope = scope
+        break
+      }
+
+      case 'MixerStatement': {
+        const key = scopeKey(typeName, from, to)
+        const scope = { key, from, to, buses: new Map<string, GoToDefinitionResult>() }
+        mixers.set(key, scope)
+        nextMixerScope = scope
+        break
+      }
+
+      case 'Assignment': {
+        nextAssignmentHasEquals = document.sliceString(from, to).includes('=')
+        break
+      }
+
+      case 'VariableDefinition': {
+        const name = document.sliceString(from, to)
+        const definition = { name, from, to }
+
+        switch (parentType) {
+          case 'Assignment':
+            // Prefer first definition; duplicates are an error elsewhere.
+            if (nextAssignmentHasEquals) {
+              globalAssignments.set(name, globalAssignments.get(name) ?? definition)
+            }
+            break
+
+          case 'PartStatement':
+            nextTrackScope?.parts.set(name, nextTrackScope.parts.get(name) ?? definition)
+            break
+
+          case 'BusStatement':
+            nextMixerScope?.buses.set(name, nextMixerScope.buses.get(name) ?? definition)
+            break
+        }
+
+        break
+      }
+
+      case 'UseAlias': {
+        const name = document.sliceString(from, to)
+        if (name !== '*') {
+          globalUseAliases.set(name, globalUseAliases.get(name) ?? { name, from, to })
+        }
+        break
+      }
+    }
+
+    if (cursor.firstChild()) {
+      do {
+        walk(cursor, nextParentType, nextTrackScope, nextMixerScope, nextAssignmentHasEquals)
+      } while (cursor.nextSibling())
+      cursor.parent()
+    }
+  }
+
+  walk(cursor, undefined, undefined, undefined, false)
+
+  return { globalAssignments, globalUseAliases, tracks, mixers }
+}
+
+function resolveDefinition (index: DefinitionIndex, identifier: IdentifierAt, document: TextLike): GoToDefinitionResult | undefined {
+  const name = identifier.name
+
+  const effectiveKind = ((): IdentifierKind | undefined => {
+    if (identifier.kind !== 'VariableDefinition') {
+      return identifier.kind
+    }
+
+    const parent = identifier.node?.parent
+    switch (parent?.type.name) {
+      case 'Assignment':
+        // Lezer error recovery can classify arbitrary statements as an Assignment with a VariableDefinition
+        // even when '=' is missing (e.g. a top-level expression like `lib.foo()`).
+        return document.sliceString(parent.from, parent.to).includes('=') ? identifier.kind : 'VariableName'
+
+      case 'PartStatement':
+        return /^\s*part\b/.test(document.sliceString(parent.from, Math.min(parent.to, parent.from + 16))) ? identifier.kind : 'VariableName'
+
+      case 'BusStatement':
+        return /^\s*bus\b/.test(document.sliceString(parent.from, Math.min(parent.to, parent.from + 16))) ? identifier.kind : 'VariableName'
+
+      default:
+        return identifier.kind
+    }
+  })()
+
+  switch (effectiveKind) {
+    // Jumping from a definition jumps to itself.
+    case 'VariableDefinition':
+    case 'UseAlias':
+      return { name, from: identifier.from, to: identifier.to }
+
+    // Named argument keys (e.g. tempo: 140.bpm) are not identifier usages.
+    case 'PropertyName':
+      return undefined
+
+    // Module aliases are typically used as bare identifiers (e.g. lib in lib.foo()).
+    case 'Callee':
+      return index.globalUseAliases.get(name) ?? index.globalAssignments.get(name)
+  }
+
+  // If this identifier is preceded by a dot, it is likely part of a member access chain.
+  // Resolve the root identifier of the chain instead of the member name.
+  const root = findAccessChainRootBefore(document, identifier.from)
+  if (root != null) {
+    const rootName = document.sliceString(root.from, root.to)
+    if (rootName.length > 0 && rootName !== name) {
+      const resolvedRoot = resolveDefinition(index, {
+        kind: 'VariableName',
+        name: rootName,
+        from: root.from,
+        to: root.to,
+        node: identifier.node
+      }, document)
+
+      if (resolvedRoot != null) {
+        return resolvedRoot
+      }
+    }
+  }
+
+  // Remaining kinds: VariableName | undefined
+
+  const trackKey = findEnclosingScopeKey(identifier.node, 'TrackStatement')
+  if (trackKey != null) {
+    const definition = index.tracks.get(trackKey)?.parts.get(name)
+    if (definition != null) {
+      return definition
+    }
+  }
+
+  const mixerKey = findEnclosingScopeKey(identifier.node, 'MixerStatement')
+  if (mixerKey != null) {
+    const definition = index.mixers.get(mixerKey)?.buses.get(name)
+    if (definition != null) {
+      return definition
+    }
+  }
+
+  const global = index.globalAssignments.get(name) ?? index.globalUseAliases.get(name)
+  if (global != null) {
+    return global
+  }
+
+  // Fallback: resolve to any known part/bus definition.
+  for (const track of index.tracks.values()) {
+    const definition = track.parts.get(name)
+    if (definition != null) {
+      return definition
+    }
+  }
+
+  for (const mixer of index.mixers.values()) {
+    const definition = mixer.buses.get(name)
+    if (definition != null) {
+      return definition
+    }
+  }
+
+  return undefined
+}
+
+export function goToDefinitionInTree (tree: Tree, document: TextLike, pos: number): GoToDefinitionResult | undefined {
+  const identifier = findIdentifierAt(tree, document, pos)
+  if (identifier == null || identifier.name.length === 0) {
+    return undefined
+  }
+
+  const index = buildDefinitionIndex(tree, document)
+  return resolveDefinition(index, identifier, document)
+}
+
+export function goToDefinitionWithParser (parser: LRParser, source: string, pos: number): GoToDefinitionResult | undefined {
+  const tree = parser.parse(source)
+  return goToDefinitionInTree(tree, {
+    length: source.length,
+    sliceString: (from, to) => source.slice(from, to)
+  }, pos)
+}

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -1,1 +1,2 @@
 export { cadenceLanguageSupport } from './language-support.js'
+export { goToDefinitionInTree, goToDefinitionWithParser } from './go-to-definition.js'

--- a/packages/language-support/test/index.test.ts
+++ b/packages/language-support/test/index.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { readFile } from 'node:fs/promises'
+import { buildParser } from '@lezer/generator'
+import { goToDefinitionWithParser } from '../src/go-to-definition.js'
+
+const cadenceGrammar = await readFile(new URL('../src/cadence.grammar', import.meta.url), 'utf8')
+const cadenceParser = buildParser(cadenceGrammar)
+
+describe('go-to-definition.ts', () => {
+  it('resolves assignment references', () => {
+    const source = [
+      'foo = 1',
+      'bar = foo',
+      ''
+    ].join('\n')
+
+    const refPos = source.lastIndexOf('foo') + 1
+    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
+    assert.ok(def)
+
+    const defFrom = source.indexOf('foo')
+    assert.strictEqual(def.from, defFrom)
+    assert.strictEqual(def.to, defFrom + 'foo'.length)
+    assert.strictEqual(def.name, 'foo')
+  })
+
+  it('resolves bus references inside mixer', () => {
+    const source = 'mixer { bus a { } bus b { a } }'
+
+    const refPos = source.lastIndexOf(' a ') + 2
+    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
+    assert.ok(def)
+
+    const defFrom = source.indexOf('bus a') + 'bus '.length
+    assert.strictEqual(def.from, defFrom)
+    assert.strictEqual(def.to, defFrom + 1)
+    assert.strictEqual(def.name, 'a')
+  })
+
+  it('resolves import alias usage', () => {
+    const source = [
+      'use "std" as lib',
+      'lib.foo()',
+      ''
+    ].join('\n')
+
+    const refPos = source.indexOf('lib.foo') + 1
+    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
+    assert.ok(def)
+
+    const defFrom = source.indexOf('as lib') + 'as '.length
+    assert.strictEqual(def.from, defFrom)
+    assert.strictEqual(def.to, defFrom + 'lib'.length)
+    assert.strictEqual(def.name, 'lib')
+  })
+
+  it('tolerates incomplete input', () => {
+    const source = 'mixer { bus a { } bus b { a '
+
+    const refPos = source.lastIndexOf('a') + 1
+    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
+    assert.ok(def)
+
+    const defFrom = source.indexOf('bus a') + 'bus '.length
+    assert.strictEqual(def.from, defFrom)
+    assert.strictEqual(def.to, defFrom + 1)
+    assert.strictEqual(def.name, 'a')
+  })
+
+  it('does not resolve member access by member name', () => {
+    const source = [
+      'use "foo" as gain',
+      '',
+      'synth = sample("...")',
+      '',
+      'track {',
+      '  part p {',
+      '    automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const pos = source.indexOf('synth.gain') + 'synth.'.length + 1
+    const def = goToDefinitionWithParser(cadenceParser, source, pos)
+    assert.ok(def)
+
+    const synthFrom = source.indexOf('\nsynth =') + 1
+    assert.strictEqual(def.from, synthFrom)
+    assert.strictEqual(def.to, synthFrom + 'synth'.length)
+    assert.strictEqual(def.name, 'synth')
+  })
+
+  it('does not resolve named argument keys', () => {
+    const source = [
+      'tempo = 128.bpm',
+      'track (tempo: 140.bpm) {}',
+      ''
+    ].join('\n')
+
+    const pos = source.indexOf('tempo:') + 1
+    const def = goToDefinitionWithParser(cadenceParser, source, pos)
+    assert.strictEqual(def, undefined)
+  })
+})


### PR DESCRIPTION
This patch implements a heuristic for finding the definition of a symbol at a given editor position, based on the forgiving Lezer syntax tree which was previously used for highlighting only.
The heuristic is used for a new "Go to definition" command, which is bound to F12 in the editor.