### PR TITLE
refactor: Compute lookup maps in binding analysis

### DIFF
--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -2,34 +2,28 @@ import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import type { SourceRange } from '../../utilities/range.js'
 import type { TextLike } from '../../utilities/text.js'
 import { toSourceRange } from '../../utilities/text.js'
-import type { BaseModel, Binding, BindingKind, Identifier, ImportStatement, Scope } from '../model.js'
+import type { BaseModel, Binding, BindingKind, Identifier, ImportStatement, Scope, ScopeKind } from '../model.js'
 
 export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
   const rootRange = toSourceRange(document, 0, document.length)
 
-  const rootScopeId = scopeKey('Root', rootRange)
+  const rootScopeId = scopeKey('root', rootRange)
 
-  const scopes = new Map<string, Scope>()
-  scopes.set(rootScopeId, {
-    id: rootScopeId,
-    kind: 'root',
-    range: rootRange
-  })
-
+  const scopes: Scope[] = [{ id: rootScopeId, kind: 'root', range: rootRange }]
   const identifiers: Identifier[] = []
   const bindings: Binding[] = []
-  const bindingsByName = new Map<string, Binding[]>()
-  const bindingsByScope = new Map<string, Binding[]>()
   const imports: ImportStatement[] = []
 
-  const addBinding = (input: Omit<Binding, 'id'>): void => {
-    const { kind, scopeId, name, range } = input
+  const addScope = (input: Omit<Scope, 'id'>): Scope => {
+    const scope = { ...input, id: scopeKey(input.kind, input.range) }
+    scopes.push(scope)
+    return scope
+  }
 
-    const binding = { ...input, id: bindingKey(kind, scopeId, range) }
+  const addBinding = (input: Omit<Binding, 'id'>): Binding => {
+    const binding = { ...input, id: bindingKey(input.kind, input.scopeId, input.range) }
     bindings.push(binding)
-
-    appendIndexedValue(bindingsByName, name, binding)
-    appendIndexedValue(bindingsByScope, scopeId, binding)
+    return binding
   }
 
   const cursor = tree.cursor()
@@ -71,18 +65,16 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       }
 
       case 'TrackStatement': {
-        const id = scopeKey(typeName, range)
-        scopes.set(id, { id, kind: 'track', range, parentId: currentScopeId })
-        nextScopeId = id
-        nextTrackScopeId = id
+        const scope = addScope({ kind: 'track', range, parentId: currentScopeId })
+        nextScopeId = scope.id
+        nextTrackScopeId = scope.id
         break
       }
 
       case 'MixerStatement': {
-        const id = scopeKey(typeName, range)
-        scopes.set(id, { id, kind: 'mixer', range, parentId: currentScopeId })
-        nextScopeId = id
-        nextMixerScopeId = id
+        const scope = addScope({ kind: 'mixer', range, parentId: currentScopeId })
+        nextScopeId = scope.id
+        nextMixerScopeId = scope.id
         break
       }
 
@@ -196,19 +188,16 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
   walk(cursor, undefined, rootScopeId, undefined, undefined, false)
 
-  identifiers.sort((a, b) => a.range.offset - b.range.offset)
-  bindings.sort((a, b) => a.range.offset - b.range.offset)
-  imports.sort((a, b) => a.range.offset - b.range.offset)
+  sortByOffset(scopes)
+  sortByOffset(identifiers)
+  sortByOffset(bindings)
+  sortByOffset(imports)
 
-  return { rootScopeId, scopes, identifiers, bindings, bindingsByName, bindingsByScope, imports }
+  return { rootScopeId, scopes, identifiers, bindings, imports }
 }
 
