### PR TITLE
fix: Move member access resolution into the model

### DIFF
--- a/packages/language-support/src/analysis/model.ts
+++ b/packages/language-support/src/analysis/model.ts
@@ -31,6 +31,12 @@ export interface Identifier {
   readonly scopeId: string
   readonly name: string
   readonly range: SourceRange
+
+  /**
+   * For member accesses (e.g. "bar" or "baz" in "foo.bar.baz"),
+   * this points to the previous identifier in the access chain.
+   */
+  readonly previousSibling?: Identifier
 }
 
 const IDENTIFIER_KINDS = [
@@ -116,8 +122,9 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
     currentScopeId: string,
     trackScopeId: string | undefined,
     mixerScopeId: string | undefined,
-    assignmentHasEquals: boolean
-  ): void => {
+    assignmentHasEquals: boolean,
+    previousSibling?: Identifier
+  ): Identifier | undefined => {
     const typeName = cursor.type.name
     const from = cursor.from
     const to = cursor.to
@@ -130,6 +137,7 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
     let nextTrackScopeId = trackScopeId
     let nextMixerScopeId = mixerScopeId
     let nextAssignmentHasEquals = assignmentHasEquals
+    let accessChainTail: Identifier | undefined
 
     switch (typeName) {
       case 'UseStatement': {
@@ -161,7 +169,16 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
       }
 
       case 'Assignment': {
-        nextAssignmentHasEquals = document.sliceString(from, to).includes('=')
+        nextAssignmentHasEquals = false
+
+        cursor.node.cursor().iterate((node) => {
+          if (node.type.name === '=') {
+            nextAssignmentHasEquals = true
+            return false
+          }
+          return true
+        })
+
         break
       }
 
@@ -179,7 +196,8 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
         if (binding == null) {
           // Invalid/incomplete syntax encountered.
           // We still add an identifier as a best-effort approach to provide some level of functionality.
-          identifiers.push({ kind: 'VariableName', scopeId: currentScopeId, name, range })
+          accessChainTail = { kind: 'VariableName', scopeId: currentScopeId, name, range, previousSibling }
+          identifiers.push(accessChainTail)
           break
         }
 
@@ -192,19 +210,66 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
       case 'VariableName':
       case 'Callee':
       case 'MemberAccess':
+      case 'BusNamespace':
       case 'PropertyName': {
+        const kind = typeName === 'BusNamespace' ? 'VariableName' : typeName
         const name = document.sliceString(from, to)
-        identifiers.push({ kind: typeName, scopeId: currentScopeId, name, range })
+
+        const identifier: Identifier = { kind, scopeId: currentScopeId, name, range, previousSibling }
+        identifiers.push(identifier)
+
+        if (kind !== 'PropertyName') {
+          accessChainTail = identifier
+        }
+
         break
       }
     }
 
+    // The parser defaults to 'Assignment' for incomplete syntax (e.g. standalone 'fx.delay'),
+    // so we use heuristics to still collect identifiers in that case.
+    const trackAccessChain = typeName === 'AccessOrCall' || (typeName === 'Assignment' && !nextAssignmentHasEquals)
+
+    let nextPreviousSibling = previousSibling
+
     if (cursor.firstChild()) {
       do {
-        walk(cursor, nextParentType, nextScopeId, nextTrackScopeId, nextMixerScopeId, nextAssignmentHasEquals)
+        const childTypeName = cursor.type.name
+
+        const childPreviousSibling = (() => {
+          if (typeName === 'Call') {
+            return childTypeName === 'Callee' ? previousSibling : undefined
+          }
+
+          return trackAccessChain && shouldKeepPreviousSibling(cursor.node)
+            ? nextPreviousSibling
+            : undefined
+        })()
+
+        const childAccessChainTail = walk(
+          cursor,
+          nextParentType,
+          nextScopeId,
+          nextTrackScopeId,
+          nextMixerScopeId,
+          nextAssignmentHasEquals,
+          childPreviousSibling
+        )
+
+        if (typeName === 'Call') {
+          accessChainTail ??= childAccessChainTail
+          continue
+        }
+
+        if (trackAccessChain && childAccessChainTail != null) {
+          nextPreviousSibling = childAccessChainTail
+          accessChainTail = childAccessChainTail
+        }
       } while (cursor.nextSibling())
       cursor.parent()
     }
+
+    return accessChainTail
   }
 
   walk(cursor, undefined, rootScopeId, undefined, undefined, false)
