### PR TITLE
feat: Enable go-to-definition via Ctrl+Click

### DIFF
--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -3,7 +3,7 @@ import type { Diagnostic } from '@codemirror/lint'
 import type { EditorView } from '@codemirror/view'
 import type { EditorLocation, PanelProps } from '@editor'
 import { Editor, getProjectFileContent, setProjectFileContent, useProjectSource, useProjectSourceDispatch } from '@editor'
-import { cadenceLanguageSupport } from '@language-support'
+import { cadenceLanguageSupport, goToDefinitionExtension } from '@language-support'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo } from 'react'
 import { useCompilationState } from '../../../compilation/CompilationContext.js'
@@ -15,7 +15,8 @@ import { cadenceDarkTheme, cadenceLightTheme } from '../theme.js'
 
 const indent = '  ' // 2 spaces
 const extensions = [
-  cadenceLanguageSupport()
+  cadenceLanguageSupport(),
+  goToDefinitionExtension()
 ]
 
 function convertError (message: string, range: SourceRange | undefined): Diagnostic {

--- a/packages/language-support/src/go-to-definition/common.ts
+++ b/packages/language-support/src/go-to-definition/common.ts
@@ -1,0 +1,77 @@
+import type { Tree } from '@lezer/common'
+
+export interface TextLike {
+  readonly length: number
+  readonly sliceString: (from: number, to?: number) => string
+}
+
+export interface WordRange {
+  readonly from: number
+  readonly to: number
+}
+
+const IDENTIFIER_KINDS = [
+  'VariableName',
+  'Callee',
+  'MemberAccess',
+  'PropertyName',
+  'VariableDefinition',
+  'UseAlias'
+] as const
+
+export type IdentifierKind = typeof IDENTIFIER_KINDS[number]
+
+export function isIdentifierKind (value: string): value is IdentifierKind {
+  return IDENTIFIER_KINDS.includes(value as IdentifierKind)
+}
+
+const WORD_REGEXP = /[a-zA-Z_0-9#]/
+
+export function isWordChar (char: string): boolean {
+  return char.length === 1 && WORD_REGEXP.test(char)
+}
+
+export function charAt (document: TextLike, index: number): string {
+  return index >= 0 && index < document.length ? document.sliceString(index, index + 1) : ''
+}
+
+export function getWordRangeAt (document: TextLike, position: number): WordRange | undefined {
+  if (position < 0 || position > document.length) {
+    return undefined
+  }
+
+  // Prefer the character under the cursor; fall back to the left neighbor.
+  const right = charAt(document, position)
+  const left = charAt(document, position - 1)
+  const anchor = isWordChar(right) ? position : (isWordChar(left) ? position - 1 : undefined)
+  if (anchor == null) {
+    return undefined
+  }
+
+  let from = anchor
+  while (from > 0 && isWordChar(charAt(document, from - 1))) {
+    --from
+  }
+
+  let to = anchor + 1
+  while (to < document.length && isWordChar(charAt(document, to))) {
+    ++to
+  }
+
+  return { from, to }
+}
+
+export function findIdentifierRangeAt (tree: Tree, document: TextLike, position: number): WordRange | undefined {
+  const maxDepth = 8
+  let node = tree.resolveInner(position, -1)
+
+  // Climb to a meaningful identifier wrapper node.
+  for (let depth = 0; depth < maxDepth && node.parent != null; ++depth) {
+    if (isIdentifierKind(node.type.name)) {
+      return { from: node.from, to: node.to }
+    }
+    node = node.parent
+  }
+
+  return getWordRangeAt(document, position)
+}

--- a/packages/language-support/src/go-to-definition/extension.ts
+++ b/packages/language-support/src/go-to-definition/extension.ts
@@ -1,0 +1,325 @@
+import { syntaxTree } from '@codemirror/language'
+import type { Extension } from '@codemirror/state'
+import { EditorSelection, StateEffect, StateField } from '@codemirror/state'
+import type { DecorationSet, ViewUpdate } from '@codemirror/view'
+import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
+import type { WordRange } from './common.js'
+import { findIdentifierRangeAt } from './common.js'
+import { goToDefinitionInTree } from './operation.js'
+
+function isApplePlatform (): boolean {
+  const userAgent = navigator.userAgent.toLowerCase()
+
+  return [
+    'iphone',
+    'ipad',
+    'ipod',
+    'macintosh',
+    'mac os'
+  ].some((platform) => userAgent.includes(platform))
+}
+
+const APPLE_PLATFORM = isApplePlatform()
+
+function isPrimaryModifierPressed (event: MouseEvent | KeyboardEvent): boolean {
+  return APPLE_PLATFORM ? event.metaKey : event.ctrlKey
+}
+
+function isPrimaryModifierKey (key: string): boolean {
+  return APPLE_PLATFORM ? key === 'Meta' : key === 'Control'
+}
+
+function rangeContainsMouseX (view: EditorView, range: WordRange, mouse: MousePosition): boolean {
+  const start = view.coordsAtPos(range.from)
+  const end = view.coordsAtPos(range.to)
+  if (start == null || end == null) {
+    return false
+  }
+
+  const minX = Math.min(start.left, start.right, end.left, end.right)
+  const maxX = Math.max(start.left, start.right, end.left, end.right)
+
+  // Small tolerance to avoid flicker on exact boundaries.
+  const tolerance = 1
+  return mouse.x >= minX - tolerance && mouse.x <= maxX + tolerance
+}
+
+const HOVER_CLASS = 'cm-cadence-go-to-definition-hover'
+
+const hoverMark = Decoration.mark({ class: HOVER_CLASS })
+
+const theme = EditorView.baseTheme({
+  [`.${HOVER_CLASS}`]: {
+    textDecoration: 'underline',
+    cursor: 'pointer'
+  }
+})
+
+const setHover = StateEffect.define<WordRange | undefined>()
+
+const hoverDecorations = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+
+  update: (value, transaction) => {
+    let next = value
+
+    if (transaction.docChanged) {
+      next = next.map(transaction.changes)
+    }
+
+    for (const effect of transaction.effects) {
+      if (!effect.is(setHover)) {
+        continue
+      }
+
+      next = effect.value == null
+        ? Decoration.none
+        : Decoration.set([hoverMark.range(effect.value.from, effect.value.to)])
+    }
+
+    return next
+  },
+
+  provide: (field) => EditorView.decorations.from(field)
+})
+
+function sameRange (a: WordRange | undefined, b: WordRange | undefined): boolean {
+  return a?.from === b?.from && a?.to === b?.to
+}
+
+interface MousePosition {
+  readonly x: number
+  readonly y: number
+}
+
+interface HoverMeasure {
+  readonly hoverRange: WordRange | undefined
+  readonly underlineRange: WordRange | undefined
+}
+
+interface MeasureRequest<T> {
+  readonly read: (view: EditorView) => T
+  readonly write?: (measure: T, view: EditorView) => void
+  readonly key?: unknown
+}
+
+class GoToDefinitionInteractionsPlugin {
+  private readonly view: EditorView
+
+  private readonly hoverMeasureRequest: MeasureRequest<HoverMeasure>
+
+  private lastMousePosition: MousePosition | undefined
+  private modifierHeld = false
+  private lastHoverRange: WordRange | undefined
+  private lastDispatchedRange: WordRange | undefined
+  private pendingHoverDispatchRange: WordRange | undefined
+  private hoverDispatchScheduled = false
+
+  constructor (view: EditorView) {
+    this.view = view
+
+    this.hoverMeasureRequest = {
+      key: this,
+
+      read: (view: EditorView): HoverMeasure => {
+        if (!this.modifierHeld || this.lastMousePosition == null) {
+          return { hoverRange: undefined, underlineRange: undefined }
+        }
+
+        const position = view.posAtCoords(this.lastMousePosition)
+        if (position == null) {
+          return { hoverRange: undefined, underlineRange: undefined }
+        }
+
+        const tree = syntaxTree(view.state)
+        const hoverRange = findIdentifierRangeAt(tree, view.state.doc, position)
+        if (hoverRange == null) {
+          return { hoverRange: undefined, underlineRange: undefined }
+        }
+
+        // Don't treat trailing whitespace (right of token) as hovering the token.
+        if (!rangeContainsMouseX(view, hoverRange, this.lastMousePosition)) {
+          return { hoverRange: undefined, underlineRange: undefined }
+        }
+
+        const target = goToDefinitionInTree(tree, view.state.doc, position)
+        const underlineRange = target == null ? undefined : hoverRange
+
+        return { hoverRange, underlineRange }
+      },
+
+      write: (measure: HoverMeasure) => {
+        this.lastHoverRange = measure.hoverRange
+        this.scheduleHoverDispatch(measure.underlineRange)
+      }
+    }
+  }
+
+  update (update: ViewUpdate): void {
+    if (!update.docChanged) {
+      return
+    }
+
+    this.lastHoverRange = undefined
+
+    if (this.modifierHeld && this.lastMousePosition != null) {
+      this.view.requestMeasure(this.hoverMeasureRequest)
+      return
+    }
+
+    this.scheduleHoverDispatch(undefined)
+  }
+
+  onMouseMove (event: MouseEvent): void {
+    this.lastMousePosition = { x: event.clientX, y: event.clientY }
+    this.modifierHeld = isPrimaryModifierPressed(event)
+    this.refreshHover()
+  }
+
+  onMouseLeave (): void {
+    this.lastMousePosition = undefined
+    this.modifierHeld = false
+    this.lastHoverRange = undefined
+    this.scheduleHoverDispatch(undefined)
+  }
+
+  onKeyDown (event: KeyboardEvent): void {
+    if (isPrimaryModifierKey(event.key)) {
+      this.modifierHeld = true
+      this.refreshHover()
+    }
+  }
+
+  onKeyUp (event: KeyboardEvent): void {
+    if (isPrimaryModifierKey(event.key)) {
+      this.modifierHeld = false
+      this.lastHoverRange = undefined
+      this.scheduleHoverDispatch(undefined)
+    }
+  }
+
+  onMouseDown (event: MouseEvent): void {
+    if (event.button !== 0 || !isPrimaryModifierPressed(event)) {
+      return
+    }
+
+    const mouse = { x: event.clientX, y: event.clientY }
+    const position = this.view.posAtCoords(mouse)
+    if (position == null) {
+      return
+    }
+
+    const tree = syntaxTree(this.view.state)
+    const hoverRange = findIdentifierRangeAt(tree, this.view.state.doc, position)
+    if (hoverRange == null || !rangeContainsMouseX(this.view, hoverRange, mouse)) {
+      return
+    }
+
+    const target = goToDefinitionInTree(tree, this.view.state.doc, position)
+    if (target == null) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const selection = EditorSelection.single(target.from)
+    this.view.dispatch({ selection, scrollIntoView: true })
+    this.view.focus()
+  }
+
+  private refreshHover (): void {
+    if (!this.modifierHeld || this.lastMousePosition == null) {
+      this.scheduleHoverDispatch(undefined)
+      return
+    }
+
+    const position = this.view.posAtCoords(this.lastMousePosition)
+    if (position == null) {
+      this.scheduleHoverDispatch(undefined)
+      return
+    }
+
+    const range = findIdentifierRangeAt(syntaxTree(this.view.state), this.view.state.doc, position)
+
+    if (range == null || !rangeContainsMouseX(this.view, range, this.lastMousePosition)) {
+      this.lastHoverRange = undefined
+      this.scheduleHoverDispatch(undefined)
+      return
+    }
+
+    if (sameRange(range, this.lastHoverRange)) {
+      return
+    }
+
+    this.lastHoverRange = range
+
+    // Only underline identifiers that actually resolve.
+    const tree = syntaxTree(this.view.state)
+    const target = goToDefinitionInTree(tree, this.view.state.doc, position)
+    if (target == null) {
+      this.scheduleHoverDispatch(undefined)
+      return
+    }
+
+    this.scheduleHoverDispatch(range)
+  }
+
+  private scheduleHoverDispatch (range: WordRange | undefined): void {
+    this.pendingHoverDispatchRange = range
+    if (this.hoverDispatchScheduled) {
+      return
+    }
+
+    this.hoverDispatchScheduled = true
+
+    // In some CodeMirror update paths (notably measure flush), dispatching immediately
+    // can be re-entrant and throw "Calls to EditorView.update are not allowed while an update is in progress".
+    // Deferring ensures we dispatch after the current update/measure cycle completes.
+    queueMicrotask(() => {
+      this.hoverDispatchScheduled = false
+
+      const next = this.pendingHoverDispatchRange
+      this.pendingHoverDispatchRange = undefined
+
+      if (!this.view.dom.isConnected) {
+        return
+      }
+
+      this.dispatchHover(next)
+    })
+  }
+
+  private dispatchHover (range: WordRange | undefined): void {
+    if (!sameRange(this.lastDispatchedRange, range)) {
+      this.view.dispatch({ effects: setHover.of(range) })
+    }
+    this.lastDispatchedRange = range
+  }
+}
+
+const plugin = ViewPlugin.fromClass(GoToDefinitionInteractionsPlugin, {
+  eventHandlers: {
+    mousemove: (event, view) => {
+      view.plugin(plugin)?.onMouseMove(event)
+    },
+    mouseleave: (_event, view) => {
+      view.plugin(plugin)?.onMouseLeave()
+    },
+    keydown: (event, view) => {
+      view.plugin(plugin)?.onKeyDown(event)
+      return false
+    },
+    keyup: (event, view) => {
+      view.plugin(plugin)?.onKeyUp(event)
+      return false
+    },
+    mousedown: (event, view) => {
+      view.plugin(plugin)?.onMouseDown(event)
+    }
+  }
+})
+
+export function goToDefinitionExtension (): Extension {
+  return [theme, hoverDecorations, plugin]
+}

