### PR TITLE
refactor: Refactor language support operations

### DIFF
--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -5,7 +5,7 @@ import type { EditorLocation, PanelProps, Problem } from '@editor'
 import { Editor, getProjectFileContent, setProjectFileContent, useProjectSource, useProjectSourceDispatch, useProvideProblems } from '@editor'
 import type { RangeError } from '@language'
 import type { LanguageDiagnostic, SourceRange } from '@language-support'
-import { cadenceLanguageSupport, findUnusedVariablesInTree, goToDefinitionExtension, highlightOccurrencesExtension } from '@language-support'
+import { applySemanticOperation, cadenceLanguageSupport, findUnusedVariables, goToDefinitionExtension, highlightOccurrencesExtension } from '@language-support'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useCompilationState } from '../../../compilation/CompilationContext.js'
@@ -77,7 +77,7 @@ export const EditorPanel: FunctionComponent<PanelProps> = ({ panelProps, tabId }
 
   const unusedVariables = useMemo(() => {
     return editorView != null
-      ? findUnusedVariablesInTree(syntaxTree(editorView.state), editorView.state.doc)
+      ? applySemanticOperation(findUnusedVariables, syntaxTree(editorView.state), editorView.state.doc)
       : []
   }, [analysisRevision, editorView])
 

--- a/packages/app/src/modules/editor/index.ts
+++ b/packages/app/src/modules/editor/index.ts
@@ -2,7 +2,7 @@ import { syntaxTree } from '@codemirror/language'
 import { EditorSelection } from '@codemirror/state'
 import type { CommandId, MenuId, MenuSectionId, Module, ModuleId, PanelId, Problem } from '@editor'
 import { activateTabOfType, getProjectFileContent, setProjectFileContent, useDialogService, useLatestRef, useLayout, useLayoutDispatch, useProjectSource, useProjectSourceDispatch, useProvideProblems, useRegisterCommand } from '@editor'
-import { goToDefinitionInTree } from '@language-support'
+import { applySemanticOperation, goToDefinition } from '@language-support'
 import type { FunctionComponent } from 'react'
 import { useMemo } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
@@ -137,13 +137,13 @@ const GlobalHooks: FunctionComponent = () => {
 
       const tree = syntaxTree(view.state)
       const caret = view.state.selection.main.head
-      const target = goToDefinitionInTree(tree, view.state.doc, caret)
+      const target = applySemanticOperation(goToDefinition, tree, view.state.doc, caret)
       if (target == null) {
         view.focus()
         return
       }
 
-      const selection = EditorSelection.single(target.range.offset)
+      const selection = EditorSelection.single(target.offset)
       view.dispatch({ selection, scrollIntoView: true })
       view.focus()
     }

--- a/packages/language-support/src/analysis/model.ts
+++ b/packages/language-support/src/analysis/model.ts
@@ -1,7 +1,6 @@
 import type { Tree, TreeCursor } from '@lezer/common'
 import type { LRParser } from '@lezer/lr'
-import type { SourceRange } from '../types.js'
-import type { TextLike } from './text.js'
+import type { SourceRange, TextLike } from '../types.js'
 import { textFromString, toSourceRange } from './text.js'
 
 export type ScopeKind = 'root' | 'track' | 'mixer'

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -1,8 +1,7 @@
 import type { SyntaxNode, Tree } from '@lezer/common'
-import type { SourceRange } from '../types.js'
+import type { SourceRange, TextLike } from '../types.js'
 import type { Binding, BindingKind, Model } from './model.js'
 import { scopeKey } from './model.js'
-import type { TextLike } from './text.js'
 import { toSourceRange } from './text.js'
 
 export type IdentifierKind = typeof IDENTIFIER_KINDS[number]

--- a/packages/language-support/src/analysis/text.ts
+++ b/packages/language-support/src/analysis/text.ts
@@ -1,15 +1,4 @@
-import type { SourceRange } from '../types.js'
-
-export interface TextLine {
-  readonly from: number
-  readonly number: number
-}
-
-export interface TextLike {
-  readonly length: number
-  readonly sliceString: (from: number, to?: number) => string
-  readonly lineAt: (position: number) => TextLine
-}
+import type { SourceRange, TextLike } from '../types.js'
 
 export function textFromString (source: string): TextLike {
   const lineStarts = getLineStarts(source)

--- a/packages/language-support/src/go-to-definition/extension.ts
+++ b/packages/language-support/src/go-to-definition/extension.ts
@@ -4,8 +4,9 @@ import { EditorSelection, StateEffect, StateField } from '@codemirror/state'
 import type { DecorationSet, ViewUpdate } from '@codemirror/view'
 import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
 import { findIdentifierRangeAt, sameRange } from '../analysis/query.js'
+import { applySemanticOperation } from '../operations.js'
 import type { SourceRange } from '../types.js'
-import { goToDefinitionInTree } from './operation.js'
+import { goToDefinition } from './operation.js'
 
 function isApplePlatform (): boolean {
   const userAgent = navigator.userAgent.toLowerCase()
@@ -138,7 +139,7 @@ class GoToDefinitionInteractionsPlugin {
           return { hoverRange: undefined, underlineRange: undefined }
         }
 
-        const target = goToDefinitionInTree(tree, view.state.doc, position)
+        const target = applySemanticOperation(goToDefinition, tree, view.state.doc, position)
         const underlineRange = target == null ? undefined : hoverRange
 
         return { hoverRange, underlineRange }
@@ -211,7 +212,7 @@ class GoToDefinitionInteractionsPlugin {
       return
     }
 
-    const target = goToDefinitionInTree(tree, this.view.state.doc, position)
+    const target = applySemanticOperation(goToDefinition, tree, this.view.state.doc, position)
     if (target == null) {
       return
     }
@@ -219,7 +220,7 @@ class GoToDefinitionInteractionsPlugin {
     event.preventDefault()
     event.stopPropagation()
 
-    const selection = EditorSelection.single(target.range.offset)
+    const selection = EditorSelection.single(target.offset)
     this.view.dispatch({ selection, scrollIntoView: true })
     this.view.focus()
   }
@@ -252,7 +253,7 @@ class GoToDefinitionInteractionsPlugin {
 
     // Only underline identifiers that actually resolve.
     const tree = syntaxTree(this.view.state)
-    const target = goToDefinitionInTree(tree, this.view.state.doc, position)
+    const target = applySemanticOperation(goToDefinition, tree, this.view.state.doc, position)
     if (target == null) {
       this.scheduleHoverDispatch(undefined)
       return

--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -1,27 +1,13 @@
-import type { Tree } from '@lezer/common'
-import type { LRParser } from '@lezer/lr'
-import { analyzeTree } from '../analysis/model.js'
 import { findDefinitionBindingAt } from '../analysis/query.js'
+import type { SemanticOperation } from '../operations.js'
 import type { SourceRange } from '../types.js'
-import type { TextLike } from '../analysis/text.js'
-import { textFromString } from '../analysis/text.js'
 
 export interface GoToDefinitionResult {
   readonly name: string
   readonly range: SourceRange
 }
 
-export function goToDefinitionInTree (tree: Tree, document: TextLike, pos: number): GoToDefinitionResult | undefined {
-  const model = analyzeTree(tree, document)
+export const goToDefinition: SemanticOperation<[pos: number], SourceRange | undefined> = (model, tree, document, pos) => {
   const binding = findDefinitionBindingAt(model, tree, document, pos)
-  if (binding == null) {
-    return undefined
-  }
-
-  return { name: binding.name, range: binding.range }
-}
-
-export function goToDefinitionWithParser (parser: LRParser, source: string, pos: number): GoToDefinitionResult | undefined {
-  const tree = parser.parse(source)
-  return goToDefinitionInTree(tree, textFromString(source), pos)
+  return binding?.range
 }

--- a/packages/language-support/src/highlight-occurrences/operation.ts
+++ b/packages/language-support/src/highlight-occurrences/operation.ts
@@ -1,17 +1,7 @@
-import type { Tree } from '@lezer/common'
-import type { LRParser } from '@lezer/lr'
-import { analyzeTree } from '../analysis/model.js'
 import { findReferenceRangesAt } from '../analysis/query.js'
-import type { TextLike } from '../analysis/text.js'
-import { textFromString } from '../analysis/text.js'
+import type { SemanticOperation } from '../operations.js'
 import type { SourceRange } from '../types.js'
 
-export function findHighlightedOccurrencesInTree (tree: Tree, document: TextLike, pos: number): readonly SourceRange[] {
-  const model = analyzeTree(tree, document)
+export const findHighlightedOccurrences: SemanticOperation<[pos: number], readonly SourceRange[]> = (model, tree, document, pos) => {
   return findReferenceRangesAt(model, tree, document, pos)
-}
-
-export function findHighlightedOccurrencesWithParser (parser: LRParser, source: string, pos: number): readonly SourceRange[] {
-  const tree = parser.parse(source)
-  return findHighlightedOccurrencesInTree(tree, textFromString(source), pos)
 }

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -2,13 +2,16 @@
 export type * from './types.js'
 export { cadenceLanguageSupport } from './language-support.js'
 
+export type { SemanticOperation } from './operations.js'
+export { applySemanticOperation, applySemanticOperationWithParser } from './operations.js'
+
 // "go to definition" feature
-export { goToDefinitionInTree, goToDefinitionWithParser } from './go-to-definition/operation.js'
+export { goToDefinition } from './go-to-definition/operation.js'
 export { goToDefinitionExtension } from './go-to-definition/extension.js'
 
 // "highlight occurrences" feature
-export { findHighlightedOccurrencesInTree, findHighlightedOccurrencesWithParser } from './highlight-occurrences/operation.js'
+export { findHighlightedOccurrences } from './highlight-occurrences/operation.js'
 export { highlightOccurrencesExtension } from './highlight-occurrences/extension.js'
 
 // "unused variable" diagnostics
-export { findUnusedVariablesInTree, findUnusedVariablesWithParser } from './unused-variable/operation.js'
+export { findUnusedVariables } from './unused-variable/operation.js'

--- a/packages/language-support/src/operations.ts
+++ b/packages/language-support/src/operations.ts
@@ -1,0 +1,30 @@
+import type { Tree } from '@lezer/common'
+import type { LRParser } from '@lezer/lr'
+import { textFromString } from './analysis/text.js'
+import type { TextLike } from './types.js'
+import { analyzeTree, type Model } from './analysis/model.js'
+
+export type SemanticOperation<Args extends readonly unknown[], Result> =
+  (model: Model, tree: Tree, document: TextLike, ...args: Args) => Result
+
+export function applySemanticOperation<Args extends readonly unknown[], Result> (
+  operation: SemanticOperation<Args, Result>,
+  tree: Tree,
+  document: TextLike,
+  ...args: Args
+): Result {
+  const model = analyzeTree(tree, document)
+  return operation(model, tree, document, ...args)
+}
+
+export function applySemanticOperationWithParser<Args extends readonly unknown[], Result> (
+  operation: SemanticOperation<Args, Result>,
+  parser: LRParser,
+  source: string,
+  ...args: Args
+): Result {
+  const tree = parser.parse(source)
+  const document = textFromString(source)
+  const model = analyzeTree(tree, document)
+  return operation(model, tree, document, ...args)
+}

--- a/packages/language-support/src/types.ts
+++ b/packages/language-support/src/types.ts
@@ -10,3 +10,14 @@ export interface LanguageDiagnostic {
   readonly message: string
   readonly range: SourceRange
 }
+
+export interface TextLine {
+  readonly from: number
+  readonly number: number
+}
+
+export interface TextLike {
+  readonly length: number
+  readonly sliceString: (from: number, to?: number) => string
+  readonly lineAt: (position: number) => TextLine
+}

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -1,22 +1,11 @@
-import type { Tree } from '@lezer/common'
-import type { LRParser } from '@lezer/lr'
-import { analyzeTree } from '../analysis/model.js'
 import { findUnusedAssignmentBindings } from '../analysis/query.js'
+import type { SemanticOperation } from '../operations.js'
 import type { LanguageDiagnostic } from '../types.js'
-import type { TextLike } from '../analysis/text.js'
-import { textFromString } from '../analysis/text.js'
 
-export function findUnusedVariablesInTree (tree: Tree, document: TextLike): readonly LanguageDiagnostic[] {
-  const model = analyzeTree(tree, document)
-
+export const findUnusedVariables: SemanticOperation<[], readonly LanguageDiagnostic[]> = (model, tree, document) => {
   return findUnusedAssignmentBindings(model, tree, document).map((binding) => ({
     name: binding.name,
     message: `Unused variable "${binding.name}".`,
     range: binding.range
   }))
-}
-
-export function findUnusedVariablesWithParser (parser: LRParser, source: string): readonly LanguageDiagnostic[] {
-  const tree = parser.parse(source)
-  return findUnusedVariablesInTree(tree, textFromString(source))
 }

--- a/packages/language-support/test/analysis/query.test.ts
+++ b/packages/language-support/test/analysis/query.test.ts
@@ -5,9 +5,9 @@ import { readFile } from 'node:fs/promises'
 import { describe, it } from 'node:test'
 import { analyzeTree } from '../../src/analysis/model.js'
 import { findDefinitionBindingAt } from '../../src/analysis/query.js'
-import { getRangeAt } from '../helpers.js'
-import type { TextLike } from '../../src/analysis/text.js'
 import { textFromString } from '../../src/analysis/text.js'
+import type { TextLike } from '../../src/types.js'
+import { getRangeAt } from '../helpers.js'
 
 const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
 const cadenceParser = buildParser(cadenceGrammar)

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -2,7 +2,8 @@ import { buildParser } from '@lezer/generator'
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { describe, it } from 'node:test'
-import { goToDefinitionWithParser } from '../../src/go-to-definition/operation.js'
+import { goToDefinition } from '../../src/go-to-definition/operation.js'
+import { applySemanticOperationWithParser } from '../../src/operations.js'
 import { getRangeAt } from '../helpers.js'
 
 const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
@@ -16,25 +17,25 @@ describe('go-to-definition/operation.ts', () => {
       ''
     ].join('\n')
 
+    const defPos = source.indexOf('foo =')
     const refPos = source.lastIndexOf('foo') + 1
-    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
-    assert.ok(def)
 
-    const defFrom = source.indexOf('foo')
-    assert.strictEqual(def.name, 'foo')
-    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 'foo'.length))
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      getRangeAt(source, defPos, 'foo'.length)
+    )
   })
 
   it('resolves bus references inside mixer', () => {
     const source = 'mixer { bus a { } bus b { a } }'
 
+    const defPos = source.indexOf('bus a') + 'bus '.length
     const refPos = source.lastIndexOf(' a ') + 2
-    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
-    assert.ok(def)
 
-    const defFrom = source.indexOf('bus a') + 'bus '.length
-    assert.strictEqual(def.name, 'a')
-    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 1))
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      getRangeAt(source, defPos, 1)
+    )
   })
 
   it('resolves import alias usage', () => {
@@ -44,25 +45,25 @@ describe('go-to-definition/operation.ts', () => {
       ''
     ].join('\n')
 
+    const defPos = source.indexOf('as lib') + 'as '.length
     const refPos = source.indexOf('lib.foo') + 1
-    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
-    assert.ok(def)
 
-    const defFrom = source.indexOf('as lib') + 'as '.length
-    assert.strictEqual(def.name, 'lib')
-    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 'lib'.length))
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      getRangeAt(source, defPos, 'lib'.length)
+    )
   })
 
   it('tolerates incomplete input', () => {
     const source = 'mixer { bus a { } bus b { a '
 
+    const defPos = source.indexOf('bus a') + 'bus '.length
     const refPos = source.lastIndexOf('a') + 1
-    const def = goToDefinitionWithParser(cadenceParser, source, refPos)
-    assert.ok(def)
 
-    const defFrom = source.indexOf('bus a') + 'bus '.length
-    assert.strictEqual(def.name, 'a')
-    assert.deepStrictEqual(def.range, getRangeAt(source, defFrom, 1))
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      getRangeAt(source, defPos, 1)
+    )
   })
 
   it('does not resolve member access by member name', () => {
@@ -79,13 +80,13 @@ describe('go-to-definition/operation.ts', () => {
       ''
     ].join('\n')
 
-    const pos = source.indexOf('synth.gain') + 'synth.'.length + 1
-    const def = goToDefinitionWithParser(cadenceParser, source, pos)
-    assert.ok(def)
+    const defPos = source.indexOf('synth =')
+    const refPos = source.indexOf('synth.gain') + 'synth.'.length + 1
 
-    const synthFrom = source.indexOf('\nsynth =') + 1
-    assert.strictEqual(def.name, 'synth')
-    assert.deepStrictEqual(def.range, getRangeAt(source, synthFrom, 'synth'.length))
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      getRangeAt(source, defPos, 'synth'.length)
+    )
   })
 
   it('does not resolve named argument keys', () => {
@@ -96,7 +97,10 @@ describe('go-to-definition/operation.ts', () => {
     ].join('\n')
 
     const pos = source.indexOf('tempo:') + 1
-    const def = goToDefinitionWithParser(cadenceParser, source, pos)
-    assert.strictEqual(def, undefined)
+
+    assert.strictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, pos),
+      undefined
+    )
   })
 })

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -2,7 +2,8 @@ import { buildParser } from '@lezer/generator'
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { describe, it } from 'node:test'
-import { findHighlightedOccurrencesWithParser } from '../../src/highlight-occurrences/operation.js'
+import { findHighlightedOccurrences } from '../../src/highlight-occurrences/operation.js'
+import { applySemanticOperationWithParser } from '../../src/operations.js'
 import { getRangeAt } from '../helpers.js'
 
 const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
