### PR TITLE
feat: Report unused named imports

### DIFF
--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -9,7 +9,7 @@ export const findUnusedVariables: SemanticOperation<[], readonly LanguageDiagnos
 
 function isUnused (binding: Binding, model: ReferenceModel): boolean {
   // Buses and parts are implicitly used by the runtime.
-  if (binding.kind !== 'assignment') {
+  if (binding.kind === 'bus' || binding.kind === 'part') {
     return false
   }
 
@@ -20,9 +20,11 @@ function isUnused (binding: Binding, model: ReferenceModel): boolean {
 }
 
 function toDiagnostic (binding: Binding): LanguageDiagnostic {
+  const type = binding.kind === 'use-alias' ? 'import' : 'variable'
+
   return {
     name: binding.name,
-    message: `Unused variable "${binding.name}".`,
+    message: `Unused ${type} "${binding.name}"`,
     range: binding.range
   }
 }

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -24,7 +24,7 @@ describe('unused-variable/operation.ts', () => {
       [
         {
           name: 'unused',
-          message: 'Unused variable "unused".',
+          message: 'Unused variable "unused"',
           range: getRangeAt(source, source.indexOf('unused ='), 'unused'.length)
         }
       ]
@@ -86,8 +86,26 @@ describe('unused-variable/operation.ts', () => {
       [
         {
           name: 'foo',
-          message: 'Unused variable "foo".',
+          message: 'Unused variable "foo"',
           range: getRangeAt(source, source.indexOf('foo ='), 'foo'.length)
+        }
+      ]
+    )
+  })
+
+  it('reports unused imports', () => {
+    const source = [
+      'use "patterns" as patterns',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      [
+        {
+          name: 'patterns',
+          message: 'Unused import "patterns"',
+          range: getRangeAt(source, source.indexOf('as patterns') + 'as '.length, 'patterns'.length)
         }
       ]
     )


### PR DESCRIPTION
The unused variable analysis now also reports unused imports, as long as they are are not default imports (e.g. `use "foo" as foo` is reported, but `use "foo" as *` is not (yet)).