### PR TITLE
feat: Allow curve segments to omit start point

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -39,7 +39,7 @@ track (120.bpm) {
     snare << snare_pattern
     synth << arp_intro
 
-    automate synth.gain as curve [hold(-60.db):3 lin(-60.db, 0.db):1]
+    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]
   }
 
   part main (8.bars) {

--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -2,7 +2,7 @@ import type { SourceRange } from '@ast'
 import { ast } from '@ast'
 import type { Unit } from '@utility'
 import { busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from './common.js'
-import { curveParameterCounts } from './curves.js'
+import { getCurveSegmentType } from './curves.js'
 import { CompileError } from './error.js'
 import { getStandardModule, standardLibraryModuleNames } from './modules.js'
 import type { PropertySchema, PropertySpec } from './schema.js'
@@ -597,8 +597,18 @@ function checkCurve (context: Context, curve: ast.Curve): Checked<Type> {
     return { errors }
   }
 
-  const segmentChecks = segments.map((segment) => checkCurveSegment(context, segment))
-  errors.push(...segmentChecks.flatMap((c) => c.errors))
+  const segmentChecks: Array<Checked<Unit>> = []
+  let previousUnit: Unit | undefined
+
+  for (let i = 0; i < segments.length; ++i) {
+    const segmentCheck = checkCurveSegment(context, segments[i], i > 0, previousUnit)
+    segmentChecks.push(segmentCheck)
+    errors.push(...segmentCheck.errors)
+
+    if (segmentCheck.errors.length === 0) {
+      previousUnit = segmentCheck.result
+    }
+  }
 
   if (errors.length > 0) {
     return { errors }
@@ -615,7 +625,7 @@ function checkCurve (context: Context, curve: ast.Curve): Checked<Type> {
   return { errors, result: CurveType.with(firstUnit) }
 }
 
-function checkCurveSegment (context: Context, segment: ast.CurveSegment): Checked<Unit> {
+function checkCurveSegment (context: Context, segment: ast.CurveSegment, hasPrevious: boolean, previousUnit: Unit | undefined): Checked<Unit> {
   const errors: CompileError[] = []
 
   if (segment.length != null) {
@@ -627,12 +637,19 @@ function checkCurveSegment (context: Context, segment: ast.CurveSegment): Checke
     }
   }
 
-  const expectedParameters = curveParameterCounts.get(segment.curveType)
+  const expectedParameters = getCurveSegmentType(segment.curveType)?.parameterCount
   if (expectedParameters == null) {
     return { errors: [new CompileError(`Unknown curve type "${segment.curveType}"`, segment.range)] }
   }
 
-  if (segment.parameters.length !== expectedParameters) {
+  const actualParameters = segment.parameters.length
+  const omittedFirstParameter = expectedParameters > 0 && actualParameters === expectedParameters - 1
+
+  if (omittedFirstParameter && !hasPrevious) {
+    return { errors: [new CompileError('First curve segment cannot omit its first parameter', segment.range)] }
+  }
+
+  if (!omittedFirstParameter && actualParameters !== expectedParameters) {
     const message = `Expected ${expectedParameters} ${expectedParameters === 1 ? 'parameter' : 'parameters'} for ${segment.curveType} curve, got ${segment.parameters.length}`
     return { errors: [new CompileError(message, segment.range)] }
   }
@@ -644,14 +661,8 @@ function checkCurveSegment (context: Context, segment: ast.CurveSegment): Checke
     errors.push(...pointCheck.errors)
 
     if (pointCheck.result != null) {
-      const typeErrors = checkType([NumberType], pointCheck.result, point.range)
-      errors.push(...typeErrors)
-
-      const generics = typeErrors.length === 0
-        ? NumberType.detail(pointCheck.result)
-        : undefined
-
-      units.push(generics?.unit)
+      errors.push(...checkType([NumberType], pointCheck.result, point.range))
+      units.push(NumberType.detail(pointCheck.result).unit)
     }
   }
 
@@ -659,9 +670,10 @@ function checkCurveSegment (context: Context, segment: ast.CurveSegment): Checke
     return { errors }
   }
 
-  const firstUnit = units[0]
+  const firstUnit = omittedFirstParameter ? previousUnit : units[0]
+
   const expected = NumberType.with(firstUnit)
-  for (let i = 1; i < units.length; ++i) {
+  for (let i = omittedFirstParameter ? 0 : 1; i < units.length; ++i) {
     errors.push(...checkType([expected], NumberType.with(units[i]), segment.parameters[i].range))
   }
 

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -27,10 +27,44 @@ export interface LinearCurveSegment<U extends Unit> {
   readonly end: Numeric<U>
 }
 
-export const curveParameterCounts = new Map<string, number>([
-  [SEGMENT_TYPE_HOLD, 1],
-  [SEGMENT_TYPE_LINEAR, 2]
+export interface CurveSegmentType {
+  readonly type: CurveSegment<any>['type']
+  readonly parameterCount: number
+  readonly create: <U extends Unit>(parameters: ReadonlyArray<Numeric<U>>, length: Numeric<undefined>) => CurveSegment<U>
+  readonly start: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
+  readonly end: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
+  readonly endCurve: AutomationPoint<any>['curve']
+}
+
+const curveSegmentTypes: ReadonlyMap<string, CurveSegmentType> = new Map([
+  [SEGMENT_TYPE_HOLD, {
+    type: SEGMENT_TYPE_HOLD,
+    parameterCount: 1,
+    create: (parameters, length) => {
+      const [value] = parameters
+      return { type: SEGMENT_TYPE_HOLD, length, unit: value.unit, value }
+    },
+    start: <U extends Unit>(segment: CurveSegment<U>) => (segment as HoldCurveSegment<U>).value,
+    end: <U extends Unit>(segment: CurveSegment<U>) => (segment as HoldCurveSegment<U>).value,
+    endCurve: 'step'
+  }],
+
+  [SEGMENT_TYPE_LINEAR, {
+    type: SEGMENT_TYPE_LINEAR,
+    parameterCount: 2,
+    create: (parameters, length) => {
+      const [start, end] = parameters
+      return { type: SEGMENT_TYPE_LINEAR, length, unit: start.unit, start, end }
+    },
+    start: <U extends Unit>(segment: CurveSegment<U>) => (segment as LinearCurveSegment<U>).start,
+    end: <U extends Unit>(segment: CurveSegment<U>) => (segment as LinearCurveSegment<U>).end,
+    endCurve: 'linear'
+  }]
 ])
+
+export function getCurveSegmentType (type: string): CurveSegmentType | undefined {
+  return curveSegmentTypes.get(type)
+}
 
 export function createCurve<U extends Unit> (segments: ReadonlyArray<CurveSegment<U>>): Curve<U> {
   const unit = segments.at(0)?.unit as U
@@ -42,26 +76,16 @@ export function createCurveSegment<U extends Unit> (
   parameters: ReadonlyArray<Numeric<U>>,
   length = numeric(undefined, 1)
 ): CurveSegment<U> {
-  if (curveParameterCounts.get(type) !== parameters.length) {
+  const definition = curveSegmentTypes.get(type)
+  if (definition == null) {
+    throw new Error(`Unknown curve type: ${type}`)
+  }
+
+  if (definition.parameterCount !== parameters.length) {
     throw new Error('Invalid curve parameters')
   }
 
-  const unit = parameters.at(0)?.unit as U
-
-  switch (type) {
-    case SEGMENT_TYPE_HOLD: {
-      const [value] = parameters
-      return { type, length, unit, value }
-    }
-
-    case SEGMENT_TYPE_LINEAR: {
-      const [start, end] = parameters
-      return { type, length, unit, start, end }
-    }
-
-    default:
-      throw new Error(`Unknown curve type: ${type}`)
-  }
+  return definition.create(parameters, length)
 }
 
 export function renderCurvePoints<U extends Unit> (curve: Curve<U>, timeStart: Numeric<'beats'>, timeEnd: Numeric<'beats'>): ReadonlyArray<AutomationPoint<U>> {
@@ -76,9 +100,9 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, timeStart: N
 
   const getTimeAtWeight = (weight: number) => {
     if (totalWeight === 0) {
-      return timeStart.value
+      return timeStart
     }
-    return timeStart.value + totalDuration * (weight / totalWeight)
+    return numeric('beats', timeStart.value + totalDuration * (weight / totalWeight))
   }
 
   const points: Array<AutomationPoint<U>> = []
@@ -88,23 +112,19 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, timeStart: N
     const segment = segments[i]
     const segmentWeight = segmentWeights[i]
 
-    const segmentStart = getTimeAtWeight(currentWeight)
-    const segmentEnd = i === segments.length - 1
-      ? getTimeAtWeight(totalWeight)
-      : getTimeAtWeight(currentWeight + segmentWeight)
-
-    const endCurve = segment.type === SEGMENT_TYPE_LINEAR && segmentWeight > 0
-      ? 'linear'
-      : 'step'
+    const definition = getCurveSegmentType(segment.type)
+    if (definition == null) {
+      throw new Error(`Unknown curve segment type: ${segment.type}`)
+    }
 
     points.push({
-      time: numeric('beats', segmentStart),
-      value: segment.type === SEGMENT_TYPE_LINEAR ? segment.start : segment.value,
+      time: getTimeAtWeight(currentWeight),
+      value: definition.start(segment),
       curve: 'step'
     }, {
-      time: numeric('beats', segmentEnd),
-      value: segment.type === SEGMENT_TYPE_LINEAR ? segment.end : segment.value,
-      curve: endCurve
+      time: getTimeAtWeight(i === segments.length - 1 ? totalWeight : currentWeight + segmentWeight),
+      value: definition.end(segment),
+      curve: segmentWeight <= 0 ? 'step' : definition.endCurve
     })
 
     currentWeight += segmentWeight

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -4,7 +4,8 @@ import { concatPatterns, createParallelPattern, createSerialPattern, mergePatter
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
 import { busSchema, partSchema, stepSchema, trackSchema } from './common.js'
-import { createCurve, createCurveSegment, renderCurvePoints } from './curves.js'
+import type { CurveSegment as GeneratedCurveSegment } from './curves.js'
+import { createCurve, createCurveSegment, getCurveSegmentType, renderCurvePoints } from './curves.js'
 import { CompileError } from './error.js'
 import { getStandardModule } from './modules.js'
 import type { InferSchema, PropertySchema } from './schema.js'
@@ -441,7 +442,15 @@ function generateCurve (context: Context, curve: ast.Curve): CurveValue {
   assert(segments.length > 0)
   assert(otherChildren.length === 0)
 
-  const generatedSegments = segments.map((segment) => {
+  const generatedSegments: Array<GeneratedCurveSegment<Unit>> = []
+
+  const getPreviousSegmentEnd = (): Numeric<Unit> => {
+    const previous = nonNull(generatedSegments.at(-1))
+    const definition = nonNull(getCurveSegmentType(previous.type))
+    return definition.end(previous)
+  }
+
+  for (const segment of segments) {
     const parameters = segment.parameters.map((point) => {
       return NumberType.cast(resolve(context, point)).data
     })
@@ -450,8 +459,13 @@ function generateCurve (context: Context, curve: ast.Curve): CurveValue {
       ? NumberType.with(undefined).cast(resolve(context, segment.length)).data
       : undefined
 
-    return nonNull(createCurveSegment(segment.curveType, parameters, length))
-  })
+    const { parameterCount } = nonNull(getCurveSegmentType(segment.curveType))
+    const resolvedParameters = parameters.length < parameterCount
+      ? [getPreviousSegmentEnd(), ...parameters]
+      : parameters
+
+    generatedSegments.push(createCurveSegment(segment.curveType, resolvedParameters, length))
+  }
 
   return CurveType.of(
     createCurve(generatedSegments)

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -513,6 +513,145 @@ describe('compiler/checker.ts', () => {
 
       assert.deepStrictEqual(check(program), [])
     })
+
+    it('should accept lin curves that omit the start after the first segment', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'synth' }),
+            value: ast.make('Call', RANGE, {
+              callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+              arguments: [
+                ast.make('String', RANGE, { parts: ['synth.wav'] })
+              ]
+            })
+          }),
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'hold',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -60 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ],
+                          length: ast.make('Number', RANGE, { value: 3 })
+                        }),
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'lin',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: 0 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ],
+                          length: ast.make('Number', RANGE, { value: 1 })
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [])
+    })
+
+    it('should accept hold curves that omit the value after the first segment', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'synth' }),
+            value: ast.make('Call', RANGE, {
+              callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+              arguments: [
+                ast.make('String', RANGE, { parts: ['synth.wav'] })
+              ]
+            })
+          }),
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'lin',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -60 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            }),
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -30 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ],
+                          length: ast.make('Number', RANGE, { value: 3 })
+                        }),
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'hold',
+                          parameters: [],
+                          length: ast.make('Number', RANGE, { value: 1 })
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [])
+    })
   })
 
   describe('invalid', () => {
@@ -713,6 +852,193 @@ describe('compiler/checker.ts', () => {
       })
       assert.deepStrictEqual(check(program), [
         new CompileError('Duplicate part named "intro"', RANGE)
+      ])
+    })
+
+    it('should reject lin curves that omit the start for the first segment', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'synth' }),
+            value: ast.make('Call', RANGE, {
+              callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+              arguments: [
+                ast.make('String', RANGE, { parts: ['synth.wav'] })
+              ]
+            })
+          }),
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'lin',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: 0 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ]
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [
+        new CompileError('First curve segment cannot omit its first parameter', RANGE)
+      ])
+    })
+
+    it('should reject hold curves that omit the value for the first segment', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'synth' }),
+            value: ast.make('Call', RANGE, {
+              callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+              arguments: [
+                ast.make('String', RANGE, { parts: ['synth.wav'] })
+              ]
+            })
+          }),
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'hold',
+                          parameters: []
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [
+        new CompileError('First curve segment cannot omit its first parameter', RANGE)
+      ])
+    })
+
+    it('should reject omitted lin starts when the inherited and explicit units differ', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'synth' }),
+            value: ast.make('Call', RANGE, {
+              callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+              arguments: [
+                ast.make('String', RANGE, { parts: ['synth.wav'] })
+              ]
+            })
+          }),
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'hold',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -60 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ]
+                        }),
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'lin',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: 120 }),
+                              property: ast.make('Identifier', RANGE, { name: 'bpm' })
+                            })
+                          ]
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [
+        new CompileError('Expected type number(db), got number(bpm)', RANGE)
       ])
     })
   })

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -507,6 +507,161 @@ describe('compiler/generator.ts', () => {
     ])
   })
 