-interface DefinitionBindingContext {
-  readonly parentType: string | undefined
-  readonly currentScopeId: string
-  readonly trackScopeId: string | undefined
-  readonly mixerScopeId: string | undefined
-  readonly assignmentHasEquals: boolean
+function sortByOffset (items: Array<{ readonly range: SourceRange }>): void {
+  items.sort((a, b) => a.range.offset - b.range.offset)
 }
 
 function shouldKeepPreviousSibling (node: SyntaxNode): boolean {
@@ -222,22 +211,20 @@ function shouldKeepPreviousSibling (node: SyntaxNode): boolean {
     type === 'BusNamespace'
 }
 
-function scopeKey (typeName: string, range: SourceRange): string {
-  return `${typeName}:${range.offset}:${range.length}`
+function scopeKey (kind: ScopeKind, range: SourceRange): string {
+  return `${kind}:${range.offset}:${range.length}`
 }
 
 function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): string {
   return `${kind}:${scopeId}:${range.offset}:${range.length}`
 }
 
-function appendIndexedValue<Key, Value> (index: Map<Key, Value[]>, key: Key, value: Value): void {
-  const values = index.get(key)
-  if (values == null) {
-    index.set(key, [value])
-    return
-  }
-
-  values.push(value)
+interface DefinitionBindingContext {
+  readonly parentType: string | undefined
+  readonly currentScopeId: string
+  readonly trackScopeId: string | undefined
+  readonly mixerScopeId: string | undefined
+  readonly assignmentHasEquals: boolean
 }
 
 function getDefinitionBinding (context: DefinitionBindingContext): Omit<Binding, 'id' | 'name' | 'range'> | undefined {

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -2,11 +2,13 @@ import type { BaseModel, Binding, Identifier, ReferenceModel } from '../model.js
 import { findBindingAt } from '../query.js'
 
 export function computeReferenceModel (model: BaseModel): ReferenceModel {
+  const lookup = buildBindingLookup(model)
+
   const identifierBindingMap = new Map<Identifier, Binding>()
   const referenceMap = new Map<Binding, Identifier[]>()
 
   for (const identifier of model.identifiers) {
-    const binding = resolveDefinitionBinding(model, identifier)
+    const binding = resolveDefinitionBinding(identifier, model, lookup)
     if (binding == null) {
       continue
     }
@@ -25,7 +27,56 @@ export function computeReferenceModel (model: BaseModel): ReferenceModel {
   return { identifierBindingMap, referenceMap }
 }
 
-function resolveDefinitionBinding (model: BaseModel, occurrence: Identifier): Binding | undefined {
+interface BindingLookup {
+  readonly useAliases: ReadonlyMap<string, Binding>
+  readonly buses: ReadonlyMap<string, Binding>
+  readonly byScopeAndName: ReadonlyMap<string, ReadonlyMap<string, Binding>>
+  readonly parentScopes: ReadonlyMap<string, string>
+}
+
+function buildBindingLookup (model: BaseModel): BindingLookup {
+  const useAliases = new Map<string, Binding>()
+  const buses = new Map<string, Binding>()
+  const byScopeAndName = new Map<string, Map<string, Binding>>()
+
+  for (const binding of model.bindings) {
+    switch (binding.kind) {
+      case 'use-alias':
+        if (!useAliases.has(binding.name)) {
+          useAliases.set(binding.name, binding)
+        }
+        break
+
+      case 'bus':
+        if (!buses.has(binding.name)) {
+          buses.set(binding.name, binding)
+        }
+        break
+
+      default:
+        break
+    }
+
+    let scopeMap = byScopeAndName.get(binding.scopeId)
+    if (scopeMap == null) {
+      scopeMap = new Map<string, Binding>()
+      byScopeAndName.set(binding.scopeId, scopeMap)
+    }
+
+    scopeMap.set(binding.name, binding)
+  }
+
+  const parentScopes = new Map<string, string>()
+  for (const scope of model.scopes) {
+    if (scope.parentId != null) {
+      parentScopes.set(scope.id, scope.parentId)
+    }
+  }
+
+  return { useAliases, buses, byScopeAndName, parentScopes }
+}
+
+function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, lookup: BindingLookup): Binding | undefined {
   switch (occurrence.kind) {
     case 'PropertyName':
       return undefined
@@ -38,38 +89,37 @@ function resolveDefinitionBinding (model: BaseModel, occurrence: Identifier): Bi
     case 'VariableName':
     case 'Callee':
     case 'MemberAccess':
-      return findRegularBinding(model, occurrence)
+      return findRegularBinding(occurrence, lookup)
 
     default:
       occurrence.kind satisfies never
   }
 }
 
-function findRegularBinding (model: BaseModel, occurrence: Identifier): Binding | undefined {
+function findRegularBinding (occurrence: Identifier, lookup: BindingLookup): Binding | undefined {
   if (isExplicitBusReference(occurrence)) {
-    return findExplicitBusBinding(model, occurrence.name)
+    return lookup.buses.get(occurrence.name)
   }
 
   if (occurrence.previousSibling != null) {
     return undefined
   }
 
-  if (model.imports.some((statement) => statement.alias === occurrence.name)) {
-    return model.bindingsByName.get(occurrence.name)?.find((binding) => binding.kind === 'use-alias')
+  // Prefer alias imports over other types of bindings.
+  const useAliasBinding = lookup.useAliases.get(occurrence.name)
+  if (useAliasBinding != null) {
+    return useAliasBinding
   }
 
   let scopeId: string | undefined = occurrence.scopeId
 
   while (scopeId != null) {
-    const scoped = model.bindingsByScope.get(scopeId) ?? []
-
-    const binding = scoped.find((binding) => binding.name === occurrence.name)
+    const binding = lookup.byScopeAndName.get(scopeId)?.get(occurrence.name)
     if (binding != null) {
       return binding
     }
 
-    const scope = model.scopes.get(scopeId)
-    scopeId = scope?.parentId
+    scopeId = lookup.parentScopes.get(scopeId)
   }
 
   return undefined
@@ -79,9 +129,4 @@ function isExplicitBusReference (identifier: Identifier): boolean {
   return identifier.previousSibling != null &&
     identifier.previousSibling.name === 'bus' &&
     identifier.previousSibling.previousSibling == null
-}
-
-function findExplicitBusBinding (model: BaseModel, busName: string): Binding | undefined {
-  const busBindings = model.bindingsByName.get(busName) ?? []
-  return busBindings.find((binding) => binding.kind === 'bus')
 }

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -4,11 +4,9 @@ export type Model = BaseModel & ReferenceModel & KnownValueModel
 
 export interface BaseModel {
   readonly rootScopeId: string
-  readonly scopes: ReadonlyMap<string, Scope>
+  readonly scopes: readonly Scope[]
   readonly identifiers: readonly Identifier[]
   readonly bindings: readonly Binding[]
-  readonly bindingsByName: ReadonlyMap<string, readonly Binding[]>
-  readonly bindingsByScope: ReadonlyMap<string, readonly Binding[]>
   readonly imports: readonly ImportStatement[]
 }
 

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -15,69 +15,6 @@ function analyzeSource (source: string): BaseModel {
 }
 
 describe('model/analysis/base.ts', () => {
-  it('builds scopes and bindings for valid programs', () => {
-    const source = [
-      'use "effects" as fx',
-      'kick = sample("/samples/kick.wav")',
-      'snare = sample("/samples/snare.wav", gain: -3.db)',
-      '',
-      'track (120.bpm) {',
-      '  part intro (4.bars) {',
-      '    kick << [x---]',
-      '  }',
-      '}',
-      '',
-      'mixer {',
-      '  bus drums (gain: -1.5.db) {',
-      '    kick snare',
-      '  }',
-      '  bus delay {',
-      '    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
-      '  }',
-      '}',
-      ''
-    ].join('\n')
-
-    const model = analyzeSource(source)
-
-    assert.ok(model.scopes.has(model.rootScopeId))
-
-    const trackScope = [...model.scopes.values()].find((scope) => scope.kind === 'track')
-    const mixerScope = [...model.scopes.values()].find((scope) => scope.kind === 'mixer')
-
-    assert.ok(trackScope)
-    assert.ok(mixerScope)
-    assert.strictEqual(trackScope.parentId, model.rootScopeId)
-    assert.strictEqual(mixerScope.parentId, model.rootScopeId)
-
-    assert.deepStrictEqual(
-      model.bindings.map((binding) => ({ kind: binding.kind, name: binding.name })),
-      [
-        { kind: 'use-alias', name: 'fx' },
-        { kind: 'assignment', name: 'kick' },
-        { kind: 'assignment', name: 'snare' },
-        { kind: 'part', name: 'intro' },
-        { kind: 'bus', name: 'drums' },
-        { kind: 'bus', name: 'delay' }
-      ]
-    )
-
-    assert.deepStrictEqual(
-      model.bindingsByName.get('kick')?.map((binding) => binding.kind),
-      ['assignment']
-    )
-
-    assert.deepStrictEqual(
-      model.bindingsByScope.get(trackScope.id)?.map((binding) => binding.name),
-      ['intro']
-    )
-
-    assert.deepStrictEqual(
-      model.bindingsByScope.get(mixerScope.id)?.map((binding) => binding.name),
-      ['drums', 'delay']
-    )
-  })
-
   it('builds a sorted list of identifiers', () => {
     const source = [
       'use "instruments" as *',
@@ -107,7 +44,7 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map(({ kind, scopeId, name }) => ({
         kind,
-        scope: model.scopes.get(scopeId)?.kind,
+        scope: model.scopes.find((scope) => scope.id === scopeId)?.kind,
         name
       })),
       [
@@ -258,6 +195,66 @@ describe('model/analysis/base.ts', () => {
     const delay = model.identifiers.find((item) => item.name === 'delay' && item.range.offset === source.indexOf('delay)'))
     assert.ok(delay != null, 'expected to find delay')
     assert.strictEqual(delay.previousSibling, undefined)
+  })
+
+  it('builds scopes and bindings for valid programs', () => {
+    const source = [
+      'use "effects" as fx',
+      'kick = sample("/samples/kick.wav")',
+      'snare = sample("/samples/snare.wav", gain: -3.db)',
+      '',
+      'track (120.bpm) {',
+      '  part intro (4.bars) {',
+      '    kick << [x---]',
+      '  }',
+      '} // end track',
+      '',
+      'mixer {',
+      '  bus drums (gain: -1.5.db) {',
+      '    kick snare',
+      '  }',
+      '  bus delay {',
+      '    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
+      '  }',
+      '} // end mixer',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+
+    const rootRange = getRangeAt(source, 0, source.length)
+    const rootScopeId = `root:${rootRange.offset}:${rootRange.length}`
+
+    const trackStart = source.indexOf('track')
+    const trackEnd = source.indexOf('} // end track') + '}'.length
+    const trackRange = getRangeAt(source, trackStart, trackEnd - trackStart)
+    const trackScopeId = `track:${trackRange.offset}:${trackRange.length}`
+
+    const mixerStart = source.indexOf('mixer')
+    const mixerEnd = source.indexOf('} // end mixer') + '}'.length
+    const mixerRange = getRangeAt(source, mixerStart, mixerEnd - mixerStart)
+    const mixerScopeId = `mixer:${mixerRange.offset}:${mixerRange.length}`
+
+    assert.deepStrictEqual(
+      model.scopes.map(({ id, kind, parentId }) => ({ id, kind, parentId })),
+      [
+        { id: rootScopeId, kind: 'root', parentId: undefined },
+        { id: trackScopeId, kind: 'track', parentId: rootScopeId },
+        { id: mixerScopeId, kind: 'mixer', parentId: rootScopeId }
+      ]
+    )
+
+    assert.deepStrictEqual(
+      model.bindings.map(({ kind, name }) => ({ kind, name })),
+      [
+        { kind: 'use-alias', name: 'fx' },
+        { kind: 'assignment', name: 'kick' },
+        { kind: 'assignment', name: 'snare' },
+        { kind: 'part', name: 'intro' },
+        { kind: 'bus', name: 'drums' },
+        { kind: 'bus', name: 'delay' }
+      ]
+    )
   })
 
   it('includes bindings for definitions', () => {

--- a/packages/language-support/test/model/query.test.ts
+++ b/packages/language-support/test/model/query.test.ts
@@ -10,7 +10,13 @@ describe('analysis/query.ts', () => {
 
     const model: BaseModel = {
       rootScopeId: 'root',
-      scopes: new Map(),
+      scopes: [
+        {
+          id: 'root',
+          kind: 'root',
+          range: getRangeAt(source, 0, source.length)
+        }
+      ],
       identifiers: [
         {
           kind: 'VariableName',
@@ -38,8 +44,6 @@ describe('analysis/query.ts', () => {
         }
       ],
       bindings: [],
-      bindingsByName: new Map(),
-      bindingsByScope: new Map(),
       imports: []
     }
 


### PR DESCRIPTION
This patch removes the by-name and by-scope binding maps from the base model, as they are not that useful: Usually, we need to find a binding based on both its name and scope, so the runtime regresses to a linear search. Further, a lookup for imported identifiers was missing. Instead, we compute a lookup data structure right where it is needed, i.e. in the reference model analysis. This allows us to use a structure that fits the specific use case.