### PR TITLE
feat: Add highlighting of identifier occurrences

### DIFF
--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -5,7 +5,7 @@ import type { EditorLocation, PanelProps, Problem } from '@editor'
 import { Editor, getProjectFileContent, setProjectFileContent, useProjectSource, useProjectSourceDispatch, useProvideProblems } from '@editor'
 import type { RangeError } from '@language'
 import type { LanguageDiagnostic, SourceRange } from '@language-support'
-import { cadenceLanguageSupport, findUnusedVariablesInTree, goToDefinitionExtension } from '@language-support'
+import { cadenceLanguageSupport, findUnusedVariablesInTree, goToDefinitionExtension, highlightOccurrencesExtension } from '@language-support'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useCompilationState } from '../../../compilation/CompilationContext.js'
@@ -18,6 +18,7 @@ import { cadenceDarkTheme, cadenceLightTheme } from '../theme.js'
 const indent = '  ' // 2 spaces
 const extensions = [
   cadenceLanguageSupport(),
+  highlightOccurrencesExtension(),
   goToDefinitionExtension()
 ]
 

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -50,29 +50,70 @@ export function findDefinitionBindingAt (model: Model, tree: Tree, document: Tex
     : undefined
 }
 
-export function findUnusedAssignmentBindings (model: Model, tree: Tree, document: TextLike): readonly Binding[] {
-  const usedBindings = new Set<string>()
-  const cursor = tree.cursor()
+export type RangesByBinding = ReadonlyMap<string, readonly SourceRange[]>
 
-  const walk = (): void => {
-    if (isIdentifierKind(cursor.type.name)) {
-      const occurrence = findSemanticOccurrenceAt(tree, document, cursor.from)
-      const binding = occurrence == null ? undefined : resolveDefinitionBinding(model, occurrence, document)
-
-      if (occurrence != null && binding?.kind === 'assignment' && !sameRange(binding.range, occurrence.range)) {
-        usedBindings.add(binding.id)
-      }
-    }
-
-    if (cursor.firstChild()) {
-      do {
-        walk()
-      } while (cursor.nextSibling())
-      cursor.parent()
-    }
+export function findReferenceRangesAt (
+  model: Model,
+  tree: Tree,
+  document: TextLike,
+  position: number,
+  rangesByBinding?: RangesByBinding
+): readonly SourceRange[] {
+  const occurrence = findSemanticOccurrenceAt(tree, document, position)
+  if (occurrence == null || occurrence.name.length === 0) {
+    return []
   }
 
-  walk()
+  const binding = resolveDefinitionBinding(model, occurrence, document)
+  if (binding == null) {
+    return []
+  }
+
+  const ranges = rangesByBinding ?? buildReferenceRangesByBinding(model, tree, document)
+
+  return ranges.get(binding.id) ?? []
+}
+
+export function buildReferenceRangesByBinding (model: Model, tree: Tree, document: TextLike): RangesByBinding {
+  const rangesByBinding = new Map<string, Map<string, SourceRange>>()
+
+  walkResolvedIdentifierBindings(model, tree, document, (occurrence, binding) => {
+    const range = getReferenceRangeForBindingOccurrence(occurrence, document, binding)
+    if (range == null) {
+      return
+    }
+
+    const key = `${range.offset}:${range.length}`
+    const existingRanges = rangesByBinding.get(binding.id)
+    if (existingRanges == null) {
+      rangesByBinding.set(binding.id, new Map([[key, range]]))
+      return
+    }
+
+    existingRanges.set(key, range)
+  })
+
+  const sortedByBinding = new Map<string, readonly SourceRange[]>()
+
+  for (const [bindingId, ranges] of rangesByBinding) {
+    const sortedRanges = [...ranges.values()].sort((left, right) => {
+      return left.offset - right.offset || left.length - right.length
+    })
+
+    sortedByBinding.set(bindingId, sortedRanges)
+  }
+
+  return sortedByBinding
+}
+
+export function findUnusedAssignmentBindings (model: Model, tree: Tree, document: TextLike): readonly Binding[] {
+  const usedBindings = new Set<string>()
+
+  walkResolvedIdentifierBindings(model, tree, document, (occurrence, binding) => {
+    if (binding.kind === 'assignment' && !sameRange(binding.range, occurrence.range)) {
+      usedBindings.add(binding.id)
+    }
+  })
 
   return model.bindings.filter((binding) => {
     return binding.kind === 'assignment' && !usedBindings.has(binding.id)
@@ -170,6 +211,51 @@ function getEffectiveOccurrenceKind (occurrence: SemanticOccurrence, document: T
   }
 
   return isCorrect ? occurrence.kind : 'VariableName'
+}
+
+function getReferenceRangeForBindingOccurrence (
+  occurrence: SemanticOccurrence,
+  document: TextLike,
+  binding: Binding
+): SourceRange | undefined {
+  const effectiveKind = getEffectiveOccurrenceKind(occurrence, document)
+  if (effectiveKind === 'PropertyName') {
+    return undefined
+  }
+
+  const rootRange = findAccessChainRootBefore(document, occurrence.range.offset)
+  if (rootRange != null) {
+    const rootName = document.sliceString(rootRange.offset, rootRange.offset + rootRange.length)
+    if (rootName === binding.name) {
+      return rootRange
+    }
+  }
+
+  return occurrence.name === binding.name ? occurrence.range : undefined
+}
+
+type OccurrenceVisitor = (occurrence: SemanticOccurrence, binding: Binding) => void
+
+function walkResolvedIdentifierBindings (model: Model, tree: Tree, document: TextLike, visitor: OccurrenceVisitor): void {
+  const enter = (node: SyntaxNode) => {
+    if (!isIdentifierKind(node.type.name)) {
+      return
+    }
+
+    const occurrence = findSemanticOccurrenceAt(tree, document, node.from)
+    if (occurrence == null) {
+      return
+    }
+
+    const binding = resolveDefinitionBinding(model, occurrence, document)
+    if (binding == null) {
+      return
+    }
+
+    visitor(occurrence, binding)
+  }
+
+  tree.iterate({ enter })
 }
 
 function findBindingBySpan (model: Model, occurrence: SemanticOccurrence): Binding | undefined {

--- a/packages/language-support/src/highlight-occurrences/extension.ts
+++ b/packages/language-support/src/highlight-occurrences/extension.ts
@@ -1,0 +1,87 @@
+import { syntaxTree } from '@codemirror/language'
+import type { EditorState, Extension } from '@codemirror/state'
+import type { DecorationSet, ViewUpdate } from '@codemirror/view'
+import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
+import type { Tree } from '@lezer/common'
+import type { Model } from '../analysis/model.js'
+import { analyzeTree } from '../analysis/model.js'
+import type { RangesByBinding } from '../analysis/query.js'
+import { buildReferenceRangesByBinding, findDefinitionBindingAt } from '../analysis/query.js'
+
+const OCCURRENCE_CLASS = 'cm-cadence-highlight-occurrence'
+
+const occurrenceMark = Decoration.mark({ class: OCCURRENCE_CLASS })
+
+const theme = EditorView.baseTheme({
+  [`.${OCCURRENCE_CLASS}`]: {
+    backgroundColor: 'rgb(127 127 127 / 20%)',
+    borderRadius: '2px'
+  }
+})
+
+class HighlightOccurrencesPlugin {
+  private analysisState: AnalysisState
+
+  decorations: DecorationSet
+
+  constructor (view: EditorView) {
+    this.analysisState = buildAnalysisState(view.state)
+    this.decorations = getOccurrenceDecorations(view.state, this.analysisState)
+  }
+
+  update (update: ViewUpdate): void {
+    const changed = update.docChanged || syntaxTree(update.startState) !== syntaxTree(update.state)
+
+    if (changed) {
+      this.analysisState = buildAnalysisState(update.state)
+    }
+
+    if (changed || update.selectionSet) {
+      this.decorations = getOccurrenceDecorations(update.state, this.analysisState)
+    }
+  }
+}
+
+const plugin = ViewPlugin.fromClass(HighlightOccurrencesPlugin, {
+  decorations: (plugin) => plugin.decorations
+})
+
+interface AnalysisState {
+  readonly tree: Tree
+  readonly model: Model
+  readonly rangesByBinding: RangesByBinding
+}
+
+function buildAnalysisState (state: EditorState): AnalysisState {
+  const tree = syntaxTree(state)
+  const model = analyzeTree(tree, state.doc)
+  const rangesByBinding = buildReferenceRangesByBinding(model, tree, state.doc)
+  return { tree, model, rangesByBinding }
+}
+
+function getOccurrenceDecorations (state: EditorState, analysisState: AnalysisState): DecorationSet {
+  const { doc, selection } = state
+  const { tree, model, rangesByBinding } = analysisState
+
+  if (selection.ranges.length !== 1 || !selection.main.empty) {
+    return Decoration.none
+  }
+
+  const binding = findDefinitionBindingAt(model, tree, doc, selection.main.head)
+  const ranges = binding != null ? rangesByBinding.get(binding.id) : undefined
+
+  if (ranges == null || ranges.length === 0) {
+    return Decoration.none
+  }
+
+  const isPreSorted = true
+
+  return Decoration.set(
+    ranges.map(({ offset, length }) => occurrenceMark.range(offset, offset + length)),
+    !isPreSorted
+  )
+}
+
+export function highlightOccurrencesExtension (): Extension {
+  return [theme, plugin]
+}

--- a/packages/language-support/src/highlight-occurrences/operation.ts
+++ b/packages/language-support/src/highlight-occurrences/operation.ts
@@ -1,0 +1,17 @@
+import type { Tree } from '@lezer/common'
+import type { LRParser } from '@lezer/lr'
+import { analyzeTree } from '../analysis/model.js'
+import { findReferenceRangesAt } from '../analysis/query.js'
+import type { TextLike } from '../analysis/text.js'
+import { textFromString } from '../analysis/text.js'
+import type { SourceRange } from '../types.js'
+
+export function findHighlightedOccurrencesInTree (tree: Tree, document: TextLike, pos: number): readonly SourceRange[] {
+  const model = analyzeTree(tree, document)
+  return findReferenceRangesAt(model, tree, document, pos)
+}
+
+export function findHighlightedOccurrencesWithParser (parser: LRParser, source: string, pos: number): readonly SourceRange[] {
+  const tree = parser.parse(source)
+  return findHighlightedOccurrencesInTree(tree, textFromString(source), pos)
+}

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -6,5 +6,9 @@ export { cadenceLanguageSupport } from './language-support.js'
 export { goToDefinitionInTree, goToDefinitionWithParser } from './go-to-definition/operation.js'
 export { goToDefinitionExtension } from './go-to-definition/extension.js'
 
+// "highlight occurrences" feature
+export { findHighlightedOccurrencesInTree, findHighlightedOccurrencesWithParser } from './highlight-occurrences/operation.js'
+export { highlightOccurrencesExtension } from './highlight-occurrences/extension.js'
+
 // "unused variable" diagnostics
 export { findUnusedVariablesInTree, findUnusedVariablesWithParser } from './unused-variable/operation.js'

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -1,0 +1,76 @@
+import { buildParser } from '@lezer/generator'
+import assert from 'node:assert'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { findHighlightedOccurrencesWithParser } from '../../src/highlight-occurrences/operation.js'
+import { getRangeAt } from '../helpers.js'
+
+const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
+const cadenceParser = buildParser(cadenceGrammar)
+
+describe('highlight-occurrences/operation.ts', () => {
+  it('returns definition and reference ranges for assignments', () => {
+    const source = [
+      'foo = sample("/samples/foo.wav")',
+      'bar = foo',
+      'track (4.bars) {',
+      '  part intro (4.bars) {',
+      '    foo << [x---]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.lastIndexOf('foo <<') + 1
+
+    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [
+      getRangeAt(source, source.indexOf('foo ='), 'foo'.length),
+      getRangeAt(source, source.indexOf('foo', source.indexOf('bar =')), 'foo'.length),
+      getRangeAt(source, source.lastIndexOf('foo <<'), 'foo'.length)
+    ])
+  })
+
+  it('normalizes member access references to the root identifier range', () => {
+    const source = [
+      'synth = sample("...")',
+      'track (4.bars) {',
+      '  part intro (4.bars) {',
+      '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('synth.gain') + 'synth.'.length + 1
+
+    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [
+      getRangeAt(source, source.indexOf('synth ='), 'synth'.length),
+      getRangeAt(source, source.indexOf('synth.gain'), 'synth'.length)
+    ])
+  })
+
+  it('does not highlight named argument keys', () => {
+    const source = [
+      'tempo = 128.bpm',
+      'track (tempo: 140.bpm) {}',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('tempo:') + 1
+
+    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [])
+  })
+
+  it('returns the definition when no other references exist', () => {
+    const source = [
+      'lead = sample("...")',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('lead =') + 1
+
+    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [
+      getRangeAt(source, source.indexOf('lead ='), 'lead'.length)
+    ])
+  })
+})


### PR DESCRIPTION
When the caret is on an identifier, the definition of that identifier and all its usages are now highlighted. This is not based on textual matching, but on the semantic layer that also provides diagnostics for unused variables and the "go to definition" feature.