+  it('should use the previous segment end when lin start is omitted', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['instruments'] })
+        })
+      ],
+      children: [
+        ast.make('Assignment', RANGE, {
+          key: ast.make('Identifier', RANGE, { name: 'synth' }),
+          value: ast.make('Call', RANGE, {
+            callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+            arguments: [
+              ast.make('String', RANGE, { parts: ['synth.wav'] })
+            ]
+          })
+        }),
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 8 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                    property: ast.make('Identifier', RANGE, { name: 'gain' })
+                  }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'hold',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('Number', RANGE, { value: 3 })
+                      }),
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: 0 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('Number', RANGE, { value: 1 })
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+
+    assert.strictEqual(result.automations.size, 1)
+    const automation = [...result.automations.values()][0]
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 24), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 32), value: numeric('db', 0), curve: 'linear' }
+    ])
+  })
+
+  it('should use the previous segment end when hold value is omitted', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [
+        ast.make('UseStatement', RANGE, {
+          library: ast.make('String', RANGE, { parts: ['instruments'] })
+        })
+      ],
+      children: [
+        ast.make('Assignment', RANGE, {
+          key: ast.make('Identifier', RANGE, { name: 'synth' }),
+          value: ast.make('Call', RANGE, {
+            callee: ast.make('Identifier', RANGE, { name: 'sample' }),
+            arguments: [
+              ast.make('String', RANGE, { parts: ['synth.wav'] })
+            ]
+          })
+        }),
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 8 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Identifier', RANGE, { name: 'synth' }),
+                    property: ast.make('Identifier', RANGE, { name: 'gain' })
+                  }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -60 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -30 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ],
+                        length: ast.make('Number', RANGE, { value: 3 })
+                      }),
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'hold',
+                        parameters: [],
+                        length: ast.make('Number', RANGE, { value: 1 })
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+
+    assert.strictEqual(result.automations.size, 1)
+    const automation = [...result.automations.values()][0]
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('beats', 24), value: numeric('db', -30), curve: 'linear' },
+      { time: numeric('beats', 32), value: numeric('db', -30), curve: 'step' }
+    ])
+  })
+
   it('should clamp non-positive curve segment lengths and step zero-length segments', () => {
     const program = ast.make('Program', RANGE, {
       imports: [

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -749,6 +749,50 @@ describe('parser/parser.ts', () => {
     })
   })
 
+  it('should parse curve segments without parameters', () => {
+    const result = parse(makeTokens([
+      { name: 'word', text: 'foo' },
+      { name: '=' },
+      { name: 'word', text: 'curve' },
+      { name: '[' },
+      { name: 'word', text: 'hold' },
+      { name: 'word', text: 'hold' },
+      { name: ':' },
+      { name: 'number', text: '2' },
+      { name: ']' }
+    ]))
+
+    assert.deepStrictEqual(stripRanges(result), {
+      complete: true,
+      value: {
+        type: 'Program',
+        imports: [],
+        children: [
+          {
+            type: 'Assignment',
+            key: { type: 'Identifier', name: 'foo' },
+            value: {
+              type: 'Curve',
+              children: [
+                {
+                  type: 'CurveSegment',
+                  curveType: 'hold',
+                  parameters: []
+                },
+                {
+                  type: 'CurveSegment',
+                  curveType: 'hold',
+                  parameters: [],
+                  length: { type: 'Number', value: 2 }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    })
+  })
+
   it('should parse property access with function calls', () => {
     // x = object.method1().method2()
     const nonParenthesized = makeTokens([


### PR DESCRIPTION
To avoid having to specify the start point of a curve segment when it is the same as the end point of the previous segment, we can allow curve segments to omit the start point. For example:

```
// these two are equivalent:
curve [lin(-60.db, 0.db) lin(0.db, -12.db)]
curve [lin(-60.db, 0.db) lin(-12.db)]

// these three are also equivalent:
curve [lin(-60.db, 0.db) hold(0.db)]
curve [lin(-60.db, 0.db) hold()]
curve [lin(-60.db, 0.db) hold]
```