### PR TITLE
refactor: Remove obsolete getEffectiveOccurrenceKind

### DIFF
--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -125,20 +125,21 @@ export function findUnusedAssignmentBindings (model: Model, tree: Tree, document
 }
 
 function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence, document: TextLike): Binding | undefined {
-  const name = occurrence.name
-  const effectiveKind = getEffectiveOccurrenceKind(occurrence, document)
+  const { name } = occurrence
 
-  switch (effectiveKind) {
+  switch (occurrence.kind) {
+    case 'PropertyName':
+      return undefined
+
     case 'VariableDefinition':
     case 'UseAlias':
       return findBindingBySpan(model, occurrence)
 
-    case 'PropertyName':
-      return undefined
-
     case 'Callee':
       return findFirstGlobalBinding(model, name)
   }
+
+  // VariableName, MemberAccess
 
   const explicitBusBinding = resolveExplicitBusBinding(model, occurrence, document)
   if (explicitBusBinding != null) {
@@ -181,37 +182,12 @@ function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence,
   return findFirstGlobalBinding(model, name) ?? findFallbackScopedBinding(model, name)
 }
 
-function getEffectiveOccurrenceKind (occurrence: SemanticOccurrence, document: TextLike): IdentifierKind | undefined {
-  const parent = occurrence.node?.parent
-
-  // Fix cases where Lezer classifies an identifier as a VariableDefinition even when
-  // it is not actually defining a variable.
-  let isCorrect = true
-
-  if (occurrence.kind === 'VariableDefinition' && parent != null) {
-    switch (parent.type.name) {
-      case 'Assignment':
-        isCorrect = document.sliceString(parent.from, parent.to).includes('=')
-        break
-      case 'PartStatement':
-        isCorrect = /^\s*part\b/.test(document.sliceString(parent.from, parent.from + 16))
-        break
-      case 'BusStatement':
-        isCorrect = /^\s*bus\b/.test(document.sliceString(parent.from, parent.from + 16))
-        break
-    }
-  }
-
-  return isCorrect ? occurrence.kind : 'VariableName'
-}
-
 function getReferenceRangeForBindingOccurrence (
   occurrence: SemanticOccurrence,
   document: TextLike,
   binding: Binding
 ): SourceRange | undefined {
-  const effectiveKind = getEffectiveOccurrenceKind(occurrence, document)
-  if (effectiveKind === 'PropertyName') {
+  if (occurrence.kind === 'PropertyName') {
     return undefined
   }
 

--- a/packages/language-support/test/analysis/model.test.ts
+++ b/packages/language-support/test/analysis/model.test.ts
@@ -169,4 +169,25 @@ describe('analysis/model.ts', () => {
       ]
     )
   })
+
+  it('includes identifiers that are part of an incomplete statement', () => {
+    const source = [
+      'part main {',
+      '  foo = 42',
+      '  foo',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    assert.deepStrictEqual(
+      model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
+      [
+        { kind: 'VariableName', name: 'main' },
+        { kind: 'VariableDefinition', name: 'foo' },
+        { kind: 'VariableName', name: 'foo' }
+      ]
+    )
+  })
 })

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -132,4 +132,20 @@ describe('go-to-definition/operation.ts', () => {
       undefined
     )
   })
+
+  it('resolves incomplete syntax referring to an assignment', () => {
+    const source = [
+      'foo = 42',
+      'foo',
+      ''
+    ].join('\n')
+
+    const defPos = source.indexOf('foo =')
+    const refPos = source.lastIndexOf('foo') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
+      getRangeAt(source, defPos, 'foo'.length)
+    )
+  })
 })

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -133,4 +133,22 @@ describe('highlight-occurrences/operation.ts', () => {
     assert.deepStrictEqual(endOfName.length, 2, 'end of name')
     assert.deepStrictEqual(afterName.length, 0, 'after name')
   })
+
+  it('returns the definition and reference also for incomplete syntax', () => {
+    const source = [
+      'foo = 42',
+      'foo',
+      ''
+    ].join('\n')
+
+    const position = source.lastIndexOf('foo') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('foo ='), 'foo'.length),
+        getRangeAt(source, source.lastIndexOf('foo'), 'foo'.length)
+      ]
+    )
+  })
 })


### PR DESCRIPTION
This patch removes `getEffectiveOccurrenceKind` from the language support query module, as this is already covered by model analysis.