### PR TITLE
feat: Add support for curve segment weights

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -39,7 +39,7 @@ track (120.bpm) {
     snare << snare_pattern
     synth << arp_intro
 
-    automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]
+    automate synth.gain as curve [hold(-60.db):3 lin(-60.db, 0.db):1]
   }
 
   part main (8.bars) {

--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -42,6 +42,7 @@ export interface CurveSegment extends ASTNode {
   readonly type: 'CurveSegment'
   readonly curveType: string
   readonly parameters: readonly Expression[]
+  readonly length?: Expression
 }
 
 export interface Curve extends ASTNode {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -101,7 +101,7 @@ Curve {
 }
 
 curveSegment {
-  CurveType { word } ("(" argumentList? ")")?
+  CurveType { word } ("(" argumentList? ")")? (":" primary)?
 }
 
 argumentList {

--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -618,6 +618,15 @@ function checkCurve (context: Context, curve: ast.Curve): Checked<Type> {
 function checkCurveSegment (context: Context, segment: ast.CurveSegment): Checked<Unit> {
   const errors: CompileError[] = []
 
+  if (segment.length != null) {
+    const lengthCheck = checkExpression(context, segment.length)
+    errors.push(...lengthCheck.errors)
+
+    if (lengthCheck.result != null) {
+      errors.push(...checkType([NumberType.with(undefined)], lengthCheck.result, segment.length.range))
+    }
+  }
+
   const expectedParameters = curveParameterCounts.get(segment.curveType)
   if (expectedParameters == null) {
     return { errors: [new CompileError(`Unknown curve type "${segment.curveType}"`, segment.range)] }

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -14,12 +14,14 @@ export type CurveSegment<U extends Unit> = HoldCurveSegment<U> | LinearCurveSegm
 
 export interface HoldCurveSegment<U extends Unit> {
   readonly type: typeof SEGMENT_TYPE_HOLD
+  readonly length: Numeric<undefined>
   readonly unit: U
   readonly value: Numeric<U>
 }
 
 export interface LinearCurveSegment<U extends Unit> {
   readonly type: typeof SEGMENT_TYPE_LINEAR
+  readonly length: Numeric<undefined>
   readonly unit: U
   readonly start: Numeric<U>
   readonly end: Numeric<U>
@@ -35,7 +37,11 @@ export function createCurve<U extends Unit> (segments: ReadonlyArray<CurveSegmen
   return { unit, segments }
 }
 
-export function createCurveSegment<U extends Unit> (type: string, parameters: ReadonlyArray<Numeric<U>>): CurveSegment<U> {
+export function createCurveSegment<U extends Unit> (
+  type: string,
+  parameters: ReadonlyArray<Numeric<U>>,
+  length = numeric(undefined, 1)
+): CurveSegment<U> {
   if (curveParameterCounts.get(type) !== parameters.length) {
     throw new Error('Invalid curve parameters')
   }
@@ -45,12 +51,12 @@ export function createCurveSegment<U extends Unit> (type: string, parameters: Re
   switch (type) {
     case SEGMENT_TYPE_HOLD: {
       const [value] = parameters
-      return { type, unit, value }
+      return { type, length, unit, value }
     }
 
     case SEGMENT_TYPE_LINEAR: {
       const [start, end] = parameters
-      return { type, unit, start, end }
+      return { type, length, unit, start, end }
     }
 
     default:
@@ -61,26 +67,47 @@ export function createCurveSegment<U extends Unit> (type: string, parameters: Re
 export function renderCurvePoints<U extends Unit> (curve: Curve<U>, timeStart: Numeric<'beats'>, timeEnd: Numeric<'beats'>): ReadonlyArray<AutomationPoint<U>> {
   const segments = curve.segments
   if (segments.length === 0) {
-    throw new Error('Invalid curve: no segments')
+    return []
   }
 
   const totalDuration = timeEnd.value - timeStart.value
-  const segmentDuration = totalDuration / segments.length
+  const segmentWeights = segments.map((segment) => Math.max(segment.length.value, 0))
+  const totalWeight = segmentWeights.reduce((sum, weight) => sum + weight, 0)
+
+  const getTimeAtWeight = (weight: number) => {
+    if (totalWeight === 0) {
+      return timeStart.value
+    }
+    return timeStart.value + totalDuration * (weight / totalWeight)
+  }
 
   const points: Array<AutomationPoint<U>> = []
+  let currentWeight = 0
 
   for (let i = 0; i < segments.length; ++i) {
     const segment = segments[i]
+    const segmentWeight = segmentWeights[i]
+
+    const segmentStart = getTimeAtWeight(currentWeight)
+    const segmentEnd = i === segments.length - 1
+      ? getTimeAtWeight(totalWeight)
+      : getTimeAtWeight(currentWeight + segmentWeight)
+
+    const endCurve = segment.type === SEGMENT_TYPE_LINEAR && segmentWeight > 0
+      ? 'linear'
+      : 'step'
 
     points.push({
-      time: numeric('beats', timeStart.value + segmentDuration * i),
+      time: numeric('beats', segmentStart),
       value: segment.type === SEGMENT_TYPE_LINEAR ? segment.start : segment.value,
       curve: 'step'
     }, {
-      time: numeric('beats', i === segments.length - 1 ? timeEnd.value : timeStart.value + segmentDuration * (i + 1)),
+      time: numeric('beats', segmentEnd),
       value: segment.type === SEGMENT_TYPE_LINEAR ? segment.end : segment.value,
-      curve: segment.type === SEGMENT_TYPE_LINEAR ? 'linear' : 'step'
+      curve: endCurve
     })
+
+    currentWeight += segmentWeight
   }
 
   return simplifyCurvePoints(points)

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -446,7 +446,11 @@ function generateCurve (context: Context, curve: ast.Curve): CurveValue {
       return NumberType.cast(resolve(context, point)).data
     })
 
-    return nonNull(createCurveSegment(segment.curveType, parameters))
+    const length = segment.length != null
+      ? NumberType.with(undefined).cast(resolve(context, segment.length)).data
+      : undefined
+
+    return nonNull(createCurveSegment(segment.curveType, parameters, length))
   })
 
   return CurveType.of(

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -1,10 +1,12 @@
-import { ast, combineSourceRanges, getSourceRange, type SourceRange } from '@ast'
+import type { SourceRange } from '@ast'
+import { ast, combineSourceRanges, getSourceRange } from '@ast'
 import { isStepValue } from '@core'
 import { Token } from 'leac'
 import * as p from 'peberminta'
 import { truncateString } from '../result/errors.js'
 import type { Result } from '../result/result.js'
-import { isKeyword, type Keyword } from './constants.js'
+import type { Keyword } from './constants.js'
+import { isKeyword } from './constants.js'
 import { ParseError } from './error.js'
 
 const ERROR_CONTEXT_LIMIT = 16
@@ -308,26 +310,42 @@ const parallelPattern_: p.Parser<Token, unknown, ast.Pattern> = p.abc(
 
 const curveSegment_: p.Parser<Token, unknown, ast.CurveSegment> = p.ab(
   p.token((t) => t.name === 'word' ? t : undefined),
-  p.option(
-    combine3(
-      literal('('),
-      p.sepBy(
-        p.recursive(() => optionalExpression_),
-        literal(',')
+  combine2(
+    p.option(
+      combine3(
+        literal('('),
+        p.sepBy(
+          p.recursive(() => optionalExpression_),
+          literal(',')
+        ),
+        expectLiteral(')')
       ),
-      expectLiteral(')')
+      undefined
     ),
-    undefined
+    p.option(
+      combine2(
+        literal(':'),
+        p.recursive(() => primary_)
+      ),
+      undefined
+    )
   ),
-  (curveTypeToken, callTail) => {
+  (curveTypeToken, [callTail, curveLength]) => {
     const curveType = curveTypeToken.text
     const parameters = callTail == null ? [] : callTail[1]
+    const length = curveLength?.[1]
 
-    const range = callTail == null
-      ? getSourceRange(curveTypeToken)
-      : combineSourceRanges(curveTypeToken, callTail[2])
+    const range = length != null
+      ? combineSourceRanges(curveTypeToken, length)
+      : callTail == null
+        ? getSourceRange(curveTypeToken)
+        : combineSourceRanges(curveTypeToken, callTail[2])
 
-    return ast.make('CurveSegment', range, { curveType, parameters })
+    return ast.make('CurveSegment', range, {
+      curveType,
+      parameters,
+      ...(length == null ? {} : { length })
+    })
   }
 )
 

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -439,6 +439,80 @@ describe('compiler/checker.ts', () => {
 
       assert.deepStrictEqual(check(program), [])
     })
+
+    it('should accept curve automation with weighted segments', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'synth' }),
+            value: ast.make('Call', RANGE, {
+              callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+              arguments: [
+                ast.make('String', RANGE, { parts: ['synth.wav'] })
+              ]
+            })
+          }),
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'hold',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -60 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ],
+                          length: ast.make('Number', RANGE, { value: 3 })
+                        }),
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'lin',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -60 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            }),
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: 0 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ],
+                          length: ast.make('Number', RANGE, { value: 1 })
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [])
+    })
   })
 
   describe('invalid', () => {

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -425,6 +425,187 @@ describe('compiler/generator.ts', () => {
     ])
   })
 
+  it('should allocate curve time by segment length weights', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['instruments'] })
+        })
+      ],
+      children: [
+        ast.make('Assignment', RANGE, {
+          key: ast.make('Identifier', RANGE, { name: 'synth' }),
+          value: ast.make('Call', RANGE, {
+            callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+            arguments: [
+              ast.make('String', RANGE, { parts: ['synth.wav'] })
+            ]
+          })
+        }),
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 8 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                    property: ast.make('Identifier', RANGE, { name: 'gain' })
+                  }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'hold',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('Number', RANGE, { value: 3 })
+                      }),
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: 0 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('Number', RANGE, { value: 1 })
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+
+    assert.strictEqual(result.automations.size, 1)
+    const automation = [...result.automations.values()][0]
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 24), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 32), value: numeric('db', 0), curve: 'linear' }
+    ])
+  })
+
+  it('should clamp non-positive curve segment lengths and step zero-length segments', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['instruments'] })
+        })
+      ],
+      children: [
+        ast.make('Assignment', RANGE, {
+          key: ast.make('Identifier', RANGE, { name: 'synth' }),
+          value: ast.make('Call', RANGE, {
+            callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+            arguments: [
+              ast.make('String', RANGE, { parts: ['synth.wav'] })
+            ]
+          })
+        }),
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 4 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                    property: ast.make('Identifier', RANGE, { name: 'gain' })
+                  }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'hold',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('UnaryExpression', RANGE, {
+                          operator: '-',
+                          argument: ast.make('Number', RANGE, { value: 2 })
+                        })
+                      }),
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -30 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('Number', RANGE, { value: 0 })
+                      }),
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -30 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: 0 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('Number', RANGE, { value: 1 })
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+
+    assert.strictEqual(result.automations.size, 1)
+    const automation = [...result.automations.values()][0]
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 0), value: numeric('db', -30), curve: 'step' },
+      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+    ])
+  })
+
   it('should support buses as sources in mixer', () => {
     const program = ast.make('Program', RANGE, {
       imports: [],

--- a/packages/language/test/compiler/types.test.ts
+++ b/packages/language/test/compiler/types.test.ts
@@ -203,6 +203,7 @@ describe('compiler/types.ts', () => {
         segments: [
           {
             type: 'lin',
+            length: numeric(undefined, 1),
             unit: 'db',
             start: numeric('db', -6),
             end: numeric('db', 0)
@@ -636,6 +637,7 @@ describe('compiler/types.ts', () => {
           segments: [
             {
               type: 'lin',
+              length: numeric(undefined, 1),
               unit: undefined,
               start: numeric(undefined, 0),
               end: numeric(undefined, 1)
@@ -649,6 +651,7 @@ describe('compiler/types.ts', () => {
           segments: [
             {
               type: 'hold',
+              length: numeric(undefined, 1),
               unit: 'db',
               value: numeric('db', -6)
             }

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -689,6 +689,66 @@ describe('parser/parser.ts', () => {
     })
   })
 
+  it('should parse curve segment lengths', () => {
+    const result = parse(makeTokens([
+      { name: 'word', text: 'foo' },
+      { name: '=' },
+      { name: 'word', text: 'curve' },
+      { name: '[' },
+      { name: 'word', text: 'hold' },
+      { name: '(' },
+      { name: 'number', text: '0' },
+      { name: ')' },
+      { name: ':' },
+      { name: 'number', text: '3' },
+      { name: 'word', text: 'lin' },
+      { name: '(' },
+      { name: 'number', text: '0' },
+      { name: ',' },
+      { name: 'number', text: '1' },
+      { name: ')' },
+      { name: ':' },
+      { name: 'number', text: '1' },
+      { name: ']' }
+    ]))
+
+    assert.deepStrictEqual(stripRanges(result), {
+      complete: true,
+      value: {
+        type: 'Program',
+        imports: [],
+        children: [
+          {
+            type: 'Assignment',
+            key: { type: 'Identifier', name: 'foo' },
+            value: {
+              type: 'Curve',
+              children: [
+                {
+                  type: 'CurveSegment',
+                  curveType: 'hold',
+                  parameters: [
+                    { type: 'Number', value: 0 }
+                  ],
+                  length: { type: 'Number', value: 3 }
+                },
+                {
+                  type: 'CurveSegment',
+                  curveType: 'lin',
+                  parameters: [
+                    { type: 'Number', value: 0 },
+                    { type: 'Number', value: 1 }
+                  ],
+                  length: { type: 'Number', value: 1 }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    })
+  })
+
   it('should parse property access with function calls', () => {
     // x = object.method1().method2()
     const nonParenthesized = makeTokens([


### PR DESCRIPTION
Like pattern step lengths, curve segments can now use a `:number` suffix to set relative duration. For example,
`curve [hold(-60.db):3 lin(-60.db, 0.db):1]` gives the hold segment 3x the length of the linear segment.

Clamp segment weights to zero at render time and treat zero-length segments as steps so invalid weights do not fail at runtime.