### PR TITLE
fix: Do not resolve member access to bindings

### DIFF
--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -127,38 +127,18 @@ function resolveDefinitionBinding (model: Model, occurrence: Identifier, documen
       return findFirstGlobalBinding(model, occurrence.name)
 
     case 'VariableName':
+      return resolveVariableBinding(model, occurrence, document)
+
     case 'MemberAccess':
-      return resolveVariableOrMemberBinding(model, occurrence, document)
+      return resolveExplicitBusBinding(model, occurrence, document)
 
     default:
       occurrence.kind satisfies never
   }
 }
 
-function resolveVariableOrMemberBinding (model: Model, occurrence: Identifier, document: TextLike): Binding | undefined {
+function resolveVariableBinding (model: Model, occurrence: Identifier, document: TextLike): Binding | undefined {
   const { name } = occurrence
-
-  const explicitBusBinding = resolveExplicitBusBinding(model, occurrence, document)
-  if (explicitBusBinding != null) {
-    return explicitBusBinding
-  }
-
-  const root = findAccessChainRootBefore(document, occurrence.range.offset)
-  if (root != null) {
-    const rootName = document.sliceString(root.offset, root.offset + root.length)
-    if (rootName.length > 0 && rootName !== name) {
-      const resolvedRoot = resolveDefinitionBinding(model, {
-        kind: 'VariableName',
-        scopeId: occurrence.scopeId,
-        name: rootName,
-        range: root
-      }, document)
-
-      if (resolvedRoot != null) {
-        return resolvedRoot
-      }
-    }
-  }
 
   const scope = model.scopes.get(occurrence.scopeId)
 
@@ -288,16 +268,17 @@ function getWordRangeAt (document: TextLike, position: number): SourceRange | un
   return toSourceRange(document, from, to)
 }
 
-export function findAccessChainRootBefore (document: TextLike, memberFrom: number): SourceRange | undefined {
+export function findAccessChainRootBefore (document: TextLike, memberFrom: number, limit?: number): SourceRange | undefined {
   const dot = charBeforeNonWhitespace(document, memberFrom)
   if (dot == null || dot.char !== '.') {
     return undefined
   }
 
+  let steps = 0
   let root: SourceRange | undefined
   let currentDotIndex = dot.index
 
-  while (currentDotIndex >= 0) {
+  while (currentDotIndex >= 0 && (limit == null || steps < limit)) {
     const wordEnd = skipWhitespaceLeft(document, currentDotIndex)
     const range = getWordRangeAt(document, wordEnd)
     if (range == null) {
@@ -312,13 +293,14 @@ export function findAccessChainRootBefore (document: TextLike, memberFrom: numbe
     }
 
     currentDotIndex = beforeWord.index
+    ++steps
   }
 
   return root
 }
 
 function findExplicitBusBindingRange (document: TextLike, memberFrom: number): SourceRange | undefined {
-  const root = findAccessChainRootBefore(document, memberFrom)
+  const root = findAccessChainRootBefore(document, memberFrom, 1)
   if (root == null) {
     return undefined
   }

--- a/packages/language-support/test/analysis/query.test.ts
+++ b/packages/language-support/test/analysis/query.test.ts
@@ -44,36 +44,11 @@ describe('analysis/query.ts', () => {
     assert.deepStrictEqual(binding.range, getRangeAt(source, kickOffset, 'kick'.length))
   })
 
-  it('resolves member access through the root identifier', () => {
-    const source = [
-      'use "effects" as fx',
-      'synth = sample("...")',
-      'track (120.bpm) {',
-      '  part intro (4.bars) {',
-      '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
-      '  }',
-      '}',
-      ''
-    ].join('\n')
-
-    const { tree, document } = parseDocument(source)
-    const model = analyzeTree(tree, document)
-    const position = source.indexOf('synth.gain') + 'synth.'.length + 1
-    const binding = findDefinitionBindingAt(model, document, position)
-
-    assert.ok(binding)
-    assert.strictEqual(binding.kind, 'assignment')
-    assert.strictEqual(binding.name, 'synth')
-
-    const synthOffset = source.indexOf('synth =')
-    assert.deepStrictEqual(binding.range, getRangeAt(source, synthOffset, 'synth'.length))
-  })
-
   it('resolves explicit bus namespace access to the bus binding', () => {
     const source = [
       'track (120.bpm) {',
       '  part foo (4.bars) {',
-      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '    automate bus.foo.gain as curve [hold(0.db)]',
       '  }',
       '}',
       'mixer {',
@@ -84,7 +59,7 @@ describe('analysis/query.ts', () => {
 
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
-    const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
+    const position = source.indexOf('bus.foo.gain') + 'bus.'.length + 1
     const binding = findDefinitionBindingAt(model, document, position)
 
     assert.ok(binding)
@@ -105,6 +80,46 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.indexOf('tempo:') + 1
+
+    assert.strictEqual(findDefinitionBindingAt(model, document, position), undefined)
+  })
+
+  it('does not resolve member access', () => {
+    const source = [
+      'use "effects" as fx',
+      'gain = 0.db',
+      'synth = sample("...", gain: gain)',
+      'track (120.bpm) {',
+      '  part intro (4.bars) {',
+      '    automate synth.gain as curve [hold(0.db)]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const { tree, document } = parseDocument(source)
+    const model = analyzeTree(tree, document)
+    const position = source.indexOf('synth.gain') + 'synth.'.length + 1
+
+    assert.strictEqual(findDefinitionBindingAt(model, document, position), undefined)
+  })
+
+  it('does not resolve member access of an explicit bus access', () => {
+    const source = [
+      'track (120.bpm) {',
+      '  part main (4.bars) {',
+      '    automate bus.foo.gain as curve [hold(0.db)]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus foo {}',
+      '}',
+      ''
+    ].join('\n')
+
+    const { tree, document } = parseDocument(source)
+    const model = analyzeTree(tree, document)
+    const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
 
     assert.strictEqual(findDefinitionBindingAt(model, document, position), undefined)
   })

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -73,29 +73,6 @@ describe('go-to-definition/operation.ts', () => {
     )
   })
 
-  it('does not resolve member access by member name', () => {
-    const source = [
-      'use "foo" as gain',
-      '',
-      'synth = sample("...")',
-      '',
-      'track (120.bpm) {',
-      '  part p {',
-      '    automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]',
-      '  }',
-      '}',
-      ''
-    ].join('\n')
-
-    const defPos = source.indexOf('synth =')
-    const refPos = source.indexOf('synth.gain') + 'synth.'.length + 1
-
-    assert.deepStrictEqual(
-      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
-      getRangeAt(source, defPos, 'synth'.length)
-    )
-  })
-
   it('resolves explicit bus namespace access to the bus definition', () => {
     const source = [
       'track (120.bpm) {',
@@ -110,7 +87,7 @@ describe('go-to-definition/operation.ts', () => {
     ].join('\n')
 
     const defPos = source.indexOf('bus foo') + 'bus '.length
-    const refPos = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
+    const refPos = source.indexOf('bus.foo.gain') + 'bus.'.length + 1
 
     assert.deepStrictEqual(
       applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
@@ -129,6 +106,28 @@ describe('go-to-definition/operation.ts', () => {
 
     assert.strictEqual(
       applySemanticOperationWithParser(goToDefinition, cadenceParser, source, pos),
+      undefined
+    )
+  })
+
+  it('does not resolve member access', () => {
+    const source = [
+      'use "foo" as gain',
+      '',
+      'synth = sample("...")',
+      '',
+      'track (120.bpm) {',
+      '  part p {',
+      '    automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const refPos = source.indexOf('synth.gain') + 'synth.'.length + 1
+
+    assert.strictEqual(
+      applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos),
       undefined
     )
   })

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -34,28 +34,6 @@ describe('highlight-occurrences/operation.ts', () => {
     )
   })
 
-  it('normalizes member access references to the root identifier range', () => {
-    const source = [
-      'synth = sample("...")',
-      'track (120.bpm) {',
-      '  part intro (4.bars) {',
-      '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
-      '  }',
-      '}',
-      ''
-    ].join('\n')
-
-    const position = source.indexOf('synth.gain') + 'synth.'.length + 1
-
-    assert.deepStrictEqual(
-      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
-      [
-        getRangeAt(source, source.indexOf('synth ='), 'synth'.length),
-        getRangeAt(source, source.indexOf('synth.gain'), 'synth'.length)
-      ]
-    )
-  })
-
   it('normalizes explicit bus namespace references to the bus member range', () => {
     const source = [
       'track (120.bpm) {',
@@ -69,7 +47,7 @@ describe('highlight-occurrences/operation.ts', () => {
       ''
     ].join('\n')
 
-    const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
+    const position = source.indexOf('bus.foo.gain') + 'bus.'.length + 1
 
     assert.deepStrictEqual(
       applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
@@ -88,6 +66,25 @@ describe('highlight-occurrences/operation.ts', () => {
     ].join('\n')
 
     const position = source.indexOf('tempo:') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      []
+    )
+  })
+
+  it('does not highlight member accesses', () => {
+    const source = [
+      'synth = sample("...")',
+      'track (120.bpm) {',
+      '  part intro (4.bars) {',
+      '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('synth.gain') + 'synth.'.length + 1
 
     assert.deepStrictEqual(
       applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),


### PR DESCRIPTION
Before this patch, language support features would intentionally resolve member access (e.g., the `gain` of `synth.gain` or `bus.drums.gain`) to the variable binding of the root identifier (e.g., `synth` or `drums`). This was done to allow features like "go to definition" to work for members of buses and synths, which are not explicitly declared in the source code but are implicitly defined by the bus and synth types.

However, in practice, this results in confusing behavior for users: For instance, when the caret is on `gain` in `bus.foo.gain`, `foo` would be highlighted as the occurrence instead of `gain`.

This patch removes that behavior in favor of not resolving anything.