@@ -218,6 +283,17 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
 export function analyzeSourceWithParser (parser: LRParser, source: string): Model {
   const tree = parser.parse(source)
   return analyzeTree(tree, textFromString(source))
+}
+
+function shouldKeepPreviousSibling (node: SyntaxNode): boolean {
+  const type = node.type.name
+
+  return type === 'AccessOrCall' ||
+    type === 'Callee' ||
+    type === 'Call' ||
+    type === 'MemberAccess' ||
+    type === 'VariableName' ||
+    type === 'BusNamespace'
 }
 
 function scopeKey (typeName: string, range: SourceRange): string {

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -1,6 +1,5 @@
-import type { SourceRange, TextLike } from '../types.js'
+import type { SourceRange } from '../types.js'
 import type { Binding, BindingKind, Identifier, Model } from './model.js'
-import { toSourceRange } from './text.js'
 
 const GLOBAL_BINDING_PRIORITY: readonly BindingKind[] = ['use-alias', 'assignment']
 const FALLBACK_BINDING_PRIORITY: readonly BindingKind[] = ['part', 'bus']
@@ -41,38 +40,37 @@ export function findIdentifierAt (model: Model, position: number, boundary: 'str
   return undefined
 }
 
-export function findDefinitionBindingAt (model: Model, document: TextLike, position: number): Binding | undefined {
+export function findDefinitionBindingAt (model: Model, position: number): Binding | undefined {
   const occurrence = findIdentifierAt(model, position, 'inclusive')
   if (occurrence == null) {
     return undefined
   }
 
-  return resolveDefinitionBinding(model, occurrence, document)
+  return resolveDefinitionBinding(model, occurrence)
 }
 
 export type RangesByBinding = ReadonlyMap<string, readonly SourceRange[]>
 
 export function findReferenceRangesAt (
   model: Model,
-  document: TextLike,
   position: number,
   rangesByBinding?: RangesByBinding
 ): readonly SourceRange[] {
-  const binding = findDefinitionBindingAt(model, document, position)
+  const binding = findDefinitionBindingAt(model, position)
   if (binding == null) {
     return []
   }
 
-  const ranges = rangesByBinding ?? buildReferenceRangesByBinding(model, document)
+  const ranges = rangesByBinding ?? buildReferenceRangesByBinding(model)
 
   return ranges.get(binding.id) ?? []
 }
 
-export function buildReferenceRangesByBinding (model: Model, document: TextLike): RangesByBinding {
+export function buildReferenceRangesByBinding (model: Model): RangesByBinding {
   const rangesByBinding = new Map<string, Map<string, SourceRange>>()
 
-  walkResolvedIdentifierBindings(model, document, (occurrence, binding) => {
-    const range = getReferenceRangeForBindingOccurrence(occurrence, document, binding)
+  walkResolvedIdentifierBindings(model, (occurrence, binding) => {
+    const range = getReferenceRangeForBindingOccurrence(occurrence, binding)
     if (range == null) {
       return
     }
@@ -100,10 +98,10 @@ export function buildReferenceRangesByBinding (model: Model, document: TextLike)
   return sortedByBinding
 }
 
-export function findUnusedAssignmentBindings (model: Model, document: TextLike): readonly Binding[] {
+export function findUnusedAssignmentBindings (model: Model): readonly Binding[] {
   const usedBindings = new Set<string>()
 
-  walkResolvedIdentifierBindings(model, document, (occurrence, binding) => {
+  walkResolvedIdentifierBindings(model, (occurrence, binding) => {
     if (binding.kind === 'assignment' && !sameRange(binding.range, occurrence.range)) {
       usedBindings.add(binding.id)
     }
@@ -114,7 +112,7 @@ export function findUnusedAssignmentBindings (model: Model, document: TextLike):
   })
 }
 
-export function resolveDefinitionBinding (model: Model, occurrence: Identifier, document: TextLike): Binding | undefined {
+export function resolveDefinitionBinding (model: Model, occurrence: Identifier): Binding | undefined {
   switch (occurrence.kind) {
     case 'PropertyName':
       return undefined
@@ -127,17 +125,17 @@ export function resolveDefinitionBinding (model: Model, occurrence: Identifier, 
       return findFirstGlobalBinding(model, occurrence.name)
 
     case 'VariableName':
-      return resolveVariableBinding(model, occurrence, document)
+      return resolveVariableBinding(model, occurrence)
 
     case 'MemberAccess':
-      return resolveExplicitBusBinding(model, occurrence, document)
+      return resolveExplicitBusBinding(model, occurrence)
 
     default:
       occurrence.kind satisfies never
   }
 }
 
-function resolveVariableBinding (model: Model, occurrence: Identifier, document: TextLike): Binding | undefined {
+function resolveVariableBinding (model: Model, occurrence: Identifier): Binding | undefined {
   const { name } = occurrence
 
   const scope = model.scopes.get(occurrence.scopeId)
@@ -157,19 +155,14 @@ function resolveVariableBinding (model: Model, occurrence: Identifier, document:
 
 function getReferenceRangeForBindingOccurrence (
   occurrence: Identifier,
-  document: TextLike,
   binding: Binding
 ): SourceRange | undefined {
   if (occurrence.kind === 'PropertyName') {
     return undefined
   }
 
-  const explicitBusRange = findExplicitBusBindingRange(document, occurrence.range.offset)
-  if (binding.kind === 'bus' && explicitBusRange != null) {
-    const busName = document.sliceString(explicitBusRange.offset, explicitBusRange.offset + explicitBusRange.length)
-    if (busName === binding.name) {
-      return explicitBusRange
-    }
+  if (binding.kind === 'bus' && isExplicitBusReference(occurrence) && occurrence.name === binding.name) {
+    return occurrence.range
   }
 
   return occurrence.name === binding.name ? occurrence.range : undefined
@@ -177,19 +170,17 @@ function getReferenceRangeForBindingOccurrence (
 
 type OccurrenceVisitor = (occurrence: Identifier, binding: Binding) => void
 
-function resolveExplicitBusBinding (model: Model, occurrence: Identifier, document: TextLike): Binding | undefined {
-  const explicitBusRange = findExplicitBusBindingRange(document, occurrence.range.offset)
-  if (explicitBusRange == null) {
+function resolveExplicitBusBinding (model: Model, occurrence: Identifier): Binding | undefined {
+  if (!isExplicitBusReference(occurrence)) {
     return undefined
   }
 
-  const busName = document.sliceString(explicitBusRange.offset, explicitBusRange.offset + explicitBusRange.length)
-  return findBindingByPriority(model.bindingsByName.get(busName), ['bus'], busName)
+  return findBindingByPriority(model.bindingsByName.get(occurrence.name), ['bus'], occurrence.name)
 }
 
-function walkResolvedIdentifierBindings (model: Model, document: TextLike, visitor: OccurrenceVisitor): void {
+function walkResolvedIdentifierBindings (model: Model, visitor: OccurrenceVisitor): void {
   for (const identifier of model.identifiers) {
-    const binding = resolveDefinitionBinding(model, identifier, document)
+    const binding = resolveDefinitionBinding(model, identifier)
     if (binding != null) {
       visitor(identifier, binding)
     }
@@ -235,157 +226,20 @@ function findBindingByPriority (
   return undefined
 }
 
-function getWordRangeAt (document: TextLike, position: number): SourceRange | undefined {
-  if (position < 0 || position > document.length) {
-    return undefined
-  }
-
-  const right = charAt(document, position)
-  const left = charAt(document, position - 1)
-  const anchor = isWordChar(right) ? position : (isWordChar(left) ? position - 1 : undefined)
-  if (anchor == null) {
-    return undefined
-  }
-
-  let from = anchor
-  while (from > 0 && isWordChar(charAt(document, from - 1))) {
-    --from
-  }
-
-  let to = anchor + 1
-  while (to < document.length && isWordChar(charAt(document, to))) {
-    ++to
-  }
-
-  return toSourceRange(document, from, to)
-}
-
-export function computeAccessChain (model: Model, document: TextLike, member: Identifier): readonly Identifier[] {
+export function computeAccessChain (member: Identifier): readonly Identifier[] {
   const identifiers: Identifier[] = []
 
-  let currentMember: Identifier | undefined = member
-  while (currentMember != null) {
-    identifiers.push(currentMember)
-
-    const rangeBefore = findAccessChainRootBefore(document, currentMember.range.offset, 1)
-    if (rangeBefore == null) {
-      break
-    }
-
-    currentMember = findIdentifierAt(model, rangeBefore.offset, 'strict')
+  let current: Identifier | undefined = member
+  while (current != null) {
+    identifiers.push(current)
+    current = current.previousSibling
   }
 
   // reverse to get chain in order from left to right (e.g. "foo.bar.baz" -> ["foo", "bar", "baz"])
   return identifiers.reverse()
 }
 
-function findAccessChainRootBefore (document: TextLike, memberFrom: number, limit?: number): SourceRange | undefined {
-  const dot = charBeforeNonWhitespace(document, memberFrom)
-  if (dot == null || dot.char !== '.') {
-    return undefined
-  }
-
-  let steps = 0
-  let root: SourceRange | undefined
-  let currentDotIndex = dot.index
-
-  while (currentDotIndex >= 0 && (limit == null || steps < limit)) {
-    const wordEnd = skipWhitespaceLeft(document, currentDotIndex)
-    const range = getWordRangeAt(document, wordEnd)
-    if (range == null) {
-      break
-    }
-
-    root = range
-
-    const beforeWord = charBeforeNonWhitespace(document, range.offset)
-    if (beforeWord == null || beforeWord.char !== '.') {
-      break
-    }
-
-    currentDotIndex = beforeWord.index
-    ++steps
-  }
-
-  return root
-}
-
-function findExplicitBusBindingRange (document: TextLike, memberFrom: number): SourceRange | undefined {
-  const root = findAccessChainRootBefore(document, memberFrom, 1)
-  if (root == null) {
-    return undefined
-  }
-
-  const rootName = document.sliceString(root.offset, root.offset + root.length)
-  if (rootName !== 'bus') {
-    return undefined
-  }
-
-  return findAccessChainFirstMemberAfter(document, root)
-}
-
-function findAccessChainFirstMemberAfter (document: TextLike, root: SourceRange): SourceRange | undefined {
-  const dot = charAfterNonWhitespace(document, root.offset + root.length)
-  if (dot == null || dot.char !== '.') {
-    return undefined
-  }
-
-  const memberStart = skipWhitespaceRight(document, dot.index + 1)
-  return getWordRangeAt(document, memberStart)
-}
-
-function charAt (document: TextLike, index: number): string {
-  return index >= 0 && index < document.length ? document.sliceString(index, index + 1) : ''
-}
-
-function isWhitespace (char: string): boolean {
-  return char === ' ' || char === '\t' || char === '\n' || char === '\r'
-}
-
-function skipWhitespaceLeft (document: TextLike, position: number): number {
-  for (let pos = position; pos > 0; --pos) {
-    if (!isWhitespace(charAt(document, pos - 1))) {
-      return pos
-    }
-  }
-
-  return 0
-}
-
-function skipWhitespaceRight (document: TextLike, position: number): number {
-  for (let pos = position; pos < document.length; ++pos) {
-    if (!isWhitespace(charAt(document, pos))) {
-      return pos
-    }
-  }
-
-  return document.length
-}
-
-function charBeforeNonWhitespace (document: TextLike, position: number): { readonly index: number, readonly char: string } | undefined {
-  for (let pos = position; pos > 0; --pos) {
-    const char = charAt(document, pos - 1)
-    if (!isWhitespace(char)) {
-      return { index: pos - 1, char }
-    }
-  }
-
-  return undefined
-}
-
-function charAfterNonWhitespace (document: TextLike, position: number): { readonly index: number, readonly char: string } | undefined {
-  for (let pos = position; pos < document.length; ++pos) {
-    const char = charAt(document, pos)
-    if (!isWhitespace(char)) {
-      return { index: pos, char }
-    }
-  }
-
-  return undefined
-}
-
-const WORD_REGEXP = /[a-zA-Z_0-9#]/
-
-function isWordChar (char: string): boolean {
-  return char.length === 1 && WORD_REGEXP.test(char)
+function isExplicitBusReference (identifier: Identifier): boolean {
+  const chain = computeAccessChain(identifier)
+  return chain.length === 2 && chain[0].name === 'bus'
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -119,7 +119,7 @@ Call {
   "(" argumentList? ")"
 }
 
-accessOrCall {
+AccessOrCall {
   primary
   (
     "." Unit |
@@ -129,7 +129,7 @@ accessOrCall {
 }
 
 expression {
-  accessOrCall | UnaryExpression | BinaryExpression
+  AccessOrCall | UnaryExpression | BinaryExpression
 }
 
 UnaryExpression {

--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -7,7 +7,7 @@ export interface GoToDefinitionResult {
   readonly range: SourceRange
 }
 
-export const goToDefinition: SemanticOperation<[pos: number], SourceRange | undefined> = (model, tree, document, pos) => {
-  const binding = findDefinitionBindingAt(model, document, pos)
+export const goToDefinition: SemanticOperation<[pos: number], SourceRange | undefined> = (model, pos) => {
+  const binding = findDefinitionBindingAt(model, pos)
   return binding?.range
 }

--- a/packages/language-support/src/highlight-occurrences/extension.ts
+++ b/packages/language-support/src/highlight-occurrences/extension.ts
@@ -53,19 +53,19 @@ interface AnalysisState {
 function buildAnalysisState (state: EditorState): AnalysisState {
   const tree = syntaxTree(state)
   const model = getAnalysisModel(tree, state.doc)
-  const rangesByBinding = buildReferenceRangesByBinding(model, state.doc)
+  const rangesByBinding = buildReferenceRangesByBinding(model)
   return { model, rangesByBinding }
 }
 
 function getOccurrenceDecorations (state: EditorState, analysisState: AnalysisState): DecorationSet {
-  const { doc, selection } = state
+  const { selection } = state
   const { model, rangesByBinding } = analysisState
 
   if (selection.ranges.length !== 1 || !selection.main.empty) {
     return Decoration.none
   }
 
-  const binding = findDefinitionBindingAt(model, doc, selection.main.head)
+  const binding = findDefinitionBindingAt(model, selection.main.head)
   const ranges = binding != null ? rangesByBinding.get(binding.id) : undefined
 
   if (ranges == null || ranges.length === 0) {

--- a/packages/language-support/src/highlight-occurrences/operation.ts
+++ b/packages/language-support/src/highlight-occurrences/operation.ts
@@ -2,6 +2,6 @@ import { findReferenceRangesAt } from '../analysis/query.js'
 import type { SemanticOperation } from '../operations.js'
 import type { SourceRange } from '../types.js'
 
-export const findHighlightedOccurrences: SemanticOperation<[pos: number], readonly SourceRange[]> = (model, tree, document, pos) => {
-  return findReferenceRangesAt(model, document, pos)
+export const findHighlightedOccurrences: SemanticOperation<[pos: number], readonly SourceRange[]> = (model, pos) => {
+  return findReferenceRangesAt(model, pos)
 }

--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -3,28 +3,28 @@ import { getDocumentation, getStandardModule } from '@language'
 import type { Binding, Identifier, Model } from '../analysis/model.js'
 import { computeAccessChain, findDefinitionBindingAt, findIdentifierAt, resolveDefinitionBinding, sameRange } from '../analysis/query.js'
 import type { SemanticOperation } from '../operations.js'
-import type { SourceRange, TextLike } from '../types.js'
+import type { SourceRange } from '../types.js'
 
 export interface HoverInfoWithRange extends Documentation {
   readonly range: SourceRange
 }
 
-export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange | undefined> = (model, tree, document, pos) => {
+export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange | undefined> = (model, pos) => {
   const identifier = findIdentifierAt(model, pos, 'inclusive')
   if (identifier == null || identifier.kind === 'PropertyName') {
     return undefined
   }
 
-  const chain = computeAccessChain(model, document, identifier)
+  const chain = computeAccessChain(identifier)
 
   switch (chain.length) {
     // hovering "foo" in "foo.bar.baz" -> show documentation for "foo" (module or default-imported value)
     case 1:
-      return getHoverInfoForIdentifier(model, document, chain[0])
+      return getHoverInfoForIdentifier(model, chain[0])
 
     // hovering "bar" in "foo.bar.baz" -> show documentation for "bar" export of module "foo" (if "foo" is a module alias)
     case 2:
-      return getHoverInfoForMemberAccess(model, document, chain[0], chain[1])
+      return getHoverInfoForMemberAccess(model, chain[0], chain[1])
 
     // hovering "baz" in "foo.bar.baz" -> no documentation (modules don't have nested members)
     default:
@@ -36,8 +36,8 @@ function withRange (info: Documentation | undefined, range: SourceRange): HoverI
   return info == null ? undefined : { ...info, range }
 }
 
-function getHoverInfoForIdentifier (model: Model, document: TextLike, identifier: Identifier): HoverInfoWithRange | undefined {
-  const binding = findDefinitionBindingAt(model, document, identifier.range.offset)
+function getHoverInfoForIdentifier (model: Model, identifier: Identifier): HoverInfoWithRange | undefined {
+  const binding = findDefinitionBindingAt(model, identifier.range.offset)
 
   switch (binding?.kind) {
     case undefined:
@@ -55,8 +55,8 @@ function getHoverInfoForIdentifier (model: Model, document: TextLike, identifier
   }
 }
 
-function getHoverInfoForMemberAccess (model: Model, document: TextLike, object: Identifier, property: Identifier): HoverInfoWithRange | undefined {
-  const binding = resolveDefinitionBinding(model, object, document)
+function getHoverInfoForMemberAccess (model: Model, object: Identifier, property: Identifier): HoverInfoWithRange | undefined {
+  const binding = resolveDefinitionBinding(model, object)
   if (binding == null || binding.kind !== 'use-alias') {
     return undefined
   }

--- a/packages/language-support/src/operations.ts
+++ b/packages/language-support/src/operations.ts
@@ -6,7 +6,7 @@ import type { TextLike } from './types.js'
 import type { Model } from './analysis/model.js'
 
 export type SemanticOperation<Args extends readonly unknown[], Result> =
-  (model: Model, tree: Tree, document: TextLike, ...args: Args) => Result
+  (model: Model, ...args: Args) => Result
 
 export function applySemanticOperation<Args extends readonly unknown[], Result> (
   operation: SemanticOperation<Args, Result>,
@@ -15,7 +15,7 @@ export function applySemanticOperation<Args extends readonly unknown[], Result> 
   ...args: Args
 ): Result {
   const model = getAnalysisModel(tree, document)
-  return operation(model, tree, document, ...args)
+  return operation(model, ...args)
 }
 
 export function applySemanticOperationWithParser<Args extends readonly unknown[], Result> (
@@ -27,5 +27,5 @@ export function applySemanticOperationWithParser<Args extends readonly unknown[]
   const tree = parser.parse(source)
   const document = textFromString(source)
   const model = getAnalysisModel(tree, document)
-  return operation(model, tree, document, ...args)
+  return operation(model, ...args)
 }

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -2,8 +2,8 @@ import { findUnusedAssignmentBindings } from '../analysis/query.js'
 import type { SemanticOperation } from '../operations.js'
 import type { LanguageDiagnostic } from '../types.js'
 
-export const findUnusedVariables: SemanticOperation<[], readonly LanguageDiagnostic[]> = (model, tree, document) => {
-  return findUnusedAssignmentBindings(model, document).map((binding) => ({
+export const findUnusedVariables: SemanticOperation<[], readonly LanguageDiagnostic[]> = (model) => {
+  return findUnusedAssignmentBindings(model).map((binding) => ({
     name: binding.name,
     message: `Unused variable "${binding.name}".`,
     range: binding.range

--- a/packages/language-support/test/analysis/model.test.ts
+++ b/packages/language-support/test/analysis/model.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { describe, it } from 'node:test'
 import { analyzeSourceWithParser } from '../../src/analysis/model.js'
+import { findIdentifierAt } from '../../src/analysis/query.js'
 
 const cadenceGrammar = await readFile(new URL('../../src/cadence.grammar', import.meta.url), 'utf8')
 const cadenceParser = buildParser(cadenceGrammar)
@@ -202,5 +203,53 @@ describe('analysis/model.ts', () => {
         { kind: 'VariableName', name: 'foo' }
       ]
     )
+  })
+
+  it('sets previous sibling for member accesses', () => {
+    const source = [
+      'foo = a.b',
+      'bar = d.e.f',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    const b = model.identifiers.find((identifier) => identifier.name === 'b')
+    const a = model.identifiers.find((identifier) => identifier.name === 'a')
+    assert.ok(b != null, 'expected to find b')
+    assert.ok(a != null, 'expected to find a')
+    assert.strictEqual(b.previousSibling, a)
+
+    const f = model.identifiers.find((identifier) => identifier.name === 'f')
+    const e = model.identifiers.find((identifier) => identifier.name === 'e')
+    const d = model.identifiers.find((identifier) => identifier.name === 'd')
+    assert.ok(f != null, 'expected to find f')
+    assert.ok(e != null, 'expected to find e')
+    assert.ok(d != null, 'expected to find d')
+    assert.strictEqual(f.previousSibling, e)
+    assert.strictEqual(e.previousSibling, d)
+  })
+
+  it('does not set previous sibling for call arguments', () => {
+    const source = [
+      'use "effects" as fx',
+      'delay = 1',
+      'mixer {',
+      '  bus main {',
+      '    effect fx.delay(time: delay)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    const timeProperty = findIdentifierAt(model, source.indexOf('time:'))
+    assert.strictEqual(timeProperty?.kind, 'PropertyName')
+    assert.strictEqual(timeProperty.previousSibling, undefined)
+
+    const delayArgument = findIdentifierAt(model, source.indexOf('delay)') + 1)
+    assert.strictEqual(delayArgument?.kind, 'VariableName')
+    assert.strictEqual(delayArgument.previousSibling, undefined)
   })
 })

--- a/packages/language-support/test/analysis/query.test.ts
+++ b/packages/language-support/test/analysis/query.test.ts
@@ -34,7 +34,7 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.lastIndexOf('kick <<') + 1
-    const binding = findDefinitionBindingAt(model, document, position)
+    const binding = findDefinitionBindingAt(model, position)
 
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'assignment')
@@ -60,7 +60,7 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.indexOf('bus.foo.gain') + 'bus.'.length + 1
-    const binding = findDefinitionBindingAt(model, document, position)
+    const binding = findDefinitionBindingAt(model, position)
 
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'bus')
@@ -81,7 +81,7 @@ describe('analysis/query.ts', () => {
     const model = analyzeTree(tree, document)
     const position = source.indexOf('tempo:') + 1
 
-    assert.strictEqual(findDefinitionBindingAt(model, document, position), undefined)
+    assert.strictEqual(findDefinitionBindingAt(model, position), undefined)
   })
 
   it('does not resolve member access', () => {
@@ -101,7 +101,7 @@ describe('analysis/query.ts', () => {
     const model = analyzeTree(tree, document)
     const position = source.indexOf('synth.gain') + 'synth.'.length + 1
 
-    assert.strictEqual(findDefinitionBindingAt(model, document, position), undefined)
+    assert.strictEqual(findDefinitionBindingAt(model, position), undefined)
   })
 
   it('does not resolve member access of an explicit bus access', () => {
@@ -121,7 +121,7 @@ describe('analysis/query.ts', () => {
     const model = analyzeTree(tree, document)
     const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length + 1
 
-    assert.strictEqual(findDefinitionBindingAt(model, document, position), undefined)
+    assert.strictEqual(findDefinitionBindingAt(model, position), undefined)
   })
 
   it('prefers import aliases over assignments with the same name', () => {
@@ -135,7 +135,7 @@ describe('analysis/query.ts', () => {
     const { tree, document } = parseDocument(source)
     const model = analyzeTree(tree, document)
     const position = source.lastIndexOf('fx.delay') + 1
-    const binding = findDefinitionBindingAt(model, document, position)
+    const binding = findDefinitionBindingAt(model, position)
 
     assert.ok(binding)
     assert.strictEqual(binding.kind, 'use-alias')

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -151,6 +151,26 @@ describe('hover/operation.ts', () => {
     assert.strictEqual(memberDocs?.title.slice(0, 'delay'.length), 'delay')
   })
 
+  it('does not treat call arguments as aliased module members', () => {
+    const source = [
+      'use "effects" as fx',
+      'delay = 1',
+      'mixer {',
+      '  bus main {',
+      '    effect fx.reverb(delay)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const position = source.lastIndexOf('delay)') + 1
+
+    assert.strictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, position),
+      undefined
+    )
+  })
+
   it('does not return docs for non-default imports', () => {
     const source = [
       'use "effects" as fx',


### PR DESCRIPTION
This patch extends the semantic model of the language support package to include per-identifier sibling information. Specifically, for access chains like `foo.bar.baz`, the model will now include information about the predecessor (baz's predecessor is bar, and bar's is foo). This makes it possible to resolve member accesses without needing to pass the syntax tree or document to the query operations, which improves their performance and greatly simplifies the overall package architecture.