### PR TITLE
refactor: Update identifier and binding kinds

### DIFF
--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -10,7 +10,7 @@ export interface HoverInfoWithRange extends Documentation {
 
 export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange | undefined> = (model, pos) => {
   const identifier = findIdentifierAt(model, pos)
-  if (identifier == null || identifier.kind === 'PropertyName') {
+  if (identifier == null || identifier.kind === 'property-name') {
     return undefined
   }
 

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -66,13 +66,18 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     switch (typeName) {
       case 'UseStatement': {
         const statement = parseUseStatement(document, cursor.node)
-        if (statement != null) {
-          addImport(statement)
-          if (statement.alias != null && statement.aliasRange != null) {
-            addIdentifier({ kind: 'UseAlias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
-            addBinding({ kind: 'use-alias', scopeId: currentScopeId, name: statement.alias, range: statement.aliasRange })
-          }
+        if (statement == null) {
+          break
         }
+
+        addImport(statement)
+
+        const { alias, aliasRange } = statement
+        if (alias != null && aliasRange != null) {
+          addIdentifier({ kind: 'definition', scopeId: currentScopeId, name: alias, range: aliasRange })
+          addBinding({ kind: 'use-alias', scopeId: currentScopeId, name: alias, range: aliasRange })
+        }
+
         break
       }
 
@@ -118,11 +123,11 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         if (binding == null) {
           // Invalid/incomplete syntax encountered.
           // We still add an identifier as a best-effort approach to provide some level of functionality.
-          accessChainTail = addIdentifier({ kind: 'VariableName', scopeId: currentScopeId, name, range, previousSibling })
+          accessChainTail = addIdentifier({ kind: 'plain', scopeId: currentScopeId, name, range, previousSibling })
           break
         }
 
-        addIdentifier({ kind: 'VariableDefinition', scopeId: currentScopeId, name, range })
+        addIdentifier({ kind: 'definition', scopeId: currentScopeId, name, range })
         addBinding({ ...binding, name, range })
 
         break
@@ -130,7 +135,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
       case 'PropertyName': {
         const name = document.sliceString(from, to)
-        addIdentifier({ kind: typeName, scopeId: currentScopeId, name, range })
+        addIdentifier({ kind: 'property-name', scopeId: currentScopeId, name, range })
         break
       }
 
@@ -138,14 +143,8 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       case 'Callee':
       case 'MemberAccess':
       case 'BusNamespace': {
-        let kind = typeName === 'BusNamespace' ? 'VariableName' : typeName
-        if (kind !== 'Callee' && previousSibling != null) {
-          kind = 'MemberAccess'
-        }
-
         const name = document.sliceString(from, to)
-        accessChainTail = addIdentifier({ kind, scopeId: currentScopeId, name, range, previousSibling })
-
+        accessChainTail = addIdentifier({ kind: 'plain', scopeId: currentScopeId, name, range, previousSibling })
         break
       }
     }
@@ -249,7 +248,7 @@ function getDefinitionBinding (context: DefinitionBindingContext): Omit<Binding,
   switch (context.parentType) {
     case 'Assignment':
       return context.assignmentHasEquals
-        ? { kind: 'assignment', scopeId: context.currentScopeId }
+        ? { kind: 'regular', scopeId: context.currentScopeId }
         : undefined
 
     case 'PartStatement':

--- a/packages/language-support/src/model/analysis/known-values.ts
+++ b/packages/language-support/src/model/analysis/known-values.ts
@@ -16,7 +16,7 @@ export function computeKnownValueModel (baseModel: BaseModel, referenceModel: Re
 }
 
 function resolveKnownValue (baseModel: BaseModel, referenceModel: ReferenceModel, identifier: Identifier): KnownValue | undefined {
-  if (identifier.kind === 'PropertyName') {
+  if (identifier.kind === 'property-name') {
     return undefined
   }
 

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -78,18 +78,14 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
 
 function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, lookup: BindingLookup): Binding | undefined {
   switch (occurrence.kind) {
-    case 'PropertyName':
-      return undefined
+    case 'plain':
+      return findRegularBinding(occurrence, lookup)
 
-    // Ensure that definitions resolve to themselves
-    case 'VariableDefinition':
-    case 'UseAlias':
+    case 'definition':
       return findBindingAt(model, occurrence.range.offset)
 
-    case 'VariableName':
-    case 'Callee':
-    case 'MemberAccess':
-      return findRegularBinding(occurrence, lookup)
+    case 'property-name':
+      return undefined
 
     default:
       occurrence.kind satisfies never

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -51,20 +51,7 @@ export interface Identifier {
   readonly previousSibling?: Identifier
 }
 
-const IDENTIFIER_KINDS = [
-  'VariableName',
-  'Callee',
-  'MemberAccess',
-  'PropertyName',
-  'VariableDefinition',
-  'UseAlias'
-] as const
-
-export type IdentifierKind = typeof IDENTIFIER_KINDS[number]
-
-export function isIdentifierKind (value: string): value is IdentifierKind {
-  return IDENTIFIER_KINDS.includes(value as IdentifierKind)
-}
+export type IdentifierKind = 'plain' | 'definition' | 'property-name'
 
 // binding
 
@@ -78,7 +65,7 @@ export interface Binding {
   readonly range: SourceRange
 }
 
-export type BindingKind = 'assignment' | 'use-alias' | 'part' | 'bus'
+export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus'
 
 // import
 

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -48,23 +48,23 @@ describe('model/analysis/base.ts', () => {
         name
       })),
       [
-        { kind: 'UseAlias', scope: 'root', name: 'p' },
-        { kind: 'VariableDefinition', scope: 'root', name: 'base_path' },
-        { kind: 'VariableDefinition', scope: 'root', name: 'kick' },
-        { kind: 'Callee', scope: 'root', name: 'sample' },
-        { kind: 'VariableName', scope: 'root', name: 'base_path' },
-        { kind: 'VariableDefinition', scope: 'root', name: 'tempo' },
-        { kind: 'PropertyName', scope: 'track', name: 'tempo' },
-        { kind: 'VariableName', scope: 'track', name: 'tempo' },
-        { kind: 'VariableDefinition', scope: 'track', name: 'intro' },
-        { kind: 'VariableName', scope: 'track', name: 'kick' },
-        { kind: 'VariableName', scope: 'track', name: 'p' },
-        { kind: 'Callee', scope: 'track', name: 'loop' },
-        { kind: 'VariableName', scope: 'track', name: 'kick' },
-        { kind: 'MemberAccess', scope: 'track', name: 'gain' },
-        { kind: 'VariableDefinition', scope: 'mixer', name: 'drums' },
-        { kind: 'VariableName', scope: 'mixer', name: 'kick' },
-        { kind: 'VariableName', scope: 'mixer', name: 'snare' }
+        { kind: 'definition', scope: 'root', name: 'p' },
+        { kind: 'definition', scope: 'root', name: 'base_path' },
+        { kind: 'definition', scope: 'root', name: 'kick' },
+        { kind: 'plain', scope: 'root', name: 'sample' },
+        { kind: 'plain', scope: 'root', name: 'base_path' },
+        { kind: 'definition', scope: 'root', name: 'tempo' },
+        { kind: 'property-name', scope: 'track', name: 'tempo' },
+        { kind: 'plain', scope: 'track', name: 'tempo' },
+        { kind: 'definition', scope: 'track', name: 'intro' },
+        { kind: 'plain', scope: 'track', name: 'kick' },
+        { kind: 'plain', scope: 'track', name: 'p' },
+        { kind: 'plain', scope: 'track', name: 'loop' },
+        { kind: 'plain', scope: 'track', name: 'kick' },
+        { kind: 'plain', scope: 'track', name: 'gain' },
+        { kind: 'definition', scope: 'mixer', name: 'drums' },
+        { kind: 'plain', scope: 'mixer', name: 'kick' },
+        { kind: 'plain', scope: 'mixer', name: 'snare' }
       ]
     )
   })
@@ -85,9 +85,9 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
       [
-        { kind: 'VariableName', name: 'sample' },
-        { kind: 'VariableDefinition', name: 'intro' },
-        { kind: 'VariableName', name: 'kick' }
+        { kind: 'plain', name: 'sample' },
+        { kind: 'definition', name: 'intro' },
+        { kind: 'plain', name: 'kick' }
       ]
     )
   })
@@ -103,8 +103,8 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
       [
-        { kind: 'VariableName', name: 'fx' },
-        { kind: 'MemberAccess', name: 'delay' }
+        { kind: 'plain', name: 'fx' },
+        { kind: 'plain', name: 'delay' }
       ]
     )
   })
