### PR TITLE
refactor: Collect identifiers into semantic model

### DIFF
--- a/packages/language-support/src/analysis/model.ts
+++ b/packages/language-support/src/analysis/model.ts
@@ -3,7 +3,17 @@ import type { LRParser } from '@lezer/lr'
 import type { SourceRange, TextLike } from '../types.js'
 import { textFromString, toSourceRange } from './text.js'
 
-export type ScopeKind = 'root' | 'track' | 'mixer'
+export interface Model {
+  readonly rootScopeId: string
+  readonly scopes: ReadonlyMap<string, Scope>
+  readonly identifiers: readonly Identifier[]
+  readonly bindings: readonly Binding[]
+  readonly bindingsByName: ReadonlyMap<string, readonly Binding[]>
+  readonly bindingsByScope: ReadonlyMap<string, readonly Binding[]>
+  readonly imports: readonly ImportStatement[]
+}
+
+// scope
 
 export interface Scope {
   readonly id: string
@@ -12,7 +22,33 @@ export interface Scope {
   readonly range: SourceRange
 }
 
-export type BindingKind = 'assignment' | 'use-alias' | 'part' | 'bus'
+export type ScopeKind = 'root' | 'track' | 'mixer'
+
+// identifier
+
+export interface Identifier {
+  readonly id: string
+  readonly kind: IdentifierKind
+  readonly name: string
+  readonly range: SourceRange
+}
+
+const IDENTIFIER_KINDS = [
+  'VariableName',
+  'Callee',
+  'MemberAccess',
+  'PropertyName',
+  'VariableDefinition',
+  'UseAlias'
+] as const
+
+export type IdentifierKind = typeof IDENTIFIER_KINDS[number]
+
+export function isIdentifierKind (value: string): value is IdentifierKind {
+  return IDENTIFIER_KINDS.includes(value as IdentifierKind)
+}
+
+// binding
 
 export interface Binding {
   readonly id: string
@@ -22,27 +58,17 @@ export interface Binding {
   readonly range: SourceRange
 }
 
+export type BindingKind = 'assignment' | 'use-alias' | 'part' | 'bus'
+
+// import
+
 export interface ImportStatement {
   readonly moduleName: string
   readonly alias?: string
   readonly aliasRange?: SourceRange
 }
 
-export interface Model {
-  readonly rootScopeId: string
-  readonly scopes: ReadonlyMap<string, Scope>
-  readonly bindings: readonly Binding[]
-  readonly bindingsByName: ReadonlyMap<string, readonly Binding[]>
-  readonly bindingsByScope: ReadonlyMap<string, readonly Binding[]>
-  readonly imports: readonly ImportStatement[]
-}
-
-interface BindingInput {
-  readonly kind: BindingKind
-  readonly scopeId: string
-  readonly name: string
-  readonly range: SourceRange
-}
+// analysis
 
 interface DefinitionBindingContext {
   readonly parentType: string | undefined
@@ -51,6 +77,8 @@ interface DefinitionBindingContext {
   readonly mixerScopeId: string | undefined
   readonly assignmentHasEquals: boolean
 }
+
+// public API
 
 export function analyzeTree (tree: Tree, document: TextLike): Model {
   const rootRange = toSourceRange(document, 0, document.length)
@@ -64,12 +92,17 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
     range: rootRange
   })
 
+  const identifiers: Identifier[] = []
   const bindings: Binding[] = []
   const bindingsByName = new Map<string, Binding[]>()
   const bindingsByScope = new Map<string, Binding[]>()
   const imports: ImportStatement[] = []
 
-  const addBinding = (input: BindingInput): void => {
+  const addIdentifier = (input: Omit<Identifier, 'id'>): void => {
+    identifiers.push({ ...input, id: identifierKey(input.kind, input.range) })
+  }
+
+  const addBinding = (input: Omit<Binding, 'id'>): void => {
     const { kind, scopeId, name, range } = input
 
     const binding = { ...input, id: bindingKey(kind, scopeId, range) }
@@ -108,6 +141,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
         if (statement != null) {
           imports.push(statement)
           if (statement.alias != null && statement.aliasRange != null) {
+            addIdentifier({ kind: 'UseAlias', name: statement.alias, range: statement.aliasRange })
             addBinding({ kind: 'use-alias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
           }
         }
@@ -146,10 +180,25 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
           assignmentHasEquals: nextAssignmentHasEquals
         })
 
-        if (binding != null) {
-          addBinding({ ...binding, name, range })
+        if (binding == null) {
+          // Invalid/incomplete syntax encountered.
+          // We still add an identifier as a best-effort approach to provide some level of functionality.
+          addIdentifier({ kind: 'VariableName', name, range })
+          break
         }
 
+        addIdentifier({ kind: 'VariableDefinition', name, range })
+        addBinding({ ...binding, name, range })
+
+        break
+      }
+
+      case 'VariableName':
+      case 'Callee':
+      case 'MemberAccess':
+      case 'PropertyName': {
+        const name = document.sliceString(from, to)
+        addIdentifier({ kind: typeName, name, range })
         break
       }
     }
@@ -164,7 +213,10 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
 
   walk(cursor, undefined, rootScopeId, undefined, undefined, false)
 
-  return { rootScopeId, scopes, bindings, bindingsByName, bindingsByScope, imports }
+  identifiers.sort((a, b) => a.range.offset - b.range.offset)
+  bindings.sort((a, b) => a.range.offset - b.range.offset)
+
+  return { rootScopeId, scopes, identifiers, bindings, bindingsByName, bindingsByScope, imports }
 }
 
 export function analyzeSourceWithParser (parser: LRParser, source: string): Model {
@@ -174,6 +226,10 @@ export function analyzeSourceWithParser (parser: LRParser, source: string): Mode
 
 export function scopeKey (typeName: string, range: SourceRange): string {
   return `${typeName}:${range.offset}:${range.length}`
+}
+
+function identifierKey (kind: IdentifierKind, range: SourceRange): string {
+  return `${kind}:${range.offset}:${range.length}`
 }
 
 function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): string {
@@ -190,7 +246,7 @@ function appendIndexedValue<Key, Value> (index: Map<Key, Value[]>, key: Key, val
   values.push(value)
 }
 
-function getDefinitionBinding (context: DefinitionBindingContext): Omit<BindingInput, 'name' | 'range'> | undefined {
+function getDefinitionBinding (context: DefinitionBindingContext): Omit<Binding, 'id' | 'name' | 'range'> | undefined {
   switch (context.parentType) {
     case 'Assignment':
       return context.assignmentHasEquals
@@ -243,6 +299,7 @@ function parseUseStatement (document: TextLike, node: SyntaxNode): ImportStateme
   }
 }
 
+// TODO Use proper string parsing instead of JSON.parse
 function parseStringLiteral (text: string): string | undefined {
   try {
     const value = JSON.parse(text)

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -1,10 +1,8 @@
 import type { SyntaxNode, Tree } from '@lezer/common'
 import type { SourceRange, TextLike } from '../types.js'
-import type { Binding, BindingKind, Model } from './model.js'
-import { scopeKey } from './model.js'
+import type { Binding, BindingKind, Identifier, IdentifierKind, Model } from './model.js'
+import { isIdentifierKind, scopeKey } from './model.js'
 import { toSourceRange } from './text.js'
-
-export type IdentifierKind = typeof IDENTIFIER_KINDS[number]
 
 export interface SemanticOccurrence {
   readonly kind: IdentifierKind | undefined
@@ -13,40 +11,52 @@ export interface SemanticOccurrence {
   readonly node?: SyntaxNode
 }
 
-const IDENTIFIER_KINDS = [
-  'VariableName',
-  'Callee',
-  'MemberAccess',
-  'PropertyName',
-  'VariableDefinition',
-  'UseAlias'
-] as const
-
 const GLOBAL_BINDING_PRIORITY: readonly BindingKind[] = ['use-alias', 'assignment']
 const FALLBACK_BINDING_PRIORITY: readonly BindingKind[] = ['part', 'bus']
-
-function isIdentifierKind (value: string): value is IdentifierKind {
-  return IDENTIFIER_KINDS.includes(value as IdentifierKind)
-}
 
 export function sameRange (a: SourceRange, b: SourceRange): boolean {
   return a.offset === b.offset && a.length === b.length
 }
 
-export function findIdentifierRangeAt (tree: Tree, document: TextLike, position: number): SourceRange | undefined {
-  const node = findIdentifierNodeAt(tree, position)
-  if (node == null) {
+export function findIdentifierAt (model: Model, position: number, boundary: 'strict' | 'inclusive' = 'strict'): Identifier | undefined {
+  let low = 0
+  let high = model.identifiers.length - 1
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2)
+    const identifier = model.identifiers[mid]
+
+    if (position < identifier.range.offset) {
+      high = mid - 1
+    } else if (position >= identifier.range.offset + identifier.range.length) {
+      low = mid + 1
+    } else {
+      return identifier
+    }
+  }
+
+  if (boundary === 'inclusive') {
+    const leftCandidate = model.identifiers.at(high)
+    if (leftCandidate != null && leftCandidate.range.offset + leftCandidate.range.length === position) {
+      return leftCandidate
+    }
+
+    const rightCandidate = model.identifiers.at(low)
+    if (rightCandidate != null && rightCandidate.range.offset === position) {
+      return rightCandidate
+    }
+  }
+
+  return undefined
+}
+
+export function findDefinitionBindingAt (model: Model, document: TextLike, position: number): Binding | undefined {
+  const occurrence = findIdentifierAt(model, position, 'inclusive')
+  if (occurrence == null) {
     return undefined
   }
 
-  return toSourceRange(document, node.from, node.to)
-}
-
-export function findDefinitionBindingAt (model: Model, tree: Tree, document: TextLike, position: number): Binding | undefined {
-  const occurrence = findSemanticOccurrenceAt(tree, document, position)
-  return occurrence != null && occurrence.name.length > 0
-    ? resolveDefinitionBinding(model, occurrence, document)
-    : undefined
+  return resolveDefinitionBinding(model, occurrence, document)
 }
 
 export type RangesByBinding = ReadonlyMap<string, readonly SourceRange[]>
@@ -58,12 +68,7 @@ export function findReferenceRangesAt (
   position: number,
   rangesByBinding?: RangesByBinding
 ): readonly SourceRange[] {
-  const occurrence = findSemanticOccurrenceAt(tree, document, position)
-  if (occurrence == null || occurrence.name.length === 0) {
-    return []
-  }
-
-  const binding = resolveDefinitionBinding(model, occurrence, document)
+  const binding = findDefinitionBindingAt(model, document, position)
   if (binding == null) {
     return []
   }
@@ -117,23 +122,6 @@ export function findUnusedAssignmentBindings (model: Model, tree: Tree, document
   return model.bindings.filter((binding) => {
     return binding.kind === 'assignment' && !usedBindings.has(binding.id)
   })
-}
-
-export function findSemanticOccurrenceAt (tree: Tree, document: TextLike, position: number): SemanticOccurrence | undefined {
-  const node = findIdentifierNodeAt(tree, position)
-  if (node != null) {
-    return {
-      kind: node.type.name as IdentifierKind,
-      name: document.sliceString(node.from, node.to),
-      node,
-      range: toSourceRange(document, node.from, node.to)
-    }
-  }
-
-  const range = getWordRangeAt(document, position)
-  return range != null
-    ? { kind: undefined, name: document.sliceString(range.offset, range.offset + range.length), range }
-    : undefined
 }
 
 function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence, document: TextLike): Binding | undefined {
@@ -265,7 +253,7 @@ function walkResolvedIdentifierBindings (model: Model, tree: Tree, document: Tex
     }
 
     const lookupPosition = node.to - node.from > 1 ? node.from + 1 : node.from
-    const occurrence = findSemanticOccurrenceAt(tree, document, lookupPosition)
+    const occurrence = findIdentifierAt(model, lookupPosition)
     if (occurrence == null) {
       return
     }
@@ -315,21 +303,6 @@ function findBindingByPriority (
     if (binding != null) {
       return binding
     }
-  }
-
-  return undefined
-}
-
-function findIdentifierNodeAt (tree: Tree, position: number): SyntaxNode | undefined {
-  const maxDepth = 8
-  let node: SyntaxNode | undefined = tree.resolveInner(position, -1)
-
-  for (let depth = 0; depth < maxDepth && node != null; ++depth) {
-    if (isIdentifierKind(node.type.name)) {
-      return node
-    }
-
-    node = node.parent ?? undefined
   }
 
   return undefined

--- a/packages/language-support/src/go-to-definition/extension.ts
+++ b/packages/language-support/src/go-to-definition/extension.ts
@@ -3,7 +3,8 @@ import type { Extension } from '@codemirror/state'
 import { EditorSelection, StateEffect, StateField } from '@codemirror/state'
 import type { DecorationSet, ViewUpdate } from '@codemirror/view'
 import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
-import { findIdentifierRangeAt, sameRange } from '../analysis/query.js'
+import { getAnalysisModel } from '../analysis/cache.js'
+import { findIdentifierAt, sameRange } from '../analysis/query.js'
 import { applySemanticOperation } from '../operations.js'
 import type { SourceRange } from '../types.js'
 import { goToDefinition } from './operation.js'
@@ -28,6 +29,15 @@ function isPrimaryModifierPressed (event: MouseEvent | KeyboardEvent): boolean {
 
 function isPrimaryModifierKey (key: string): boolean {
   return APPLE_PLATFORM ? key === 'Meta' : key === 'Control'
+}
+
+function getPositionForMouse (view: EditorView, mouse: MousePosition): number | undefined {
+  const pos = view.posAndSideAtCoords(mouse)
+  if (pos == null) {
+    return undefined
+  }
+
+  return pos.assoc < 0 ? pos.pos - 1 : pos.pos
 }
 
 function rangeContainsMouseX (view: EditorView, range: SourceRange, mouse: MousePosition): boolean {
@@ -123,13 +133,16 @@ class GoToDefinitionInteractionsPlugin {
           return { hoverRange: undefined, underlineRange: undefined }
         }
 
-        const position = view.posAtCoords(this.lastMousePosition)
+        const position = getPositionForMouse(view, this.lastMousePosition)
         if (position == null) {
           return { hoverRange: undefined, underlineRange: undefined }
         }
 
         const tree = syntaxTree(view.state)
-        const hoverRange = findIdentifierRangeAt(tree, view.state.doc, position)
+        const model = getAnalysisModel(tree, view.state.doc)
+
+        // TODO use just one model and avoid re-parsing for this
+        const hoverRange = findIdentifierAt(model, position)?.range
         if (hoverRange == null) {
           return { hoverRange: undefined, underlineRange: undefined }
         }
@@ -201,13 +214,15 @@ class GoToDefinitionInteractionsPlugin {
     }
 
     const mouse = { x: event.clientX, y: event.clientY }
-    const position = this.view.posAtCoords(mouse)
+    const position = getPositionForMouse(this.view, mouse)
     if (position == null) {
       return
     }
 
     const tree = syntaxTree(this.view.state)
-    const hoverRange = findIdentifierRangeAt(tree, this.view.state.doc, position)
+    const model = getAnalysisModel(tree, this.view.state.doc)
+
+    const hoverRange = findIdentifierAt(model, position)?.range
     if (hoverRange == null || !rangeContainsMouseX(this.view, hoverRange, mouse)) {
       return
     }
@@ -231,13 +246,16 @@ class GoToDefinitionInteractionsPlugin {
       return
     }
 
-    const position = this.view.posAtCoords(this.lastMousePosition)
+    const position = getPositionForMouse(this.view, this.lastMousePosition)
     if (position == null) {
       this.scheduleHoverDispatch(undefined)
       return
     }
 
-    const range = findIdentifierRangeAt(syntaxTree(this.view.state), this.view.state.doc, position)
+    const tree = syntaxTree(this.view.state)
+    const model = getAnalysisModel(tree, this.view.state.doc)
+
+    const range = findIdentifierAt(model, position)?.range
 
     if (range == null || !rangeContainsMouseX(this.view, range, this.lastMousePosition)) {
       this.lastHoverRange = undefined
@@ -252,7 +270,6 @@ class GoToDefinitionInteractionsPlugin {
     this.lastHoverRange = range
 
     // Only underline identifiers that actually resolve.
-    const tree = syntaxTree(this.view.state)
     const target = applySemanticOperation(goToDefinition, tree, this.view.state.doc, position)
     if (target == null) {
       this.scheduleHoverDispatch(undefined)

--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -8,6 +8,6 @@ export interface GoToDefinitionResult {
 }
 
 export const goToDefinition: SemanticOperation<[pos: number], SourceRange | undefined> = (model, tree, document, pos) => {
-  const binding = findDefinitionBindingAt(model, tree, document, pos)
+  const binding = findDefinitionBindingAt(model, document, pos)
   return binding?.range
 }

--- a/packages/language-support/src/highlight-occurrences/extension.ts
+++ b/packages/language-support/src/highlight-occurrences/extension.ts
@@ -2,7 +2,6 @@ import { syntaxTree } from '@codemirror/language'
 import type { EditorState, Extension } from '@codemirror/state'
 import type { DecorationSet, ViewUpdate } from '@codemirror/view'
 import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
-import type { Tree } from '@lezer/common'
 import { getAnalysisModel } from '../analysis/cache.js'
 import type { Model } from '../analysis/model.js'
 import type { RangesByBinding } from '../analysis/query.js'
@@ -47,7 +46,6 @@ const plugin = ViewPlugin.fromClass(HighlightOccurrencesPlugin, {
 })
 
 interface AnalysisState {
-  readonly tree: Tree
   readonly model: Model
   readonly rangesByBinding: RangesByBinding
 }
@@ -56,18 +54,18 @@ function buildAnalysisState (state: EditorState): AnalysisState {
   const tree = syntaxTree(state)
   const model = getAnalysisModel(tree, state.doc)
   const rangesByBinding = buildReferenceRangesByBinding(model, tree, state.doc)
-  return { tree, model, rangesByBinding }
+  return { model, rangesByBinding }
 }
 
 function getOccurrenceDecorations (state: EditorState, analysisState: AnalysisState): DecorationSet {
   const { doc, selection } = state
-  const { tree, model, rangesByBinding } = analysisState
+  const { model, rangesByBinding } = analysisState
 
   if (selection.ranges.length !== 1 || !selection.main.empty) {
     return Decoration.none
   }
 
-  const binding = findDefinitionBindingAt(model, tree, doc, selection.main.head)
+  const binding = findDefinitionBindingAt(model, doc, selection.main.head)
   const ranges = binding != null ? rangesByBinding.get(binding.id) : undefined
 
   if (ranges == null || ranges.length === 0) {

--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -1,8 +1,7 @@
 import type { HoverInfo } from '@language'
 import { getStandardLibraryHoverInfo } from '@language'
-import type { Tree } from '@lezer/common'
 import type { Binding, ImportStatement, Model } from '../analysis/model.js'
-import { findAccessChainRootBefore, findDefinitionBindingAt, findSemanticOccurrenceAt } from '../analysis/query.js'
+import { findAccessChainRootBefore, findDefinitionBindingAt, findIdentifierAt } from '../analysis/query.js'
 import type { SemanticOperation } from '../operations.js'
 import type { SourceRange, TextLike } from '../types.js'
 
@@ -11,17 +10,17 @@ export interface HoverInfoWithRange extends HoverInfo {
 }
 
 export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange | undefined> = (model, tree, document, pos) => {
-  const occurrence = findSemanticOccurrenceAt(tree, document, pos)
-  if (occurrence?.kind == null || occurrence.name.length === 0) {
+  const occurrence = findIdentifierAt(model, pos, 'inclusive')
+  if (occurrence == null) {
     return undefined
   }
 
-  const memberInfo = resolveMemberHover(model, tree, document, occurrence.range, occurrence.name)
+  const memberInfo = resolveMemberHover(model, document, occurrence.range, occurrence.name)
   if (memberInfo != null) {
     return { ...memberInfo, range: occurrence.range }
   }
 
-  const binding = findDefinitionBindingAt(model, tree, document, pos)
+  const binding = findDefinitionBindingAt(model, document, pos)
   if (binding?.kind === 'use-alias') {
     const moduleName = findModuleNameForBinding(model.imports, binding)
 
@@ -56,7 +55,6 @@ export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange |
 
 function resolveMemberHover (
   model: Model,
-  tree: Tree,
   document: TextLike,
   range: SourceRange,
   memberName: string
@@ -67,7 +65,7 @@ function resolveMemberHover (
   }
 
   const rootPosition = rootRange.offset + Math.min(rootRange.length - 1, 1)
-  const rootBinding = findDefinitionBindingAt(model, tree, document, rootPosition)
+  const rootBinding = findDefinitionBindingAt(model, document, rootPosition)
   if (rootBinding?.kind !== 'use-alias') {
     return undefined
   }

--- a/packages/language-support/test/analysis/model.test.ts
+++ b/packages/language-support/test/analysis/model.test.ts
@@ -70,4 +70,103 @@ describe('analysis/model.ts', () => {
       ['drums', 'delay']
     )
   })
+
+  it('builds a sorted list of identifiers', () => {
+    const source = [
+      'use "instruments" as *',
+      'use "patterns" as p',
+      '',
+      'base_path = "/samples"',
+      'kick = sample("{base_path}/kick.wav")',
+      'tempo = 120.bpm',
+      '',
+      'track (tempo: tempo) {',
+      '  part intro (4.bars) {',
+      '    kick << p.loop([x---])',
+      '    automate kick.gain as curve [hold(-60.db)]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    assert.deepStrictEqual(
+      model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
+      [
+        { kind: 'UseAlias', name: 'p' },
+        { kind: 'VariableDefinition', name: 'base_path' },
+        { kind: 'VariableDefinition', name: 'kick' },
+        { kind: 'Callee', name: 'sample' },
+        { kind: 'VariableName', name: 'base_path' },
+        { kind: 'VariableDefinition', name: 'tempo' },
+        { kind: 'PropertyName', name: 'tempo' },
+        { kind: 'VariableName', name: 'tempo' },
+        { kind: 'VariableDefinition', name: 'intro' },
+        { kind: 'VariableName', name: 'kick' },
+        { kind: 'VariableName', name: 'p' },
+        { kind: 'Callee', name: 'loop' },
+        { kind: 'VariableName', name: 'kick' },
+        { kind: 'MemberAccess', name: 'gain' }
+      ]
+    )
+  })
+
+  it('includes identifiers not part of valid syntax', () => {
+    const source = [
+      'sample',
+      'track {',
+      '  part intro {',
+      '    kick',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    assert.deepStrictEqual(
+      model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
+      [
+        { kind: 'VariableName', name: 'sample' },
+        { kind: 'VariableDefinition', name: 'intro' },
+        { kind: 'VariableName', name: 'kick' }
+      ]
+    )
+  })
+
+  it('includes member expressions not part of valid syntax', () => {
+    const source = [
+      'fx.delay',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    assert.deepStrictEqual(
+      model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
+      [
+        { kind: 'VariableName', name: 'fx' },
+        // should be MemberAccess, but this is a known limitation of the model when parsing incomplete code
+        { kind: 'VariableName', name: 'delay' }
+      ]
+    )
+  })
+
+  it('includes call expressions not part of valid syntax', () => {
+    const source = [
+      'delay(0.5.beats)',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    assert.deepStrictEqual(
+      model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
+      [
+        // should be Callee, but this is a known limitation of the model when parsing incomplete code
+        { kind: 'VariableName', name: 'delay' }
+      ]
+    )
+  })
 })

--- a/packages/language-support/test/analysis/query.test.ts
+++ b/packages/language-support/test/analysis/query.test.ts
@@ -34,7 +34,7 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.lastIndexOf('kick <<') + 1
-    const binding = findDefinitionBindingAt(model, tree, document, position)
+    const binding = findDefinitionBindingAt(model, document, position)
 
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'assignment')
@@ -59,7 +59,7 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.indexOf('synth.gain') + 'synth.'.length + 1
-    const binding = findDefinitionBindingAt(model, tree, document, position)
+    const binding = findDefinitionBindingAt(model, document, position)
 
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'assignment')
@@ -85,7 +85,7 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
-    const binding = findDefinitionBindingAt(model, tree, document, position)
+    const binding = findDefinitionBindingAt(model, document, position)
 
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'bus')
@@ -106,7 +106,7 @@ describe('analysis/query.ts', () => {
     const model = analyzeTree(tree, document)
     const position = source.indexOf('tempo:') + 1
 
-    assert.strictEqual(findDefinitionBindingAt(model, tree, document, position), undefined)
+    assert.strictEqual(findDefinitionBindingAt(model, document, position), undefined)
   })
 
   it('prefers import aliases over assignments with the same name', () => {
@@ -120,7 +120,7 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.lastIndexOf('fx.delay') + 1
-    const binding = findDefinitionBindingAt(model, tree, document, position)
+    const binding = findDefinitionBindingAt(model, document, position)
 
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'use-alias')

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -30,10 +30,17 @@ describe('go-to-definition/operation.ts', () => {
     const source = 'mixer { bus a { } bus b { a } }'
 
     const defPos = source.indexOf('bus a') + 'bus '.length
-    const refPos = source.lastIndexOf(' a ') + 2
+
+    const refPosLeft = source.lastIndexOf(' a ') + 1
+    const refPosRight = source.lastIndexOf(' a ') + 2
 
     assert.deepStrictEqual(
-      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPosLeft),
+      getRangeAt(source, defPos, 1)
+    )
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPosRight),
       getRangeAt(source, defPos, 1)
     )
   })

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -110,4 +110,27 @@ describe('highlight-occurrences/operation.ts', () => {
       ]
     )
   })
+
+  it('uses correct boundary for identifier lookup', () => {
+    const source = [
+      'foo = 42',
+      'bar = foo // reference',
+      ''
+    ].join('\n')
+
+    const beforeNamePosition = source.indexOf(' foo // reference')
+    const startOfNamePosition = source.indexOf('foo // reference')
+    const endOfNamePosition = source.indexOf('foo // reference') + 'foo'.length
+    const afterNamePosition = source.indexOf('foo // reference') + 'foo'.length + 1
+
+    const beforeName = applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, beforeNamePosition)
+    const startOfName = applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, startOfNamePosition)
+    const endOfName = applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, endOfNamePosition)
+    const afterName = applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, afterNamePosition)
+
+    assert.deepStrictEqual(beforeName.length, 0, 'before name')
+    assert.deepStrictEqual(startOfName.length, 2, 'start of name')
+    assert.deepStrictEqual(endOfName.length, 2, 'end of name')
+    assert.deepStrictEqual(afterName.length, 0, 'after name')
+  })
 })

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -108,4 +108,46 @@ describe('hover/operation.ts', () => {
       undefined
     )
   })
+
+  it('uses correct boundary for identifier lookup', () => {
+    const source = [
+      'use "instruments" as *',
+      'foo = sample("...")',
+      ''
+    ].join('\n')
+
+    const beforeNamePosition = source.indexOf(' sample')
+    const startOfNamePosition = source.indexOf('sample')
+    const endOfNamePosition = source.indexOf('sample') + 'sample'.length
+    const afterNamePosition = source.indexOf('sample') + 'sample'.length + 1
+
+    const beforeName = applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, beforeNamePosition)
+    const startOfName = applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, startOfNamePosition)
+    const endOfName = applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, endOfNamePosition)
+    const afterName = applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, afterNamePosition)
+
+    assert.ok(beforeName == null, 'before name')
+    assert.ok(startOfName != null, 'start of name')
+    assert.ok(endOfName != null, 'end of name')
+    assert.ok(afterName == null, 'after name')
+  })
+
+  it('returns docs for identifiers not part of valid syntax', () => {
+    // member accesses cannot be standalone expressions, but should still show hover info
+    const source = [
+      'use "effects" as fx',
+      'fx.delay',
+      ''
+    ].join('\n')
+
+    const modulePosition = source.indexOf('fx.delay') + 1
+    const moduleDocs = applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, modulePosition)
+
+    assert.strictEqual(moduleDocs?.title, 'module effects')
+
+    const memberPosition = source.indexOf('delay') + 1
+    const memberDocs = applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, memberPosition)
+
+    assert.strictEqual(memberDocs?.title.slice(0, 'delay'.length), 'delay')
+  })
 })


### PR DESCRIPTION
This patch improves the split between model analysis and query functions by collecting all identifiers into the model, instead of only those that are definitions. This allows queries to find identifiers at a position without having to traverse the syntax tree.