### PR TITLE
refactor: Include scope information for identifier

### DIFF
--- a/packages/language-support/src/analysis/model.ts
+++ b/packages/language-support/src/analysis/model.ts
@@ -27,8 +27,8 @@ export type ScopeKind = 'root' | 'track' | 'mixer'
 // identifier
 
 export interface Identifier {
-  readonly id: string
   readonly kind: IdentifierKind
+  readonly scopeId: string
   readonly name: string
   readonly range: SourceRange
 }
@@ -98,10 +98,6 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
   const bindingsByScope = new Map<string, Binding[]>()
   const imports: ImportStatement[] = []
 
-  const addIdentifier = (input: Omit<Identifier, 'id'>): void => {
-    identifiers.push({ ...input, id: identifierKey(input.kind, input.range) })
-  }
-
   const addBinding = (input: Omit<Binding, 'id'>): void => {
     const { kind, scopeId, name, range } = input
 
@@ -141,7 +137,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
         if (statement != null) {
           imports.push(statement)
           if (statement.alias != null && statement.aliasRange != null) {
-            addIdentifier({ kind: 'UseAlias', name: statement.alias, range: statement.aliasRange })
+            identifiers.push({ kind: 'UseAlias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
             addBinding({ kind: 'use-alias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
           }
         }
@@ -183,11 +179,11 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
         if (binding == null) {
           // Invalid/incomplete syntax encountered.
           // We still add an identifier as a best-effort approach to provide some level of functionality.
-          addIdentifier({ kind: 'VariableName', name, range })
+          identifiers.push({ kind: 'VariableName', scopeId: currentScopeId, name, range })
           break
         }
 
-        addIdentifier({ kind: 'VariableDefinition', name, range })
+        identifiers.push({ kind: 'VariableDefinition', scopeId: currentScopeId, name, range })
         addBinding({ ...binding, name, range })
 
         break
@@ -198,7 +194,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
       case 'MemberAccess':
       case 'PropertyName': {
         const name = document.sliceString(from, to)
-        addIdentifier({ kind: typeName, name, range })
+        identifiers.push({ kind: typeName, scopeId: currentScopeId, name, range })
         break
       }
     }
@@ -224,12 +220,8 @@ export function analyzeSourceWithParser (parser: LRParser, source: string): Mode
   return analyzeTree(tree, textFromString(source))
 }
 
-export function scopeKey (typeName: string, range: SourceRange): string {
+function scopeKey (typeName: string, range: SourceRange): string {
   return `${typeName}:${range.offset}:${range.length}`
-}
-
-function identifierKey (kind: IdentifierKind, range: SourceRange): string {
-  return `${kind}:${range.offset}:${range.length}`
 }
 
 function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): string {

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -1,7 +1,7 @@
 import type { SyntaxNode, Tree } from '@lezer/common'
 import type { SourceRange, TextLike } from '../types.js'
 import type { Binding, BindingKind, Identifier, IdentifierKind, Model } from './model.js'
-import { isIdentifierKind, scopeKey } from './model.js'
+import { isIdentifierKind } from './model.js'
 import { toSourceRange } from './text.js'
 
 export interface SemanticOccurrence {
@@ -9,6 +9,7 @@ export interface SemanticOccurrence {
   readonly name: string
   readonly range: SourceRange
   readonly node?: SyntaxNode
+  readonly scopeId: string
 }
 
 const GLOBAL_BINDING_PRIORITY: readonly BindingKind[] = ['use-alias', 'assignment']
@@ -152,6 +153,7 @@ function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence,
     if (rootName.length > 0 && rootName !== name) {
       const resolvedRoot = resolveDefinitionBinding(model, {
         kind: 'VariableName',
+        scopeId: occurrence.scopeId,
         name: rootName,
         node: occurrence.node,
         range: root
@@ -163,20 +165,16 @@ function resolveDefinitionBinding (model: Model, occurrence: SemanticOccurrence,
     }
   }
 
-  const trackScopeId = findEnclosingScopeId(document, occurrence.node, 'TrackStatement')
-  if (trackScopeId != null) {
-    const definition = findScopedBinding(model, trackScopeId, name, 'part')
-    if (definition != null) {
-      return definition
-    }
+  const scope = model.scopes.get(occurrence.scopeId)
+
+  const part = scope?.kind === 'track' ? findScopedBinding(model, scope.id, name, 'part') : undefined
+  if (part != null) {
+    return part
   }
 
-  const mixerScopeId = findEnclosingScopeId(document, occurrence.node, 'MixerStatement')
-  if (mixerScopeId != null) {
-    const definition = findScopedBinding(model, mixerScopeId, name, 'bus')
-    if (definition != null) {
-      return definition
-    }
+  const bus = scope?.kind === 'mixer' ? findScopedBinding(model, scope.id, name, 'bus') : undefined
+  if (bus != null) {
+    return bus
   }
 
   return findFirstGlobalBinding(model, name) ?? findFallbackScopedBinding(model, name)
@@ -307,20 +305,6 @@ function getWordRangeAt (document: TextLike, position: number): SourceRange | un
   }
 
   return toSourceRange(document, from, to)
-}
-
-function findEnclosingScopeId (
-  document: TextLike,
-  node: SyntaxNode | undefined,
-  scopeTypeName: 'TrackStatement' | 'MixerStatement'
-): string | undefined {
-  for (let current = node; current != null; current = current.parent ?? undefined) {
-    if (current.type.name === scopeTypeName) {
-      return scopeKey(current.type.name, toSourceRange(document, current.from, current.to))
-    }
-  }
-
-  return undefined
 }
 
 export function findAccessChainRootBefore (document: TextLike, memberFrom: number): SourceRange | undefined {

--- a/packages/language-support/test/analysis/model.test.ts
+++ b/packages/language-support/test/analysis/model.test.ts
@@ -86,28 +86,41 @@ describe('analysis/model.ts', () => {
       '    automate kick.gain as curve [hold(-60.db)]',
       '  }',
       '}',
+      '',
+      'mixer {',
+      '  bus drums {',
+      '    kick snare',
+      '  }',
+      '}',
       ''
     ].join('\n')
 
     const model = analyzeSourceWithParser(cadenceParser, source)
 
     assert.deepStrictEqual(
-      model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
+      model.identifiers.map(({ kind, scopeId, name }) => ({
+        kind,
+        scope: model.scopes.get(scopeId)?.kind,
+        name
+      })),
       [
-        { kind: 'UseAlias', name: 'p' },
-        { kind: 'VariableDefinition', name: 'base_path' },
-        { kind: 'VariableDefinition', name: 'kick' },
-        { kind: 'Callee', name: 'sample' },
-        { kind: 'VariableName', name: 'base_path' },
-        { kind: 'VariableDefinition', name: 'tempo' },
-        { kind: 'PropertyName', name: 'tempo' },
-        { kind: 'VariableName', name: 'tempo' },
-        { kind: 'VariableDefinition', name: 'intro' },
-        { kind: 'VariableName', name: 'kick' },
-        { kind: 'VariableName', name: 'p' },
-        { kind: 'Callee', name: 'loop' },
-        { kind: 'VariableName', name: 'kick' },
-        { kind: 'MemberAccess', name: 'gain' }
+        { kind: 'UseAlias', scope: 'root', name: 'p' },
+        { kind: 'VariableDefinition', scope: 'root', name: 'base_path' },
+        { kind: 'VariableDefinition', scope: 'root', name: 'kick' },
+        { kind: 'Callee', scope: 'root', name: 'sample' },
+        { kind: 'VariableName', scope: 'root', name: 'base_path' },
+        { kind: 'VariableDefinition', scope: 'root', name: 'tempo' },
+        { kind: 'PropertyName', scope: 'track', name: 'tempo' },
+        { kind: 'VariableName', scope: 'track', name: 'tempo' },
+        { kind: 'VariableDefinition', scope: 'track', name: 'intro' },
+        { kind: 'VariableName', scope: 'track', name: 'kick' },
+        { kind: 'VariableName', scope: 'track', name: 'p' },
+        { kind: 'Callee', scope: 'track', name: 'loop' },
+        { kind: 'VariableName', scope: 'track', name: 'kick' },
+        { kind: 'MemberAccess', scope: 'track', name: 'gain' },
+        { kind: 'VariableDefinition', scope: 'mixer', name: 'drums' },
+        { kind: 'VariableName', scope: 'mixer', name: 'kick' },
+        { kind: 'VariableName', scope: 'mixer', name: 'snare' }
       ]
     )
   })


### PR DESCRIPTION
This patch updates the model such that each identifier already stores the scope it belongs to, which is already available during the walk. This allows query logic to be simplified.