### PR TITLE
fix: Refactor and improve cyclic routing detection

### DIFF
--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -5,6 +5,7 @@ import { busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from './c
 import { getCurveSegmentType } from './curves.js'
 import { CompileError } from './error.js'
 import { getStandardModule, standardLibraryModuleNames } from './modules.js'
+import { checkCyclicRoutings } from './routings.js'
 import type { PropertySchema, PropertySpec } from './schema.js'
 import type { ModuleValue, Type } from './types.js'
 import { BusType, CurveType, EffectType, FunctionType, InstrumentType, ModuleType, NumberType, ParameterType, PartType, PatternType, StringType } from './types.js'
@@ -333,7 +334,11 @@ function checkMixer (context: Context, mixer: ast.MixerStatement): readonly Comp
     errors.push(...checkBus(mixerContext, bus))
   }
 
-  errors.push(...checkCyclicRoutings(mixer.buses))
+  errors.push(...checkCyclicRoutings(mixer.buses.map((bus) => ({
+    name: bus.name.name,
+    sources: bus.sources.map((s) => s.name),
+    range: bus.name.range
+  }))))
 
   return errors
 }
@@ -363,111 +368,6 @@ function checkBus (context: Context, bus: ast.BusStatement): readonly CompileErr
     if (effectCheck.result != null) {
       errors.push(...checkType([EffectType], effectCheck.result, effect.expression.range))
     }
