### PR TITLE
fix: Optimize language support algorithms

### DIFF
--- a/packages/language-support/src/highlight-occurrences/operation.ts
+++ b/packages/language-support/src/highlight-occurrences/operation.ts
@@ -15,8 +15,5 @@ export const findHighlightedOccurrences: SemanticOperation<[pos: number], readon
 
   const references = model.referenceMap.get(binding.id) ?? []
 
-  const ranges = references.map((reference) => reference.range)
-  ranges.sort((a, b) => a.offset - b.offset || a.length - b.length)
-
-  return ranges
+  return references.map((reference) => reference.range)
 }

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -44,7 +44,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
   const walk = (
     cursor: TreeCursor,
     parentType: string | undefined,
-    currentScopeId: string,
+    scopeId: string,
     trackScopeId: string | undefined,
     mixerScopeId: string | undefined,
     assignmentHasEquals: boolean,
@@ -58,7 +58,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
     const nextParentType = typeName
 
-    let nextScopeId = currentScopeId
+    let nextScopeId = scopeId
     let nextTrackScopeId = trackScopeId
     let nextMixerScopeId = mixerScopeId
     let nextAssignmentHasEquals = assignmentHasEquals
@@ -71,26 +71,26 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
           break
         }
 
-        addImport(statement)
-
-        const { alias, aliasRange } = statement
+        const { alias, aliasRange, moduleName } = statement
         if (alias != null && aliasRange != null) {
-          addIdentifier({ kind: 'definition', scopeId: currentScopeId, name: alias, range: aliasRange })
-          addBinding({ kind: 'use-alias', scopeId: currentScopeId, name: alias, range: aliasRange })
+          addIdentifier({ kind: 'definition', scopeId, name: alias, range: aliasRange })
+          addBinding({ kind: 'use-alias', scopeId, name: alias, range: aliasRange, moduleName })
         }
+
+        addImport(statement)
 
         break
       }
 
       case 'TrackStatement': {
-        const scope = addScope({ kind: 'track', range, parentId: currentScopeId })
+        const scope = addScope({ kind: 'track', range, parentId: scopeId })
         nextScopeId = scope.id
         nextTrackScopeId = scope.id
         break
       }
 
       case 'MixerStatement': {
-        const scope = addScope({ kind: 'mixer', range, parentId: currentScopeId })
+        const scope = addScope({ kind: 'mixer', range, parentId: scopeId })
         nextScopeId = scope.id
         nextMixerScopeId = scope.id
         break
@@ -115,7 +115,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
         const binding = getDefinitionBinding({
           parentType,
-          currentScopeId,
+          scopeId,
           trackScopeId: nextTrackScopeId,
           mixerScopeId: nextMixerScopeId,
           assignmentHasEquals: nextAssignmentHasEquals
@@ -124,11 +124,11 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         if (binding == null) {
           // Invalid/incomplete syntax encountered.
           // We still add an identifier as a best-effort approach to provide some level of functionality.
-          accessChainTail = addIdentifier({ kind: 'plain', scopeId: currentScopeId, name, range, previousSibling })
+          accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range, previousSibling })
           break
         }
 
-        addIdentifier({ kind: 'definition', scopeId: currentScopeId, name, range })
+        addIdentifier({ kind: 'definition', scopeId, name, range })
         addBinding({ ...binding, name, range })
 
         break
@@ -136,7 +136,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
       case 'PropertyName': {
         const name = document.sliceString(from, to)
-        addIdentifier({ kind: 'property-name', scopeId: currentScopeId, name, range })
+        addIdentifier({ kind: 'property-name', scopeId, name, range })
         break
       }
 
@@ -145,7 +145,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       case 'MemberAccess':
       case 'BusNamespace': {
         const name = document.sliceString(from, to)
-        accessChainTail = addIdentifier({ kind: 'plain', scopeId: currentScopeId, name, range, previousSibling })
+        accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range, previousSibling })
         break
       }
     }
