### PR TITLE
refactor: Extract expression cases into functions

### DIFF
--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -476,89 +476,36 @@ function checkCyclicRoutings (buses: readonly ast.BusStatement[]): readonly Comp
 function checkExpression (context: Context, expression: ast.Expression): Checked<Type> {
   switch (expression.type) {
     case 'Number':
-      return { errors: [], result: NumberType.with(undefined) }
+      return checkNumber(context, expression)
 
-    case 'String': {
+    case 'String':
       return checkString(context, expression)
-    }
 
-    case 'Pattern': {
+    case 'Pattern':
       return checkPattern(context, expression)
-    }
 
-    case 'Curve': {
+    case 'Curve':
       return checkCurve(context, expression)
-    }
 
-    case 'Identifier': {
-      const valueType = resolve(context, expression.name)
-      if (valueType == null) {
-        return { errors: [new CompileError(`Unknown identifier "${expression.name}"`, expression.range)] }
-      }
-      return { errors: [], result: valueType }
-    }
+    case 'Identifier':
+      return checkIdentifier(context, expression)
 
-    case 'UnaryExpression': {
-      const argumentCheck = checkExpression(context, expression.argument)
+    case 'UnaryExpression':
+      return checkUnaryExpression(context, expression)
 
-      if (argumentCheck.result == null) {
-        return { errors: argumentCheck.errors }
-      }
+    case 'BinaryExpression':
+      return checkBinaryExpression(context, expression)
 
-      return checkUnaryExpression(expression.operator, argumentCheck.result, expression.range)
-    }
+    case 'PropertyAccess':
+      return checkPropertyAccess(context, expression)
 
-    case 'BinaryExpression': {
-      const leftCheck = checkExpression(context, expression.left)
-      const rightCheck = checkExpression(context, expression.right)
-
-      const errors = [...leftCheck.errors, ...rightCheck.errors]
-
-      if (leftCheck.result == null || rightCheck.result == null) {
-        return { errors }
-      }
-
-      return checkBinaryExpression(expression.operator, leftCheck.result, rightCheck.result, expression.range)
-    }
-
-    case 'PropertyAccess': {
-      if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
-        const busName = expression.property.name
-        const busType = resolveBus(context, busName)
-        if (busType == null) {
-          return { errors: [new CompileError(`Unknown bus "${busName}"`, expression.property.range)] }
-        }
-        return { errors: [], result: busType }
-      }
-
-      const objectCheck = checkExpression(context, expression.object)
-      if (objectCheck.result == null) {
-        return { errors: objectCheck.errors }
-      }
-
-      return checkPropertyAccess(objectCheck.result, expression.property, expression.range)
-    }
-
-    case 'Call': {
-      const calleeCheck = checkExpression(context, expression.callee)
-      if (calleeCheck.result == null) {
-        return { errors: calleeCheck.errors }
-      }
-
-      const callee = calleeCheck.result
-      if (!FunctionType.equals(calleeCheck.result)) {
-        return { errors: [new CompileError(`Cannot call value of type ${callee.format()}`, expression.range)] }
-      }
-
-      const { schema, returnType } = FunctionType.detail(callee)
-      if (schema == null || returnType == null) {
-        return { errors: [new CompileError(`Function is missing type information`, expression.range)] }
-      }
-
-      const { errors } = checkArgumentList(context, expression.arguments, schema, expression.range)
-      return { errors, result: returnType }
-    }
+    case 'Call':
+      return checkCall(context, expression)
   }