--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -1,31 +1,13 @@
 import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import type { LRParser } from '@lezer/lr'
+import type { IdentifierKind, TextLike, WordRange } from './common.js'
+import { charAt, getWordRangeAt, isIdentifierKind } from './common.js'
 
 export interface GoToDefinitionResult {
   readonly name: string
   readonly from: number
   readonly to: number
 }
-
-interface TextLike {
-  readonly length: number
-  readonly sliceString: (from: number, to?: number) => string
-}
-
-interface WordRange {
-  readonly from: number
-  readonly to: number
-}
-
-const IDENTIFIER_KINDS = [
-  'VariableName',
-  'Callee',
-  'MemberAccess',
-  'PropertyName',
-  'VariableDefinition',
-  'UseAlias'
-] as const
-type IdentifierKind = typeof IDENTIFIER_KINDS[number]
 
 interface IdentifierAt {
   readonly kind: IdentifierKind | undefined
@@ -62,46 +44,6 @@ interface WritableTrackScope extends TrackScope {
 
 interface WritableMixerScope extends MixerScope {
   readonly buses: Map<string, GoToDefinitionResult>
-}
-
-function isIdentifierKind (value: string): value is IdentifierKind {
-  return IDENTIFIER_KINDS.includes(value as IdentifierKind)
-}
-
-const WORD_REGEXP = /[a-zA-Z_0-9#]/
-
-function isWordChar (char: string): boolean {
-  return char.length === 1 && WORD_REGEXP.test(char)
-}
-
-function charAt (document: TextLike, index: number): string {
-  return index >= 0 && index < document.length ? document.sliceString(index, index + 1) : ''
-}
-
-function getWordRangeAt (document: TextLike, position: number): WordRange | undefined {
-  if (position < 0 || position > document.length) {
-    return undefined
-  }
-
-  // Prefer the character under the cursor; fall back to the left neighbor.
-  const right = charAt(document, position)
-  const left = charAt(document, position - 1)
-  const anchor = isWordChar(right) ? position : (isWordChar(left) ? position - 1 : undefined)
-  if (anchor == null) {
-    return undefined
-  }
-
-  let from = anchor
-  while (from > 0 && isWordChar(charAt(document, from - 1))) {
-    --from
-  }
-
-  let to = anchor + 1
-  while (to < document.length && isWordChar(charAt(document, to))) {
-    ++to
-  }
-
-  return { from, to }
 }
 
 function scopeKey (typeName: string, from: number, to: number): string {

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -1,2 +1,3 @@
 export { cadenceLanguageSupport } from './language-support.js'
-export { goToDefinitionInTree, goToDefinitionWithParser } from './go-to-definition.js'
+export { goToDefinitionInTree, goToDefinitionWithParser } from './go-to-definition/operation.js'
+export { goToDefinitionExtension } from './go-to-definition/extension.js'

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -1,13 +1,13 @@
-import assert from 'node:assert'
-import { describe, it } from 'node:test'
-import { readFile } from 'node:fs/promises'
 import { buildParser } from '@lezer/generator'
-import { goToDefinitionWithParser } from '../src/go-to-definition.js'
+import assert from 'node:assert'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { goToDefinitionWithParser } from '../../src/go-to-definition/operation.js'
 
-const cadenceGrammar = await readFile(new URL('../src/cadence.grammar', import.meta.url), 'utf8')
+const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
 const cadenceParser = buildParser(cadenceGrammar)
 
-describe('go-to-definition.ts', () => {
+describe('go-to-definition/operation.ts', () => {
   it('resolves assignment references', () => {
     const source = [
       'foo = 1',


### PR DESCRIPTION
"Go to definition" was already available as a command; this patch adds interactions to trigger it via Ctrl+Click on a symbol. When hovering a symbol with Ctrl held, it will be underlined. When then clicking, the editor will jump to the symbol's definition.

On macOS, Command is used instead of Control.