### PR TITLE
feat: Add hover docs for standard library modules

### DIFF
--- a/packages/app/src/modules/editor/components/EditorPanel.tsx
+++ b/packages/app/src/modules/editor/components/EditorPanel.tsx
@@ -5,7 +5,7 @@ import type { EditorLocation, PanelProps, Problem } from '@editor'
 import { Editor, getProjectFileContent, setProjectFileContent, useProjectSource, useProjectSourceDispatch, useProvideProblems } from '@editor'
 import type { RangeError } from '@language'
 import type { LanguageDiagnostic, SourceRange } from '@language-support'
-import { applySemanticOperation, cadenceLanguageSupport, findUnusedVariables, goToDefinitionExtension, highlightOccurrencesExtension } from '@language-support'
+import { applySemanticOperation, cadenceLanguageSupport, findUnusedVariables, goToDefinitionExtension, highlightOccurrencesExtension, hoverInfoExtension } from '@language-support'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useCompilationState } from '../../../compilation/CompilationContext.js'
@@ -19,7 +19,8 @@ const indent = '  ' // 2 spaces
 const extensions = [
   cadenceLanguageSupport(),
   highlightOccurrencesExtension(),
-  goToDefinitionExtension()
+  goToDefinitionExtension(),
+  hoverInfoExtension()
 ]
 
 function getCompilerDiagnostics (filePath: string, errors: readonly RangeError[]): readonly Diagnostic[] {

--- a/packages/language-support/src/analysis/model.ts
+++ b/packages/language-support/src/analysis/model.ts
@@ -1,4 +1,4 @@
-import type { Tree, TreeCursor } from '@lezer/common'
+import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import type { LRParser } from '@lezer/lr'
 import type { SourceRange, TextLike } from '../types.js'
 import { textFromString, toSourceRange } from './text.js'
@@ -22,12 +22,19 @@ export interface Binding {
   readonly range: SourceRange
 }
 
+export interface ImportStatement {
+  readonly moduleName: string
+  readonly alias?: string
+  readonly aliasRange?: SourceRange
+}
+
 export interface Model {
   readonly rootScopeId: string
   readonly scopes: ReadonlyMap<string, Scope>
   readonly bindings: readonly Binding[]
   readonly bindingsByName: ReadonlyMap<string, readonly Binding[]>
   readonly bindingsByScope: ReadonlyMap<string, readonly Binding[]>
+  readonly imports: readonly ImportStatement[]
 }
 
 interface BindingInput {
@@ -60,6 +67,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
   const bindings: Binding[] = []
   const bindingsByName = new Map<string, Binding[]>()
   const bindingsByScope = new Map<string, Binding[]>()
+  const imports: ImportStatement[] = []
 
   const addBinding = (input: BindingInput): void => {
     const { kind, scopeId, name, range } = input
@@ -95,6 +103,17 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
     let nextAssignmentHasEquals = assignmentHasEquals
 
     switch (typeName) {
+      case 'UseStatement': {
+        const statement = parseUseStatement(document, cursor.node)
+        if (statement != null) {
+          imports.push(statement)
+          if (statement.alias != null && statement.aliasRange != null) {
+            addBinding({ kind: 'use-alias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
+          }
+        }
+        break
+      }
+
       case 'TrackStatement': {
         const id = scopeKey(typeName, range)
         scopes.set(id, { id, kind: 'track', range, parentId: currentScopeId })
@@ -133,14 +152,6 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
 
         break
       }
-
-      case 'UseAlias': {
-        const name = document.sliceString(from, to)
-        if (name !== '*') {
-          addBinding({ kind: 'use-alias', scopeId: currentScopeId, name, range })
-        }
-        break
-      }
     }
 
     if (cursor.firstChild()) {
@@ -153,7 +164,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
 
   walk(cursor, undefined, rootScopeId, undefined, undefined, false)
 
-  return { rootScopeId, scopes, bindings, bindingsByName, bindingsByScope }
+  return { rootScopeId, scopes, bindings, bindingsByName, bindingsByScope, imports }
 }
 
 export function analyzeSourceWithParser (parser: LRParser, source: string): Model {
@@ -198,4 +209,45 @@ function getDefinitionBinding (context: DefinitionBindingContext): Omit<BindingI
   }
 
   return undefined
+}
+
+function parseUseStatement (document: TextLike, node: SyntaxNode): ImportStatement | undefined {
+  let moduleName: string | undefined
+  let alias: string | undefined
+  let aliasRange: SourceRange | undefined
+
+  const cursor = node.cursor()
+
+  if (cursor.firstChild()) {
+    do {
+      switch (cursor.type.name) {
+        case 'String':
+          moduleName ??= parseStringLiteral(document.sliceString(cursor.from, cursor.to))
+          break
+        case 'UseAlias':
+          alias ??= document.sliceString(cursor.from, cursor.to)
+          aliasRange ??= toSourceRange(document, cursor.from, cursor.to)
+          break
+      }
+    } while (cursor.nextSibling())
+  }
+
+  if (moduleName == null || alias == null) {
+    return undefined
+  }
+
+  return {
+    moduleName,
+    alias: alias === '*' ? undefined : alias,
+    aliasRange
+  }
+}
+
+function parseStringLiteral (text: string): string | undefined {
+  try {
+    const value = JSON.parse(text)
+    return typeof value === 'string' ? value : undefined
+  } catch {
+    return undefined
+  }
 }

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -119,7 +119,7 @@ export function findUnusedAssignmentBindings (model: Model, tree: Tree, document
   })
 }
 
-function findSemanticOccurrenceAt (tree: Tree, document: TextLike, position: number): SemanticOccurrence | undefined {
+export function findSemanticOccurrenceAt (tree: Tree, document: TextLike, position: number): SemanticOccurrence | undefined {
   const node = findIdentifierNodeAt(tree, position)
   if (node != null) {
     return {
@@ -374,7 +374,7 @@ function findEnclosingScopeId (
   return undefined
 }
 
-function findAccessChainRootBefore (document: TextLike, memberFrom: number): SourceRange | undefined {
+export function findAccessChainRootBefore (document: TextLike, memberFrom: number): SourceRange | undefined {
   const dot = charBeforeNonWhitespace(document, memberFrom)
   if (dot == null || dot.char !== '.') {
     return undefined

--- a/packages/language-support/src/hover/extension.ts
+++ b/packages/language-support/src/hover/extension.ts
@@ -1,0 +1,56 @@
+import { syntaxTree } from '@codemirror/language'
+import type { Extension } from '@codemirror/state'
+import { EditorView, hoverTooltip } from '@codemirror/view'
+import { applySemanticOperation } from '../operations.js'
+import { getHoverInfo } from './operation.js'
+
+const theme = EditorView.baseTheme({
+  '.cm-cadence-hover': {
+    padding: '8px 10px',
+    maxWidth: '32rem',
+    boxShadow: '0 2px 4px rgb(0 0 0 / 20%)',
+    borderRadius: '4px'
+  },
+  '.cm-cadence-hoverTitle': {
+    fontFamily: 'monospace',
+    fontSize: '0.9em',
+    fontWeight: '600'
+  },
+  '.cm-cadence-hoverSummary': {
+    marginTop: '0.35rem',
+    whiteSpace: 'pre-wrap'
+  }
+})
+
+const tooltip = hoverTooltip((view, position) => {
+  const info = applySemanticOperation(getHoverInfo, syntaxTree(view.state), view.state.doc, position)
+  if (info == null) {
+    return null
+  }
+
+  const pos = info.range.offset
+  const end = info.range.offset + info.range.length
+
+  const create = () => {
+    const dom = document.createElement('div')
+    dom.className = 'cm-cadence-hover'
+
+    const title = dom.appendChild(document.createElement('div'))
+    title.className = 'cm-cadence-hoverTitle'
+    title.textContent = info.title
+
+    if (info.summary != null && info.summary.length > 0) {
+      const summary = dom.appendChild(document.createElement('div'))
+      summary.className = 'cm-cadence-hoverSummary'
+      summary.textContent = info.summary
+    }
+
+    return { dom }
+  }
+
+  return { pos, end, create }
+})
+
+export function hoverInfoExtension (): Extension {
+  return [theme, tooltip]
+}

--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -1,0 +1,105 @@
+import type { HoverInfo } from '@language'
+import { getStandardLibraryHoverInfo } from '@language'
+import type { Tree } from '@lezer/common'
+import type { Binding, ImportStatement, Model } from '../analysis/model.js'
+import { findAccessChainRootBefore, findDefinitionBindingAt, findSemanticOccurrenceAt } from '../analysis/query.js'
+import type { SemanticOperation } from '../operations.js'
+import type { SourceRange, TextLike } from '../types.js'
+
+export interface HoverInfoWithRange extends HoverInfo {
+  readonly range: SourceRange
+}
+
+export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange | undefined> = (model, tree, document, pos) => {
+  const occurrence = findSemanticOccurrenceAt(tree, document, pos)
+  if (occurrence?.kind == null || occurrence.name.length === 0) {
+    return undefined
+  }
+
+  const memberInfo = resolveMemberHover(model, tree, document, occurrence.range, occurrence.name)
+  if (memberInfo != null) {
+    return { ...memberInfo, range: occurrence.range }
+  }
+
+  const binding = findDefinitionBindingAt(model, tree, document, pos)
+  if (binding?.kind === 'use-alias') {
+    const moduleName = findModuleNameForBinding(model.imports, binding)
+
+    const info = moduleName == null ? undefined : getStandardLibraryHoverInfo(moduleName)
+    if (info == null) {
+      return undefined
+    }
+
+    return { ...info, range: occurrence.range }
+  }
+
+  if (binding != null) {
+    return undefined
+  }
+
+  if (!isHoverableWildcardOccurrenceKind(occurrence.kind)) {
+    return undefined
+  }
+
+  const moduleName = findWildcardModuleForExport(model.imports, occurrence.name)
+  if (moduleName == null) {
+    return undefined
+  }
+
+  const info = getStandardLibraryHoverInfo(moduleName, occurrence.name)
+  if (info == null) {
+    return undefined
+  }
+
+  return { ...info, range: occurrence.range }
+}
+
+function resolveMemberHover (
+  model: Model,
+  tree: Tree,
+  document: TextLike,
+  range: SourceRange,
+  memberName: string
+): HoverInfo | undefined {
+  const rootRange = findAccessChainRootBefore(document, range.offset)
+  if (rootRange == null) {
+    return undefined
+  }
+
+  const rootPosition = rootRange.offset + Math.min(rootRange.length - 1, 1)
+  const rootBinding = findDefinitionBindingAt(model, tree, document, rootPosition)
+  if (rootBinding?.kind !== 'use-alias') {
+    return undefined
+  }
+
+  const moduleName = findModuleNameForBinding(model.imports, rootBinding)
+  if (moduleName == null) {
+    return undefined
+  }
+
+  return getStandardLibraryHoverInfo(moduleName, memberName)
+}
+
+function findModuleNameForBinding (imports: readonly ImportStatement[], binding: Binding): string | undefined {
+  return imports.find((statement) => statement.alias === binding.name)?.moduleName
+}
+
+function isHoverableWildcardOccurrenceKind (kind: string): boolean {
+  return kind === 'VariableName' || kind === 'Callee'
+}
+
+function findWildcardModuleForExport (imports: readonly ImportStatement[], exportName: string): string | undefined {
+  let resolvedModuleName: string | undefined
+
+  for (const statement of imports) {
+    if (statement.alias != null) {
+      continue
+    }
+
+    if (getStandardLibraryHoverInfo(statement.moduleName, exportName) != null) {
+      resolvedModuleName = statement.moduleName
+    }
+  }
+
+  return resolvedModuleName
+}

--- a/packages/language-support/src/index.ts
+++ b/packages/language-support/src/index.ts
@@ -13,5 +13,10 @@ export { goToDefinitionExtension } from './go-to-definition/extension.js'
 export { findHighlightedOccurrences } from './highlight-occurrences/operation.js'
 export { highlightOccurrencesExtension } from './highlight-occurrences/extension.js'
 
+// "hover info" feature
+export type { HoverInfoWithRange } from './hover/operation.js'
+export { getHoverInfo } from './hover/operation.js'
+export { hoverInfoExtension } from './hover/extension.js'
+
 // "unused variable" diagnostics
 export { findUnusedVariables } from './unused-variable/operation.js'

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -1,0 +1,111 @@
+import { buildParser } from '@lezer/generator'
+import assert from 'node:assert'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { getHoverInfo } from '../../src/hover/operation.js'
+import { applySemanticOperationWithParser } from '../../src/operations.js'
+import { getRangeAt } from '../helpers.js'
+
+const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
+const cadenceParser = buildParser(cadenceGrammar)
+
+describe('hover/operation.ts', () => {
+  it('returns function docs for wildcard-imported symbols', () => {
+    const source = [
+      'use "patterns" as *',
+      'track {',
+      '  part main (8.bars) {',
+      '    drum << loop([x:8])',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('loop(') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, position),
+      {
+        range: getRangeAt(source, source.indexOf('loop('), 'loop'.length),
+        title: 'loop(pattern: pattern, times?: number) -> pattern',
+        summary: 'Repeats a pattern for a fixed number of cycles, or indefinitely when times is omitted.'
+      }
+    )
+  })
+
+  it('returns module docs for aliased imports', () => {
+    const source = [
+      'use "effects" as fx',
+      'mixer {',
+      '  bus drum_bus {',
+      '    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('fx.delay') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, position),
+      {
+        range: getRangeAt(source, source.indexOf('fx.delay'), 'fx'.length),
+        title: 'module effects',
+        summary: 'Effect functions for shaping mixer bus audio.'
+      }
+    )
+  })
+
+  it('returns function docs for aliased module members', () => {
+    const source = [
+      'use "effects" as fx',
+      'mixer {',
+      '  bus drum_bus {',
+      '    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
+      '    effect fx.reverb(mix: 0.3, decay: 1.s)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const delayPosition = source.indexOf('fx.delay') + 'fx.'.length + 1
+    const reverbPosition = source.indexOf('fx.reverb') + 'fx.'.length + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, delayPosition),
+      {
+        range: getRangeAt(source, source.indexOf('delay('), 'delay'.length),
+        title: 'delay(mix: number, time: number(beats) | number(s), feedback: number) -> effect',
+        summary: 'Adds echoes with configurable mix, time, and feedback.'
+      }
+    )
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, reverbPosition),
+      {
+        range: getRangeAt(source, source.indexOf('reverb('), 'reverb'.length),
+        title: 'reverb(mix: number, decay: number(beats) | number(s)) -> effect',
+        summary: 'Adds reverberation with configurable mix and decay.'
+      }
+    )
+  })
+
+  it('does not return docs for property names that only textually match wildcard imports', () => {
+    const source = [
+      'use "effects" as *',
+      'mixer {',
+      '  bus drum_bus {',
+      '    effect delay(gain: 0.5)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('gain:') + 1
+
+    assert.strictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, position),
+      undefined
+    )
+  })
+})

--- a/packages/language/src/compiler/functions.ts
+++ b/packages/language/src/compiler/functions.ts
@@ -5,6 +5,7 @@ import type { InstrumentValue, Type, Value } from './types.js'
 import { InstrumentType } from './types.js'
 
 export interface FunctionDefinition<S extends PropertySchema = PropertySchema, R extends Type = Type> {
+  readonly summary?: string
   readonly arguments: S
   readonly returnType: R
   readonly invoke: FunctionHandler<S>

--- a/packages/language/src/compiler/hover.ts
+++ b/packages/language/src/compiler/hover.ts
@@ -1,0 +1,75 @@
+import type { FunctionDefinition } from './functions.js'
+import { getStandardModule, type ModuleDefinition } from './modules.js'
+import type { AcceptedType } from './schema.js'
+import { FunctionType } from './types.js'
+import type { Type, Value } from './types.js'
+
+export interface HoverInfo {
+  readonly title: string
+  readonly summary?: string
+}
+
+export function getStandardLibraryHoverInfo (moduleName: string, exportName?: string): HoverInfo | undefined {
+  const module = getStandardModule(moduleName)
+  if (module == null) {
+    return undefined
+  }
+
+  if (exportName == null) {
+    return describeModule(module.data)
+  }
+
+  const value = module.data.exports.get(exportName)
+  return value == null ? undefined : describeValue(exportName, value)
+}
+
+function describeModule (definition: ModuleDefinition): HoverInfo {
+  return {
+    title: `module ${definition.name}`,
+    summary: definition.summary
+  }
+}
+
+function describeValue (name: string, value: Value): HoverInfo {
+  if (FunctionType.is(value)) {
+    return {
+      title: formatFunctionSignature(name, value.data),
+      summary: value.data.summary
+    }
+  }
+
+  return {
+    title: `${name}: ${value.type.format()}`,
+    summary: getValueSummary(value)
+  }
+}
+
+function formatFunctionSignature (name: string, definition: FunctionDefinition): string {
+  const argumentsText = definition.arguments
+    .map((argument) => `${argument.name}${argument.required ? '' : '?'}: ${formatAcceptedType(argument.type)}`)
+    .join(', ')
+
+  return `${name}(${argumentsText}) -> ${definition.returnType.format()}`
+}
+
+function formatAcceptedType (type: AcceptedType): string {
+  if (isTypeArray(type)) {
+    return type.map((option) => option.format()).join(' | ')
+  }
+
+  return type.format()
+}
+
+function isTypeArray (type: AcceptedType): type is readonly Type[] {
+  return Array.isArray(type)
+}
+
+function getValueSummary (value: Value): string | undefined {
+  const data = value.data
+  if (typeof data !== 'object' || !('summary' in data)) {
+    return undefined
+  }
+
+  const summary = (data as { readonly summary?: unknown }).summary
+  return typeof summary === 'string' ? summary : undefined
+}

--- a/packages/language/src/compiler/index.ts
+++ b/packages/language/src/compiler/index.ts
@@ -9,6 +9,9 @@ import { generate, type GenerateOptions } from './generator.js'
 export type CompileOptions = GenerateOptions
 export type CompileResult = Result<Program, CompoundError<CompileError>>
 
+export type { HoverInfo } from './hover.js'
+export { getStandardLibraryHoverInfo } from './hover.js'
+
 /**
  * Compile an AST into a runnable program. This includes semantic analysis followed by
  * synthesis of the program structure.

--- a/packages/language/src/compiler/modules.ts
+++ b/packages/language/src/compiler/modules.ts
@@ -5,6 +5,7 @@ import type { ModuleValue, Value } from './types.js'
 
 export interface ModuleDefinition {
   readonly name: string
+  readonly summary?: string
   readonly exports: ReadonlyMap<string, Value>
 }
 

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -9,10 +9,12 @@ import { EffectType, FunctionType, ModuleType, NumberType } from '../types.js'
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 const createEffectConstructor = <T extends Effect, const S extends PropertySchema>(
+  summary: string,
   schema: S,
   create: (context: FunctionContext, args: InferSchema<S>) => T
 ) => {
   return FunctionType.of({
+    summary,
     arguments: schema,
     returnType: EffectType,
     invoke: (context, args) => EffectType.of(create(context, args))
@@ -21,42 +23,42 @@ const createEffectConstructor = <T extends Effect, const S extends PropertySchem
 
 // Effects
 
-const gain = createEffectConstructor([
+const gain = createEffectConstructor('Applies a gain adjustment to the signal.', [
   { name: 'gain', type: NumberType.with('db'), required: true }
 ], (context, args) => ({
   type: 'gain',
   gain: allocateParameter(context, args.gain)
 }))
 
-const pan = createEffectConstructor([
+const pan = createEffectConstructor('Places the signal in the stereo field.', [
   { name: 'pan', type: NumberType.with(undefined), required: true }
 ], (context, args) => ({
   type: 'pan',
   pan: args.pan
 }))
 
-const lowpass = createEffectConstructor([
+const lowpass = createEffectConstructor('Filters out frequencies above the cutoff.', [
   { name: 'frequency', type: NumberType.with('hz'), required: true }
 ], (context, args) => ({
   type: 'lowpass',
   frequency: args.frequency
 }))
 
-const highpass = createEffectConstructor([
+const highpass = createEffectConstructor('Filters out frequencies below the cutoff.', [
   { name: 'frequency', type: NumberType.with('hz'), required: true }
 ], (context, args) => ({
   type: 'highpass',
   frequency: args.frequency
 }))
 
-const width = createEffectConstructor([
+const width = createEffectConstructor('Adjusts the stereo width of the signal.', [
   { name: 'width', type: NumberType.with(undefined), required: true }
 ], (context, args) => ({
   type: 'width',
   width: args.width
 }))
 
-const delay = createEffectConstructor([
+const delay = createEffectConstructor('Adds echoes with configurable mix, time, and feedback.', [
   { name: 'mix', type: NumberType.with(undefined), required: true },
   { name: 'time', type: [NumberType.with('beats'), NumberType.with('s')], required: true },
   { name: 'feedback', type: NumberType.with(undefined), required: true }
@@ -67,7 +69,7 @@ const delay = createEffectConstructor([
   feedback: args.feedback
 }))
 
-const reverb = createEffectConstructor([
+const reverb = createEffectConstructor('Adds reverberation with configurable mix and decay.', [
   { name: 'mix', type: NumberType.with(undefined), required: true },
   { name: 'decay', type: [NumberType.with('beats'), NumberType.with('s')], required: true }
 ], (context, args) => ({
@@ -78,6 +80,7 @@ const reverb = createEffectConstructor([
 
 export const effectsModule = ModuleType.of({
   name: 'effects',
+  summary: 'Effect functions for shaping mixer bus audio.',
 
   exports: new Map<string, Value>([
     ['gain', gain],

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -7,6 +7,7 @@ import { FunctionType, InstrumentType, ModuleType, NumberType, StringType } from
 const UNITY_GAIN = numeric('db', 0)
 
 const sample = FunctionType.of({
+  summary: 'Creates a sample-backed instrument from a URL.',
   arguments: [
     { name: 'url', type: StringType, required: true },
     { name: 'gain', type: NumberType.with('db'), required: false },
@@ -32,6 +33,7 @@ const sample = FunctionType.of({
 
 export const instrumentsModule = ModuleType.of({
   name: 'instruments',
+  summary: 'Functions for creating and manipulating instruments.',
 
   exports: new Map<string, Value>([
     ['sample', sample]

--- a/packages/language/src/compiler/modules/patterns.ts
+++ b/packages/language/src/compiler/modules/patterns.ts
@@ -3,6 +3,7 @@ import { numeric } from '@utility'
 import { FunctionType, ModuleType, NumberType, PatternType, Value } from '../types.js'
 
 const loop = FunctionType.of({
+  summary: 'Repeats a pattern for a fixed number of cycles, or indefinitely when times is omitted.',
   arguments: [
     { name: 'pattern', type: PatternType, required: true },
     { name: 'times', type: NumberType.with(undefined), required: false }
@@ -33,6 +34,7 @@ const loop = FunctionType.of({
 
 export const patternsModule = ModuleType.of({
   name: 'patterns',
+  summary: 'Functions for creating and manipulating patterns.',
 
   exports: new Map<string, Value>([
     ['loop', loop]


### PR DESCRIPTION
When hovering over an imported module name or a member of an imported module, the editor will now show a hover tooltip with a short summary of the module or member. For functions, the signature will also be shown.

This is implemented by annotating the standard library definitions in the "language" package, and adding lookup logic in "language-support" to find the relevant definition, along with a CodeMirror extension for the tooltip UI.

In the future, we can expand this to support local variables and blocks.