### PR TITLE
feat: Limit playback output to [-1, 1]

### DIFF
--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -18,7 +18,7 @@ export function createWebAudioGraph (graph: AudioGraph<Node>, transport: Transpo
   const instances = createInstances(graph, transport, fetcher)
   const promises = Array.from(instances.values(), (item) => item.loaded)
 
-  setupRoutings(graph, instances, transport.output)
+  setupRoutings(graph, instances, transport.input)
   scheduleNoteEvents(graph, instances)
 
   return {

--- a/packages/webaudio/src/transport/transport.ts
+++ b/packages/webaudio/src/transport/transport.ts
@@ -12,6 +12,7 @@ export interface OfflineTransportOptions {
 
 export interface Transport {
   readonly ctx: BaseAudioContext
+  readonly input: AudioNode
   readonly output: GainNode
 
   readonly schedule: (time: number, callback: (time: number) => void) => void
@@ -47,7 +48,15 @@ export function createOnlineTransport (): OnlineTransport {
     void ctx.suspend()
   }
 
+  // Hard limit the output before applying output gain, as otherwise
+  // users could apply positive gain to the input (producing a signal >1)
+  // and therefore circumvent the output gain.
+  const input = ctx.createWaveShaper()
+  input.curve = new Float32Array([-1, 0, 1])
+  disposeStack.push(() => input.disconnect())
+
   const output = ctx.createGain()
+  input.connect(output)
   output.connect(ctx.destination)
   disposeStack.push(() => output.disconnect())
 
@@ -82,7 +91,7 @@ export function createOnlineTransport (): OnlineTransport {
       }
 
       try {
-        return await createWorkletTimeTracker(ctx, output, options)
+        return await createWorkletTimeTracker(ctx, input, options)
       } catch {
         return createIntervalTimeTracker(ctx, options)
       }
@@ -100,7 +109,7 @@ export function createOnlineTransport (): OnlineTransport {
     scheduler.schedule(time, callback)
   }
 
-  return { ctx, output, time, start, dispose, schedule }
+  return { ctx, input, output, time, start, dispose, schedule }
 }
 
 export function createOfflineTransport (options: OfflineTransportOptions): OfflineTransport {
@@ -113,7 +122,8 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
     sampleRate: options.sampleRate
   })
 
-  const output = ctx.createGain()
+  const input = ctx.createGain()
+  const output = input
   output.connect(ctx.destination)
   disposeStack.push(() => output.disconnect())
 
@@ -126,7 +136,7 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
     scheduler.start(0)
 
     try {
-      const tracker = await createWorkletTimeTracker(ctx, output, {
+      const tracker = await createWorkletTimeTracker(ctx, input, {
         updateInterval: TIME_UPDATE_INTERVAL_OFFLINE,
         offsetTime: numeric('s', 0)
       })
@@ -148,5 +158,5 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
     scheduler.schedule(time, callback)
   }
 
-  return { ctx, output, time, render, schedule }
+  return { ctx, input, output, time, render, schedule }
 }

--- a/packages/webaudio/test-browser/graph/effect.test.ts
+++ b/packages/webaudio/test-browser/graph/effect.test.ts
@@ -11,9 +11,11 @@ const length = 1024
 
 function createTestTransport () {
   const ctx = new OfflineAudioContext({ sampleRate, length, numberOfChannels: 2 })
+  const output = ctx.createGain()
   const transport: Transport = {
     ctx,
-    output: ctx.createGain(),
+    input: output,
+    output,
     schedule: (_time, onSchedule) => onSchedule(0)
   }
 
@@ -70,9 +72,11 @@ async function renderDelay (options: {
   const renderLength = delaySamples + 256
 
   const ctx = new OfflineAudioContext({ sampleRate, length: renderLength, numberOfChannels: 1 })
+  const output = ctx.createGain()
   const transport: Transport = {
     ctx,
-    output: ctx.createGain(),
+    input: output,
+    output,
     schedule: (_time, onSchedule) => onSchedule(0)
   }
 


### PR DESCRIPTION
The previous signal flow was:
user-provided input -> master output gain -> destination. This meant that users could apply positive gain to the input, which could produce a signal >1, and therefore circumvent the output gain.

This change adds a hard limiter before the output gain, so that the output is always limited to [-1, 1], regardless of the input gain: user-provided input -> limiter -> master output gain -> destination.

This only affects the online transport (i.e. real-time playback).

Obviously, this will result in clipping/distortion if positive gain is applied to the input, which could be solved by a more sophisticated limiter (likely via a worklet) in the future.