@@ -120,8 +120,7 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
       [
-        // should be Callee, but this is a known limitation of the model when parsing incomplete code
-        { kind: 'VariableName', name: 'delay' }
+        { kind: 'plain', name: 'delay' }
       ]
     )
   })
@@ -140,9 +139,9 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
       [
-        { kind: 'VariableName', name: 'main' },
-        { kind: 'VariableDefinition', name: 'foo' },
-        { kind: 'VariableName', name: 'foo' }
+        { kind: 'plain', name: 'main' },
+        { kind: 'definition', name: 'foo' },
+        { kind: 'plain', name: 'foo' }
       ]
     )
   })
@@ -248,8 +247,8 @@ describe('model/analysis/base.ts', () => {
       model.bindings.map(({ kind, name }) => ({ kind, name })),
       [
         { kind: 'use-alias', name: 'fx' },
-        { kind: 'assignment', name: 'kick' },
-        { kind: 'assignment', name: 'snare' },
+        { kind: 'regular', name: 'kick' },
+        { kind: 'regular', name: 'snare' },
         { kind: 'part', name: 'intro' },
         { kind: 'bus', name: 'drums' },
         { kind: 'bus', name: 'delay' }
@@ -280,7 +279,7 @@ describe('model/analysis/base.ts', () => {
       model.bindings.map((binding) => ({ kind: binding.kind, name: binding.name, range: binding.range })),
       [
         {
-          kind: 'assignment',
+          kind: 'regular',
           name: 'kick',
           range: getRangeAt(source, source.indexOf('kick ='), 'kick'.length)
         },

--- a/packages/language-support/test/model/analysis/known-values.test.ts
+++ b/packages/language-support/test/model/analysis/known-values.test.ts
@@ -80,7 +80,7 @@ describe('model/analysis/known-values.ts', () => {
     const model = analyzeSource(source)
 
     const gainProperty = findIdentifierAt(model, source.indexOf('gain:'))
-    assert.strictEqual(gainProperty?.kind, 'PropertyName')
+    assert.strictEqual(gainProperty?.kind, 'property-name')
     assert.strictEqual(model.knownValues.get(gainProperty.id), undefined)
   })
 })

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -32,7 +32,7 @@ describe('model/analysis/references.ts', () => {
 
     const binding = model.identifierBindingMap.get(identifier.id)
     assert.ok(binding != null)
-    assert.strictEqual(binding.kind, 'assignment')
+    assert.strictEqual(binding.kind, 'regular')
     assert.strictEqual(binding.name, 'kick')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('kick ='), 'kick'.length))
 
@@ -59,7 +59,7 @@ describe('model/analysis/references.ts', () => {
 
     const binding = model.identifierBindingMap.get(identifier.id)
     assert.ok(binding != null)
-    assert.strictEqual(binding.kind, 'assignment')
+    assert.strictEqual(binding.kind, 'regular')
     assert.strictEqual(binding.name, 'kick')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('kick ='), 'kick'.length))
 

--- a/packages/language-support/test/model/query.test.ts
+++ b/packages/language-support/test/model/query.test.ts
@@ -20,28 +20,28 @@ describe('analysis/query.ts', () => {
       identifiers: [
         {
           id: '1' as IdentifierId,
-          kind: 'VariableName',
+          kind: 'plain',
           scopeId: 'root' as ScopeId,
           name: 'foo',
           range: getRangeAt(source, source.indexOf('foo'), 'foo'.length)
         },
         {
           id: '2' as IdentifierId,
-          kind: 'Callee',
+          kind: 'plain',
           scopeId: 'root' as ScopeId,
           name: 'bar',
           range: getRangeAt(source, source.indexOf('bar'), 'bar'.length)
         },
         {
           id: '3' as IdentifierId,
-          kind: 'PropertyName',
+          kind: 'property-name',
           scopeId: 'root' as ScopeId,
           name: 'baz',
           range: getRangeAt(source, source.indexOf('baz'), 'baz'.length)
         },
         {
           id: '4' as IdentifierId,
-          kind: 'VariableName',
+          kind: 'plain',
           scopeId: 'root' as ScopeId,
           name: 'qux',
           range: getRangeAt(source, source.indexOf('qux'), 'qux'.length)


### PR DESCRIPTION
Identifiers are now categorized based on what is needed for analysis, rather than based on the grammar node type. In particular, we only need to distinguish plain identifiers, identifiers that are definitions, and property names.

The binding kind "assignment" has been renamed to "regular", since this type of binding can be introduced by both assignments and imports.