### PR TITLE
feat: Add unused variable analysis and diagnostics

### DIFF
--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -1,11 +1,13 @@
-import type { SourceRange } from '@ast'
+import { syntaxTree } from '@codemirror/language'
 import type { Diagnostic } from '@codemirror/lint'
-import type { EditorView } from '@codemirror/view'
-import type { EditorLocation, PanelProps } from '@editor'
-import { Editor, getProjectFileContent, setProjectFileContent, useProjectSource, useProjectSourceDispatch } from '@editor'
-import { cadenceLanguageSupport, goToDefinitionExtension } from '@language-support'
+import type { EditorView, ViewUpdate } from '@codemirror/view'
+import type { EditorLocation, PanelProps, Problem } from '@editor'
+import { Editor, getProjectFileContent, setProjectFileContent, useProjectSource, useProjectSourceDispatch, useProvideProblems } from '@editor'
+import type { RangeError } from '@language'
+import type { LanguageDiagnostic, SourceRange } from '@language-support'
+import { cadenceLanguageSupport, findUnusedVariablesInTree, goToDefinitionExtension } from '@language-support'
 import type { FunctionComponent } from 'react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useCompilationState } from '../../../compilation/CompilationContext.js'
 import { getCspNonce } from '../../../csp.js'
 import { useEffectiveTheme } from '../../../theme.js'
@@ -19,11 +21,21 @@ const extensions = [
   goToDefinitionExtension()
 ]
 