@@ -23,11 +24,14 @@ describe('highlight-occurrences/operation.ts', () => {
 
     const position = source.lastIndexOf('foo <<') + 1
 
-    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [
-      getRangeAt(source, source.indexOf('foo ='), 'foo'.length),
-      getRangeAt(source, source.indexOf('foo', source.indexOf('bar =')), 'foo'.length),
-      getRangeAt(source, source.lastIndexOf('foo <<'), 'foo'.length)
-    ])
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('foo ='), 'foo'.length),
+        getRangeAt(source, source.indexOf('foo', source.indexOf('bar =')), 'foo'.length),
+        getRangeAt(source, source.lastIndexOf('foo <<'), 'foo'.length)
+      ]
+    )
   })
 
   it('normalizes member access references to the root identifier range', () => {
@@ -43,10 +47,13 @@ describe('highlight-occurrences/operation.ts', () => {
 
     const position = source.indexOf('synth.gain') + 'synth.'.length + 1
 
-    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [
-      getRangeAt(source, source.indexOf('synth ='), 'synth'.length),
-      getRangeAt(source, source.indexOf('synth.gain'), 'synth'.length)
-    ])
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('synth ='), 'synth'.length),
+        getRangeAt(source, source.indexOf('synth.gain'), 'synth'.length)
+      ]
+    )
   })
 
   it('does not highlight named argument keys', () => {
@@ -58,7 +65,10 @@ describe('highlight-occurrences/operation.ts', () => {
 
     const position = source.indexOf('tempo:') + 1
 
-    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [])
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      []
+    )
   })
 
   it('returns the definition when no other references exist', () => {
@@ -69,8 +79,11 @@ describe('highlight-occurrences/operation.ts', () => {
 
     const position = source.indexOf('lead =') + 1
 
-    assert.deepStrictEqual(findHighlightedOccurrencesWithParser(cadenceParser, source, position), [
-      getRangeAt(source, source.indexOf('lead ='), 'lead'.length)
-    ])
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('lead ='), 'lead'.length)
+      ]
+    )
   })
 })

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -2,7 +2,8 @@ import { buildParser } from '@lezer/generator'
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { describe, it } from 'node:test'
-import { findUnusedVariablesWithParser } from '../../src/unused-variable/operation.js'
+import { applySemanticOperationWithParser } from '../../src/operations.js'
+import { findUnusedVariables } from '../../src/unused-variable/operation.js'
 import { getRangeAt } from '../helpers.js'
 
 const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
