### PR TITLE
refactor: Provide known value information in model

### DIFF
--- a/packages/language-support/src/analysis/model.ts
+++ b/packages/language-support/src/analysis/model.ts
@@ -1,3 +1,4 @@
+import { getStandardModule } from '@language'
 import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import type { LRParser } from '@lezer/lr'
 import type { SourceRange, TextLike } from '../types.js'
@@ -18,7 +19,11 @@ export interface ReferenceModel {
   readonly referenceMap: ReadonlyMap<Binding, readonly Identifier[]>
 }
 
-export type Model = BaseModel & ReferenceModel
+export interface KnownValueModel {
+  readonly knownValues: ReadonlyMap<Identifier, KnownValue>
+}
+
+export type Model = BaseModel & ReferenceModel & KnownValueModel
 
 // scope
 
@@ -79,6 +84,13 @@ export interface ImportStatement {
   readonly moduleName: string
   readonly alias?: string
   readonly aliasRange?: SourceRange
+}
+
+// known values
+
+export interface KnownValue {
+  readonly moduleName: string
+  readonly exportName?: string
 }
 
 // analysis
@@ -289,8 +301,10 @@ export function analyzeTree (tree: Tree, document: TextLike): Model {
   bindings.sort((a, b) => a.range.offset - b.range.offset)
 
   const baseModel = { rootScopeId, scopes, identifiers, bindings, bindingsByName, bindingsByScope, imports }
+  const referenceModel = resolveReferences(baseModel)
+  const knownValueModel = resolveKnownValues(baseModel, referenceModel)
 
-  return { ...baseModel, ...resolveReferences(baseModel) }
+  return { ...baseModel, ...referenceModel, ...knownValueModel }
 }
 
 export function analyzeSourceWithParser (parser: LRParser, source: string): Model {
@@ -497,4 +511,89 @@ function isExplicitBusReference (identifier: Identifier): boolean {
 function findExplicitBusBinding (model: BaseModel, busName: string): Binding | undefined {
   const busBindings = model.bindingsByName.get(busName) ?? []
   return busBindings.find((binding) => binding.kind === 'bus')
+}
+
+function resolveKnownValues (baseModel: BaseModel, referenceModel: ReferenceModel): KnownValueModel {
+  const knownValues = new Map<Identifier, KnownValue>()
+
+  for (const identifier of baseModel.identifiers) {
+    const value = resolveKnownValue(baseModel, referenceModel, identifier)
+    if (value != null) {
+      knownValues.set(identifier, value)
+    }
+  }
+
+  return { knownValues }
+}
+
+function resolveKnownValue (baseModel: BaseModel, referenceModel: ReferenceModel, identifier: Identifier): KnownValue | undefined {
+  if (identifier.kind === 'PropertyName') {
+    return undefined
+  }
+
+  if (identifier.previousSibling == null) {
+    // resolving "foo" in "foo.bar.baz" -> either a module or default-imported value
+    return resolveKnownValueForIdentifier(baseModel, referenceModel, identifier)
+  }
+
+  if (identifier.previousSibling.previousSibling == null) {
+    // resolving "bar" in "foo.bar.baz" -> could be an export of the module aliased as "foo"
+    return resolveKnownValueWithMember(baseModel, referenceModel, identifier.previousSibling, identifier)
+  }
+
+  // resolving "baz" in "foo.bar.baz" -> not known (modules don't have nested members)
+  return undefined
+}
+
+function resolveKnownValueForIdentifier (baseModel: BaseModel, referenceModel: ReferenceModel, identifier: Identifier): KnownValue | undefined {
+  const binding = referenceModel.identifierBindingMap.get(identifier)
+
+  switch (binding?.kind) {
+    case undefined:
+      return resolveKnownValueForDefaultImport(baseModel, identifier)
+
+    case 'use-alias': {
+      const moduleName = findModuleNameForBinding(baseModel, binding)
+      return moduleName != null ? { moduleName } : undefined
+    }
+
+    default:
+      return undefined
+  }
+}
+
+function resolveKnownValueWithMember (baseModel: BaseModel, referenceModel: ReferenceModel, object: Identifier, property: Identifier): KnownValue | undefined {
+  const binding = referenceModel.identifierBindingMap.get(object)
+  if (binding == null || binding.kind !== 'use-alias') {
+    return undefined
+  }
+
+  const moduleName = findModuleNameForBinding(baseModel, binding)
+  return moduleName != null ? { moduleName, exportName: property.name } : undefined
+}
+
+function resolveKnownValueForDefaultImport (baseModel: BaseModel, identifier: Identifier): KnownValue | undefined {
+  for (const { alias, moduleName } of baseModel.imports) {
+    // Must not have an alias (i.e. be a default import)
+    if (alias == null && getStandardModule(moduleName)?.exports.has(identifier.name)) {
+      return { moduleName, exportName: identifier.name }
+    }
+  }
+
+  return undefined
+}
+
+function findModuleNameForBinding (model: BaseModel, binding: Binding): string | undefined {
+  if (binding.kind !== 'use-alias') {
+    return undefined
+  }
+
+  const importStatement = model.imports.find((statement) =>
+    statement.alias != null &&
+    statement.alias === binding.name &&
+    statement.aliasRange != null &&
+    sameRange(statement.aliasRange, binding.range)
+  )
+
+  return importStatement?.moduleName
 }

--- a/packages/language-support/src/analysis/query.ts
+++ b/packages/language-support/src/analysis/query.ts
@@ -80,16 +80,3 @@ export function findUnusedAssignmentBindings (model: Model): readonly Binding[] 
 export function resolveDefinitionBinding (model: Model, occurrence: Identifier): Binding | undefined {
   return model.identifierBindingMap.get(occurrence)
 }
-
-export function computeAccessChain (member: Identifier): readonly Identifier[] {
-  const identifiers: Identifier[] = []
-
-  let current: Identifier | undefined = member
-  while (current != null) {
-    identifiers.push(current)
-    current = current.previousSibling
-  }
-
-  // reverse to get chain in order from left to right (e.g. "foo.bar.baz" -> ["foo", "bar", "baz"])
-  return identifiers.reverse()
-}

--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -1,8 +1,6 @@
 import type { Documentation } from '@language'
-import { getDocumentation, getStandardModule } from '@language'
-import type { Binding, Identifier, Model } from '../analysis/model.js'
-import { sameRange } from '../analysis/model.js'
-import { computeAccessChain, findDefinitionBindingAt, findIdentifierAt, resolveDefinitionBinding } from '../analysis/query.js'
+import { getDocumentation } from '@language'
+import { findIdentifierAt } from '../analysis/query.js'
 import type { SemanticOperation } from '../operations.js'
 import type { SourceRange } from '../types.js'
 
@@ -16,76 +14,11 @@ export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange |
     return undefined
   }
 
-  const chain = computeAccessChain(identifier)
-
-  switch (chain.length) {
-    // hovering "foo" in "foo.bar.baz" -> show documentation for "foo" (module or default-imported value)
-    case 1:
-      return getHoverInfoForIdentifier(model, chain[0])
-
-    // hovering "bar" in "foo.bar.baz" -> show documentation for "bar" export of module "foo" (if "foo" is a module alias)
-    case 2:
-      return getHoverInfoForMemberAccess(model, chain[0], chain[1])
-
-    // hovering "baz" in "foo.bar.baz" -> no documentation (modules don't have nested members)
-    default:
-      return undefined
-  }
-}
-
-function withRange (info: Documentation | undefined, range: SourceRange): HoverInfoWithRange | undefined {
-  return info == null ? undefined : { ...info, range }
-}
-
-function getHoverInfoForIdentifier (model: Model, identifier: Identifier): HoverInfoWithRange | undefined {
-  const binding = findDefinitionBindingAt(model, identifier.range.offset)
-
-  switch (binding?.kind) {
-    case undefined:
-      return getHoverInfoForDefaultImport(model, identifier)
-
-    case 'use-alias': {
-      const moduleName = findModuleNameForBinding(model, binding)
-      return moduleName != null
-        ? withRange(getDocumentation(moduleName), identifier.range)
-        : undefined
-    }
-
-    default:
-      return undefined
-  }
-}
-
-function getHoverInfoForMemberAccess (model: Model, object: Identifier, property: Identifier): HoverInfoWithRange | undefined {
-  const binding = resolveDefinitionBinding(model, object)
-  if (binding == null || binding.kind !== 'use-alias') {
-    return undefined
-  }
-
-  const moduleName = findModuleNameForBinding(model, binding)
-  return moduleName != null
-    ? withRange(getDocumentation(moduleName, property.name), property.range)
-    : undefined
-}
-
-function getHoverInfoForDefaultImport (model: Model, identifier: Identifier): HoverInfoWithRange | undefined {
-  for (const { alias, moduleName } of model.imports) {
-    if (alias != null) {
-      continue // not a default import
-    }
-
-    if (getStandardModule(moduleName)?.exports.has(identifier.name)) {
-      return withRange(getDocumentation(moduleName, identifier.name), identifier.range)
-    }
+  const knownValue = model.knownValues.get(identifier)
+  if (knownValue != null) {
+    const info = getDocumentation(knownValue.moduleName, knownValue.exportName)
+    return info == null ? undefined : { ...info, range: identifier.range }
   }
 
   return undefined
-}
-
-function findModuleNameForBinding (model: Model, binding: Binding): string | undefined {
-  const module = model.imports.find((statement) => {
-    return statement.aliasRange != null && sameRange(statement.aliasRange, binding.range)
-  })
-
-  return module?.moduleName
 }

--- a/packages/language-support/test/analysis/model.test.ts
+++ b/packages/language-support/test/analysis/model.test.ts
@@ -251,4 +251,66 @@ describe('analysis/model.ts', () => {
     assert.strictEqual(delayArgument?.kind, 'VariableName')
     assert.strictEqual(delayArgument.previousSibling, undefined)
   })
+
+  it('resolves known values for identifiers', () => {
+    const source = [
+      'use "instruments" as *',
+      'use "patterns" as p',
+      '',
+      'kick = sample("/samples/kick.wav")',
+      'snare = sample("/samples/snare.wav")',
+      '',
+      'track {',
+      '  part intro {',
+      '    kick << p.loop([x---])',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    const aliasIdentifier = findIdentifierAt(model, source.indexOf('as p') + 'as '.length)
+    assert.strictEqual(aliasIdentifier?.name, 'p')
+    assert.deepStrictEqual(model.knownValues.get(aliasIdentifier), {
+      moduleName: 'patterns'
+    })
+
+    const sampleIdentifier = findIdentifierAt(model, source.indexOf('sample("/samples/kick.wav")'))
+    assert.strictEqual(sampleIdentifier?.name, 'sample')
+    assert.deepStrictEqual(model.knownValues.get(sampleIdentifier), {
+      moduleName: 'instruments',
+      exportName: 'sample'
+    })
+
+    const pIdentifier = findIdentifierAt(model, source.indexOf('p.loop'))
+    assert.strictEqual(pIdentifier?.name, 'p')
+    assert.deepStrictEqual(model.knownValues.get(pIdentifier), {
+      moduleName: 'patterns'
+    })
+
+    const loopIdentifier = findIdentifierAt(model, source.indexOf('loop([x---])'))
+    assert.strictEqual(loopIdentifier?.name, 'loop')
+    assert.deepStrictEqual(model.knownValues.get(loopIdentifier), {
+      moduleName: 'patterns',
+      exportName: 'loop'
+    })
+  })
+
+  it('does not set known values for property names', () => {
+    const source = [
+      'use "effects" as *',
+      '',
+      'mixer {',
+      '  bus main (gain: -3.db) {}',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSourceWithParser(cadenceParser, source)
+
+    const gainProperty = findIdentifierAt(model, source.indexOf('gain:'))
+    assert.strictEqual(gainProperty?.kind, 'PropertyName')
+    assert.strictEqual(model.knownValues.get(gainProperty), undefined)
+  })
 })


### PR DESCRIPTION
This patch moves the logic for determining the "known value" of an identifier (i.e., whether it corresponds to an imported module, or an export of one) from the hover operation to the analysis model to slim down the hover operation.