### PR TITLE
fix: Fix checker exceptions for incompatible types

### DIFF
--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -280,11 +280,12 @@ function checkAutomation (context: Context, automation: ast.AutomateStatement): 
   const curveCheck = checkExpression(context, automation.curve)
   errors.push(...curveCheck.errors)
 
-  if (targetCheck.result != null && curveCheck.result != null) {
-    const { unit } = ParameterType.detail(targetCheck.result)
-    errors.push(...checkType([CurveType.with(unit)], curveCheck.result, automation.curve.range))
-  } else if (curveCheck.result != null) {
-    errors.push(...checkType([CurveType], curveCheck.result, automation.curve.range))
+  if (curveCheck.result != null) {
+    const curveType = targetCheck.result != null && ParameterType.equals(targetCheck.result)
+      ? CurveType.with(ParameterType.detail(targetCheck.result).unit)
+      : CurveType
+
+    errors.push(...checkType([curveType], curveCheck.result, automation.curve.range))
   }
 
   return errors
@@ -478,19 +479,7 @@ function checkExpression (context: Context, expression: ast.Expression): Checked
       return { errors: [], result: NumberType.with(undefined) }
 
     case 'String': {
-      const errors: CompileError[] = []
-
-      for (const part of expression.parts) {
-        if (typeof part !== 'string') {
-          const partCheck = checkExpression(context, part)
-          if (partCheck.result == null) {
-            return { errors: partCheck.errors }
-          }
-          errors.push(...checkType([StringType], partCheck.result, part.range))
-        }
-      }
-
-      return { errors, result: StringType }
+      return checkString(context, expression)
     }
 
     case 'Pattern': {
@@ -572,6 +561,22 @@ function checkExpression (context: Context, expression: ast.Expression): Checked
   }
 }
 
+function checkString (context: Context, string: ast.String): Checked<Type> {
+  const errors: CompileError[] = []
+
+  for (const part of string.parts) {
+    if (typeof part !== 'string') {
+      const partCheck = checkExpression(context, part)
+      if (partCheck.result == null) {
+        return { errors: partCheck.errors }
+      }
+      errors.push(...checkType([StringType], partCheck.result, part.range))
+    }
+  }
+
+  return { errors, result: StringType }
+}
+
 function checkPattern (context: Context, pattern: ast.Pattern): Checked<Type> {
   const errors: CompileError[] = []
 
@@ -589,7 +594,7 @@ function checkPattern (context: Context, pattern: ast.Pattern): Checked<Type> {
     }
   }
 
-  return { errors, result: errors.length > 0 ? undefined : PatternType }
+  return { errors, result: PatternType }
 }
 
 function checkStep (context: Context, step: ast.Step): readonly CompileError[] {
@@ -691,8 +696,11 @@ function checkCurveSegment (context: Context, segment: ast.CurveSegment, hasPrev
     errors.push(...pointCheck.errors)
 
     if (pointCheck.result != null) {
-      errors.push(...checkType([NumberType], pointCheck.result, point.range))
-      units.push(NumberType.detail(pointCheck.result).unit)
+      const typeErrors = checkType([NumberType], pointCheck.result, point.range)
+      errors.push(...typeErrors)
+      if (typeErrors.length === 0) {
+        units.push(NumberType.detail(pointCheck.result).unit)
+      }
     }
   }
 

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -919,6 +919,35 @@ describe('compiler/checker.ts', () => {
       ])
     })
 
+    it('should reject curves with non-numeric parameters', () => {
+      const program = ast.make('Program', RANGE, {
+        imports: [
+          ast.make('UseStatement', RANGE, {
+            library: ast.make('String', RANGE, { parts: ['instruments'] })
+          })
+        ],
+        children: [
+          ast.make('Assignment', RANGE, {
+            key: ast.make('Identifier', RANGE, { name: 'my_curve' }),
+            value: ast.make('Curve', RANGE, {
+              children: [
+                ast.make('CurveSegment', RANGE, {
+                  curveType: 'hold',
+                  parameters: [
+                    ast.make('String', RANGE, { parts: ['not a number'] })
+                  ]
+                })
+              ]
+            })
+          })
+        ]
+      })
+
+      assert.deepStrictEqual(check(program), [
+        new CompileError('Expected type number, got string', RANGE)
+      ])
+    })
+
     it('should reject lin curves that omit the start for the first segment', () => {
       const program = ast.make('Program', RANGE, {
         imports: [
@@ -1105,6 +1134,50 @@ describe('compiler/checker.ts', () => {
         new CompileError('Expected type number(db), got number(bpm)', RANGE)
       ])
     })
+  })
+
+  it('should reject automations that target non-parameters', () => {
+    const program = ast.make('Program', RANGE, {
+      imports: [],
+      children: [
+        ast.make('Assignment', RANGE, {
+          key: ast.make('Identifier', RANGE, { name: 'some_value' }),
+          value: ast.make('String', RANGE, { parts: [''] })
+        }),
+        ast.make('TrackStatement', RANGE, {
+          properties: [],
+          parts: [
+            ast.make('PartStatement', RANGE, {
+              name: ast.make('Identifier', RANGE, { name: 'intro' }),
+              properties: [
+                ast.make('PropertyAccess', RANGE, {
+                  object: ast.make('Number', RANGE, { value: 4 }),
+                  property: ast.make('Identifier', RANGE, { name: 'bars' })
+                })
+              ],
+              routings: [],
+              automations: [
+                ast.make('AutomateStatement', RANGE, {
+                  target: ast.make('Identifier', RANGE, { name: 'some_value' }),
+                  curve: ast.make('Curve', RANGE, {
+                    children: [
+                      ast.make('CurveSegment', RANGE, {
+                        curveType: 'hold',
+                        parameters: [ast.make('Number', RANGE, { value: -60 })]
+                      })
+                    ]
+                  })
+                })
+              ]
+            })
+          ]
+        })
+      ]
+    })
+
+    assert.deepStrictEqual(check(program), [
+      new CompileError('Expected type parameter, got string', RANGE)
+    ])
   })
 
   it('should reject duplicate mixer blocks', () => {


### PR DESCRIPTION
This patch fixes two situations in which an invalid type would cause the checker to throw an exception instead of returning a type error. See the test cases for details.