-function convertError (message: string, range: SourceRange | undefined): Diagnostic {
+function getCompilerDiagnostics (filePath: string, errors: readonly RangeError[]): readonly Diagnostic[] {
+  return errors
+    .filter((error) => error.range?.filePath === filePath)
+    .map((error) => toDiagnostic('error', error.message, error.range))
+}
+
+function getLanguageDiagnostics (diagnostics: readonly LanguageDiagnostic[]): readonly Diagnostic[] {
+  return diagnostics.map((item) => toDiagnostic('warning', item.message, item.range))
+}
+
+function toDiagnostic (severity: 'error' | 'warning', message: string, range: SourceRange | undefined): Diagnostic {
   return {
     from: range?.offset ?? 0,
     to: (range?.offset ?? 0) + (range?.length ?? 0),
-    severity: 'error',
+    severity,
     message
   }
 }
@@ -32,6 +44,8 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
   const { filePath } = getEditorPanelProps(panelProps)
   const source = useProjectSource()
   const sourceDispatch = useProjectSourceDispatch()
+  const [analysisRevision, setAnalysisRevision] = useState(0)
+  const [editorView, setEditorView] = useState<EditorView>()
 
   const code = getProjectFileContent(source, filePath) ?? ''
 
@@ -44,7 +58,14 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
 
   const onEditorViewChange = useCallback((view: EditorView | undefined) => {
     editorRuntime.viewRef.current = view
+    setEditorView(view)
   }, [editorRuntime])
+
+  const onEditorViewUpdate = useCallback((update: ViewUpdate) => {
+    if (syntaxTree(update.startState) !== syntaxTree(update.state)) {
+      setAnalysisRevision((value) => value + 1)
+    }
+  }, [])
 
   const onLocationChange = useCallback((caret: EditorLocation | undefined) => {
     editorDispatch((prev) => ({ ...prev, carets: { ...prev.carets, [tabId]: caret } }))
@@ -53,12 +74,33 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
   const effectiveTheme = useEffectiveTheme()
   const theme = effectiveTheme === 'dark' ? cadenceDarkTheme : cadenceLightTheme
 
+  const unusedVariables = useMemo(() => {
+    return editorView != null
+      ? findUnusedVariablesInTree(syntaxTree(editorView.state), editorView.state.doc)
+      : []
+  }, [analysisRevision, editorView])
+
   const { result: { errors } } = useCompilationState()
   const diagnostics = useMemo(() => {
-    return errors
-      .filter((error) => error.range?.filePath === filePath)
-      .map((error) => convertError(error.message, error.range))
-  }, [errors, filePath])
+    return [
+      ...getCompilerDiagnostics(filePath, errors),
+      ...getLanguageDiagnostics(unusedVariables)
+    ]
+  }, [errors, filePath, unusedVariables])
+
+  const problems = useMemo(() => {
+    return unusedVariables.map((diagnostic): Problem => ({
+      kind: 'warning',
+      label: 'Analysis',
+      message: diagnostic.message,
+      range: {
+        ...diagnostic.range,
+        filePath
+      }
+    }))
+  }, [unusedVariables, filePath])
+
+  useProvideProblems(problems)
 
   return (
     <Editor
@@ -71,6 +113,7 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
       className='relative h-full overflow-hidden'
       onChange={onChange}
       onEditorViewChange={onEditorViewChange}
+      onEditorViewUpdate={onEditorViewUpdate}
       onLocationChange={onLocationChange}
     />
   )

--- a/packages/app/src/modules/editor/index.ts
+++ b/packages/app/src/modules/editor/index.ts
@@ -1,6 +1,6 @@
 import { syntaxTree } from '@codemirror/language'
 import { EditorSelection } from '@codemirror/state'
-import type { CommandId, MenuId, MenuSectionId, Module, ModuleId, PanelId, ProblemInput } from '@editor'
+import type { CommandId, MenuId, MenuSectionId, Module, ModuleId, PanelId, Problem } from '@editor'
 import { activateTabOfType, getProjectFileContent, setProjectFileContent, useDialogService, useLatestRef, useLayout, useLayoutDispatch, useProjectSource, useProjectSourceDispatch, useProvideProblems, useRegisterCommand } from '@editor'
 import { goToDefinitionInTree } from '@language-support'
 import type { FunctionComponent } from 'react'
@@ -57,10 +57,11 @@ const GlobalHooks: FunctionComponent = () => {
 
   const { result: { errors } } = useCompilationState()
   const problems = useMemo(() => {
-    return errors.map((error): ProblemInput => ({
+    return errors.map((error): Problem => ({
       kind: 'error',
       label: 'Compiler',
       message: error.message,
+      range: error.range,
       error
     }))
   }, [errors])
@@ -148,7 +149,7 @@ const GlobalHooks: FunctionComponent = () => {
     }
   }), [])
 
-  useProvideProblems(moduleId, problems)
+  useProvideProblems(problems)
 
   return null
 }

--- a/packages/app/src/modules/editor/theme.ts
+++ b/packages/app/src/modules/editor/theme.ts
@@ -44,7 +44,8 @@ const darkColors = {
   cursor: '#528bff',
   matchingBracket: '#bad0f847',
   selectionMatchBackground: '#aafe661a',
-  diagnosticError: '#ff605a'
+  diagnosticError: '#ff605a',
+  diagnosticWarning: '#ffb347'
 }
 
 const lightColors = {
@@ -75,7 +76,8 @@ const lightColors = {
   cursor: '#526eff',
   matchingBracket: '#7894e847',
   selectionMatchBackground: '#504ebf22',
-  diagnosticError: '#d00010'
+  diagnosticError: '#d00010',
+  diagnosticWarning: '#a08000'
 }
 
 // The editor theme styles for this theme.
@@ -168,13 +170,27 @@ const cadenceEditorTheme = (dark: boolean) => {
       borderLeftColor: colors.diagnosticError
     },
 
+    '.cm-diagnostic-warning': {
+      borderLeftColor: colors.diagnosticWarning
+    },
+
     '.cm-lintRange-error': {
       backgroundImage: createUnderline(colors.diagnosticError)
+    },
+
+    '.cm-lintRange-warning': {
+      backgroundImage: createUnderline(colors.diagnosticWarning)
     },
 
     '.cm-lintPoint-error': {
       '&:after': {
         borderBottomColor: colors.diagnosticError
+      }
+    },
+
+    '.cm-lintPoint-warning': {
+      '&:after': {
+        borderBottomColor: colors.diagnosticWarning
       }
     }
   }, { dark })

--- a/packages/app/src/modules/playback/index.ts
+++ b/packages/app/src/modules/playback/index.ts
@@ -1,5 +1,5 @@
 import { createAudioGraph } from '@audiograph'
