### PR TITLE
refactor: Use SourceRange in language support

### DIFF
--- a/packages/app/src/modules/editor/index.ts
+++ b/packages/app/src/modules/editor/index.ts
@@ -142,7 +142,7 @@ const GlobalHooks: FunctionComponent = () => {
         return
       }
 
-      const selection = EditorSelection.single(target.from)
+      const selection = EditorSelection.single(target.range.offset)
       view.dispatch({ selection, scrollIntoView: true })
       view.focus()
     }

--- a/packages/language-support/src/analysis/model.ts
+++ b/packages/language-support/src/analysis/model.ts
@@ -1,19 +1,16 @@
 import type { Tree, TreeCursor } from '@lezer/common'
 import type { LRParser } from '@lezer/lr'
-
-export interface TextLike {
-  readonly length: number
-  readonly sliceString: (from: number, to?: number) => string
-}
+import type { SourceRange } from '../types.js'
+import type { TextLike } from './text.js'
+import { textFromString, toSourceRange } from './text.js'
 
 export type ScopeKind = 'root' | 'track' | 'mixer'
 
 export interface Scope {
   readonly id: string
   readonly kind: ScopeKind
-  readonly from: number
-  readonly to: number
   readonly parentId?: string
+  readonly range: SourceRange
 }
 
 export type BindingKind = 'assignment' | 'use-alias' | 'part' | 'bus'
