### PR TITLE
feat: Expose bus gain as an automation parameter

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -3,11 +3,13 @@ import type { PanelProps } from '@editor'
 import { useNonNullValue } from '@editor'
 import { Flowchart } from '@flowchart'
 import clsx from 'clsx'
-import { useCallback, useMemo, useState, type CSSProperties, type FunctionComponent, type PropsWithChildren } from 'react'
+import type { CSSProperties, FunctionComponent, PropsWithChildren } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
 import { Popover } from '../../components/popover/Popover.js'
 import { pluralize } from '../../utilities/format.js'
-import { createMixerFlowchart, type MixerFlowchartOptions, type MixerFlowNode } from './flowchart.js'
+import type { MixerFlowchartOptions, MixerFlowNode } from './flowchart.js'
+import { createMixerFlowchart } from './flowchart.js'
 
 const FLOWCHART_OPTIONS: MixerFlowchartOptions = {
   nodeSize: {
@@ -182,9 +184,7 @@ const BusNodeInfo: FunctionComponent<{
   return (
     <>
       <div className='font-bold'>bus.{object.name}</div>
-      {object.gain != null && (
-        <div>gain: {object.gain.value.toFixed(2)} {object.gain.unit}</div>
-      )}
+      <div>gain: {object.gain.initial.value.toFixed(2)} {object.gain.initial.unit}</div>
       {object.pan != null && (
         <div>pan: {object.pan.value.toFixed(2)}</div>
       )}

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -2,8 +2,9 @@ import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Progra
 import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents, timeToSeconds } from '@core'
 import { numeric } from '@utility'
 import { gainTransform, timeVariant, toTimeVariant } from './automation.js'
-import { createAudioGraphBuilder, type AudioGraphBuilder } from './builder.js'
-import { dbToGain, DEFAULT_ROOT_NOTE } from './constants.js'
+import type { AudioGraphBuilder } from './builder.js'
+import { createAudioGraphBuilder } from './builder.js'
+import { DEFAULT_ROOT_NOTE } from './constants.js'
 import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
 import type { BiquadNode, DelayNode, GainNode, IdentityNode, Node, PanNode, ReverbNode, SampleNode, WidthNode } from './nodes.js'
 
@@ -72,7 +73,9 @@ function createBus (program: Program, bus: Bus, builder: Builder): SubGraph {
     appendEffect({ type: 'pan', pan: bus.pan })
   }
 
-  if (bus.gain != null) {
+  // Optimization: Skip adding a node if gain is 0 and is not automated.
+  // TODO: Make this more generic and move into appendEffect?
+  if (bus.gain.initial.value !== 0 || program.automations.has(bus.gain.id)) {
     appendEffect({ type: 'gain', gain: bus.gain })
   }
 
@@ -121,8 +124,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
   switch (effect.type) {
     case 'gain': {
       return toSubGraph(builder.addNode<GainNode>('gain', {
-        // TODO time variant
-        gain: timeVariant(numeric(undefined, dbToGain(effect.gain.value)), [])
+        gain: toTimeVariant(effect.gain, program, gainTransform)
       }))
     }
 

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -45,6 +45,7 @@ describe('lowering.ts', () => {
     const instrumentId = 100 as InstrumentId
     const instrumentGainId = 200 as ParameterId
     const busId = 300 as BusId
+    const busGainId = 400 as ParameterId
 
     const program: Program = {
       beatsPerBar: 4,
@@ -75,6 +76,10 @@ describe('lowering.ts', () => {
           {
             id: busId,
             name: 'Bus 1',
+            gain: {
+              id: busGainId,
+              initial: numeric('db', -3)
+            },
             effects: []
           } satisfies Bus
         ],
@@ -115,8 +120,12 @@ describe('lowering.ts', () => {
       } satisfies IdentityNode,
       {
         id: 2 as NodeId,
-        type: 'identity'
-      } satisfies IdentityNode,
+        type: 'gain',
+        gain: {
+          initial: numeric(undefined, dbToGain(-3)),
+          points: []
+        }
+      } satisfies GainNode,
       {
         id: 3 as NodeId,
         length: undefined,
@@ -328,6 +337,10 @@ describe('lowering.ts', () => {
             {
               id: 100 as BusId,
               name: 'Bus 1',
+              gain: {
+                id: 400 as ParameterId,
+                initial: numeric('db', 0)
+              },
               effects: [effect]
             }
           ],
@@ -350,7 +363,10 @@ describe('lowering.ts', () => {
     it('should handle gain', () => {
       const graph = createAudioGraph(createProgramWithEffect({
         type: 'gain',
-        gain: numeric('db', -3)
+        gain: {
+          id: 400 as ParameterId,
+          initial: numeric('db', -3)
+        }
       }))
       assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
         id: 2 as NodeId,

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -125,7 +125,7 @@ export interface Bus {
   readonly id: BusId
   readonly name: string
   readonly pan?: Numeric<undefined>
-  readonly gain?: Numeric<'db'>
+  readonly gain: Parameter<'db'>
   readonly effects: readonly Effect[]
 }
 
@@ -140,7 +140,7 @@ export type Effect =
 
 export interface GainEffect {
   readonly type: 'gain'
-  readonly gain: Numeric<'db'>
+  readonly gain: Parameter<'db'>
 }
 
 export interface PanEffect {

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -152,6 +152,11 @@ function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence,
       return findFirstGlobalBinding(model, name)
   }
 
+  const explicitBusBinding = resolveExplicitBusBinding(model, occurrence, document)
+  if (explicitBusBinding != null) {
+    return explicitBusBinding
+  }
+
   const root = findAccessChainRootBefore(document, occurrence.range.offset)
   if (root != null) {
     const rootName = document.sliceString(root.offset, root.offset + root.length)
@@ -222,6 +227,14 @@ function getReferenceRangeForBindingOccurrence (
     return undefined
   }
 
+  const explicitBusRange = findExplicitBusBindingRange(document, occurrence.range.offset)
+  if (binding.kind === 'bus' && explicitBusRange != null) {
+    const busName = document.sliceString(explicitBusRange.offset, explicitBusRange.offset + explicitBusRange.length)
+    if (busName === binding.name) {
+      return explicitBusRange
+    }
+  }
+
   const rootRange = findAccessChainRootBefore(document, occurrence.range.offset)
   if (rootRange != null) {
     const rootName = document.sliceString(rootRange.offset, rootRange.offset + rootRange.length)
@@ -235,13 +248,24 @@ function getReferenceRangeForBindingOccurrence (
 
 type OccurrenceVisitor = (occurrence: SemanticOccurrence, binding: Binding) => void
 
+function resolveExplicitBusBinding (model: Model, occurrence: SemanticOccurrence, document: TextLike): Binding | undefined {
+  const explicitBusRange = findExplicitBusBindingRange(document, occurrence.range.offset)
+  if (explicitBusRange == null) {
+    return undefined
+  }
+
+  const busName = document.sliceString(explicitBusRange.offset, explicitBusRange.offset + explicitBusRange.length)
+  return findBindingByPriority(model.bindingsByName.get(busName), ['bus'], busName)
+}
+
 function walkResolvedIdentifierBindings (model: Model, tree: Tree, document: TextLike, visitor: OccurrenceVisitor): void {
   const enter = (node: SyntaxNode) => {
     if (!isIdentifierKind(node.type.name)) {
       return
     }
 
-    const occurrence = findSemanticOccurrenceAt(tree, document, node.from)
+    const lookupPosition = node.to - node.from > 1 ? node.from + 1 : node.from
+    const occurrence = findSemanticOccurrenceAt(tree, document, lookupPosition)
     if (occurrence == null) {
       return
     }
@@ -379,6 +403,30 @@ function findAccessChainRootBefore (document: TextLike, memberFrom: number): Sou
   return root
 }
 
+function findExplicitBusBindingRange (document: TextLike, memberFrom: number): SourceRange | undefined {
+  const root = findAccessChainRootBefore(document, memberFrom)
+  if (root == null) {
+    return undefined
+  }
+
+  const rootName = document.sliceString(root.offset, root.offset + root.length)
+  if (rootName !== 'bus') {
+    return undefined
+  }
+
+  return findAccessChainFirstMemberAfter(document, root)
+}
+
+function findAccessChainFirstMemberAfter (document: TextLike, root: SourceRange): SourceRange | undefined {
+  const dot = charAfterNonWhitespace(document, root.offset + root.length)
+  if (dot == null || dot.char !== '.') {
+    return undefined
+  }
+
+  const memberStart = skipWhitespaceRight(document, dot.index + 1)
+  return getWordRangeAt(document, memberStart)
+}
+
 function charAt (document: TextLike, index: number): string {
   return index >= 0 && index < document.length ? document.sliceString(index, index + 1) : ''
 }
@@ -397,11 +445,32 @@ function skipWhitespaceLeft (document: TextLike, position: number): number {
   return 0
 }
 
+function skipWhitespaceRight (document: TextLike, position: number): number {
+  for (let pos = position; pos < document.length; ++pos) {
+    if (!isWhitespace(charAt(document, pos))) {
+      return pos
+    }
+  }
+
+  return document.length
+}
+
 function charBeforeNonWhitespace (document: TextLike, position: number): { readonly index: number, readonly char: string } | undefined {
   for (let pos = position; pos > 0; --pos) {
     const char = charAt(document, pos - 1)
     if (!isWhitespace(char)) {
       return { index: pos - 1, char }
+    }
+  }
+
+  return undefined
+}
+
+function charAfterNonWhitespace (document: TextLike, position: number): { readonly index: number, readonly char: string } | undefined {
+  for (let pos = position; pos < document.length; ++pos) {
+    const char = charAt(document, pos)
+    if (!isWhitespace(char)) {
+      return { index: pos, char }
     }
   }
 

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -64,6 +64,7 @@ interpolationExpression {
 
 VariableDefinition { word }
 VariableName { word }
+BusNamespace { kw<"bus"> }
 
 Number { number }
 
@@ -110,7 +111,7 @@ argumentList {
 }
 
 primary {
-  "(" expression ")" | Number | String | Pattern | Curve | Call | VariableName
+  "(" expression ")" | Number | String | Pattern | Curve | Call | VariableName | BusNamespace
 }
 
 Call {

--- a/packages/language-support/test/analysis/query.test.ts
+++ b/packages/language-support/test/analysis/query.test.ts
@@ -23,7 +23,7 @@ describe('analysis/query.ts', () => {
   it('resolves assignment bindings from the shared analysis query', () => {
     const source = [
       'kick = sample("/samples/kick.wav")',
-      'track (4.bars) {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    kick << [x---]',
       '  }',
@@ -48,7 +48,7 @@ describe('analysis/query.ts', () => {
     const source = [
       'use "effects" as fx',
       'synth = sample("...")',
-      'track (4.bars) {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
       '  }',
@@ -67,6 +67,32 @@ describe('analysis/query.ts', () => {
 
     const synthOffset = source.indexOf('synth =')
     assert.deepStrictEqual(binding.range, getRangeAt(source, synthOffset, 'synth'.length))
+  })
+
+  it('resolves explicit bus namespace access to the bus binding', () => {
+    const source = [
+      'track (120.bpm) {',
+      '  part foo (4.bars) {',
+      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus foo {}',
+      '}',
+      ''
+    ].join('\n')
+
+    const { tree, document } = parseDocument(source)
+    const model = analyzeTree(tree, document)
+    const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
+    const binding = findDefinitionBindingAt(model, tree, document, position)
+
+    assert.ok(binding)
+    assert.strictEqual(binding.kind, 'bus')
+    assert.strictEqual(binding.name, 'foo')
+
+    const busOffset = source.indexOf('bus foo') + 'bus '.length
+    assert.deepStrictEqual(binding.range, getRangeAt(source, busOffset, 'foo'.length))
   })
 
   it('does not resolve named argument keys', () => {

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -72,7 +72,7 @@ describe('go-to-definition/operation.ts', () => {
       '',
       'synth = sample("...")',
       '',
-      'track {',
+      'track (120.bpm) {',
       '  part p {',
       '    automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]',
       '  }',
@@ -86,6 +86,28 @@ describe('go-to-definition/operation.ts', () => {
     assert.deepStrictEqual(
       applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
       getRangeAt(source, defPos, 'synth'.length)
+    )
+  })
+
+  it('resolves explicit bus namespace access to the bus definition', () => {
+    const source = [
+      'track (120.bpm) {',
+      '  part foo {',
+      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus foo {}',
+      '}',
+      ''
+    ].join('\n')
+
+    const defPos = source.indexOf('bus foo') + 'bus '.length
+    const refPos = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      getRangeAt(source, defPos, 'foo'.length)
     )
   })
 

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -14,7 +14,7 @@ describe('highlight-occurrences/operation.ts', () => {
     const source = [
       'foo = sample("/samples/foo.wav")',
       'bar = foo',
-      'track (4.bars) {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    foo << [x---]',
       '  }',
@@ -37,7 +37,7 @@ describe('highlight-occurrences/operation.ts', () => {
   it('normalizes member access references to the root identifier range', () => {
     const source = [
       'synth = sample("...")',
-      'track (4.bars) {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
       '  }',
@@ -52,6 +52,30 @@ describe('highlight-occurrences/operation.ts', () => {
       [
         getRangeAt(source, source.indexOf('synth ='), 'synth'.length),
         getRangeAt(source, source.indexOf('synth.gain'), 'synth'.length)
+      ]
+    )
+  })
+
+  it('normalizes explicit bus namespace references to the bus member range', () => {
+    const source = [
+      'track (120.bpm) {',
+      '  part foo {',
+      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus foo {}',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('bus.foo.gain') + 'bus.'.length, 'foo'.length),
+        getRangeAt(source, source.indexOf('bus foo') + 'bus '.length, 'foo'.length)
       ]
     )
   })

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -14,7 +14,7 @@ describe('unused-variable/operation.ts', () => {
     const source = [
       'used = sample("/samples/used.wav")',
       'unused = sample("/samples/unused.wav")',
-      'track (4.bars) {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    used << [x---]',
       '  }',
@@ -36,7 +36,7 @@ describe('unused-variable/operation.ts', () => {
 
   it('does not report parts or buses as unused', () => {
     const source = [
-      'track (4.bars) {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
       '  }',
       '}',
@@ -56,7 +56,7 @@ describe('unused-variable/operation.ts', () => {
   it('treats member access roots as references', () => {
     const source = [
       'synth = sample("...")',
-      'track (4.bars) {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
       '  }',
@@ -67,6 +67,32 @@ describe('unused-variable/operation.ts', () => {
     assert.deepStrictEqual(
       applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
       []
+    )
+  })
+
+  it('does not treat explicit bus namespace access as an assignment reference', () => {
+    const source = [
+      'foo = sample("...")',
+      'track (120.bpm) {',
+      '  part intro (4.bars) {',
+      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus foo {}',
+      '}',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      [
+        {
+          name: 'foo',
+          message: 'Unused variable "foo".',
+          range: getRangeAt(source, source.indexOf('foo ='), 'foo'.length)
+        }
+      ]
     )
   })
 })

--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -16,19 +16,30 @@ export function check (program: ast.Program): readonly CompileError[] {
     return importResult.errors
   }
 
-  const top = createGlobalScope(importResult.result)
-
-  const context = createLocalScope(top)
-
   const assignments = program.children.filter((c) => c.type === 'Assignment')
   const tracks = program.children.filter((c) => c.type === 'TrackStatement')
   const mixers = program.children.filter((c) => c.type === 'MixerStatement')
 
-  const errors = [
-    ...checkAssignments(context, assignments),
-    ...checkTracks(context, tracks),
-    ...checkMixers(context, mixers)
-  ]
+  const top = createGlobalScope({
+    resolutions: importResult.result,
+    buses: new Map()
+  })
+
+  const context = createLocalScope(top)
+
+  const errors: CompileError[] = []
+
+  errors.push(...checkAssignments(context, assignments))
+
+  // Check mixers before tracks so that tracks can reference buses defined in the mixer
+  errors.push(...checkMixers(context, mixers))
+  for (const mixer of mixers) {
+    for (const bus of mixer.buses) {
+      context.buses.set(bus.name.name, BusType)
+    }
+  }
+
+  errors.push(...checkTracks(context, tracks))
 
   return errors
 }
@@ -36,10 +47,12 @@ export function check (program: ast.Program): readonly CompileError[] {
 interface Context {
   readonly parent?: Context
   readonly resolutions: ReadonlyMap<string, Type>
+  readonly buses: ReadonlyMap<string, Type>
 }
 
 interface MutableContext extends Context {
   readonly resolutions: Map<string, Type>
+  readonly buses: Map<string, Type>
 }
 
 interface Checked<TValue> {
@@ -47,16 +60,15 @@ interface Checked<TValue> {
   readonly result?: TValue
 }
 
-function createGlobalScope (initialResolutions: ReadonlyMap<string, Type>): Context {
-  return {
-    resolutions: initialResolutions
-  }
+function createGlobalScope (value: Omit<Context, 'parent'>): Context {
+  return value
 }
 
 function createLocalScope (parent: Context): MutableContext {
   return {
     parent,
-    resolutions: new Map()
+    resolutions: new Map(),
+    buses: new Map()
   }
 }
 
@@ -69,18 +81,26 @@ function ensureStandardModule (moduleName: string): ModuleValue {
   return module
 }
 
-function resolve (context: Context, name: string): Type | undefined {
+function recursiveLookup<T> (context: Context, lookup: (context: Context) => T | undefined): T | undefined {
   let current: Context | undefined = context
 
   while (current != null) {
-    const valueType = current.resolutions.get(name)
-    if (valueType != null) {
-      return valueType
+    const result = lookup(current)
+    if (result != null) {
+      return result
     }
     current = current.parent
   }
 
   return undefined
+}
+
+function resolve (context: Context, name: string): Type | undefined {
+  return recursiveLookup(context, (ctx) => ctx.resolutions.get(name))
+}
+
+function resolveBus (context: Context, name: string): Type | undefined {
+  return recursiveLookup(context, (ctx) => ctx.buses.get(name))
 }
 
 function checkType (options: readonly Type[], actual: Type, range?: SourceRange): readonly CompileError[] {
@@ -304,6 +324,7 @@ function checkMixer (context: Context, mixer: ast.MixerStatement): readonly Comp
     seenBuses.add(bus.name.name)
 
     mixerContext.resolutions.set(bus.name.name, BusType)
+    mixerContext.buses.set(bus.name.name, BusType)
   }
 
   // Now that all buses are known, we can check the routings
@@ -512,6 +533,15 @@ function checkExpression (context: Context, expression: ast.Expression): Checked
     }
 
     case 'PropertyAccess': {
+      if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
+        const busName = expression.property.name
+        const busType = resolveBus(context, busName)
+        if (busType == null) {
+          return { errors: [new CompileError(`Unknown bus "${busName}"`, expression.property.range)] }
+        }
+        return { errors: [], result: busType }
+      }
+
       const objectCheck = checkExpression(context, expression.object)
       if (objectCheck.result == null) {
         return { errors: objectCheck.errors }

--- a/packages/language/src/compiler/functions.ts
+++ b/packages/language/src/compiler/functions.ts
@@ -1,6 +1,8 @@
-import { type Automation, type Instrument, type InstrumentId, type ParameterId } from '@core'
+import type { Automation, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
+import type { Numeric, Unit } from '@utility'
 import type { InferSchema, PropertySchema } from './schema.js'
-import { type Type, type Value } from './types.js'
+import type { InstrumentValue, Type, Value } from './types.js'
+import { InstrumentType } from './types.js'
 
 export interface FunctionDefinition<S extends PropertySchema = PropertySchema, R extends Type = Type> {
   readonly arguments: S
@@ -13,4 +15,26 @@ export type FunctionHandler<S extends PropertySchema> = (context: FunctionContex
 export interface FunctionContext {
   readonly instruments: Map<InstrumentId, Instrument>
   readonly automations: Map<ParameterId, Automation>
+}
+
+export function allocateInstrument (context: FunctionContext, data: Omit<Instrument, 'id'>): InstrumentValue {
+  const currentMaxId = Math.max(0, ...Array.from(context.instruments.keys()))
+  const id = (currentMaxId + 1) as InstrumentId
+
+  const instrument = InstrumentType.of({ ...data, id })
+  context.instruments.set(instrument.data.id, instrument.data)
+
+  return instrument
+}
+
+export function allocateParameter<U extends Unit> (context: FunctionContext, initial: Numeric<U>): Parameter<U> {
+  const currentMaxId = Math.max(0, ...Array.from(context.automations.keys()))
+  const id = (currentMaxId + 1) as ParameterId
+
+  context.automations.set(id, {
+    parameterId: id,
+    points: []
+  })
+
+  return { id, initial }
 }

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -7,6 +7,7 @@ import { busSchema, partSchema, stepSchema, trackSchema } from './common.js'
 import type { CurveSegment as GeneratedCurveSegment } from './curves.js'
 import { createCurve, createCurveSegment, getCurveSegmentType, renderCurvePoints } from './curves.js'
 import { CompileError } from './error.js'
+import { allocateParameter } from './functions.js'
 import { getStandardModule } from './modules.js'
 import type { InferSchema, PropertySchema } from './schema.js'
 import type { CurveValue, PatternValue, StringValue, Type, Value } from './types.js'
@@ -38,16 +39,17 @@ export function generate (program: ast.Program, options: GenerateOptions): Progr
 
   processAssignments(context, assignments)
 
+  // Automations in the track may refer to mixer buses, so the mixer must be generated first.
+  const mixer = mixers.length > 0
+    ? generateMixer(context, mixers[0])
+    : { buses: [], routings: [] }
+
   const track = tracks.length > 0
     ? generateTrack(context, tracks[0])
     : {
         tempo: numeric('bpm', options.tempo.default),
         parts: []
       }
-
-  const mixer = mixers.length > 0
-    ? generateMixer(context, mixers[0])
-    : { buses: [], routings: [] }
 
   return {
     beatsPerBar: options.beatsPerBar,
@@ -70,6 +72,7 @@ interface Context {
 interface TopLevelContext extends Context {
   readonly options: GenerateOptions
   readonly instruments: Map<InstrumentId, Instrument>
+  readonly buses: Map<string, Value>
   readonly automations: Map<ParameterId, Automation>
 }
 
@@ -84,6 +87,7 @@ function createGlobalScope (options: GenerateOptions, initialResolutions: Readon
     },
     options,
     instruments: new Map(),
+    buses: new Map(),
     automations: new Map(),
     resolutions: new Map(initialResolutions)
   }
@@ -233,7 +237,9 @@ function generateMixer (context: Context, mixer: ast.MixerStatement): Mixer {
 
   for (const bus of buses) {
     assert(!mixerContext.resolutions.has(bus.name))
-    mixerContext.resolutions.set(bus.name, BusType.of(bus))
+    const busValue = BusType.of(bus)
+    mixerContext.resolutions.set(bus.name, busValue)
+    context.top.buses.set(bus.name, busValue)
   }
 
   const routings: MixerRouting[] = []
@@ -280,7 +286,12 @@ function generateBus (context: Context, bus: ast.BusStatement, id: BusId): Bus {
     return EffectType.cast(resolve(context, effect.expression)).data
   })
 
-  return { id, name, ...properties, effects }
+  // Gain must always be allocated even if not explicitly set,
+  // as it could still be automated.
+  const gain = allocateParameter(context.top, properties.gain ?? numeric('db', 0))
+  const pan = properties.pan
+
+  return { id, name, gain, pan, effects }
 }
 
 function generateBusRoutings (mixerContext: Context, bus: ast.BusStatement, buses: readonly Bus[]): readonly MixerRouting[] {
@@ -353,6 +364,10 @@ function resolve (context: Context, expression: ast.Expression): Value {
     }
 
     case 'PropertyAccess': {
+      if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
+        return nonNull(context.top.buses.get(expression.property.name))
+      }
+
       const object = resolve(context, expression.object)
       const property = expression.property.name
 

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -1,51 +1,80 @@
 import type { Effect } from '@core'
-import type { PropertySchema } from '../schema.js'
+import type { FunctionContext } from '../functions.js'
+import { allocateParameter } from '../functions.js'
+import type { InferSchema, PropertySchema } from '../schema.js'
 import type { Value } from '../types.js'
 import { EffectType, FunctionType, ModuleType, NumberType } from '../types.js'
 
 // Factory
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-const createEffectConstructor = <T extends Effect>(type: T['type'], schema: PropertySchema) => {
+const createEffectConstructor = <T extends Effect, const S extends PropertySchema>(
+  schema: S,
+  create: (context: FunctionContext, args: InferSchema<S>) => T
+) => {
   return FunctionType.of({
     arguments: schema,
     returnType: EffectType,
-    invoke: (context, args) => EffectType.of({ ...args, type } as T)
+    invoke: (context, args) => EffectType.of(create(context, args))
   })
 }
 
 // Effects
 
-const gain = createEffectConstructor('gain', [
+const gain = createEffectConstructor([
   { name: 'gain', type: NumberType.with('db'), required: true }
-])
+], (context, args) => ({
+  type: 'gain',
+  gain: allocateParameter(context, args.gain)
+}))
 
-const pan = createEffectConstructor('pan', [
+const pan = createEffectConstructor([
   { name: 'pan', type: NumberType.with(undefined), required: true }
-])
+], (context, args) => ({
+  type: 'pan',
+  pan: args.pan
+}))
 
-const lowpass = createEffectConstructor('lowpass', [
+const lowpass = createEffectConstructor([
   { name: 'frequency', type: NumberType.with('hz'), required: true }
-])
+], (context, args) => ({
+  type: 'lowpass',
+  frequency: args.frequency
+}))
 
-const highpass = createEffectConstructor('highpass', [
+const highpass = createEffectConstructor([
   { name: 'frequency', type: NumberType.with('hz'), required: true }
-])
+], (context, args) => ({
+  type: 'highpass',
+  frequency: args.frequency
+}))
 
-const width = createEffectConstructor('width', [
+const width = createEffectConstructor([
   { name: 'width', type: NumberType.with(undefined), required: true }
-])
+], (context, args) => ({
+  type: 'width',
+  width: args.width
+}))
 
-const delay = createEffectConstructor('delay', [
+const delay = createEffectConstructor([
   { name: 'mix', type: NumberType.with(undefined), required: true },
   { name: 'time', type: [NumberType.with('beats'), NumberType.with('s')], required: true },
   { name: 'feedback', type: NumberType.with(undefined), required: true }
-])
+], (context, args) => ({
+  type: 'delay',
+  mix: args.mix,
+  time: args.time,
+  feedback: args.feedback
+}))
 
-const reverb = createEffectConstructor('reverb', [
+const reverb = createEffectConstructor([
   { name: 'mix', type: NumberType.with(undefined), required: true },
   { name: 'decay', type: [NumberType.with('beats'), NumberType.with('s')], required: true }
-])
+], (context, args) => ({
+  type: 'reverb',
+  mix: args.mix,
+  decay: args.decay
+}))
 
 export const effectsModule = ModuleType.of({
   name: 'effects',

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -1,34 +1,10 @@
-import type { Instrument, InstrumentId, Parameter, ParameterId } from '@core'
 import { isPitch } from '@core'
-import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
-import type { FunctionContext } from '../functions.js'
-import type { InstrumentValue, Value } from '../types.js'
+import { allocateInstrument, allocateParameter } from '../functions.js'
+import type { Value } from '../types.js'
 import { FunctionType, InstrumentType, ModuleType, NumberType, StringType } from '../types.js'
 
 const UNITY_GAIN = numeric('db', 0)
-
-function allocateInstrument (context: FunctionContext, data: Omit<Instrument, 'id'>): InstrumentValue {
-  const currentMaxId = Math.max(0, ...Array.from(context.instruments.keys()))
-  const id = (currentMaxId + 1) as InstrumentId
-
-  const instrument = InstrumentType.of({ ...data, id })
-  context.instruments.set(instrument.data.id, instrument.data)
-
-  return instrument
-}
-
-function allocateParameter<U extends Unit> (context: FunctionContext, initial: Numeric<U>): Parameter<U> {
-  const currentMaxId = Math.max(0, ...Array.from(context.automations.keys()))
-  const id = (currentMaxId + 1) as ParameterId
-
-  context.automations.set(id, {
-    parameterId: id,
-    points: []
-  })
-
-  return { id, initial }
-}
 
 const sample = FunctionType.of({
   arguments: [

--- a/packages/language/src/compiler/types.ts
+++ b/packages/language/src/compiler/types.ts
@@ -190,6 +190,7 @@ export const NumberType = {
 }
 
 export const StringType = makeType<'string', {}, StringValue>('string')
+
 export const PatternType = makeType<'pattern', {}, PatternValue>('pattern')
 
 export const ParameterType = {
@@ -265,5 +266,25 @@ export const InstrumentType = makeType<'instrument', {}, InstrumentValue>('instr
 })
 
 export const PartType = makeType<'part', {}, PartValue>('part')
+
 export const EffectType = makeType<'effect', {}, EffectValue>('effect')
-export const BusType = makeType<'bus', {}, BusValue>('bus')
+
+export const BusType = makeType<'bus', {}, BusValue>('bus', undefined, {
+  propertyType (name: string): Type | undefined {
+    switch (name) {
+      case 'gain':
+        return ParameterType.with('db')
+      default:
+        return undefined
+    }
+  },
+
+  propertyValue (value, name: string): AnyValue | undefined {
+    switch (name) {
+      case 'gain':
+        return ParameterType.of(value.data.gain)
+      default:
+        return undefined
+    }
+  }
+})

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -77,6 +77,11 @@ const identifier_: p.Parser<Token, unknown, ast.Identifier> = p.token((t) => {
     : undefined
 })
 
+const busNamespaceRoot_: p.Parser<Token, unknown, ast.Identifier> = p.map(
+  keyword('bus'),
+  (token) => ast.make('Identifier', getSourceRange(token), { name: token.text })
+)
+
 const number_: p.Parser<Token, unknown, ast.Number> = p.token((t) => {
   return t.name === 'number'
     ? ast.make('Number', getSourceRange(t), { value: Number.parseFloat(t.text) })
@@ -389,7 +394,7 @@ const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
 
 // Parse an identifier, a property access, or a call; chained as needed.
 const accessOrCall_: p.Parser<Token, unknown, ast.Expression> = p.ab(
-  primary_,
+  p.eitherOr(primary_, busNamespaceRoot_),
   p.many(
     p.eitherOr(
       p.ab(

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -440,6 +440,70 @@ describe('compiler/checker.ts', () => {
       assert.deepStrictEqual(check(program), [])
     })
 
+    it('should accept bus gain automation via explicit namespace', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [],
+        children: [
+          ast.make('TrackStatement', RANGE, {
+            properties: [],
+            parts: [
+              ast.make('PartStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'intro' }),
+                properties: [
+                  ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('Number', RANGE, { value: 4 }),
+                    property: ast.make('Identifier', RANGE, { name: 'bars' })
+                  })
+                ],
+                routings: [],
+                automations: [
+                  ast.make('AutomateStatement', RANGE, {
+                    target: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('PropertyAccess', RANGE, {
+                        object: ast.make('Identifier', RANGE, { name: 'bus' }),
+                        property: ast.make('Identifier', RANGE, { name: 'main' })
+                      }),
+                      property: ast.make('Identifier', RANGE, { name: 'gain' })
+                    }),
+                    curve: ast.make('Curve', RANGE, {
+                      children: [
+                        ast.make('CurveSegment', RANGE, {
+                          curveType: 'lin',
+                          parameters: [
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: -20 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            }),
+                            ast.make('PropertyAccess', RANGE, {
+                              object: ast.make('Number', RANGE, { value: 0 }),
+                              property: ast.make('Identifier', RANGE, { name: 'db' })
+                            })
+                          ]
+                        })
+                      ]
+                    })
+                  })
+                ]
+              })
+            ]
+          }),
+          ast.make('MixerStatement', RANGE, {
+            properties: [],
+            buses: [
+              ast.make('BusStatement', RANGE, {
+                name: ast.make('Identifier', RANGE, { name: 'main' }),
+                properties: [],
+                sources: [],
+                effects: []
+              })
+            ]
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [])
+    })
+
     it('should accept curve automation with weighted segments', () => {
       const program = ast.make('Program', RANGE, {
         imports: [

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -761,6 +761,79 @@ describe('compiler/generator.ts', () => {
     ])
   })
 
+  it('should automate bus gain via explicit namespace', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [],
+      children: [
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 4 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('PropertyAccess', RANGE, {
+                    object: ast.make('PropertyAccess', RANGE, {
+                      object: ast.make('Identifier', RANGE, { name: 'bus' }),
+                      property: ast.make('Identifier', RANGE, { name: 'main' })
+                    }),
+                    property: ast.make('Identifier', RANGE, { name: 'gain' })
+                  }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'lin',
+                        parameters: [
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: -20 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          }),
+                          ast.make('PropertyAccess', RANGE, {
+                            object: ast.make('Number', RANGE, { value: 0 }),
+                            property: ast.make('Identifier', RANGE, { name: 'db' })
+                          })
+                        ]
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        }),
+        ast.make('MixerStatement', RANGE, {
+          properties: [],
+          buses: [
+            ast.make('BusStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'main' }),
+              properties: [],
+              sources: [],
+              effects: []
+            })
+          ]
+        })
+      ]
+    })
+
+    const result = generate(program, OPTIONS)
+
+    assert.strictEqual(result.automations.size, 1)
+    const busGain = result.mixer.buses[0].gain
+    const automation = result.automations.get(busGain.id)
+    assert.ok(automation)
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('db', -20), curve: 'step' },
+      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+    ])
+  })
+
   it('should support buses as sources in mixer', () => {
     const program = ast.make('Program', RANGE, {
       imports: [],

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -31,7 +31,10 @@ describe('compiler/modules/effects.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         type: 'gain',
-        gain: numeric('db', -6)
+        gain: {
+          id: 1,
+          initial: numeric('db', -6)
+        }
       })
     })
   })
@@ -117,6 +120,7 @@ describe('compiler/modules/effects.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         type: 'delay',
+        mix: undefined,
         time: beats(0.5),
         feedback: numeric(undefined, 0.3)
       })
@@ -131,6 +135,7 @@ describe('compiler/modules/effects.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         type: 'delay',
+        mix: undefined,
         time: seconds(1.5),
         feedback: numeric(undefined, 0.3)
       })

--- a/packages/language/test/compiler/types.test.ts
+++ b/packages/language/test/compiler/types.test.ts
@@ -5,7 +5,8 @@ import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { ModuleDefinition } from '../../src/compiler/modules.js'
-import { BusType, BusValue, CurveType, type CurveValue, EffectType, type EffectValue, FunctionType, type FunctionValue, InstrumentType, type InstrumentValue, ModuleType, type ModuleValue, NumberType, type NumberValue, ParameterType, type ParameterValue, PartType, PartValue, PatternType, type PatternValue, StringType, type StringValue, type Value, type ValueFor } from '../../src/compiler/types.js'
+import type { BusValue, CurveValue, EffectValue, FunctionValue, InstrumentValue, ModuleValue, NumberValue, ParameterValue, PartValue, PatternValue, StringValue, Value, ValueFor } from '../../src/compiler/types.js'
+import { BusType, CurveType, EffectType, FunctionType, InstrumentType, ModuleType, NumberType, ParameterType, PartType, PatternType, StringType } from '../../src/compiler/types.js'
 import { expectTypeEquals } from '../test-utils.js'
 
 describe('compiler/types.ts', () => {
@@ -620,6 +621,32 @@ describe('compiler/types.ts', () => {
       assert.strictEqual(BusType.name, 'bus')
       assert.strictEqual(BusType.generics, undefined)
       assert.strictEqual(BusType.format(), 'bus')
+    })
+
+    describe('propertyType()', () => {
+      it('should return property types', () => {
+        const gainType = BusType.propertyType('gain')
+        assert.strictEqual(gainType?.name, 'parameter')
+        assert.deepStrictEqual(gainType.generics, { unit: 'db' })
+      })
+    })
+
+    describe('propertyValue()', () => {
+      it('should return property values', () => {
+        const busValue = BusType.of({
+          id: 1 as any,
+          name: 'main',
+          pan: undefined,
+          gain: {
+            id: 2 as ParameterId,
+            initial: numeric('db', -3)
+          },
+          effects: []
+        })
+
+        const gainValue = BusType.propertyValue(busValue, 'gain')
+        assert.deepStrictEqual(gainValue?.data, busValue.data.gain)
+      })
     })
   })
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -195,6 +195,41 @@ describe('parser/parser.ts', () => {
     })
   })
 
+  it('should parse explicit bus parameter access', () => {
+    const result = parse(makeTokens([
+      { name: 'word', text: 'target' },
+      { name: '=' },
+      { name: 'word', text: 'bus' },
+      { name: '.' },
+      { name: 'word', text: 'main' },
+      { name: '.' },
+      { name: 'word', text: 'gain' }
+    ]))
+
+    assert.deepStrictEqual(stripRanges(result), {
+      complete: true,
+      value: {
+        type: 'Program',
+        imports: [],
+        children: [
+          {
+            type: 'Assignment',
+            key: { type: 'Identifier', name: 'target' },
+            value: {
+              type: 'PropertyAccess',
+              object: {
+                type: 'PropertyAccess',
+                object: { type: 'Identifier', name: 'bus' },
+                property: { type: 'Identifier', name: 'main' }
+              },
+              property: { type: 'Identifier', name: 'gain' }
+            }
+          }
+        ]
+      }
+    })
+  })
+
   it('should parse string literals with escapes and interpolations', () => {
     const result = parse(makeTokens([
       { name: 'word', text: 'foo' },


### PR DESCRIPTION
This patch introduces new syntax for accessing mixer buses and their properties from outside the mixer by prefixing them with `bus.`. For example, `bus.drums.gain` would refer to the gain parameter of the "drums" bus.

Additionally, the gain effect is now parameter-typed instead of number- typed to support its use as an automation target.