### PR TITLE
refactor: Use IDs for model objects

### DIFF
--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -20,7 +20,7 @@ export const goToDefinition: SemanticOperation<[pos: number], GoToDefinitionResu
     return undefined
   }
 
-  const binding = model.identifierBindingMap.get(identifier)
+  const binding = model.identifierBindingMap.get(identifier.id)
   if (binding == null) {
     return undefined
   }

--- a/packages/language-support/src/highlight-occurrences/operation.ts
+++ b/packages/language-support/src/highlight-occurrences/operation.ts
@@ -8,12 +8,12 @@ export const findHighlightedOccurrences: SemanticOperation<[pos: number], readon
     return []
   }
 
-  const binding = model.identifierBindingMap.get(identifier)
+  const binding = model.identifierBindingMap.get(identifier.id)
   if (binding == null) {
     return []
   }
 
-  const references = model.referenceMap.get(binding) ?? []
+  const references = model.referenceMap.get(binding.id) ?? []
 
   const ranges = references.map((reference) => reference.range)
   ranges.sort((a, b) => a.offset - b.offset || a.length - b.length)

--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -14,7 +14,7 @@ export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange |
     return undefined
   }
 
-  const knownValue = model.knownValues.get(identifier)
+  const knownValue = model.knownValues.get(identifier.id)
   if (knownValue != null) {
     const info = getDocumentation(knownValue.moduleName, knownValue.exportName)
     return info == null ? undefined : { ...info, range: identifier.range }

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -2,7 +2,7 @@ import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import type { SourceRange } from '../../utilities/range.js'
 import type { TextLike } from '../../utilities/text.js'
 import { toSourceRange } from '../../utilities/text.js'
-import type { BaseModel, Binding, BindingKind, Identifier, ImportStatement, Scope, ScopeKind } from '../model.js'
+import type { BaseModel, Binding, BindingId, BindingKind, Identifier, IdentifierId, IdentifierKind, Import, ImportId, Scope, ScopeId, ScopeKind } from '../model.js'
 
 export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
   const rootRange = toSourceRange(document, 0, document.length)
@@ -12,7 +12,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
   const scopes: Scope[] = [{ id: rootScopeId, kind: 'root', range: rootRange }]
   const identifiers: Identifier[] = []
   const bindings: Binding[] = []
-  const imports: ImportStatement[] = []
+  const imports: Import[] = []
 
   const addScope = (input: Omit<Scope, 'id'>): Scope => {
     const scope = { ...input, id: scopeKey(input.kind, input.range) }
@@ -20,10 +20,22 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     return scope
   }
 
+  const addIdentifier = (input: Omit<Identifier, 'id'>): Identifier => {
+    const identifier = { ...input, id: identifierKey(input.kind, input.scopeId, input.range) }
+    identifiers.push(identifier)
+    return identifier
+  }
+
   const addBinding = (input: Omit<Binding, 'id'>): Binding => {
     const binding = { ...input, id: bindingKey(input.kind, input.scopeId, input.range) }
     bindings.push(binding)
     return binding
+  }
+
+  const addImport = (input: Omit<Import, 'id'>): Import => {
+    const statement = { ...input, id: importKey(input.moduleName, input.range) }
+    imports.push(statement)
+    return statement
   }
 
   const cursor = tree.cursor()
@@ -55,9 +67,9 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       case 'UseStatement': {
         const statement = parseUseStatement(document, cursor.node)
         if (statement != null) {
-          imports.push(statement)
+          addImport(statement)
           if (statement.alias != null && statement.aliasRange != null) {
-            identifiers.push({ kind: 'UseAlias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
+            addIdentifier({ kind: 'UseAlias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
             addBinding({ kind: 'use-alias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
           }
         }
@@ -106,12 +118,11 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         if (binding == null) {
           // Invalid/incomplete syntax encountered.
           // We still add an identifier as a best-effort approach to provide some level of functionality.
-          accessChainTail = { kind: 'VariableName', scopeId: currentScopeId, name, range, previousSibling }
-          identifiers.push(accessChainTail)
+          accessChainTail = addIdentifier({ kind: 'VariableName', scopeId: currentScopeId, name, range, previousSibling })
           break
         }
 
-        identifiers.push({ kind: 'VariableDefinition', scopeId: currentScopeId, name, range })
+        addIdentifier({ kind: 'VariableDefinition', scopeId: currentScopeId, name, range })
         addBinding({ ...binding, name, range })
 
         break
@@ -119,7 +130,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
       case 'PropertyName': {
         const name = document.sliceString(from, to)
-        identifiers.push({ kind: typeName, scopeId: currentScopeId, name, range })
+        addIdentifier({ kind: typeName, scopeId: currentScopeId, name, range })
         break
       }
 
@@ -133,8 +144,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         }
 
         const name = document.sliceString(from, to)
-        accessChainTail = { kind, scopeId: currentScopeId, name, range, previousSibling }
-        identifiers.push(accessChainTail)
+        accessChainTail = addIdentifier({ kind, scopeId: currentScopeId, name, range, previousSibling })
 
         break
       }
@@ -211,12 +221,20 @@ function shouldKeepPreviousSibling (node: SyntaxNode): boolean {
     type === 'BusNamespace'
 }
 
-function scopeKey (kind: ScopeKind, range: SourceRange): string {
-  return `${kind}:${range.offset}:${range.length}`
+function scopeKey (kind: ScopeKind, range: SourceRange): ScopeId {
+  return `${kind}:${range.offset}:${range.length}` as ScopeId
 }
 
-function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): string {
-  return `${kind}:${scopeId}:${range.offset}:${range.length}`
+function identifierKey (kind: IdentifierKind, scopeId: string, range: SourceRange): IdentifierId {
+  return `${kind}:${scopeId}:${range.offset}:${range.length}` as IdentifierId
+}
+
+function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): BindingId {
+  return `${kind}:${scopeId}:${range.offset}:${range.length}` as BindingId
+}
+
+function importKey (moduleName: string, range: SourceRange): ImportId {
+  return `${moduleName}:${range.offset}:${range.length}` as ImportId
 }
 
 interface DefinitionBindingContext {
@@ -248,7 +266,7 @@ function getDefinitionBinding (context: DefinitionBindingContext): Omit<Binding,
   return undefined
 }
 
-function parseUseStatement (document: TextLike, node: SyntaxNode): ImportStatement | undefined {
+function parseUseStatement (document: TextLike, node: SyntaxNode): Omit<Import, 'id'> | undefined {
   let moduleName: string | undefined
   let alias: string | undefined
   let aliasRange: SourceRange | undefined

--- a/packages/language-support/src/model/analysis/known-values.ts
+++ b/packages/language-support/src/model/analysis/known-values.ts
@@ -1,14 +1,14 @@
 import { getStandardModule } from '@language'
-import type { BaseModel, Binding, Identifier, KnownValue, KnownValueModel, ReferenceModel } from '../model.js'
+import type { BaseModel, Binding, Identifier, IdentifierId, KnownValue, KnownValueModel, ReferenceModel } from '../model.js'
 import { findImportAt } from '../query.js'
 
 export function computeKnownValueModel (baseModel: BaseModel, referenceModel: ReferenceModel): KnownValueModel {
-  const knownValues = new Map<Identifier, KnownValue>()
+  const knownValues = new Map<IdentifierId, KnownValue>()
 
   for (const identifier of baseModel.identifiers) {
     const value = resolveKnownValue(baseModel, referenceModel, identifier)
     if (value != null) {
-      knownValues.set(identifier, value)
+      knownValues.set(identifier.id, value)
     }
   }
 
@@ -35,7 +35,7 @@ function resolveKnownValue (baseModel: BaseModel, referenceModel: ReferenceModel
 }
 
 function resolveKnownValueForIdentifier (baseModel: BaseModel, referenceModel: ReferenceModel, identifier: Identifier): KnownValue | undefined {
-  const binding = referenceModel.identifierBindingMap.get(identifier)
+  const binding = referenceModel.identifierBindingMap.get(identifier.id)
 
   switch (binding?.kind) {
     case undefined:
@@ -52,7 +52,7 @@ function resolveKnownValueForIdentifier (baseModel: BaseModel, referenceModel: R
 }
 
 function resolveKnownValueWithMember (baseModel: BaseModel, referenceModel: ReferenceModel, object: Identifier, property: Identifier): KnownValue | undefined {
-  const binding = referenceModel.identifierBindingMap.get(object)
+  const binding = referenceModel.identifierBindingMap.get(object.id)
   if (binding == null || binding.kind !== 'use-alias') {
     return undefined
   }

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -1,11 +1,11 @@
-import type { BaseModel, Binding, Identifier, ReferenceModel } from '../model.js'
+import type { BaseModel, Binding, BindingId, Identifier, IdentifierId, ReferenceModel } from '../model.js'
 import { findBindingAt } from '../query.js'
 
 export function computeReferenceModel (model: BaseModel): ReferenceModel {
   const lookup = buildBindingLookup(model)
 
-  const identifierBindingMap = new Map<Identifier, Binding>()
-  const referenceMap = new Map<Binding, Identifier[]>()
+  const identifierBindingMap = new Map<IdentifierId, Binding>()
+  const referenceMap = new Map<BindingId, Identifier[]>()
 
   for (const identifier of model.identifiers) {
     const binding = resolveDefinitionBinding(identifier, model, lookup)
@@ -13,11 +13,11 @@ export function computeReferenceModel (model: BaseModel): ReferenceModel {
       continue
     }
 
-    identifierBindingMap.set(identifier, binding)
+    identifierBindingMap.set(identifier.id, binding)
 
-    const references = referenceMap.get(binding)
+    const references = referenceMap.get(binding.id)
     if (references == null) {
-      referenceMap.set(binding, [identifier])
+      referenceMap.set(binding.id, [identifier])
       continue
     }
 

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -1,28 +1,31 @@
+import type { Brand } from '@utility'
 import type { SourceRange } from '../utilities/range.js'
 
 export type Model = BaseModel & ReferenceModel & KnownValueModel
 
 export interface BaseModel {
-  readonly rootScopeId: string
+  readonly rootScopeId: ScopeId
   readonly scopes: readonly Scope[]
   readonly identifiers: readonly Identifier[]
   readonly bindings: readonly Binding[]
-  readonly imports: readonly ImportStatement[]
+  readonly imports: readonly Import[]
 }
 
 export interface ReferenceModel {
-  readonly identifierBindingMap: ReadonlyMap<Identifier, Binding>
-  readonly referenceMap: ReadonlyMap<Binding, readonly Identifier[]>
+  readonly identifierBindingMap: ReadonlyMap<IdentifierId, Binding>
+  readonly referenceMap: ReadonlyMap<BindingId, readonly Identifier[]>
 }
 
 export interface KnownValueModel {
-  readonly knownValues: ReadonlyMap<Identifier, KnownValue>
+  readonly knownValues: ReadonlyMap<IdentifierId, KnownValue>
 }
 
 // scope
 
+export type ScopeId = Brand<string, 'language-support.ScopeId'>
+
 export interface Scope {
-  readonly id: string
+  readonly id: ScopeId
   readonly kind: ScopeKind
   readonly parentId?: string
   readonly range: SourceRange
@@ -32,7 +35,10 @@ export type ScopeKind = 'root' | 'track' | 'mixer'
 
 // identifier
 
+export type IdentifierId = Brand<string, 'language-support.IdentifierId'>
+
 export interface Identifier {
+  readonly id: IdentifierId
   readonly kind: IdentifierKind
   readonly scopeId: string
   readonly name: string
@@ -62,8 +68,10 @@ export function isIdentifierKind (value: string): value is IdentifierKind {
 
 // binding
 
+export type BindingId = Brand<string, 'language-support.BindingId'>
+
 export interface Binding {
-  readonly id: string
+  readonly id: BindingId
   readonly kind: BindingKind
   readonly scopeId: string
   readonly name: string
@@ -74,7 +82,10 @@ export type BindingKind = 'assignment' | 'use-alias' | 'part' | 'bus'
 
 // import
 
-export interface ImportStatement {
+export type ImportId = Brand<string, 'language-support.ImportId'>
+
+export interface Import {
+  readonly id: ImportId
   readonly moduleName: string
   readonly range: SourceRange
   readonly alias?: string

--- a/packages/language-support/src/model/query.ts
+++ b/packages/language-support/src/model/query.ts
@@ -1,5 +1,5 @@
 import type { SourceRange } from '../utilities/range.js'
-import type { BaseModel, Binding, Identifier, ImportStatement } from './model.js'
+import type { BaseModel, Binding, Identifier, Import } from './model.js'
 
 export function findIdentifierAt (model: BaseModel, position: number): Identifier | undefined {
   return binarySearch(model.identifiers, position)
@@ -9,7 +9,7 @@ export function findBindingAt (model: BaseModel, position: number): Binding | un
   return binarySearch(model.bindings, position)
 }
 
-export function findImportAt (model: BaseModel, position: number): ImportStatement | undefined {
+export function findImportAt (model: BaseModel, position: number): Import | undefined {
   return binarySearch(model.imports, position)
 }
 

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -13,7 +13,7 @@ function isUnused (binding: Binding, model: ReferenceModel): boolean {
     return false
   }
 
-  const references = model.referenceMap.get(binding) ?? []
+  const references = model.referenceMap.get(binding.id) ?? []
 
   // The binding itself counts as a reference, so check if there are any others.
   return references.every((reference) => sameRange(binding.range, reference.range))

--- a/packages/language-support/test/model/analysis/known-values.test.ts
+++ b/packages/language-support/test/model/analysis/known-values.test.ts
@@ -42,26 +42,26 @@ describe('model/analysis/known-values.ts', () => {
 
     const aliasIdentifier = findIdentifierAt(model, source.indexOf('as p') + 'as '.length)
     assert.strictEqual(aliasIdentifier?.name, 'p')
-    assert.deepStrictEqual(model.knownValues.get(aliasIdentifier), {
+    assert.deepStrictEqual(model.knownValues.get(aliasIdentifier.id), {
       moduleName: 'patterns'
     })
 
     const sampleIdentifier = findIdentifierAt(model, source.indexOf('sample("/samples/kick.wav")'))
     assert.strictEqual(sampleIdentifier?.name, 'sample')
-    assert.deepStrictEqual(model.knownValues.get(sampleIdentifier), {
+    assert.deepStrictEqual(model.knownValues.get(sampleIdentifier.id), {
       moduleName: 'instruments',
       exportName: 'sample'
     })
 
     const pIdentifier = findIdentifierAt(model, source.indexOf('p.loop'))
     assert.strictEqual(pIdentifier?.name, 'p')
-    assert.deepStrictEqual(model.knownValues.get(pIdentifier), {
+    assert.deepStrictEqual(model.knownValues.get(pIdentifier.id), {
       moduleName: 'patterns'
     })
 
     const loopIdentifier = findIdentifierAt(model, source.indexOf('loop([x---])'))
     assert.strictEqual(loopIdentifier?.name, 'loop')
-    assert.deepStrictEqual(model.knownValues.get(loopIdentifier), {
+    assert.deepStrictEqual(model.knownValues.get(loopIdentifier.id), {
       moduleName: 'patterns',
       exportName: 'loop'
     })
@@ -81,6 +81,6 @@ describe('model/analysis/known-values.ts', () => {
 
     const gainProperty = findIdentifierAt(model, source.indexOf('gain:'))
     assert.strictEqual(gainProperty?.kind, 'PropertyName')
-    assert.strictEqual(model.knownValues.get(gainProperty), undefined)
+    assert.strictEqual(model.knownValues.get(gainProperty.id), undefined)
   })
 })

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -30,13 +30,13 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.name === 'kick')
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier)
+    const binding = model.identifierBindingMap.get(identifier.id)
     assert.ok(binding != null)
     assert.strictEqual(binding.kind, 'assignment')
     assert.strictEqual(binding.name, 'kick')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('kick ='), 'kick'.length))
 
-    const references = model.referenceMap.get(binding)
+    const references = model.referenceMap.get(binding.id)
     assert.deepStrictEqual(references, [identifier])
   })
 
@@ -57,13 +57,13 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier)
+    const binding = model.identifierBindingMap.get(identifier.id)
     assert.ok(binding != null)
     assert.strictEqual(binding.kind, 'assignment')
     assert.strictEqual(binding.name, 'kick')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('kick ='), 'kick'.length))
 
-    const references = model.referenceMap.get(binding)
+    const references = model.referenceMap.get(binding.id)
     assert.ok(references != null)
     assert.ok(references.includes(identifier))
   })
@@ -87,13 +87,13 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier)
+    const binding = model.identifierBindingMap.get(identifier.id)
     assert.ok(binding != null)
     assert.strictEqual(binding.kind, 'bus')
     assert.strictEqual(binding.name, 'foo')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('bus foo') + 'bus '.length, 'foo'.length))
 
-    const references = model.referenceMap.get(binding)
+    const references = model.referenceMap.get(binding.id)
     assert.ok(references != null)
     assert.ok(references.includes(identifier))
   })
@@ -111,7 +111,7 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier)
+    const binding = model.identifierBindingMap.get(identifier.id)
     assert.strictEqual(binding, undefined)
   })
 
@@ -134,7 +134,7 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier)
+    const binding = model.identifierBindingMap.get(identifier.id)
     assert.strictEqual(binding, undefined)
   })
 
@@ -157,7 +157,7 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier)
+    const binding = model.identifierBindingMap.get(identifier.id)
     assert.strictEqual(binding, undefined)
   })
 
@@ -175,7 +175,7 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier)
+    const binding = model.identifierBindingMap.get(identifier.id)
     assert.ok(binding != null)
     assert.strictEqual(binding.kind, 'use-alias')
     assert.strictEqual(binding.name, 'fx')

--- a/packages/language-support/test/model/query.test.ts
+++ b/packages/language-support/test/model/query.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import type { BaseModel } from '../../src/model/model.js'
+import type { BaseModel, IdentifierId, ScopeId } from '../../src/model/model.js'
 import { findIdentifierAt } from '../../src/model/query.js'
 import { getRangeAt } from '../helpers.js'
 
@@ -9,36 +9,40 @@ describe('analysis/query.ts', () => {
     const source = '  foo = bar(baz: qux)  '
 
     const model: BaseModel = {
-      rootScopeId: 'root',
+      rootScopeId: 'root' as ScopeId,
       scopes: [
         {
-          id: 'root',
+          id: 'root' as ScopeId,
           kind: 'root',
           range: getRangeAt(source, 0, source.length)
         }
       ],
       identifiers: [
         {
+          id: '1' as IdentifierId,
           kind: 'VariableName',
-          scopeId: 'root',
+          scopeId: 'root' as ScopeId,
           name: 'foo',
           range: getRangeAt(source, source.indexOf('foo'), 'foo'.length)
         },
         {
+          id: '2' as IdentifierId,
           kind: 'Callee',
-          scopeId: 'root',
+          scopeId: 'root' as ScopeId,
           name: 'bar',
           range: getRangeAt(source, source.indexOf('bar'), 'bar'.length)
         },
         {
+          id: '3' as IdentifierId,
           kind: 'PropertyName',
-          scopeId: 'root',
+          scopeId: 'root' as ScopeId,
           name: 'baz',
           range: getRangeAt(source, source.indexOf('baz'), 'baz'.length)
         },
         {
+          id: '4' as IdentifierId,
           kind: 'VariableName',
-          scopeId: 'root',
+          scopeId: 'root' as ScopeId,
           name: 'qux',
           range: getRangeAt(source, source.indexOf('qux'), 'qux'.length)
         }


### PR DESCRIPTION
By attaching IDs to identifiers as well, it is possible to avoid using object references as map keys.