### PR TITLE
feat: Allow effect times to be seconds or beats

### DIFF
--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,5 +1,5 @@
 import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Program, Track } from '@core'
-import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents } from '@core'
+import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents, timeToSeconds } from '@core'
 import { numeric } from '@utility'
 import { gainTransform, timeVariant, toTimeVariant } from './automation.js'
 import { createAudioGraphBuilder, type AudioGraphBuilder } from './builder.js'
@@ -163,7 +163,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
     case 'delay': {
       const delayNode = builder.addNode<DelayNode>('delay', {
         // TODO time variant
-        time: beatsToSeconds(effect.time, program.track.tempo)
+        time: timeToSeconds(effect.time, program.track.tempo)
       })
 
       if (effect.feedback.value > 0) {
@@ -189,7 +189,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const reverb = builder.addNode<ReverbNode>('reverb', {
         // TODO time variant
-        decay: effect.decay
+        decay: timeToSeconds(effect.decay, program.track.tempo)
       })
 
       return createDryWetMix(reverb, mix, builder)

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -525,5 +525,34 @@ describe('lowering.ts', () => {
         { from: 4 as NodeId, to: 1 as NodeId }
       ])
     })
+
+    it('should handle reverb specified in beats', () => {
+      const graph = createAudioGraph(createProgramWithEffect({
+        type: 'reverb',
+        mix: numeric(undefined, 0.75),
+        decay: numeric('beats', 2)
+      }))
+
+      assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
+        id: 2 as NodeId,
+        type: 'reverb',
+        decay: beatsToSeconds(numeric('beats', 2), numeric('bpm', 120))
+      } satisfies ReverbNode)
+    })
+
+    it('should handle delay specified in seconds', () => {
+      const graph = createAudioGraph(createProgramWithEffect({
+        type: 'delay',
+        mix: numeric(undefined, 0.25),
+        time: numeric('s', 1.5),
+        feedback: numeric(undefined, 0.4)
+      }))
+
+      assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
+        id: 2 as NodeId,
+        type: 'delay',
+        time: numeric('s', 1.5)
+      } satisfies DelayNode)
+    })
   })
 })

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -166,14 +166,14 @@ export interface WidthEffect {
 export interface DelayEffect {
   readonly type: 'delay'
   readonly mix: Numeric<undefined>
-  readonly time: Numeric<'beats'>
+  readonly time: Numeric<'beats'> | Numeric<'s'>
   readonly feedback: Numeric<undefined>
 }
 
 export interface ReverbEffect {
   readonly type: 'reverb'
   readonly mix: Numeric<undefined>
-  readonly decay: Numeric<'s'>
+  readonly decay: Numeric<'beats'> | Numeric<'s'>
 }
 
 export interface MixerRouting {

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -1,4 +1,5 @@
-import { type Numeric, numeric } from '@utility'
+import type { Numeric } from '@utility'
+import { numeric } from '@utility'
 import type { Program } from './program.js'
 
 export interface BeatRange {
@@ -11,6 +12,13 @@ export function beatsToSeconds (
   tempo: Numeric<'bpm'>
 ): Numeric<'s'> {
   return numeric('s', (beats.value * 60) / tempo.value)
+}
+
+export function timeToSeconds (
+  time: Numeric<'beats'> | Numeric<'s'>,
+  tempo: Numeric<'bpm'>
+): Numeric<'s'> {
+  return time.unit === 's' ? time : beatsToSeconds(time, tempo)
 }
 
 export function calculateTotalLength (program: Program): Numeric<'beats'> {

--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -792,6 +792,7 @@ function checkArgumentList (
   const errorArguments = new Set<string>()
 
   const schemaAsMap = new Map<string, PropertySpec>(schema.map((spec) => [spec.name, spec]))
+  const getSpecTypes = (spec: PropertySpec): readonly Type[] => (Array.isArray(spec.type) ? spec.type : [spec.type]) as readonly Type[]
 
   const checkArgumentValue = (spec: PropertySpec, value: ast.Expression): void => {
     const expressionCheck = checkExpression(context, value)
@@ -802,7 +803,7 @@ function checkArgumentList (
       return
     }
 
-    errors.push(...checkType([spec.type], expressionCheck.result, value.range))
+    errors.push(...checkType(getSpecTypes(spec), expressionCheck.result, value.range))
     result.set(spec.name, expressionCheck.result)
   }
 

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -1,6 +1,7 @@
 import type { Effect } from '@core'
 import type { PropertySchema } from '../schema.js'
-import { EffectType, FunctionType, ModuleType, NumberType, type Value } from '../types.js'
+import type { Value } from '../types.js'
+import { EffectType, FunctionType, ModuleType, NumberType } from '../types.js'
 
 // Factory
 
@@ -37,13 +38,13 @@ const width = createEffectConstructor('width', [
 
 const delay = createEffectConstructor('delay', [
   { name: 'mix', type: NumberType.with(undefined), required: true },
-  { name: 'time', type: NumberType.with('beats'), required: true },
+  { name: 'time', type: [NumberType.with('beats'), NumberType.with('s')], required: true },
   { name: 'feedback', type: NumberType.with(undefined), required: true }
 ])
 
 const reverb = createEffectConstructor('reverb', [
   { name: 'mix', type: NumberType.with(undefined), required: true },
-  { name: 'decay', type: NumberType.with('s'), required: true }
+  { name: 'decay', type: [NumberType.with('beats'), NumberType.with('s')], required: true }
 ])
 
 export const effectsModule = ModuleType.of({

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -1,7 +1,10 @@
-import { isPitch, type Instrument, type InstrumentId, type Parameter, type ParameterId } from '@core'
-import { numeric, type Numeric, type Unit } from '@utility'
+import type { Instrument, InstrumentId, Parameter, ParameterId } from '@core'
+import { isPitch } from '@core'
+import type { Numeric, Unit } from '@utility'
+import { numeric } from '@utility'
 import type { FunctionContext } from '../functions.js'
-import { FunctionType, InstrumentType, ModuleType, NumberType, StringType, type InstrumentValue, type Value } from '../types.js'
+import type { InstrumentValue, Value } from '../types.js'
+import { FunctionType, InstrumentType, ModuleType, NumberType, StringType } from '../types.js'
 
 const UNITY_GAIN = numeric('db', 0)
 

--- a/packages/language/src/compiler/schema.ts
+++ b/packages/language/src/compiler/schema.ts
@@ -2,6 +2,7 @@ import type { SourceRange } from '@ast'
 import type { AnyValue, Type, ValueFor } from './types.js'
 
 export type Properties = readonly Property[]
+export type AcceptedType = Type | readonly Type[]
 
 export interface Property {
   readonly key: {
@@ -17,14 +18,21 @@ export type PropertySchema = readonly PropertySpec[]
 
 export interface PropertySpec {
   readonly name: string
-  readonly type: Type
+  readonly type: AcceptedType
   readonly required: boolean
 }
 
+type InferPropertyType<T extends AcceptedType> =
+  T extends readonly Type[]
+    ? ValueFor<T[number]> extends AnyValue ? ValueFor<T[number]>['data'] : never
+    : T extends Type
+      ? ValueFor<T> extends AnyValue ? ValueFor<T>['data'] : never
+      : never
+
 export type InferSchema<S extends PropertySchema> = {
-  [P in S[number] as P['required'] extends true ? P['name'] : never]: ValueFor<P['type']> extends AnyValue ? ValueFor<P['type']>['data'] : never
+  [P in S[number] as P['required'] extends true ? P['name'] : never]: InferPropertyType<P['type']>
 } & {
-  [P in S[number] as P['required'] extends false ? P['name'] : never]?: ValueFor<P['type']> extends AnyValue ? ValueFor<P['type']>['data'] : never
+  [P in S[number] as P['required'] extends false ? P['name'] : never]?: InferPropertyType<P['type']>
 }
 
 export function definePropertySchema<const T extends PropertySchema> (schema: T): T {

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -142,6 +142,130 @@ describe('compiler/checker.ts', () => {
       assert.deepStrictEqual(check(program), [])
     })
 
+    it('should accept delay effect time in beats or seconds', () => {
+      const createDelayCall = (value: number, unit: 'beats' | 's') => ast.make('Call', RANGE, {
+        callee: ast.make('PropertyAccess', RANGE, {
+          object: ast.make('Identifier', RANGE, { name: 'fx' }),
+          property: ast.make('Identifier', RANGE, { name: 'delay' })
+        }),
+        arguments: [
+          ast.make('Property', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'mix' }),
+            value: ast.make('Number', RANGE, { value: 0.25 })
+          }),
+          ast.make('Property', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'time' }),
+            value: ast.make('PropertyAccess', RANGE, {
+              object: ast.make('Number', RANGE, { value }),
+              property: ast.make('Identifier', RANGE, { name: unit })
+            })
+          }),
+          ast.make('Property', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'feedback' }),
+            value: ast.make('Number', RANGE, { value: 0.4 })
+          })
+        ]
+      })
+
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['effects'] }),
+            alias: 'fx'
+          })
+        ],
+        children: [
+          ast.make('MixerStatement', RANGE, {
+            properties: [],
+            buses: [
+              ast.make('BusStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'bus1' }),
+                properties: [],
+                sources: [],
+                effects: [
+                  ast.make('EffectStatement', RANGE, {
+                    expression: createDelayCall(3, 'beats')
+                  })
+                ]
+              }),
+              ast.make('BusStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'bus2' }),
+                properties: [],
+                sources: [],
+                effects: [
+                  ast.make('EffectStatement', RANGE, {
+                    expression: createDelayCall(1.5, 's')
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [])
+    })
+
+    it('should accept reverb effect decay in beats or seconds', () => {
+      const createReverbCall = (value: number, unit: 'beats' | 's') => ast.make('Call', RANGE, {
+        callee: ast.make('PropertyAccess', RANGE, {
+          object: ast.make('Identifier', RANGE, { name: 'fx' }),
+          property: ast.make('Identifier', RANGE, { name: 'reverb' })
+        }),
+        arguments: [
+          ast.make('Property', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'mix' }),
+            value: ast.make('Number', RANGE, { value: 0.25 })
+          }),
+          ast.make('Property', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'decay' }),
+            value: ast.make('PropertyAccess', RANGE, {
+              object: ast.make('Number', RANGE, { value }),
+              property: ast.make('Identifier', RANGE, { name: unit })
+            })
+          })
+        ]
+      })
+
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['effects'] }),
+            alias: 'fx'
+          })
+        ],
+        children: [
+          ast.make('MixerStatement', RANGE, {
+            properties: [],
+            buses: [
+              ast.make('BusStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'bus1' }),
+                properties: [],
+                sources: [],
+                effects: [
+                  ast.make('EffectStatement', RANGE, {
+                    expression: createReverbCall(3, 'beats')
+                  })
+                ]
+              }),
+              ast.make('BusStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'bus2' }),
+                properties: [],
+                sources: [],
+                effects: [
+                  ast.make('EffectStatement', RANGE, {
+                    expression: createReverbCall(1.5, 's')
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [])
+    })
+
     it('should allow parts and buses to shadow top-level variables', () => {
       const program = ast.make('Program', RANGE, {
         imports: [],

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -465,6 +465,117 @@ describe('compiler/generator.ts', () => {
     ])
   })
 
+  it('should preserve seconds for delay effect time', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['effects'] }),
+          alias: 'fx'
+        })
+      ],
+      children: [
+        ast.make('MixerStatement', RANGE, {
+          properties: [],
+          buses: [
+            ast.make('BusStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'bus1' }),
+              properties: [],
+              sources: [],
+              effects: [
+                ast.make('EffectStatement', RANGE, {
+                  expression: ast.make('Call', RANGE, {
+                    callee: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'fx' }),
+                      property: ast.make('Identifier', RANGE, { name: 'delay' })
+                    }),
+                    arguments: [
+                      ast.make('Property', RANGE, {
+                        key: ast.make('Identifier', RANGE, { name: 'mix' }),
+                        value: ast.make('Number', RANGE, { value: 0.25 })
+                      }),
+                      ast.make('Property', RANGE, {
+                        key: ast.make('Identifier', RANGE, { name: 'time' }),
+                        value: ast.make('PropertyAccess', RANGE, {
+                          object: ast.make('Number', RANGE, { value: 1.5 }),
+                          property: ast.make('Identifier', RANGE, { name: 's' })
+                        })
+                      }),
+                      ast.make('Property', RANGE, {
+                        key: ast.make('Identifier', RANGE, { name: 'feedback' }),
+                        value: ast.make('Number', RANGE, { value: 0.4 })
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+    assert.deepStrictEqual(result.mixer.buses[0].effects[0], {
+      type: 'delay',
+      mix: numeric(undefined, 0.25),
+      time: numeric('s', 1.5),
+      feedback: numeric(undefined, 0.4)
+    })
+  })
+
+  it('should preserve beats for reverb decay', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['effects'] }),
+          alias: 'fx'
+        })
+      ],
+      children: [
+        ast.make('MixerStatement', RANGE, {
+          properties: [],
+          buses: [
+            ast.make('BusStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'bus1' }),
+              properties: [],
+              sources: [],
+              effects: [
+                ast.make('EffectStatement', RANGE, {
+                  expression: ast.make('Call', RANGE, {
+                    callee: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'fx' }),
+                      property: ast.make('Identifier', RANGE, { name: 'reverb' })
+                    }),
+                    arguments: [
+                      ast.make('Property', RANGE, {
+                        key: ast.make('Identifier', RANGE, { name: 'mix' }),
+                        value: ast.make('Number', RANGE, { value: 0.25 })
+                      }),
+                      ast.make('Property', RANGE, {
+                        key: ast.make('Identifier', RANGE, { name: 'decay' }),
+                        value: ast.make('PropertyAccess', RANGE, {
+                          object: ast.make('Number', RANGE, { value: 2 }),
+                          property: ast.make('Identifier', RANGE, { name: 'beats' })
+                        })
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+    assert.deepStrictEqual(result.mixer.buses[0].effects[0], {
+      type: 'reverb',
+      mix: numeric(undefined, 0.25),
+      decay: numeric('beats', 2)
+    })
+  })
+
   describe('instruments.sample', () => {
     it('should allocate instrument and parameter IDs correctly', () => {
       const program = ast.make('Program', RANGE, {

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -15,6 +15,7 @@ function createFunctionContext (): FunctionContext {
 describe('compiler/modules/effects.ts', () => {
   // helper to create Numeric<'beats'>
   const beats = (value: number) => numeric('beats', value)
+  const seconds = (value: number) => numeric('s', value)
 
   const effects = effectsModule.data
 
@@ -120,6 +121,20 @@ describe('compiler/modules/effects.ts', () => {
         feedback: numeric(undefined, 0.3)
       })
     })
+
+    it('should create delay effect with seconds', () => {
+      const context = createFunctionContext()
+      const result = delay.data.invoke(context, {
+        time: seconds(1.5),
+        feedback: numeric(undefined, 0.3)
+      })
+
+      assert.deepStrictEqual(result.data, {
+        type: 'delay',
+        time: seconds(1.5),
+        feedback: numeric(undefined, 0.3)
+      })
+    })
   })
 
   describe('reverb', () => {
@@ -136,6 +151,20 @@ describe('compiler/modules/effects.ts', () => {
       assert.deepStrictEqual(result.data, {
         type: 'reverb',
         decay: numeric('s', 2.0),
+        mix: numeric(undefined, 0.4)
+      })
+    })
+
+    it('should create reverb effect with beats', () => {
+      const context = createFunctionContext()
+      const result = reverb.data.invoke(context, {
+        decay: beats(2),
+        mix: numeric(undefined, 0.4)
+      })
+
+      assert.deepStrictEqual(result.data, {
+        type: 'reverb',
+        decay: beats(2),
         mix: numeric(undefined, 0.4)
       })
     })

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -86,7 +86,7 @@ export function createWidthInstance (node: WidthNode, transport: Transport): Ins
 }
 
 export function createDelayInstance (node: DelayNode, transport: Transport): Instance {
-  const audioNode = transport.ctx.createDelay()
+  const audioNode = transport.ctx.createDelay(Math.max(1, node.time.value))
   audioNode.delayTime.value = node.time.value
   return toInstance(audioNode)
 }

--- a/packages/webaudio/test-browser/graph/effect.test.ts
+++ b/packages/webaudio/test-browser/graph/effect.test.ts
@@ -1,7 +1,8 @@
 import type { NodeId } from '@audiograph'
-import { numeric, type Numeric } from '@utility'
+import type { Numeric } from '@utility'
+import { numeric } from '@utility'
 import { describe, expect, it } from 'vitest'
-import { createWidthInstance } from '../../src/graph/effect.js'
+import { createDelayInstance, createWidthInstance } from '../../src/graph/effect.js'
 import type { Transport } from '../../src/transport/transport.js'
 import { average, expectSamplesClose, fillSignal } from '../helpers.js'
 
@@ -52,6 +53,48 @@ async function renderWidth (options: {
     const output = await ctx.startRendering()
 
     return { input, output }
+  } finally {
+    instance.dispose()
+  }
+}
+
+async function renderDelay (options: {
+  readonly time: Numeric<'s'>
+}): Promise<{
+  readonly output: AudioBuffer
+}> {
+  const { time } = options
+
+  const delaySeconds = Math.max(1.25, time.value + 0.25)
+  const delaySamples = Math.ceil(delaySeconds * sampleRate)
+  const renderLength = delaySamples + 256
+
+  const ctx = new OfflineAudioContext({ sampleRate, length: renderLength, numberOfChannels: 1 })
+  const transport: Transport = {
+    ctx,
+    output: ctx.createGain(),
+    schedule: (_time, onSchedule) => onSchedule(0)
+  }
+
+  const instance = createDelayInstance({
+    id: 42 as NodeId,
+    type: 'delay',
+    time
+  }, transport)
+
+  try {
+    const source = ctx.createBufferSource()
+    const input = ctx.createBuffer(1, renderLength, sampleRate)
+    input.getChannelData(0)[0] = 1
+    source.buffer = input
+
+    source.connect(instance.input ?? ctx.destination)
+    instance.output?.connect(ctx.destination)
+
+    source.start(0)
+
+    const output = await ctx.startRendering()
+    return { output }
   } finally {
     instance.dispose()
   }
@@ -171,6 +214,20 @@ describe('graph/effect.ts', () => {
 
       expect(average(inverted.output.getChannelData(0))).toBeCloseTo(-0.25, 3)
       expect(average(inverted.output.getChannelData(1))).toBeCloseTo(1.25, 3)
+    })
+  })
+
+  describe('createDelayInstance', () => {
+    it('supports delay times longer than one second', async () => {
+      const time = numeric('s', 1.5)
+      const { output } = await renderDelay({ time })
+
+      const channel = output.getChannelData(0)
+      const peakIndex = channel.reduce((bestIndex, value, index, data) => {
+        return Math.abs(value) > Math.abs(data[bestIndex]) ? index : bestIndex
+      }, 0)
+
+      expect(peakIndex / sampleRate).toBeCloseTo(time.value, 2)
     })
   })
 })


### PR DESCRIPTION
The delay effect `time` and the reverb effect `decay` parameters can now be specified as either seconds or beats. This allows the user to choose the most convenient unit for their use case (i.e. tempo-synced or not).

This is done by extending the schema checker to allow multiple types for a parameter, which will be inferred as a union type, and propagating the value through the pipeline until audiograph lowering, where time values are converted to seconds using the track tempo if necessary.