### PR TITLE
fix: Cache language support models for performance

### DIFF
--- a/packages/language-support/src/analysis/cache.ts
+++ b/packages/language-support/src/analysis/cache.ts
@@ -1,0 +1,23 @@
+import type { Tree } from '@lezer/common'
+import type { TextLike } from '../types.js'
+import type { Model } from './model.js'
+import { analyzeTree } from './model.js'
+
+interface CachedModel {
+  readonly document: TextLike
+  readonly model: Model
+}
+
+const cachedModels = new WeakMap<Tree, CachedModel>()
+
+export function getAnalysisModel (tree: Tree, document: TextLike): Model {
+  const cached = cachedModels.get(tree)
+  if (cached != null && cached.document === document) {
+    return cached.model
+  }
+
+  const model = analyzeTree(tree, document)
+  cachedModels.set(tree, { document, model })
+
+  return model
+}

--- a/packages/language-support/src/highlight-occurrences/extension.ts
+++ b/packages/language-support/src/highlight-occurrences/extension.ts
@@ -3,8 +3,8 @@ import type { EditorState, Extension } from '@codemirror/state'
 import type { DecorationSet, ViewUpdate } from '@codemirror/view'
 import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
 import type { Tree } from '@lezer/common'
+import { getAnalysisModel } from '../analysis/cache.js'
 import type { Model } from '../analysis/model.js'
-import { analyzeTree } from '../analysis/model.js'
 import type { RangesByBinding } from '../analysis/query.js'
 import { buildReferenceRangesByBinding, findDefinitionBindingAt } from '../analysis/query.js'
 
@@ -54,7 +54,7 @@ interface AnalysisState {
 
 function buildAnalysisState (state: EditorState): AnalysisState {
   const tree = syntaxTree(state)
-  const model = analyzeTree(tree, state.doc)
+  const model = getAnalysisModel(tree, state.doc)
   const rangesByBinding = buildReferenceRangesByBinding(model, tree, state.doc)
   return { tree, model, rangesByBinding }
 }

--- a/packages/language-support/src/operations.ts
+++ b/packages/language-support/src/operations.ts
@@ -1,8 +1,9 @@
 import type { Tree } from '@lezer/common'
 import type { LRParser } from '@lezer/lr'
+import { getAnalysisModel } from './analysis/cache.js'
 import { textFromString } from './analysis/text.js'
 import type { TextLike } from './types.js'
-import { analyzeTree, type Model } from './analysis/model.js'
+import type { Model } from './analysis/model.js'
 
 export type SemanticOperation<Args extends readonly unknown[], Result> =
   (model: Model, tree: Tree, document: TextLike, ...args: Args) => Result
@@ -13,7 +14,7 @@ export function applySemanticOperation<Args extends readonly unknown[], Result> 
   document: TextLike,
   ...args: Args
 ): Result {
-  const model = analyzeTree(tree, document)
+  const model = getAnalysisModel(tree, document)
   return operation(model, tree, document, ...args)
 }
 
@@ -25,6 +26,6 @@ export function applySemanticOperationWithParser<Args extends readonly unknown[]
 ): Result {
   const tree = parser.parse(source)
   const document = textFromString(source)
-  const model = analyzeTree(tree, document)
+  const model = getAnalysisModel(tree, document)
   return operation(model, tree, document, ...args)
 }

--- a/packages/language-support/test/analysis/cache.test.ts
+++ b/packages/language-support/test/analysis/cache.test.ts
@@ -1,0 +1,44 @@
+import { buildParser } from '@lezer/generator'
+import assert from 'node:assert'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { getAnalysisModel } from '../../src/analysis/cache.js'
+import { textFromString } from '../../src/analysis/text.js'
+
+const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
+const cadenceParser = buildParser(cadenceGrammar)
+
+describe('analysis/cache.ts', () => {
+  it('reuses the analyzed model for repeated lookups on the same tree and document', () => {
+    const source = [
+      'foo = 1',
+      'bar = foo',
+      ''
+    ].join('\n')
+
+    const tree = cadenceParser.parse(source)
+    const document = textFromString(source)
+
+    const firstModel = getAnalysisModel(tree, document)
+    const secondModel = getAnalysisModel(tree, document)
+
+    assert.strictEqual(secondModel, firstModel)
+  })
+
+  it('does not share models across different trees', () => {
+    const source = [
+      'foo = 1',
+      'bar = foo',
+      ''
+    ].join('\n')
+
+    const firstTree = cadenceParser.parse(source)
+    const secondTree = cadenceParser.parse(source)
+    const document = textFromString(source)
+
+    const firstModel = getAnalysisModel(firstTree, document)
+    const secondModel = getAnalysisModel(secondTree, document)
+
+    assert.notStrictEqual(secondModel, firstModel)
+  })
+})


### PR DESCRIPTION
Multiple language support features require analyzing the syntax tree of the document. This patch adds a simple caching mechanism to store the analysis results in a WeakMap, such that any number of model requests can be served by a single analysis pass.