+}
+
+function checkNumber (context: Context, number: ast.Number): Checked<Type> {
+  return { errors: [], result: NumberType.with(undefined) }
 }
 
 function checkString (context: Context, string: ast.String): Checked<Type> {
@@ -718,7 +665,25 @@ function checkCurveSegment (context: Context, segment: ast.CurveSegment, hasPrev
   return { errors, result: firstUnit }
 }
 
-function checkUnaryExpression (operator: ast.UnaryOperator, argument: Type, range: SourceRange): Checked<Type> {
+function checkIdentifier (context: Context, identifier: ast.Identifier): Checked<Type> {
+  const valueType = resolve(context, identifier.name)
+  if (valueType == null) {
+    return { errors: [new CompileError(`Unknown identifier "${identifier.name}"`, identifier.range)] }
+  }
+
+  return { errors: [], result: valueType }
+}
+
+function checkUnaryExpression (context: Context, expression: ast.UnaryExpression): Checked<Type> {
+  const argumentCheck = checkExpression(context, expression.argument)
+
+  if (argumentCheck.result == null) {
+    return { errors: argumentCheck.errors }
+  }
+
+  const { range, operator } = expression
+  const argument = argumentCheck.result
+
   if (!NumberType.equals(argument)) {
     return { errors: [new CompileError(`Incompatible operand for "${operator}": ${argument.format()}`, range)] }
   }
@@ -731,7 +696,20 @@ function checkUnaryExpression (operator: ast.UnaryOperator, argument: Type, rang
   }
 }
 
-function checkBinaryExpression (operator: ast.BinaryOperator, left: Type, right: Type, range: SourceRange): Checked<Type> {
+function checkBinaryExpression (context: Context, expression: ast.BinaryExpression): Checked<Type> {
+  const leftCheck = checkExpression(context, expression.left)
+  const rightCheck = checkExpression(context, expression.right)
+
+  const errors = [...leftCheck.errors, ...rightCheck.errors]
+
+  if (leftCheck.result == null || rightCheck.result == null) {
+    return { errors }
+  }
+
+  const { range, operator } = expression
+  const left = leftCheck.result
+  const right = rightCheck.result
+
   switch (operator) {
     case '+':
       return checkPlus(left, right, range)
@@ -806,7 +784,25 @@ function checkDivide (left: Type, right: Type, range: SourceRange): Checked<Type
   return { errors: [new CompileError(`Incompatible operands for "/": ${left.format()} and ${right.format()}`, range)] }
 }
 
-function checkPropertyAccess (object: Type, property: ast.Identifier, range: SourceRange): Checked<Type> {
+function checkPropertyAccess (context: Context, expression: ast.PropertyAccess): Checked<Type> {
+  // Special case: "bus" namespace
+  if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
+    const busName = expression.property.name
+    const busType = resolveBus(context, busName)
+    if (busType == null) {
+      return { errors: [new CompileError(`Unknown bus "${busName}"`, expression.property.range)] }
+    }
+    return { errors: [], result: busType }
+  }
+
+  const objectCheck = checkExpression(context, expression.object)
+  if (objectCheck.result == null) {
+    return { errors: objectCheck.errors }
+  }
+
+  const { property } = expression
+  const object = objectCheck.result
+
   if (NumberType.equals(object)) {
     if (!isSyntaxUnit(property.name)) {
       return { errors: [new CompileError(`Unknown unit "${property.name}"`, property.range)] }
@@ -832,6 +828,26 @@ function checkPropertyAccess (object: Type, property: ast.Identifier, range: Sou
   }
 
   return { errors: [new CompileError(`Type ${object.format()} has no property named "${property.name}"`, property.range)] }
+}
+
+function checkCall (context: Context, expression: ast.Call): Checked<Type> {
+  const calleeCheck = checkExpression(context, expression.callee)
+  if (calleeCheck.result == null) {
+    return { errors: calleeCheck.errors }
+  }
+
+  const callee = calleeCheck.result
+  if (!FunctionType.equals(calleeCheck.result)) {
+    return { errors: [new CompileError(`Cannot call value of type ${callee.format()}`, expression.range)] }
+  }
+
+  const { schema, returnType } = FunctionType.detail(callee)
+  if (schema == null || returnType == null) {
+    return { errors: [new CompileError(`Function is missing type information`, expression.range)] }
+  }
+
+  const { errors } = checkArgumentList(context, expression.arguments, schema, expression.range)
+  return { errors, result: returnType }
 }
 
 function checkArgumentList (

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -338,52 +338,20 @@ function resolve (context: Context, expression: ast.Expression): Value {
     case 'Curve':
       return generateCurve(context, expression)
 
-    case 'Identifier': {
-      let current: Context | undefined = context
+    case 'Identifier':
+      return resolveIdentifier(context, expression)
 
-      while (current != null) {
-        const value = current.resolutions.get(expression.name)
-        if (value != null) {
-          return value
-        }
-        current = current.parent
-      }
+    case 'UnaryExpression':
+      return computeUnaryExpression(context, expression)
 
-      throw new CompileError(`Unknown identifier "${expression.name}"`, expression.range)
-    }
+    case 'BinaryExpression':
+      return computeBinaryExpression(context, expression)
 
-    case 'UnaryExpression': {
-      const arg = resolve(context, expression.argument)
-      return computeUnaryExpression(expression.operator, arg)
-    }
+    case 'PropertyAccess':
+      return resolvePropertyAccess(context, expression)
 
-    case 'BinaryExpression': {
-      const left = resolve(context, expression.left)
-      const right = resolve(context, expression.right)
-      return computeBinaryExpression(expression.operator, left, right)
-    }
-
-    case 'PropertyAccess': {
-      if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
-        return nonNull(context.top.buses.get(expression.property.name))
-      }
-
-      const object = resolve(context, expression.object)
-      const property = expression.property.name
-
-      if (NumberType.is(object)) {
-        assert(isSyntaxUnit(property))
-        return toNumberValue(context.top.options, property, object.data.value)
-      }
-
-      return nonNull(object.type.propertyValue(object, property)) as Value
-    }
-
-    case 'Call': {
-      const func = FunctionType.cast(resolve(context, expression.callee))
-      const args = resolveArgumentList(context, expression.arguments, func.data.arguments)
-      return func.data.invoke(context.top, args)
-    }
+    case 'Call':
+      return resolveCall(context, expression)
   }
 }
 
@@ -487,8 +455,24 @@ function generateCurve (context: Context, curve: ast.Curve): CurveValue {
   )
 }
 
-function computeUnaryExpression (operator: ast.UnaryOperator, argument: Value): Value {
-  switch (operator) {
+function resolveIdentifier (context: Context, identifier: ast.Identifier): Value {
+  let current: Context | undefined = context
+
+  while (current != null) {
+    const value = current.resolutions.get(identifier.name)
+    if (value != null) {
+      return value
+    }
+    current = current.parent
+  }
+
+  throw new CompileError(`Unknown identifier "${identifier.name}"`, identifier.range)
+}
+
+function computeUnaryExpression (context: Context, expression: ast.UnaryExpression): Value {
+  const argument = resolve(context, expression.argument)
+
+  switch (expression.operator) {
     case '+':
       if (NumberType.is(argument)) {
         return argument
@@ -505,8 +489,11 @@ function computeUnaryExpression (operator: ast.UnaryOperator, argument: Value): 
   assert(false)
 }
 
-function computeBinaryExpression (operator: ast.BinaryOperator, left: Value, right: Value): Value {
-  switch (operator) {
+function computeBinaryExpression (context: Context, expression: ast.BinaryExpression): Value {
+  const left = resolve(context, expression.left)
+  const right = resolve(context, expression.right)
+
+  switch (expression.operator) {
     case '+':
       return computePlus(left, right)
     case '-':
@@ -570,6 +557,30 @@ function computeDivide (left: Value, right: Value): Value {
   }
 
   assert(false)
+}
+
+function resolvePropertyAccess (context: Context, expression: ast.PropertyAccess): Value {
+  // Special case: "bus" namespace
+  if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
+    return nonNull(context.top.buses.get(expression.property.name))
+  }
+
+  const object = resolve(context, expression.object)
+  const property = expression.property.name
+
+  if (NumberType.is(object)) {
+    assert(isSyntaxUnit(property))
+    return toNumberValue(context.top.options, property, object.data.value)
+  }
+
+  return nonNull(object.type.propertyValue(object, property)) as Value
+}
+
+function resolveCall (context: Context, expression: ast.Call): Value {
+  const func = FunctionType.cast(resolve(context, expression.callee))
+  const args = resolveArgumentList(context, expression.arguments, func.data.arguments)
+
+  return func.data.invoke(context.top, args)
 }
 
 function resolveArgumentList<S extends PropertySchema> (context: Context, args: ast.ArgumentList, schema: S): InferSchema<S> {


### PR DESCRIPTION
The expression switch statements in the checker and generator were mixed between inlined cases and calls to functions. This commit extracts all cases into functions for consistency and readability.