@@ -239,7 +239,7 @@ function importKey (moduleName: string, range: SourceRange): ImportId {
 
 interface DefinitionBindingContext {
   readonly parentType: string | undefined
-  readonly currentScopeId: string
+  readonly scopeId: string
   readonly trackScopeId: string | undefined
   readonly mixerScopeId: string | undefined
   readonly assignmentHasEquals: boolean
@@ -249,7 +249,7 @@ function getDefinitionBinding (context: DefinitionBindingContext): Omit<Binding,
   switch (context.parentType) {
     case 'Assignment':
       return context.assignmentHasEquals
-        ? { kind: 'regular', scopeId: context.currentScopeId }
+        ? { kind: 'regular', scopeId: context.scopeId }
         : undefined
 
     case 'PartStatement':

--- a/packages/language-support/src/model/analysis/known-values.ts
+++ b/packages/language-support/src/model/analysis/known-values.ts
@@ -1,6 +1,5 @@
 import { getStandardModule } from '@language'
-import type { BaseModel, Binding, Identifier, IdentifierId, KnownValue, KnownValueModel, ReferenceModel } from '../model.js'
-import { findImportAt } from '../query.js'
+import type { BaseModel, Identifier, IdentifierId, KnownValue, KnownValueModel, ReferenceModel } from '../model.js'
 
 export function computeKnownValueModel (baseModel: BaseModel, referenceModel: ReferenceModel): KnownValueModel {
   const knownValues = new Map<IdentifierId, KnownValue>()
@@ -27,7 +26,7 @@ function resolveKnownValue (baseModel: BaseModel, referenceModel: ReferenceModel
 
   if (identifier.previousSibling.previousSibling == null) {
     // resolving "bar" in "foo.bar.baz" -> could be an export of the module aliased as "foo"
-    return resolveKnownValueWithMember(baseModel, referenceModel, identifier.previousSibling, identifier)
+    return resolveKnownValueWithMember(referenceModel, identifier.previousSibling, identifier)
   }
 
   // resolving "baz" in "foo.bar.baz" -> not known (modules don't have nested members)
@@ -39,48 +38,32 @@ function resolveKnownValueForIdentifier (baseModel: BaseModel, referenceModel: R
 
   switch (binding?.kind) {
     case undefined:
-      return resolveKnownValueForDefaultImport(baseModel, identifier)
+      return resolveKnownValueForDefaultImport(baseModel, identifier.name)
 
-    case 'use-alias': {
-      const moduleName = findModuleNameForBinding(baseModel, binding)
-      return moduleName != null ? { moduleName } : undefined
-    }
+    case 'use-alias':
+      return binding.moduleName != null ? { moduleName: binding.moduleName } : undefined
 
     default:
       return undefined
   }
 }
 
-function resolveKnownValueWithMember (baseModel: BaseModel, referenceModel: ReferenceModel, object: Identifier, property: Identifier): KnownValue | undefined {
+function resolveKnownValueWithMember (referenceModel: ReferenceModel, object: Identifier, property: Identifier): KnownValue | undefined {
   const binding = referenceModel.identifierBindingMap.get(object.id)
-  if (binding == null || binding.kind !== 'use-alias') {
+  if (binding == null || binding.kind !== 'use-alias' || binding.moduleName == null) {
     return undefined
   }
 
-  const moduleName = findModuleNameForBinding(baseModel, binding)
-  return moduleName != null ? { moduleName, exportName: property.name } : undefined
+  return { moduleName: binding.moduleName, exportName: property.name }
 }
 
-function resolveKnownValueForDefaultImport (baseModel: BaseModel, identifier: Identifier): KnownValue | undefined {
+function resolveKnownValueForDefaultImport (baseModel: BaseModel, name: string): KnownValue | undefined {
   for (const { alias, moduleName } of baseModel.imports) {
     // Must not have an alias (i.e. be a default import)
-    if (alias == null && getStandardModule(moduleName)?.exports.has(identifier.name)) {
-      return { moduleName, exportName: identifier.name }
+    if (alias == null && getStandardModule(moduleName)?.exports.has(name)) {
+      return { moduleName, exportName: name }
     }
   }
 
   return undefined
-}
-
-function findModuleNameForBinding (model: BaseModel, binding: Binding): string | undefined {
-  if (binding.kind !== 'use-alias') {
-    return undefined
-  }
-
-  const importStatement = findImportAt(model, binding.range.offset)
-  if (importStatement == null || importStatement.alias !== binding.name) {
-    return undefined
-  }
-
-  return importStatement.moduleName
 }

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -24,6 +24,10 @@ export function computeReferenceModel (model: BaseModel): ReferenceModel {
     references.push(identifier)
   }
 
+  for (const references of referenceMap.values()) {
+    references.sort((a, b) => a.range.offset - b.range.offset)
+  }
+
   return { identifierBindingMap, referenceMap }
 }
 

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -63,6 +63,11 @@ export interface Binding {
   readonly scopeId: string
   readonly name: string
   readonly range: SourceRange
+
+  /**
+   * For use-aliases, this is the module that is being imported.
+   */
+  readonly moduleName?: string
 }
 
 export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus'

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -1,7 +1,6 @@
 import type { Binding, ReferenceModel } from '../model/model.js'
 import type { LanguageDiagnostic } from '../utilities/diagnostic.js'
 import type { SemanticOperation } from '../utilities/operations.js'
-import { sameRange } from '../utilities/range.js'
 
 export const findUnusedVariables: SemanticOperation<[], readonly LanguageDiagnostic[]> = (model) => {
   return model.bindings.filter((binding) => isUnused(binding, model)).map(toDiagnostic)
@@ -13,10 +12,10 @@ function isUnused (binding: Binding, model: ReferenceModel): boolean {
     return false
   }
 
-  const references = model.referenceMap.get(binding.id) ?? []
+  const references = model.referenceMap.get(binding.id)
 
-  // The binding itself counts as a reference, so check if there are any others.
-  return references.every((reference) => sameRange(binding.range, reference.range))
+  // At most one reference, which would be the definition itself.
+  return references == null || references.length <= 1
 }
 
 function toDiagnostic (binding: Binding): LanguageDiagnostic {


### PR DESCRIPTION
This patch contains three optimizations:

1. For imports, store the module name on the binding to make lookup constant time instead of logarithmic in the number of imports.
2. Determine unused variables via reference count and without traversing each reference, making it constant time instead of linear in the number of references.
3. Sort the references already during construction instead of later during the "highlight occurrences" operation. This reduces the amount of work done when the caret is moved around.