@@ -23,8 +20,7 @@ export interface Binding {
   readonly kind: BindingKind
   readonly scopeId: string
   readonly name: string
-  readonly from: number
-  readonly to: number
+  readonly range: SourceRange
 }
 
 export interface Model {
@@ -39,8 +35,7 @@ interface BindingInput {
   readonly kind: BindingKind
   readonly scopeId: string
   readonly name: string
-  readonly from: number
-  readonly to: number
+  readonly range: SourceRange
 }
 
 interface DefinitionBindingContext {
@@ -52,15 +47,15 @@ interface DefinitionBindingContext {
 }
 
 export function analyzeTree (tree: Tree, document: TextLike): Model {
-  const rootScopeId = scopeKey('Root', 0, document.length)
+  const rootRange = toSourceRange(document, 0, document.length)
+
+  const rootScopeId = scopeKey('Root', rootRange)
 
   const scopes = new Map<string, Scope>()
-
   scopes.set(rootScopeId, {
     id: rootScopeId,
     kind: 'root',
-    from: 0,
-    to: document.length
+    range: rootRange
   })
 
   const bindings: Binding[] = []
@@ -68,9 +63,9 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
   const bindingsByScope = new Map<string, Binding[]>()
 
   const addBinding = (input: BindingInput): void => {
-    const { kind, scopeId, name, from, to } = input
+    const { kind, scopeId, name, range } = input
 
-    const binding = { ...input, id: bindingKey(kind, scopeId, from, to) }
+    const binding = { ...input, id: bindingKey(kind, scopeId, range) }
     bindings.push(binding)
 
     appendIndexedValue(bindingsByName, name, binding)
@@ -91,6 +86,8 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
     const from = cursor.from
     const to = cursor.to
 
+    const range = toSourceRange(document, from, to)
+
     const nextParentType = typeName
 
     let nextScopeId = currentScopeId
@@ -100,16 +97,16 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
 
     switch (typeName) {
       case 'TrackStatement': {
-        const id = scopeKey(typeName, from, to)
-        scopes.set(id, { id, kind: 'track', from, to, parentId: currentScopeId })
+        const id = scopeKey(typeName, range)
+        scopes.set(id, { id, kind: 'track', range, parentId: currentScopeId })
         nextScopeId = id
         nextTrackScopeId = id
         break
       }
 
       case 'MixerStatement': {
-        const id = scopeKey(typeName, from, to)
-        scopes.set(id, { id, kind: 'mixer', from, to, parentId: currentScopeId })
+        const id = scopeKey(typeName, range)
+        scopes.set(id, { id, kind: 'mixer', range, parentId: currentScopeId })
         nextScopeId = id
         nextMixerScopeId = id
         break
@@ -132,7 +129,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
         })
 
         if (binding != null) {
-          addBinding({ ...binding, name, from, to })
+          addBinding({ ...binding, name, range })
         }
 
         break
@@ -141,7 +138,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
       case 'UseAlias': {
         const name = document.sliceString(from, to)
         if (name !== '*') {
-          addBinding({ kind: 'use-alias', scopeId: currentScopeId, name, from, to })
+          addBinding({ kind: 'use-alias', scopeId: currentScopeId, name, range })
         }
         break
       }
@@ -162,18 +159,15 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
 
 export function analyzeSourceWithParser (parser: LRParser, source: string): Model {
   const tree = parser.parse(source)
-  return analyzeTree(tree, {
-    length: source.length,
-    sliceString: (from, to) => source.slice(from, to)
-  })
+  return analyzeTree(tree, textFromString(source))
 }
 
-export function scopeKey (typeName: string, from: number, to: number): string {
-  return `${typeName}:${from}:${to}`
+export function scopeKey (typeName: string, range: SourceRange): string {
+  return `${typeName}:${range.offset}:${range.length}`
 }
 
-function bindingKey (kind: BindingKind, scopeId: string, from: number, to: number): string {
-  return `${kind}:${scopeId}:${from}:${to}`
+function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): string {
+  return `${kind}:${scopeId}:${range.offset}:${range.length}`
 }
 
 function appendIndexedValue<Key, Value> (index: Map<Key, Value[]>, key: Key, value: Value): void {
@@ -186,7 +180,7 @@ function appendIndexedValue<Key, Value> (index: Map<Key, Value[]>, key: Key, val
   values.push(value)
 }
 
-function getDefinitionBinding (context: DefinitionBindingContext): Omit<BindingInput, 'name' | 'from' | 'to'> | undefined {
+function getDefinitionBinding (context: DefinitionBindingContext): Omit<BindingInput, 'name' | 'range'> | undefined {
   switch (context.parentType) {
     case 'Assignment':
       return context.assignmentHasEquals

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -1,19 +1,16 @@
 import type { SyntaxNode, Tree } from '@lezer/common'
-import type { Binding, BindingKind, Model, TextLike } from './model.js'
+import type { SourceRange } from '../types.js'
+import type { Binding, BindingKind, Model } from './model.js'
 import { scopeKey } from './model.js'
-
-export interface WordRange {
-  readonly from: number
-  readonly to: number
-}
+import type { TextLike } from './text.js'
+import { toSourceRange } from './text.js'
 
 export type IdentifierKind = typeof IDENTIFIER_KINDS[number]
 
 export interface SemanticOccurrence {
   readonly kind: IdentifierKind | undefined
   readonly name: string
-  readonly from: number
-  readonly to: number
+  readonly range: SourceRange
   readonly node?: SyntaxNode
 }
 
@@ -33,11 +30,17 @@ function isIdentifierKind (value: string): value is IdentifierKind {
   return IDENTIFIER_KINDS.includes(value as IdentifierKind)
 }
 
-export function findIdentifierRangeAt (tree: Tree, document: TextLike, position: number): WordRange | undefined {
+export function sameRange (a: SourceRange, b: SourceRange): boolean {
+  return a.offset === b.offset && a.length === b.length
+}
+
+export function findIdentifierRangeAt (tree: Tree, document: TextLike, position: number): SourceRange | undefined {
   const node = findIdentifierNodeAt(tree, position)
-  return node != null
-    ? { from: node.from, to: node.to }
-    : getWordRangeAt(document, position)
+  if (node == null) {
+    return undefined
+  }
+
+  return toSourceRange(document, node.from, node.to)
 }
 
 export function findDefinitionBindingAt (model: Model, tree: Tree, document: TextLike, position: number): Binding | undefined {
@@ -53,15 +56,14 @@ function findSemanticOccurrenceAt (tree: Tree, document: TextLike, position: num
     return {
       kind: node.type.name as IdentifierKind,
       name: document.sliceString(node.from, node.to),
-      from: node.from,
-      to: node.to,
-      node
+      node,
+      range: toSourceRange(document, node.from, node.to)
     }
   }
 
   const range = getWordRangeAt(document, position)
   return range != null
-    ? { ...range, kind: undefined, name: document.sliceString(range.from, range.to) }
+    ? { kind: undefined, name: document.sliceString(range.offset, range.offset + range.length), range }
     : undefined
 }
 
@@ -81,16 +83,15 @@ function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence,
       return findFirstGlobalBinding(model, name)
   }
 
-  const root = findAccessChainRootBefore(document, occurrence.from)
+  const root = findAccessChainRootBefore(document, occurrence.range.offset)
   if (root != null) {
-    const rootName = document.sliceString(root.from, root.to)
+    const rootName = document.sliceString(root.offset, root.offset + root.length)
     if (rootName.length > 0 && rootName !== name) {
       const resolvedRoot = resolveDefinitionBinding(model, {
         kind: 'VariableName',
         name: rootName,
-        from: root.from,
-        to: root.to,
-        node: occurrence.node
+        node: occurrence.node,
+        range: root
       }, document)
 
       if (resolvedRoot != null) {
@@ -99,7 +100,7 @@ function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence,
     }
   }
 
-  const trackScopeId = findEnclosingScopeId(occurrence.node, 'TrackStatement')
+  const trackScopeId = findEnclosingScopeId(document, occurrence.node, 'TrackStatement')
   if (trackScopeId != null) {
     const definition = findScopedBinding(model, trackScopeId, name, 'part')
     if (definition != null) {
@@ -107,7 +108,7 @@ function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence,
     }
   }
 
-  const mixerScopeId = findEnclosingScopeId(occurrence.node, 'MixerStatement')
+  const mixerScopeId = findEnclosingScopeId(document, occurrence.node, 'MixerStatement')
   if (mixerScopeId != null) {
     const definition = findScopedBinding(model, mixerScopeId, name, 'bus')
     if (definition != null) {
@@ -144,7 +145,7 @@ function getEffectiveOccurrenceKind (occurrence: SemanticOccurrence, document: T
 
 function findBindingBySpan (model: Model, occurrence: SemanticOccurrence): Binding | undefined {
   const bindings = model.bindingsByName.get(occurrence.name)
-  return bindings?.find((binding) => binding.from === occurrence.from && binding.to === occurrence.to)
+  return bindings?.find((binding) => sameRange(binding.range, occurrence.range))
 }
 
 function findFirstGlobalBinding (model: Model, name: string): Binding | undefined {
@@ -196,7 +197,7 @@ function findIdentifierNodeAt (tree: Tree, position: number): SyntaxNode | undef
   return undefined
 }
 
-function getWordRangeAt (document: TextLike, position: number): WordRange | undefined {
+function getWordRangeAt (document: TextLike, position: number): SourceRange | undefined {
   if (position < 0 || position > document.length) {
     return undefined
   }
@@ -218,26 +219,30 @@ function getWordRangeAt (document: TextLike, position: number): WordRange | unde
     ++to
   }
 
-  return { from, to }
+  return toSourceRange(document, from, to)
 }
 
-function findEnclosingScopeId (node: SyntaxNode | undefined, scopeTypeName: 'TrackStatement' | 'MixerStatement'): string | undefined {
+function findEnclosingScopeId (
+  document: TextLike,
+  node: SyntaxNode | undefined,
+  scopeTypeName: 'TrackStatement' | 'MixerStatement'
+): string | undefined {
   for (let current = node; current != null; current = current.parent ?? undefined) {
     if (current.type.name === scopeTypeName) {
-      return scopeKey(current.type.name, current.from, current.to)
+      return scopeKey(current.type.name, toSourceRange(document, current.from, current.to))
     }
   }
 
   return undefined
 }
 
-function findAccessChainRootBefore (document: TextLike, memberFrom: number): WordRange | undefined {
+function findAccessChainRootBefore (document: TextLike, memberFrom: number): SourceRange | undefined {
   const dot = charBeforeNonWhitespace(document, memberFrom)
   if (dot == null || dot.char !== '.') {
     return undefined
   }
 
-  let root: WordRange | undefined
+  let root: SourceRange | undefined
   let currentDotIndex = dot.index
 
   while (currentDotIndex >= 0) {
@@ -249,7 +254,7 @@ function findAccessChainRootBefore (document: TextLike, memberFrom: number): Wor
 
     root = range
 
-    const beforeWord = charBeforeNonWhitespace(document, range.from)
+    const beforeWord = charBeforeNonWhitespace(document, range.offset)
     if (beforeWord == null || beforeWord.char !== '.') {
       break
     }

--- a/packages/language-support/src/analysis/text.ts
+++ b/packages/language-support/src/analysis/text.ts
@@ -1,0 +1,84 @@
+import type { SourceRange } from '../types.js'
+
+export interface TextLine {
+  readonly from: number
+  readonly number: number
+}
+
+export interface TextLike {
+  readonly length: number
+  readonly sliceString: (from: number, to?: number) => string
+  readonly lineAt: (position: number) => TextLine
+}
+
+export function textFromString (source: string): TextLike {
+  const lineStarts = getLineStarts(source)
+
+  return {
+    length: source.length,
+    sliceString: (from, to) => source.slice(from, to),
+    lineAt: (position) => {
+      if (position < 0 || position > source.length) {
+        throw new RangeError(`Invalid position ${position} in document of length ${source.length}`)
+      }
+
+      const lineIndex = findLineIndex(lineStarts, position)
+      return {
+        from: lineStarts[lineIndex],
+        number: lineIndex + 1
+      }
+    }
+  }
+}
+
+export function toSourceRange (document: TextLike, from: number, to: number): SourceRange {
+  const line = document.lineAt(from)
+
+  return {
+    offset: from,
+    length: to - from,
+    line: line.number,
+    column: from - line.from + 1
+  }
+}
+
+function getLineStarts (source: string): readonly number[] {
+  const lineStarts = [0]
+
+  for (let index = 0; index < source.length; ++index) {
+    switch (source[index]) {
+      case '\r': {
+        if (source[index + 1] === '\n') {
+          ++index
+        }
+
+        lineStarts.push(index + 1)
+        break
+      }
+
+      case '\n': {
+        lineStarts.push(index + 1)
+        break
+      }
+    }
+  }
+
+  return lineStarts
+}
+
+function findLineIndex (lineStarts: readonly number[], position: number): number {
+  let low = 0
+  let high = lineStarts.length
+
+  while (low + 1 < high) {
+    const middle = Math.floor((low + high) / 2)
+
+    if (lineStarts[middle] <= position) {
+      low = middle
+    } else {
+      high = middle
+    }
+  }
+
+  return low
+}

--- a/packages/language-support/src/go-to-definition/extension.ts
+++ b/packages/language-support/src/go-to-definition/extension.ts
@@ -3,8 +3,8 @@ import type { Extension } from '@codemirror/state'
 import { EditorSelection, StateEffect, StateField } from '@codemirror/state'
 import type { DecorationSet, ViewUpdate } from '@codemirror/view'
 import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
-import type { WordRange } from '../analysis/query.js'
-import { findIdentifierRangeAt } from '../analysis/query.js'
+import { findIdentifierRangeAt, sameRange } from '../analysis/query.js'
+import type { SourceRange } from '../types.js'
 import { goToDefinitionInTree } from './operation.js'
 
 function isApplePlatform (): boolean {
@@ -29,9 +29,9 @@ function isPrimaryModifierKey (key: string): boolean {
   return APPLE_PLATFORM ? key === 'Meta' : key === 'Control'
 }
 
-function rangeContainsMouseX (view: EditorView, range: WordRange, mouse: MousePosition): boolean {
-  const start = view.coordsAtPos(range.from)
-  const end = view.coordsAtPos(range.to)
+function rangeContainsMouseX (view: EditorView, range: SourceRange, mouse: MousePosition): boolean {
+  const start = view.coordsAtPos(range.offset)
+  const end = view.coordsAtPos(range.offset + range.length)
   if (start == null || end == null) {
     return false
   }
@@ -55,7 +55,7 @@ const theme = EditorView.baseTheme({
   }
 })
 
-const setHover = StateEffect.define<WordRange | undefined>()
+const setHover = StateEffect.define<SourceRange | undefined>()
 
 const hoverDecorations = StateField.define<DecorationSet>({
   create: () => Decoration.none,
@@ -74,7 +74,7 @@ const hoverDecorations = StateField.define<DecorationSet>({
 
       next = effect.value == null
         ? Decoration.none
-        : Decoration.set([hoverMark.range(effect.value.from, effect.value.to)])
+        : Decoration.set([hoverMark.range(effect.value.offset, effect.value.offset + effect.value.length)])
     }
 
     return next
@@ -83,18 +83,14 @@ const hoverDecorations = StateField.define<DecorationSet>({
   provide: (field) => EditorView.decorations.from(field)
 })
 
-function sameRange (a: WordRange | undefined, b: WordRange | undefined): boolean {
-  return a?.from === b?.from && a?.to === b?.to
-}
-
 interface MousePosition {
   readonly x: number
   readonly y: number
 }
 
 interface HoverMeasure {
-  readonly hoverRange: WordRange | undefined
-  readonly underlineRange: WordRange | undefined
+  readonly hoverRange: SourceRange | undefined
+  readonly underlineRange: SourceRange | undefined
 }
 
 interface MeasureRequest<T> {
@@ -110,9 +106,9 @@ class GoToDefinitionInteractionsPlugin {
 
   private lastMousePosition: MousePosition | undefined
   private modifierHeld = false
-  private lastHoverRange: WordRange | undefined
-  private lastDispatchedRange: WordRange | undefined
-  private pendingHoverDispatchRange: WordRange | undefined
+  private lastHoverRange: SourceRange | undefined
+  private lastDispatchedRange: SourceRange | undefined
+  private pendingHoverDispatchRange: SourceRange | undefined
   private hoverDispatchScheduled = false
 
   constructor (view: EditorView) {
@@ -223,7 +219,7 @@ class GoToDefinitionInteractionsPlugin {
     event.preventDefault()
     event.stopPropagation()
 
-    const selection = EditorSelection.single(target.from)
+    const selection = EditorSelection.single(target.range.offset)
     this.view.dispatch({ selection, scrollIntoView: true })
     this.view.focus()
   }
@@ -248,7 +244,7 @@ class GoToDefinitionInteractionsPlugin {
       return
     }
 
-    if (sameRange(range, this.lastHoverRange)) {
+    if (this.lastHoverRange != null && sameRange(range, this.lastHoverRange)) {
       return
     }
 
@@ -265,7 +261,7 @@ class GoToDefinitionInteractionsPlugin {
     this.scheduleHoverDispatch(range)
   }
 
-  private scheduleHoverDispatch (range: WordRange | undefined): void {
+  private scheduleHoverDispatch (range: SourceRange | undefined): void {
     this.pendingHoverDispatchRange = range
     if (this.hoverDispatchScheduled) {
       return
@@ -290,10 +286,15 @@ class GoToDefinitionInteractionsPlugin {
     })
   }
 
-  private dispatchHover (range: WordRange | undefined): void {
-    if (!sameRange(this.lastDispatchedRange, range)) {
+  private dispatchHover (range: SourceRange | undefined): void {
+    if (
+      (this.lastDispatchedRange == null && range != null) ||
+      (this.lastDispatchedRange != null && range == null) ||
+      (this.lastDispatchedRange != null && range != null && !sameRange(this.lastDispatchedRange, range))
+    ) {
       this.view.dispatch({ effects: setHover.of(range) })
     }
+
     this.lastDispatchedRange = range
   }
 }

--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -1,13 +1,14 @@
 import type { Tree } from '@lezer/common'
 import type { LRParser } from '@lezer/lr'
-import type { TextLike } from '../analysis/model.js'
 import { analyzeTree } from '../analysis/model.js'
 import { findDefinitionBindingAt } from '../analysis/query.js'
+import type { SourceRange } from '../types.js'
+import type { TextLike } from '../analysis/text.js'
+import { textFromString } from '../analysis/text.js'
 
 export interface GoToDefinitionResult {
   readonly name: string
-  readonly from: number
-  readonly to: number
+  readonly range: SourceRange
 }
 
 export function goToDefinitionInTree (tree: Tree, document: TextLike, pos: number): GoToDefinitionResult | undefined {
@@ -17,13 +18,10 @@ export function goToDefinitionInTree (tree: Tree, document: TextLike, pos: numbe
     return undefined
   }
 
-  return { name: binding.name, from: binding.from, to: binding.to }
+  return { name: binding.name, range: binding.range }
 }
 
 export function goToDefinitionWithParser (parser: LRParser, source: string, pos: number): GoToDefinitionResult | undefined {
   const tree = parser.parse(source)
-  return goToDefinitionInTree(tree, {
-    length: source.length,
-    sliceString: (from, to) => source.slice(from, to)
-  }, pos)
+  return goToDefinitionInTree(tree, textFromString(source), pos)
 }

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -1,3 +1,7 @@
+// main language support exports
+export type * from './types.js'
 export { cadenceLanguageSupport } from './language-support.js'
+
+// "go to definition" feature
 export { goToDefinitionInTree, goToDefinitionWithParser } from './go-to-definition/operation.js'
 export { goToDefinitionExtension } from './go-to-definition/extension.js'

--- a/packages/language-support/src/types.ts
+++ b/packages/language-support/src/types.ts
@@ -1,0 +1,6 @@
+export interface SourceRange {
+  readonly offset: number
+  readonly length: number
+  readonly line: number
+  readonly column: number
+}

--- a/packages/language-support/test/analysis/query.test.ts
+++ b/packages/language-support/test/analysis/query.test.ts
@@ -1,23 +1,21 @@
+import type { Tree } from '@lezer/common'
 import { buildParser } from '@lezer/generator'
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { describe, it } from 'node:test'
 import { analyzeTree } from '../../src/analysis/model.js'
 import { findDefinitionBindingAt } from '../../src/analysis/query.js'
+import { getRangeAt } from '../helpers.js'
+import type { TextLike } from '../../src/analysis/text.js'
+import { textFromString } from '../../src/analysis/text.js'
 
 const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
 const cadenceParser = buildParser(cadenceGrammar)
 
-function parseDocument (source: string): {
-  readonly tree: ReturnType<typeof cadenceParser.parse>
-  readonly document: { readonly length: number, readonly sliceString: (from: number, to?: number) => string }
-} {
+function parseDocument (source: string): Readonly<{ tree: Tree, document: TextLike }> {
   return {
     tree: cadenceParser.parse(source),
-    document: {
-      length: source.length,
-      sliceString: (from, to) => source.slice(from, to)
-    }
+    document: textFromString(source)
   }
 }
 
@@ -41,7 +39,9 @@ describe('analysis/query.ts', () => {
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'assignment')
     assert.strictEqual(binding.name, 'kick')
-    assert.strictEqual(binding.from, source.indexOf('kick ='))
+
+    const kickOffset = source.indexOf('kick =')
+    assert.deepStrictEqual(binding.range, getRangeAt(source, kickOffset, 'kick'.length))
   })
 
   it('resolves member access through the root identifier', () => {
@@ -64,7 +64,9 @@ describe('analysis/query.ts', () => {
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'assignment')
     assert.strictEqual(binding.name, 'synth')
-    assert.strictEqual(binding.from, source.indexOf('synth ='))
+
+    const synthOffset = source.indexOf('synth =')
+    assert.deepStrictEqual(binding.range, getRangeAt(source, synthOffset, 'synth'.length))
   })
 
   it('does not resolve named argument keys', () => {
@@ -97,6 +99,8 @@ describe('analysis/query.ts', () => {
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'use-alias')
     assert.strictEqual(binding.name, 'fx')
-    assert.strictEqual(binding.from, source.indexOf('as fx') + 'as '.length)
+
+    const aliasOffset = source.indexOf('use "effects" as fx') + 'use "effects" as '.length
+    assert.deepStrictEqual(binding.range, getRangeAt(source, aliasOffset, 'fx'.length))
   })
 })

--- a/packages/language-support/test/analysis/text.test.ts
+++ b/packages/language-support/test/analysis/text.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { textFromString, toSourceRange } from '../../src/analysis/text.js'
+
+describe('analysis/text.ts', () => {
+  describe('textFromString()', () => {
+    it('maps offsets to the correct line starts across mixed newlines', () => {
+      const source = 'alpha\r\nbeta\rgamma\ndelta'
+      const text = textFromString(source)
+
+      assert.deepStrictEqual(text.lineAt(0), { from: 0, number: 1 })
+      assert.deepStrictEqual(text.lineAt(source.indexOf('beta')), { from: 7, number: 2 })
+      assert.deepStrictEqual(text.lineAt(source.indexOf('gamma')), { from: 12, number: 3 })
+      assert.deepStrictEqual(text.lineAt(source.indexOf('delta')), { from: 18, number: 4 })
+      assert.deepStrictEqual(text.lineAt(source.length), { from: 18, number: 4 })
+    })
+
+    it('throws for positions outside the document bounds', () => {
+      const text = textFromString('tempo = 128.bpm')
+
+      assert.throws(() => text.lineAt(-1), /Invalid position -1/)
+      assert.throws(() => text.lineAt(text.length + 1), new RegExp(`Invalid position ${text.length + 1}`))
+    })
+
+    it('creates source ranges with 1-based line and column values', () => {
+      const source = [
+        'kick = sample("/samples/kick.wav")',
+        'snare = sample("/samples/snare.wav")',
+        '  clap = sample("/samples/clap.wav")',
+        ''
+      ].join('\n')
+
+      const text = textFromString(source)
+      const snareOffset = source.indexOf('snare =')
+      const clapOffset = source.indexOf('clap =')
+
+      assert.deepStrictEqual(toSourceRange(text, snareOffset, snareOffset + 'snare'.length), {
+        offset: snareOffset,
+        length: 'snare'.length,
+        line: 2,
+        column: 1
+      })
+
+      assert.deepStrictEqual(toSourceRange(text, clapOffset, clapOffset + 'clap'.length), {
+        offset: clapOffset,
+        length: 'clap'.length,
+        line: 3,
+        column: 3
+      })
+    })
+  })
+})

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { describe, it } from 'node:test'
 import { goToDefinitionWithParser } from '../../src/go-to-definition/operation.js'
+import { getRangeAt } from '../helpers.js'
 
 const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
 const cadenceParser = buildParser(cadenceGrammar)
@@ -20,9 +21,8 @@ describe('go-to-definition/operation.ts', () => {
     assert.ok(def)
 
     const defFrom = source.indexOf('foo')
-    assert.strictEqual(def.from, defFrom)
-    assert.strictEqual(def.to, defFrom + 'foo'.length)
     assert.strictEqual(def.name, 'foo')
+    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 'foo'.length))
   })
 
   it('resolves bus references inside mixer', () => {
@@ -33,9 +33,8 @@ describe('go-to-definition/operation.ts', () => {
     assert.ok(def)
 
     const defFrom = source.indexOf('bus a') + 'bus '.length
-    assert.strictEqual(def.from, defFrom)
-    assert.strictEqual(def.to, defFrom + 1)
     assert.strictEqual(def.name, 'a')
+    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 1))
   })
 
   it('resolves import alias usage', () => {
@@ -50,9 +49,8 @@ describe('go-to-definition/operation.ts', () => {
     assert.ok(def)
 
     const defFrom = source.indexOf('as lib') + 'as '.length
-    assert.strictEqual(def.from, defFrom)
-    assert.strictEqual(def.to, defFrom + 'lib'.length)
     assert.strictEqual(def.name, 'lib')
+    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 'lib'.length))
   })
 
   it('tolerates incomplete input', () => {
@@ -63,9 +61,8 @@ describe('go-to-definition/operation.ts', () => {
     assert.ok(def)
 
     const defFrom = source.indexOf('bus a') + 'bus '.length
-    assert.strictEqual(def.from, defFrom)
-    assert.strictEqual(def.to, defFrom + 1)
     assert.strictEqual(def.name, 'a')
+    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 1))
   })
 
   it('does not resolve member access by member name', () => {
@@ -87,9 +84,8 @@ describe('go-to-definition/operation.ts', () => {
     assert.ok(def)
 
     const synthFrom = source.indexOf('\nsynth =') + 1
-    assert.strictEqual(def.from, synthFrom)
-    assert.strictEqual(def.to, synthFrom + 'synth'.length)
     assert.strictEqual(def.name, 'synth')
+    assert.deepStrictEqual(def.range, getRangeAt(source, synthFrom, 'synth'.length))
   })
 
   it('does not resolve named argument keys', () => {

--- a/packages/language-support/test/helpers.ts
+++ b/packages/language-support/test/helpers.ts
@@ -1,0 +1,10 @@
+export function getRangeAt (source: string, offset: number, length: number) {
+  const lines = source.slice(0, offset).split(/(?:\r\n|\r|\n)/)
+
+  return {
+    offset,
+    length,
+    line: lines.length,
+    column: (lines.at(-1)?.length ?? 0) + 1
+  }
+}


### PR DESCRIPTION
Language support analysis now uses a range type that includes line and column information, in addition to plain offsets. This will help when implementing diagnostics.