-  }
-
-  return errors
-}
-
-function checkCyclicRoutings (buses: readonly ast.BusStatement[]): readonly CompileError[] {
-  const errors: CompileError[] = []
-
-  const busByName = new Map<string, ast.BusStatement>(
-    buses.map((bus) => [bus.name.name, bus])
-  )
-
-  const busIndex = new Map<string, number>(
-    buses.map((bus, index) => [bus.name.name, index])
-  )
-
-  const graph = new Map<string, readonly string[]>(
-    buses.map((bus) => [
-      bus.name.name,
-      bus.sources.map((s) => s.name).filter((name) => busByName.has(name))
-    ])
-  )
-
-  type VisitState = 'unvisited' | 'visiting' | 'visited'
-
-  const state = new Map<string, VisitState>()
-  const path: string[] = []
-  const pathIndex = new Map<string, number>()
-
-  const renderCycle = (members: readonly string[]) => {
-    return members.length === 0 ? '' : [...members, members[0]].join(' -> ')
-  }
-
-  // Keyed by member set
-  const cycles = new Map<string, { readonly members: readonly string[] }>()
-
-  const visit = (node: string): void => {
-    const nodeState = state.get(node) ?? 'unvisited'
-    if (nodeState === 'visited') {
-      return
-    }
-    if (nodeState === 'visiting') {
-      // Already on stack; caller will record the cycle
-      return
-    }
-
-    state.set(node, 'visiting')
-    pathIndex.set(node, path.length)
-    path.push(node)
-
-    for (const neighbor of graph.get(node) ?? []) {
-      const neighborState = state.get(neighbor) ?? 'unvisited'
-
-      if (neighborState === 'visiting') {
-        const startIndex = pathIndex.get(neighbor)
-        if (startIndex != null) {
-          const members = path.slice(startIndex)
-          const key = [...members]
-            .sort((a, b) => (busIndex.get(a) ?? 0) - (busIndex.get(b) ?? 0))
-            .join('\0')
-
-          if (!cycles.has(key)) {
-            cycles.set(key, { members })
-          }
-        }
-        continue
-      }
-
-      if (neighborState === 'unvisited') {
-        visit(neighbor)
-      }
-    }
-
-    path.pop()
-    pathIndex.delete(node)
-    state.set(node, 'visited')
-  }
-
-  for (const node of graph.keys()) {
-    if ((state.get(node) ?? 'unvisited') === 'unvisited') {
-      visit(node)
-    }
-  }
-
-  const sortedCycles = [...cycles.values()].sort((a, b) => {
-    const aMin = Math.min(...a.members.map((m) => busIndex.get(m) ?? Number.POSITIVE_INFINITY))
-    const bMin = Math.min(...b.members.map((m) => busIndex.get(m) ?? Number.POSITIVE_INFINITY))
-    return aMin - bMin
-  })
-
-  for (const { members } of sortedCycles) {
-    const message = renderCycle(members)
-
-    let bestMember: string | undefined
-    let bestIndex = Number.POSITIVE_INFINITY
-    for (const member of members) {
-      const index = busIndex.get(member) ?? Number.POSITIVE_INFINITY
-      if (index < bestIndex) {
-        bestIndex = index
-        bestMember = member
-      }
-    }
-
-    const range = bestMember == null ? undefined : busByName.get(bestMember)?.name.range
-    errors.push(new CompileError(`Cyclic routing: ${message}`, range))
   }
 
   return errors

--- a/packages/language/src/compiler/routings.ts
+++ b/packages/language/src/compiler/routings.ts
@@ -1,0 +1,87 @@
+import type { SourceRange } from '@ast'
+import { getEmptySourceRange } from '@ast'
+import { CompileError } from './error.js'
+
+export interface Bus {
+  readonly name: string
+  readonly sources: readonly string[]
+  readonly range: SourceRange
+}
+
+export function checkCyclicRoutings (buses: readonly Bus[]): CompileError[] {
+  const busRanges = new Map<string, SourceRange>(
+    buses.map((bus) => [bus.name, bus.range])
+  )
+  const busIndex = new Map<string, number>(
+    buses.map((bus, index) => [bus.name, index])
+  )
+
+  const graph = new Map<string, readonly string[]>(
+    // Keep only sources that refer to defined buses.
+    buses.map((bus) => [
+      bus.name,
+      bus.sources.filter((name) => busRanges.has(name))
+    ])
+  )
+
+  const errors: CompileError[] = []
+  const seenCycles = new Set<string>()
+  const path: string[] = []
+  const pathMembers = new Set<string>()
+
+  const visit = (start: string, node: string, startIndex: number): void => {
+    path.push(node)
+    pathMembers.add(node)
+
+    for (const neighbor of graph.get(node) ?? []) {
+      if (neighbor === start) {
+        const key = getCycleKey(path, busIndex)
+        if (!seenCycles.has(key)) {
+          seenCycles.add(key)
+          errors.push(getCycleError(path, busRanges))
+        }
+        continue
+      }
+
+      if ((busIndex.get(neighbor) ?? -1) < startIndex || pathMembers.has(neighbor)) {
+        continue
+      }
+
+      visit(start, neighbor, startIndex)
+    }
+
+    path.pop()
+    pathMembers.delete(node)
+  }
+
+  for (const [start, startIndex] of busIndex) {
+    visit(start, start, startIndex)
+  }
+
+  return errors.sort((a, b) => (a.range?.offset ?? 0) - (b.range?.offset ?? 0))
+}
+
+function getCycleKey (members: readonly string[], indices: ReadonlyMap<string, number>): string {
+  return [...members]
+    .sort((left, right) => (indices.get(left) ?? 0) - (indices.get(right) ?? 0))
+    .join('\0')
+}
+
+function getCycleError (members: readonly string[], ranges: ReadonlyMap<string, SourceRange>): CompileError {
+  const initialRange = ranges.get(members[0]) ?? getEmptySourceRange()
+
+  const range = members.reduce((previous, member) => {
+    const range = ranges.get(member)
+    return range != null && range.offset < previous.offset ? range : previous
+  }, initialRange)
+
+  // We have traversed the cycle from targets to sources, so reverse it for the error message.
+  // The first member is repeated at the end to make the cycle explicit.
+  const path = members.length === 0
+    ? []
+    : [members[0], ...members.slice(1).reverse(), members[0]]
+
+  const pathString = path.join(' -> ')
+
+  return new CompileError(`Cyclic routing: ${pathString}`, range)
+}

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -1028,7 +1028,7 @@ describe('compiler/checker.ts', () => {
       ]
     })
     assert.deepStrictEqual(check(program), [
-      new CompileError('Cyclic routing: bus1 -> bus3 -> bus2 -> bus1', RANGE)
+      new CompileError('Cyclic routing: bus1 -> bus2 -> bus3 -> bus1', RANGE)
     ])
   })
 