-import type { CommandId, MenuSectionId, Module, ModuleId, PanelId, ProblemInput } from '@editor'
+import type { CommandId, MenuSectionId, Module, ModuleId, PanelId, Problem } from '@editor'
 import { activateTabOfType, useLatestRef, useLayoutDispatch, useNotificationService, useObservable, useProvideProblems, useRegisterCommand } from '@editor'
 import { numeric } from '@utility'
 import type { FunctionComponent } from 'react'
@@ -31,7 +31,7 @@ const GlobalHooks: FunctionComponent = () => {
   const audioEngine = useAudioEngine()
   const errors = useObservable(audioEngine.errors)
   const problems = useMemo(() => {
-    return errors.map((error): ProblemInput => ({
+    return errors.map((error): Problem => ({
       kind: 'error',
       label: 'Playback',
       message: error.message,
@@ -77,7 +77,7 @@ const GlobalHooks: FunctionComponent = () => {
     }
   }), [])
 
-  useProvideProblems(moduleId, problems)
+  useProvideProblems(problems)
 
   return null
 }

--- a/packages/app/src/modules/problems/ProblemsPanel.tsx
+++ b/packages/app/src/modules/problems/ProblemsPanel.tsx
@@ -1,5 +1,4 @@
-import type { SourceRange } from '@ast'
-import type { PanelProps, ProblemKind } from '@editor'
+import type { PanelProps, ProblemKind, ProblemRange } from '@editor'
 import { useProblems } from '@editor'
 import { RangeError } from '@language'
 import { Error, Warning } from '@mui/icons-material'
@@ -18,22 +17,26 @@ export const ProblemsPanel: FunctionComponent<PanelProps> = () => {
           </div>
         )}
 
-        {problems.map(({ kind, label, message, error }, index) => (
-          <div key={index}>
-            <span className='text-content-100 mr-1'>
-              {renderIconForProblemKind(kind)}
-            </span>
-            <span className='text-content-100'>
-              {`${label}: `}
-            </span>
-            {message}
-            {error instanceof RangeError && error.range != null && (
-              <span className='text-content-100 text-sm'>
-                {` (${stringifyRange(error.range)})`}
+        {problems.map(({ kind, label, message, range, error }, index) => {
+          const problemRange = range ?? (error instanceof RangeError ? error.range : undefined)
+
+          return (
+            <div key={index}>
+              <span className='text-content-100 mr-1'>
+                {renderIconForProblemKind(kind)}
               </span>
-            )}
-          </div>
-        ))}
+              <span className='text-content-100'>
+                {`${label}: `}
+              </span>
+              {message}
+              {problemRange != null && (
+                <span className='text-content-100 text-sm'>
+                  {` (${stringifyRange(problemRange)})`}
+                </span>
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )
@@ -50,7 +53,7 @@ function renderIconForProblemKind (kind: ProblemKind): ReactNode {
   }
 }
 
-function stringifyRange (range: SourceRange, maxPathLength = 32): string {
+function stringifyRange (range: ProblemRange, maxPathLength = 32): string {
   const { filePath, line, column } = range
 
   if (filePath != null) {

--- a/packages/editor/src/editor/components/Editor.tsx
+++ b/packages/editor/src/editor/components/Editor.tsx
@@ -1,6 +1,6 @@
 import type { Diagnostic } from '@codemirror/lint'
 import type { Extension } from '@codemirror/state'
-import type { EditorView } from '@codemirror/view'
+import type { EditorView, ViewUpdate } from '@codemirror/view'
 import { FunctionComponent, useCallback, useEffect, useRef } from 'react'
 import { useLatestRef } from '../../hooks/latest-ref.js'
 import { createCadenceEditor, type CadenceEditorHandle } from '../handle.js'
@@ -15,6 +15,7 @@ export const Editor: FunctionComponent<{
   cspNonce?: string
   className?: string
   onEditorViewChange?: (view: EditorView | undefined) => void
+  onEditorViewUpdate?: (viewUpdate: ViewUpdate) => void
   onChange: (document: string) => void
   onLocationChange?: (location: EditorLocation | undefined) => void
 }> = ({ document, indent, theme, extensions, diagnostics, cspNonce, className, ...props }) => {
@@ -22,6 +23,7 @@ export const Editor: FunctionComponent<{
   const onChange = useLatestRef(props.onChange)
   const onLocationChange = useLatestRef(props.onLocationChange)
   const onEditorViewChange = useLatestRef(props.onEditorViewChange)
+  const onEditorViewUpdate = useLatestRef(props.onEditorViewUpdate)
 
   // Initialize editor
   const initialize = useCallback((container: HTMLDivElement | null) => {
@@ -40,7 +42,8 @@ export const Editor: FunctionComponent<{
       diagnostics,
       cspNonce,
       onChange: (...args) => onChange.current(...args),
-      onLocationChange: (...args) => onLocationChange.current?.(...args)
+      onLocationChange: (...args) => onLocationChange.current?.(...args),
+      onEditorViewUpdate: (...args) => onEditorViewUpdate.current?.(...args)
     })
 
     onEditorViewChange.current?.(handleRef.current.view)

--- a/packages/editor/src/editor/handle.ts
+++ b/packages/editor/src/editor/handle.ts
@@ -6,6 +6,7 @@ import { lintKeymap, setDiagnostics } from '@codemirror/lint'
 import { highlightSelectionMatches, searchKeymap } from '@codemirror/search'
 import type { Extension, SelectionRange, Text } from '@codemirror/state'
 import { Compartment, EditorState } from '@codemirror/state'
+import type { ViewUpdate } from '@codemirror/view'
 import { drawSelection, dropCursor, EditorView, highlightActiveLine, highlightActiveLineGutter, highlightSpecialChars, keymap, lineNumbers, rectangularSelection } from '@codemirror/view'
 import type { EditorLocation } from './types.js'
 
@@ -78,6 +79,7 @@ export interface CadenceEditorOptions {
 
   readonly onChange: (value: string) => void
   readonly onLocationChange?: (location: EditorLocation | undefined) => void
+  readonly onEditorViewUpdate?: (viewUpdate: ViewUpdate) => void
 }
 
 export interface CadenceEditorHandle {
@@ -93,7 +95,11 @@ export interface CadenceEditorHandle {
 export function createCadenceEditor (parent: HTMLElement, options: CadenceEditorOptions): CadenceEditorHandle {
   const { indent, extensions } = options
 
-  const updateListener = EditorView.updateListener.of(({ state, docChanged, selectionSet }) => {
+  const updateListener = EditorView.updateListener.of((update) => {
+    const { state, docChanged, selectionSet } = update
+
+    options.onEditorViewUpdate?.(update)
+
     if (docChanged) {
       options.onChange(state.doc.toString())
     }

--- a/packages/editor/src/problems/components/ProblemContext.tsx
+++ b/packages/editor/src/problems/components/ProblemContext.tsx
@@ -1,37 +1,38 @@
 import type { FunctionComponent, PropsWithChildren } from 'react'
-import { createContext, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { useSafeContext } from '../../hooks/safe-context.js'
-import type { ModuleId } from '../../modules/types.js'
-import type { Problem, ProblemInput } from '../types.js'
+import type { Problem } from '../types.js'
+import { randomId } from '@utility'
+
+type UndoInsert = () => void
 
 interface ProblemContextValue {
   readonly problems: readonly Problem[]
-  readonly setSourceProblems: (sourceId: ModuleId, problems: readonly Problem[]) => void
-  readonly clearSourceProblems: (sourceId: ModuleId) => void
+  readonly insertProblems: (problems: readonly Problem[]) => UndoInsert
 }
 
 const ProblemContext = createContext<ProblemContextValue | undefined>(undefined)
 
 export const ProblemProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
-  const [sources, setSources] = useState<ReadonlyMap<ModuleId, readonly Problem[]>>(new Map())
+  const [problems, setProblems] = useState<ReadonlyMap<string, readonly Problem[]>>(new Map())
 
-  const setSourceProblems = useCallback((sourceId: ModuleId, problems: readonly Problem[]) => {
-    setSources((sources) => new Map(sources).set(sourceId, problems))
-  }, [])
+  const insertProblems = useCallback((problems: readonly Problem[]): UndoInsert => {
+    const id = randomId()
+    setProblems((prev) => new Map(prev).set(id, problems))
 
-  const clearSourceProblems = useCallback((sourceId: ModuleId) => {
-    setSources((sources) => {
-      const copy = new Map(sources)
-      copy.delete(sourceId)
-      return copy
-    })
+    return () => {
+      setProblems((prev) => {
+        const copy = new Map(prev)
+        copy.delete(id)
+        return copy
+      })
+    }
   }, [])
 
   const value = useMemo(() => ({
-    problems: Array.from(sources.values()).flat(),
-    setSourceProblems,
-    clearSourceProblems
-  }), [sources, setSourceProblems, clearSourceProblems])
+    problems: Array.from(problems.values()).flat(),
+    insertProblems
+  }), [problems, insertProblems])
 
   return (
     <ProblemContext value={value}>
@@ -45,20 +46,10 @@ export function useProblems (): readonly Problem[] {
   return problems
 }
 
-export function useProvideProblems (moduleId: ModuleId, sourceProblems: readonly ProblemInput[]): void {
-  const { setSourceProblems, clearSourceProblems } = useSafeContext(ProblemContext, 'ProblemContext')
+export function useProvideProblems (problems: readonly Problem[]): void {
+  const { insertProblems } = useSafeContext(ProblemContext, 'ProblemContext')
 
-  const problems = useMemo(() => {
-    return sourceProblems.map((entry): Problem => ({ moduleId, ...entry }))
-  }, [moduleId, sourceProblems])
-
-  // update problems when errors change
   useLayoutEffect(() => {
-    setSourceProblems(moduleId, problems)
-  }, [moduleId, problems, setSourceProblems])
-
-  // clear problems on unmount
-  useEffect(() => {
-    return () => clearSourceProblems(moduleId)
-  }, [moduleId, clearSourceProblems])
+    return insertProblems(problems)
+  }, [insertProblems, problems])
 }

--- a/packages/editor/src/problems/types.ts
+++ b/packages/editor/src/problems/types.ts
@@ -1,18 +1,17 @@
-import type { ModuleId } from '../modules/types.js'
-
 export type ProblemKind = 'error' | 'warning'
 
-export interface ProblemInput {
-  readonly kind: ProblemKind
-  readonly label: string
-  readonly message: string
-  readonly error?: Error
+export interface ProblemRange {
+  readonly offset: number
+  readonly length: number
+  readonly line: number
+  readonly column: number
+  readonly filePath?: string
 }
 
 export interface Problem {
-  readonly moduleId: ModuleId
   readonly kind: ProblemKind
   readonly label: string
   readonly message: string
+  readonly range?: ProblemRange
   readonly error?: Error
 }

--- a/packages/editor/test/editor/handle.spec.ts
+++ b/packages/editor/test/editor/handle.spec.ts
@@ -1,5 +1,5 @@
 import { diagnosticCount } from '@codemirror/lint'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createCadenceEditor } from '../../src/editor/handle.js'
 
 describe('editor/handle.ts', () => {
@@ -32,6 +32,29 @@ describe('editor/handle.ts', () => {
       ])
 
       expect(diagnosticCount(handle.view.state)).toBe(1)
+    } finally {
+      handle.destroy()
+    }
+  })
+
+  it('emits editor view updates when the document changes', () => {
+    const container = document.createElement('div')
+    document.body.append(container)
+
+    const onEditorViewUpdate = vi.fn()
+    const handle = createCadenceEditor(container, {
+      document: 'track main {}',
+      indent: '  ',
+      theme: [],
+      onChange: () => {},
+      onLocationChange: () => {},
+      onEditorViewUpdate
+    })
+
+    try {
+      handle.setDocument('track alt {}')
+
+      expect(onEditorViewUpdate).toHaveBeenCalled()
     } finally {
       handle.destroy()
     }

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -50,6 +50,35 @@ export function findDefinitionBindingAt (model: Model, tree: Tree, document: Tex
     : undefined
 }
 
+export function findUnusedAssignmentBindings (model: Model, tree: Tree, document: TextLike): readonly Binding[] {
+  const usedBindings = new Set<string>()
+  const cursor = tree.cursor()
+
+  const walk = (): void => {
+    if (isIdentifierKind(cursor.type.name)) {
+      const occurrence = findSemanticOccurrenceAt(tree, document, cursor.from)
+      const binding = occurrence == null ? undefined : resolveDefinitionBinding(model, occurrence, document)
+
+      if (occurrence != null && binding?.kind === 'assignment' && !sameRange(binding.range, occurrence.range)) {
+        usedBindings.add(binding.id)
+      }
+    }
+
+    if (cursor.firstChild()) {
+      do {
+        walk()
+      } while (cursor.nextSibling())
+      cursor.parent()
+    }
+  }
+
+  walk()
+
+  return model.bindings.filter((binding) => {
+    return binding.kind === 'assignment' && !usedBindings.has(binding.id)
+  })
+}
+
 function findSemanticOccurrenceAt (tree: Tree, document: TextLike, position: number): SemanticOccurrence | undefined {
   const node = findIdentifierNodeAt(tree, position)
   if (node != null) {

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -5,3 +5,6 @@ export { cadenceLanguageSupport } from './language-support.js'
 // "go to definition" feature
 export { goToDefinitionInTree, goToDefinitionWithParser } from './go-to-definition/operation.js'
 export { goToDefinitionExtension } from './go-to-definition/extension.js'
+
+// "unused variable" diagnostics
+export { findUnusedVariablesInTree, findUnusedVariablesWithParser } from './unused-variable/operation.js'

--- a/packages/language-support/src/types.ts
+++ b/packages/language-support/src/types.ts
@@ -4,3 +4,9 @@ export interface SourceRange {
   readonly line: number
   readonly column: number
 }
+
+export interface LanguageDiagnostic {
+  readonly name: string
+  readonly message: string
+  readonly range: SourceRange
+}

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -1,0 +1,22 @@
+import type { Tree } from '@lezer/common'
+import type { LRParser } from '@lezer/lr'
+import { analyzeTree } from '../analysis/model.js'
+import { findUnusedAssignmentBindings } from '../analysis/query.js'
+import type { LanguageDiagnostic } from '../types.js'
+import type { TextLike } from '../analysis/text.js'
+import { textFromString } from '../analysis/text.js'
+
+export function findUnusedVariablesInTree (tree: Tree, document: TextLike): readonly LanguageDiagnostic[] {
+  const model = analyzeTree(tree, document)
+
+  return findUnusedAssignmentBindings(model, tree, document).map((binding) => ({
+    name: binding.name,
+    message: `Unused variable "${binding.name}".`,
+    range: binding.range
+  }))
+}
+
+export function findUnusedVariablesWithParser (parser: LRParser, source: string): readonly LanguageDiagnostic[] {
+  const tree = parser.parse(source)
+  return findUnusedVariablesInTree(tree, textFromString(source))
+}

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -1,0 +1,62 @@
+import { buildParser } from '@lezer/generator'
+import assert from 'node:assert'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { findUnusedVariablesWithParser } from '../../src/unused-variable/operation.js'
+import { getRangeAt } from '../helpers.js'
+
+const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
+const cadenceParser = buildParser(cadenceGrammar)
+
+describe('unused-variable/operation.ts', () => {
+  it('reports assignments that are never referenced', () => {
+    const source = [
+      'used = sample("/samples/used.wav")',
+      'unused = sample("/samples/unused.wav")',
+      'track (4.bars) {',
+      '  part intro (4.bars) {',
+      '    used << [x---]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(findUnusedVariablesWithParser(cadenceParser, source), [
+      {
+        name: 'unused',
+        message: 'Unused variable "unused".',
+        range: getRangeAt(source, source.indexOf('unused ='), 'unused'.length)
+      }
+    ])
+  })
+
+  it('does not report parts or buses as unused', () => {
+    const source = [
+      'track (4.bars) {',
+      '  part intro (4.bars) {',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus drums {',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(findUnusedVariablesWithParser(cadenceParser, source), [])
+  })
+
+  it('treats member access roots as references', () => {
+    const source = [
+      'synth = sample("...")',
+      'track (4.bars) {',
+      '  part intro (4.bars) {',
+      '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(findUnusedVariablesWithParser(cadenceParser, source), [])
+  })
+})


### PR DESCRIPTION
The language support package now includes an analysis operation for detecting unused variables. The definition of such a variable will be reported via the regular problems system, and the editor will display a diagnostic (yellow squiggly underline) for it.

The analysis reuses the parse tree of the document for efficiency. This can only be done if there is an open editor for the document, so files that are not currently open will not have diagnostic warnings, which is a reasonable tradeoff for the performance benefits.