### PR TITLE
fix: Unify positional queries for semantic model

### DIFF
--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -1,5 +1,5 @@
 import type { Binding, Identifier } from '../model/model.js'
-import { findIdentifierAt, resolveDefinitionBinding } from '../model/query.js'
+import { findIdentifierAt } from '../model/query.js'
 import type { SemanticOperation } from '../utilities/operations.js'
 
 export interface GoToDefinitionResult {
@@ -15,12 +15,12 @@ export interface GoToDefinitionResult {
 }
 
 export const goToDefinition: SemanticOperation<[pos: number], GoToDefinitionResult | undefined> = (model, pos) => {
-  const identifier = findIdentifierAt(model, pos, 'inclusive')
+  const identifier = findIdentifierAt(model, pos)
   if (identifier == null) {
     return undefined
   }
 
-  const binding = resolveDefinitionBinding(model, identifier)
+  const binding = model.identifierBindingMap.get(identifier)
   if (binding == null) {
     return undefined
   }

--- a/packages/language-support/src/highlight-occurrences/extension.ts
+++ b/packages/language-support/src/highlight-occurrences/extension.ts
@@ -2,10 +2,8 @@ import { syntaxTree } from '@codemirror/language'
 import type { EditorState, Extension } from '@codemirror/state'
 import type { DecorationSet, ViewUpdate } from '@codemirror/view'
 import { Decoration, EditorView, ViewPlugin } from '@codemirror/view'
-import { analyzeTree } from '../model/analysis.js'
-import type { Model } from '../model/model.js'
-import type { RangesByBinding } from '../model/query.js'
-import { buildReferenceRangesByBinding, findDefinitionBindingAt } from '../model/query.js'
+import { applySemanticOperation } from '../utilities/operations.js'
+import { findHighlightedOccurrences } from './operation.js'
 
 const OCCURRENCE_CLASS = 'cm-cadence-highlight-occurrence'
 
@@ -19,24 +17,17 @@ const theme = EditorView.baseTheme({
 })
 
 class HighlightOccurrencesPlugin {
-  private analysisState: AnalysisState
-
   decorations: DecorationSet
 
   constructor (view: EditorView) {
-    this.analysisState = buildAnalysisState(view.state)
-    this.decorations = getOccurrenceDecorations(view.state, this.analysisState)
+    this.decorations = getOccurrenceDecorations(view.state)
   }
 
   update (update: ViewUpdate): void {
     const changed = update.docChanged || syntaxTree(update.startState) !== syntaxTree(update.state)
 
-    if (changed) {
-      this.analysisState = buildAnalysisState(update.state)
-    }
-
     if (changed || update.selectionSet) {
-      this.decorations = getOccurrenceDecorations(update.state, this.analysisState)
+      this.decorations = getOccurrenceDecorations(update.state)
     }
   }
 }
@@ -45,29 +36,18 @@ const plugin = ViewPlugin.fromClass(HighlightOccurrencesPlugin, {
   decorations: (plugin) => plugin.decorations
 })
 
-interface AnalysisState {
-  readonly model: Model
-  readonly rangesByBinding: RangesByBinding
-}
-
-function buildAnalysisState (state: EditorState): AnalysisState {
-  const model = analyzeTree(syntaxTree(state), state.doc)
-  const rangesByBinding = buildReferenceRangesByBinding(model)
-  return { model, rangesByBinding }
-}
-
-function getOccurrenceDecorations (state: EditorState, analysisState: AnalysisState): DecorationSet {
+function getOccurrenceDecorations (state: EditorState): DecorationSet {
   const { selection } = state
-  const { model, rangesByBinding } = analysisState
 
   if (selection.ranges.length !== 1 || !selection.main.empty) {
     return Decoration.none
   }
 
-  const binding = findDefinitionBindingAt(model, selection.main.head)
-  const ranges = binding != null ? rangesByBinding.get(binding.id) : undefined
+  const tree = syntaxTree(state)
+  const position = selection.main.head
+  const ranges = applySemanticOperation(findHighlightedOccurrences, tree, state.doc, position)
 
-  if (ranges == null || ranges.length === 0) {
+  if (ranges.length === 0) {
     return Decoration.none
   }
 

--- a/packages/language-support/src/highlight-occurrences/operation.ts
+++ b/packages/language-support/src/highlight-occurrences/operation.ts
@@ -1,7 +1,22 @@
-import { findReferenceRangesAt } from '../model/query.js'
+import { findIdentifierAt } from '../model/query.js'
 import type { SemanticOperation } from '../utilities/operations.js'
 import type { SourceRange } from '../utilities/range.js'
 
 export const findHighlightedOccurrences: SemanticOperation<[pos: number], readonly SourceRange[]> = (model, pos) => {
-  return findReferenceRangesAt(model, pos)
+  const identifier = findIdentifierAt(model, pos)
+  if (identifier == null) {
+    return []
+  }
+
+  const binding = model.identifierBindingMap.get(identifier)
+  if (binding == null) {
+    return []
+  }
+
+  const references = model.referenceMap.get(binding) ?? []
+
+  const ranges = references.map((reference) => reference.range)
+  ranges.sort((a, b) => a.offset - b.offset || a.length - b.length)
+
+  return ranges
 }

--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -9,7 +9,7 @@ export interface HoverInfoWithRange extends Documentation {
 }
 
 export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange | undefined> = (model, pos) => {
-  const identifier = findIdentifierAt(model, pos, 'inclusive')
+  const identifier = findIdentifierAt(model, pos)
   if (identifier == null || identifier.kind === 'PropertyName') {
     return undefined
   }

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -198,6 +198,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
   identifiers.sort((a, b) => a.range.offset - b.range.offset)
   bindings.sort((a, b) => a.range.offset - b.range.offset)
+  imports.sort((a, b) => a.range.offset - b.range.offset)
 
   return { rootScopeId, scopes, identifiers, bindings, bindingsByName, bindingsByScope, imports }
 }
@@ -285,11 +286,12 @@ function parseUseStatement (document: TextLike, node: SyntaxNode): ImportStateme
     return undefined
   }
 
-  return {
-    moduleName,
-    alias: alias === '*' ? undefined : alias,
-    aliasRange
+  const result = { moduleName, range: toSourceRange(document, node.from, node.to) }
+  if (alias === '*') {
+    return result
   }
+
+  return { ...result, alias, aliasRange }
 }
 
 // TODO Use proper string parsing instead of JSON.parse

--- a/packages/language-support/src/model/analysis/known-values.ts
+++ b/packages/language-support/src/model/analysis/known-values.ts
@@ -1,6 +1,6 @@
 import { getStandardModule } from '@language'
-import { sameRange } from '../../utilities/range.js'
 import type { BaseModel, Binding, Identifier, KnownValue, KnownValueModel, ReferenceModel } from '../model.js'
+import { findImportAt } from '../query.js'
 
 export function computeKnownValueModel (baseModel: BaseModel, referenceModel: ReferenceModel): KnownValueModel {
   const knownValues = new Map<Identifier, KnownValue>()
@@ -77,12 +77,10 @@ function findModuleNameForBinding (model: BaseModel, binding: Binding): string |
     return undefined
   }
 
-  const importStatement = model.imports.find((statement) =>
-    statement.alias != null &&
-    statement.alias === binding.name &&
-    statement.aliasRange != null &&
-    sameRange(statement.aliasRange, binding.range)
-  )
+  const importStatement = findImportAt(model, binding.range.offset)
+  if (importStatement == null || importStatement.alias !== binding.name) {
+    return undefined
+  }
 
-  return importStatement?.moduleName
+  return importStatement.moduleName
 }

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -1,6 +1,5 @@
-import type { SourceRange } from '../../utilities/range.js'
-import { sameRange } from '../../utilities/range.js'
 import type { BaseModel, Binding, Identifier, ReferenceModel } from '../model.js'
+import { findBindingAt } from '../query.js'
 
 export function computeReferenceModel (model: BaseModel): ReferenceModel {
   const identifierBindingMap = new Map<Identifier, Binding>()
@@ -34,7 +33,7 @@ function resolveDefinitionBinding (model: BaseModel, occurrence: Identifier): Bi
     // Ensure that definitions resolve to themselves
     case 'VariableDefinition':
     case 'UseAlias':
-      return findBindingBySpan(model, occurrence.range)
+      return findBindingAt(model, occurrence.range.offset)
 
     case 'VariableName':
     case 'Callee':
@@ -44,28 +43,6 @@ function resolveDefinitionBinding (model: BaseModel, occurrence: Identifier): Bi
     default:
       occurrence.kind satisfies never
   }
-}
-
-function findBindingBySpan (model: BaseModel, range: SourceRange): Binding | undefined {
-  let low = 0
-  let high = model.bindings.length - 1
-
-  while (low <= high) {
-    const mid = Math.floor((low + high) / 2)
-    const binding = model.bindings[mid]
-
-    if (sameRange(binding.range, range)) {
-      return binding
-    }
-
-    if (binding.range.offset < range.offset || (binding.range.offset === range.offset && binding.range.length < range.length)) {
-      low = mid + 1
-    } else {
-      high = mid - 1
-    }
-  }
-
-  return undefined
 }
 
 function findRegularBinding (model: BaseModel, occurrence: Identifier): Binding | undefined {

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -78,6 +78,7 @@ export type BindingKind = 'assignment' | 'use-alias' | 'part' | 'bus'
 
 export interface ImportStatement {
   readonly moduleName: string
+  readonly range: SourceRange
   readonly alias?: string
   readonly aliasRange?: SourceRange
 }

--- a/packages/language-support/src/model/query.ts
+++ b/packages/language-support/src/model/query.ts
@@ -1,82 +1,36 @@
 import type { SourceRange } from '../utilities/range.js'
-import { sameRange } from '../utilities/range.js'
-import type { BaseModel, Binding, Identifier, ReferenceModel } from './model.js'
+import type { BaseModel, Binding, Identifier, ImportStatement } from './model.js'
 
-export function findIdentifierAt (model: BaseModel, position: number, boundary: 'strict' | 'inclusive' = 'strict'): Identifier | undefined {
+export function findIdentifierAt (model: BaseModel, position: number): Identifier | undefined {
+  return binarySearch(model.identifiers, position)
+}
+
+export function findBindingAt (model: BaseModel, position: number): Binding | undefined {
+  return binarySearch(model.bindings, position)
+}
+
+export function findImportAt (model: BaseModel, position: number): ImportStatement | undefined {
+  return binarySearch(model.imports, position)
+}
+
+function binarySearch<T extends { readonly range: SourceRange }> (items: readonly T[], position: number): T | undefined {
   let low = 0
-  let high = model.identifiers.length - 1
+  let high = items.length - 1
 
   while (low <= high) {
     const mid = Math.floor((low + high) / 2)
-    const identifier = model.identifiers[mid]
+    const item = items[mid]
+    const start = item.range.offset
+    const end = start + item.range.length
 
-    if (position < identifier.range.offset) {
+    if (position < start) {
       high = mid - 1
-    } else if (position >= identifier.range.offset + identifier.range.length) {
+    } else if (position > end) {
       low = mid + 1
     } else {
-      return identifier
-    }
-  }
-
-  if (boundary === 'inclusive') {
-    const leftCandidate = model.identifiers.at(high)
-    if (leftCandidate != null && leftCandidate.range.offset + leftCandidate.range.length === position) {
-      return leftCandidate
-    }
-
-    const rightCandidate = model.identifiers.at(low)
-    if (rightCandidate != null && rightCandidate.range.offset === position) {
-      return rightCandidate
+      return item
     }
   }
 
   return undefined
-}
-
-export function findDefinitionBindingAt (model: BaseModel & ReferenceModel, position: number): Binding | undefined {
-  const occurrence = findIdentifierAt(model, position, 'inclusive')
-  if (occurrence == null) {
-    return undefined
-  }
-
-  return resolveDefinitionBinding(model, occurrence)
-}
-
-export type RangesByBinding = ReadonlyMap<string, readonly SourceRange[]>
-
-export function findReferenceRangesAt (model: BaseModel & ReferenceModel, position: number): readonly SourceRange[] {
-  const binding = findDefinitionBindingAt(model, position)
-  return binding == null ? [] : getReferrenceRangesForBinding(model, binding)
-}
-
-export function buildReferenceRangesByBinding (model: BaseModel & ReferenceModel): RangesByBinding {
-  return new Map(
-    model.bindings.map((binding) => [binding.id, getReferrenceRangesForBinding(model, binding)])
-  )
-}
-
-function getReferrenceRangesForBinding (model: ReferenceModel, binding: Binding): readonly SourceRange[] {
-  const references = model.referenceMap.get(binding) ?? []
-
-  const ranges = references.map((reference) => reference.range)
-  ranges.sort((a, b) => a.offset - b.offset || a.length - b.length)
-
-  return ranges
-}
-
-export function findUnusedAssignmentBindings (model: BaseModel & ReferenceModel): readonly Binding[] {
-  return model.bindings.filter((binding) => {
-    // Buses and parts are implicitly used by the runtime.
-    if (binding.kind !== 'assignment') {
-      return false
-    }
-
-    const references = model.referenceMap.get(binding) ?? []
-    return references.every((reference) => sameRange(binding.range, reference.range))
-  })
-}
-
-export function resolveDefinitionBinding (model: ReferenceModel, occurrence: Identifier): Binding | undefined {
-  return model.identifierBindingMap.get(occurrence)
 }

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -1,11 +1,28 @@
-import { findUnusedAssignmentBindings } from '../model/query.js'
-import type { SemanticOperation } from '../utilities/operations.js'
+import type { Binding, ReferenceModel } from '../model/model.js'
 import type { LanguageDiagnostic } from '../utilities/diagnostic.js'
+import type { SemanticOperation } from '../utilities/operations.js'
+import { sameRange } from '../utilities/range.js'
 
 export const findUnusedVariables: SemanticOperation<[], readonly LanguageDiagnostic[]> = (model) => {
-  return findUnusedAssignmentBindings(model).map((binding) => ({
+  return model.bindings.filter((binding) => isUnused(binding, model)).map(toDiagnostic)
+}
+
+function isUnused (binding: Binding, model: ReferenceModel): boolean {
+  // Buses and parts are implicitly used by the runtime.
+  if (binding.kind !== 'assignment') {
+    return false
+  }
+
+  const references = model.referenceMap.get(binding) ?? []
+
+  // The binding itself counts as a reference, so check if there are any others.
+  return references.every((reference) => sameRange(binding.range, reference.range))
+}
+
+function toDiagnostic (binding: Binding): LanguageDiagnostic {
+  return {
     name: binding.name,
     message: `Unused variable "${binding.name}".`,
     range: binding.range
-  }))
+  }
 }

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -321,4 +321,32 @@ describe('model/analysis/base.ts', () => {
       ]
     )
   })
+
+  it('includes list of imports', () => {
+    const source = [
+      'use "effects" as fx',
+      'use "patterns" as *',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+
+    assert.deepStrictEqual(
+      model.imports.map(({ moduleName, range, alias, aliasRange }) => ({ moduleName, range, alias, aliasRange })),
+      [
+        {
+          moduleName: 'effects',
+          range: getRangeAt(source, source.indexOf('use "effects" as fx'), 'use "effects" as fx'.length),
+          alias: 'fx',
+          aliasRange: getRangeAt(source, source.indexOf('as fx') + 'as '.length, 'fx'.length)
+        },
+        {
+          moduleName: 'patterns',
+          range: getRangeAt(source, source.indexOf('use "patterns" as *'), 'use "patterns" as *'.length),
+          alias: undefined,
+          aliasRange: undefined
+        }
+      ]
+    )
+  })
 })

--- a/packages/language-support/test/model/query.test.ts
+++ b/packages/language-support/test/model/query.test.ts
@@ -6,44 +6,44 @@ import { getRangeAt } from '../helpers.js'
 
 describe('analysis/query.ts', () => {
   describe('findIdentifierAt()', () => {
+    const source = '  foo = bar(baz: qux)  '
+
+    const model: BaseModel = {
+      rootScopeId: 'root',
+      scopes: new Map(),
+      identifiers: [
+        {
+          kind: 'VariableName',
+          scopeId: 'root',
+          name: 'foo',
+          range: getRangeAt(source, source.indexOf('foo'), 'foo'.length)
+        },
+        {
+          kind: 'Callee',
+          scopeId: 'root',
+          name: 'bar',
+          range: getRangeAt(source, source.indexOf('bar'), 'bar'.length)
+        },
+        {
+          kind: 'PropertyName',
+          scopeId: 'root',
+          name: 'baz',
+          range: getRangeAt(source, source.indexOf('baz'), 'baz'.length)
+        },
+        {
+          kind: 'VariableName',
+          scopeId: 'root',
+          name: 'qux',
+          range: getRangeAt(source, source.indexOf('qux'), 'qux'.length)
+        }
+      ],
+      bindings: [],
+      bindingsByName: new Map(),
+      bindingsByScope: new Map(),
+      imports: []
+    }
+
     it('finds the identifier at the given position', () => {
-      const source = 'foo = bar(baz: qux)'
-
-      const model: BaseModel = {
-        rootScopeId: 'root',
-        scopes: new Map(),
-        identifiers: [
-          {
-            kind: 'VariableName',
-            scopeId: 'root',
-            name: 'foo',
-            range: getRangeAt(source, source.indexOf('foo'), 'foo'.length)
-          },
-          {
-            kind: 'Callee',
-            scopeId: 'root',
-            name: 'bar',
-            range: getRangeAt(source, source.indexOf('bar'), 'bar'.length)
-          },
-          {
-            kind: 'PropertyName',
-            scopeId: 'root',
-            name: 'baz',
-            range: getRangeAt(source, source.indexOf('baz'), 'baz'.length)
-          },
-          {
-            kind: 'VariableName',
-            scopeId: 'root',
-            name: 'qux',
-            range: getRangeAt(source, source.indexOf('qux'), 'qux'.length)
-          }
-        ],
-        bindings: [],
-        bindingsByName: new Map(),
-        bindingsByScope: new Map(),
-        imports: []
-      }
-
       const foo = findIdentifierAt(model, source.indexOf('foo') + 1)
       const bar = findIdentifierAt(model, source.indexOf('bar') + 1)
       const baz = findIdentifierAt(model, source.indexOf('baz') + 1)
@@ -53,6 +53,22 @@ describe('analysis/query.ts', () => {
       assert.strictEqual(bar?.name, 'bar')
       assert.strictEqual(baz?.name, 'baz')
       assert.strictEqual(qux?.name, 'qux')
+    })
+
+    it('returns identifier when the position is at the start or end', () => {
+      const atStart = findIdentifierAt(model, source.indexOf('foo'))
+      const atEnd = findIdentifierAt(model, source.indexOf('foo') + 'foo'.length)
+
+      assert.strictEqual(atStart?.name, 'foo')
+      assert.strictEqual(atEnd?.name, 'foo')
+    })
+
+    it('returns undefined when the position is outside of any identifier', () => {
+      const before = findIdentifierAt(model, source.indexOf('foo') - 1)
+      const after = findIdentifierAt(model, source.indexOf('foo') + 'foo'.length + 1)
+
+      assert.strictEqual(before, undefined)
+      assert.strictEqual(after, undefined)
     })
   })
 })


### PR DESCRIPTION
This patch abstracts the search algorithm and adds thin wrappers for finding identifiers, bindings, and imports at a given position. This allows us to unify the logic for finding references and definitions.

The search is now always "inclusive", meaning that it will match an item also for the position at the end of its range. This mode was already selected by every caller.

Finally, the "highlight occurrences" and "unused variable" features have been slightly restructured to make better use of the new API surface.