--- a/packages/language/test/compiler/routings.test.ts
+++ b/packages/language/test/compiler/routings.test.ts
@@ -1,0 +1,121 @@
+import type { SourceRange } from '@ast'
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { checkCyclicRoutings } from '../../src/compiler/routings.js'
+
+describe('compiler/routings.ts', () => {
+  const makeRange = (id: number): SourceRange => ({
+    offset: id,
+    length: 1,
+    line: 1,
+    column: id + 1
+  })
+
+  it('handles empty list of buses', () => {
+    const errors = checkCyclicRoutings([])
+    assert.deepStrictEqual(errors, [])
+  })
+
+  it('handles acyclic routings', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B'], range: makeRange(0) },
+      { name: 'B', sources: ['C'], range: makeRange(1) },
+      { name: 'C', sources: [], range: makeRange(2) }
+    ])
+    assert.deepStrictEqual(errors, [])
+  })
+
+  it('detects simple cycle', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B'], range: makeRange(0) },
+      { name: 'B', sources: ['A'], range: makeRange(1) }
+    ])
+    assert.strictEqual(errors.length, 1)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> B -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+  })
+
+  it('detects self-cycle', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['A'], range: makeRange(0) }
+    ])
+    assert.strictEqual(errors.length, 1)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+  })
+
+  it('detects multiple cycles', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B'], range: makeRange(0) },
+      { name: 'B', sources: ['A'], range: makeRange(1) },
+      { name: 'C', sources: ['D'], range: makeRange(2) },
+      { name: 'D', sources: ['C'], range: makeRange(3) }
+    ])
+    assert.strictEqual(errors.length, 2)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> B -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+    assert.strictEqual(errors[1].message, 'Cyclic routing: C -> D -> C')
+    assert.deepStrictEqual(errors[1].range, makeRange(2))
+  })
+
+  it('ignores sources that are not buses', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B', 'X'], range: makeRange(0) },
+      { name: 'B', sources: ['A', 'Y'], range: makeRange(1) }
+    ])
+    assert.strictEqual(errors.length, 1)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> B -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+  })
+
+  it('detects complex cycle', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B'], range: makeRange(0) },
+      { name: 'B', sources: ['C'], range: makeRange(1) },
+      { name: 'C', sources: ['A'], range: makeRange(2) }
+    ])
+    assert.strictEqual(errors.length, 1)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> C -> B -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+  })
+
+  it('detects multiple cycles with shared members', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B'], range: makeRange(0) },
+      { name: 'B', sources: ['C'], range: makeRange(1) },
+      { name: 'C', sources: ['A', 'D'], range: makeRange(2) },
+      { name: 'D', sources: ['C'], range: makeRange(3) }
+    ])
+    assert.strictEqual(errors.length, 2)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> C -> B -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+    assert.strictEqual(errors[1].message, 'Cyclic routing: C -> D -> C')
+    assert.deepStrictEqual(errors[1].range, makeRange(2))
+  })
+
+  it('detects reconverging cycles with different members', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B', 'C'], range: makeRange(0) },
+      { name: 'B', sources: ['D'], range: makeRange(1) },
+      { name: 'C', sources: ['D'], range: makeRange(2) },
+      { name: 'D', sources: ['A'], range: makeRange(3) }
+    ])
+    assert.strictEqual(errors.length, 2)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> D -> B -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+    assert.strictEqual(errors[1].message, 'Cyclic routing: A -> D -> C -> A')
+    assert.deepStrictEqual(errors[1].range, makeRange(0))
+  })
+
+  it('renders longer cycles in source order', () => {
+    const errors = checkCyclicRoutings([
+      { name: 'A', sources: ['B'], range: makeRange(0) },
+      { name: 'B', sources: ['C'], range: makeRange(1) },
+      { name: 'C', sources: ['D'], range: makeRange(2) },
+      { name: 'D', sources: ['A'], range: makeRange(3) }
+    ])
+    assert.strictEqual(errors.length, 1)
+    assert.strictEqual(errors[0].message, 'Cyclic routing: A -> D -> C -> B -> A')
+    assert.deepStrictEqual(errors[0].range, makeRange(0))
+  })
+})


### PR DESCRIPTION
This patch is a rewrite of the cyclic routing detection logic, now in a separate file for readability. It fixes a bug where distinct cycles that reconverge at a common node were not all reported. Additionally, the path is now formatted in reverse order to show the signal flow instead of the algorithm's traversal order.