@@ -21,13 +22,16 @@ describe('unused-variable/operation.ts', () => {
       ''
     ].join('\n')
 
-    assert.deepStrictEqual(findUnusedVariablesWithParser(cadenceParser, source), [
-      {
-        name: 'unused',
-        message: 'Unused variable "unused".',
-        range: getRangeAt(source, source.indexOf('unused ='), 'unused'.length)
-      }
-    ])
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      [
+        {
+          name: 'unused',
+          message: 'Unused variable "unused".',
+          range: getRangeAt(source, source.indexOf('unused ='), 'unused'.length)
+        }
+      ]
+    )
   })
 
   it('does not report parts or buses as unused', () => {
@@ -43,7 +47,10 @@ describe('unused-variable/operation.ts', () => {
       ''
     ].join('\n')
 
-    assert.deepStrictEqual(findUnusedVariablesWithParser(cadenceParser, source), [])
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      []
+    )
   })
 
   it('treats member access roots as references', () => {
@@ -57,6 +64,9 @@ describe('unused-variable/operation.ts', () => {
       ''
     ].join('\n')
 
-    assert.deepStrictEqual(findUnusedVariablesWithParser(cadenceParser, source), [])
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      []
+    )
   })
 })


### PR DESCRIPTION
Introduces a common type for semantic operations, as well as functions to apply them. This avoids operations having to concern themselves with how someone may want to call them (e.g. tree+document vs. code+parser).