### PR TITLE
feat: Highlight default-imported symbol references

### DIFF
--- a/packages/language-support/src/go-to-definition/operation.ts
+++ b/packages/language-support/src/go-to-definition/operation.ts
@@ -20,10 +20,10 @@ export const goToDefinition: SemanticOperation<[pos: number], GoToDefinitionResu
     return undefined
   }
 
-  const binding = model.identifierBindingMap.get(identifier.id)
-  if (binding == null) {
+  const resolution = model.resolutions.get(identifier.id)
+  if (resolution == null || resolution.kind !== 'binding') {
     return undefined
   }
 
-  return { identifier, binding }
+  return { identifier, binding: resolution.binding }
 }

--- a/packages/language-support/src/highlight-occurrences/operation.ts
+++ b/packages/language-support/src/highlight-occurrences/operation.ts
@@ -8,12 +8,22 @@ export const findHighlightedOccurrences: SemanticOperation<[pos: number], readon
     return []
   }
 
-  const binding = model.identifierBindingMap.get(identifier.id)
-  if (binding == null) {
+  const resolution = model.resolutions.get(identifier.id)
+  if (resolution == null) {
     return []
   }
 
-  const references = model.referenceMap.get(binding.id) ?? []
+  switch (resolution.kind) {
+    // Resolves directly to a binding (an identifier that is declared in the same file).
+    case 'binding':
+      return model.bindingReferences.get(resolution.binding.id)
+        ?.map(({ range }) => range) ?? []
 
-  return references.map((reference) => reference.range)
+    // Resolves to an exported member of a default-imported module.
+    // References to other members of the same module must be filtered out.
+    case 'import':
+      return model.importReferences.get(resolution.import.id)
+        ?.filter((ref) => ref.name === identifier.name)
+        .map(({ range }) => range) ?? []
+  }
 }

--- a/packages/language-support/src/model/analysis/known-values.ts
+++ b/packages/language-support/src/model/analysis/known-values.ts
@@ -1,11 +1,10 @@
-import { getStandardModule } from '@language'
 import type { BaseModel, Identifier, IdentifierId, KnownValue, KnownValueModel, ReferenceModel } from '../model.js'
 
 export function computeKnownValueModel (baseModel: BaseModel, referenceModel: ReferenceModel): KnownValueModel {
   const knownValues = new Map<IdentifierId, KnownValue>()
 
   for (const identifier of baseModel.identifiers) {
-    const value = resolveKnownValue(baseModel, referenceModel, identifier)
+    const value = resolve(referenceModel, identifier)
     if (value != null) {
       knownValues.set(identifier.id, value)
     }
@@ -14,56 +13,35 @@ export function computeKnownValueModel (baseModel: BaseModel, referenceModel: Re
   return { knownValues }
 }
 
-function resolveKnownValue (baseModel: BaseModel, referenceModel: ReferenceModel, identifier: Identifier): KnownValue | undefined {
-  if (identifier.kind === 'property-name') {
-    return undefined
+function resolve (model: ReferenceModel, identifier: Identifier): KnownValue | undefined {
+  return identifier.previousSibling != null
+    ? resolveForMemberAccess(model, identifier.previousSibling, identifier.name)
+    : resolveForIdentifier(model, identifier)
+}
+
+function resolveForMemberAccess (model: ReferenceModel, object: Identifier, property: string): KnownValue | undefined {
+  const objectValue = resolveForIdentifier(model, object)
+  if (objectValue?.moduleName != null) {
+    return { moduleName: objectValue.moduleName, exportName: property }
   }
 
-  if (identifier.previousSibling == null) {
-    // resolving "foo" in "foo.bar.baz" -> either a module or default-imported value
-    return resolveKnownValueForIdentifier(baseModel, referenceModel, identifier)
-  }
-
-  if (identifier.previousSibling.previousSibling == null) {
-    // resolving "bar" in "foo.bar.baz" -> could be an export of the module aliased as "foo"
-    return resolveKnownValueWithMember(referenceModel, identifier.previousSibling, identifier)
-  }
-
-  // resolving "baz" in "foo.bar.baz" -> not known (modules don't have nested members)
   return undefined
 }
 
-function resolveKnownValueForIdentifier (baseModel: BaseModel, referenceModel: ReferenceModel, identifier: Identifier): KnownValue | undefined {
-  const binding = referenceModel.identifierBindingMap.get(identifier.id)
+function resolveForIdentifier (model: ReferenceModel, identifier: Identifier): KnownValue | undefined {
+  const resolution = model.resolutions.get(identifier.id)
 
-  switch (binding?.kind) {
-    case undefined:
-      return resolveKnownValueForDefaultImport(baseModel, identifier.name)
+  switch (resolution?.kind) {
+    case 'import':
+      return { moduleName: resolution.import.moduleName, exportName: identifier.name }
 
-    case 'use-alias':
-      return binding.moduleName != null ? { moduleName: binding.moduleName } : undefined
+    case 'binding':
+      if (resolution.binding.moduleName != null) {
+        return { moduleName: resolution.binding.moduleName }
+      }
+      break
 
     default:
       return undefined
   }
-}
-
-function resolveKnownValueWithMember (referenceModel: ReferenceModel, object: Identifier, property: Identifier): KnownValue | undefined {
-  const binding = referenceModel.identifierBindingMap.get(object.id)
-  if (binding == null || binding.kind !== 'use-alias' || binding.moduleName == null) {
-    return undefined
-  }
-
-  return { moduleName: binding.moduleName, exportName: property.name }
-}
-
-function resolveKnownValueForDefaultImport (baseModel: BaseModel, name: string): KnownValue | undefined {
-  for (const { alias, moduleName } of baseModel.imports) {
-    // Must not have an alias (i.e. be a default import)
-    if (alias == null && getStandardModule(moduleName)?.exports.has(name)) {
-      return { moduleName, exportName: name }
-    }
-  }
-
-  return undefined
 }

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -1,53 +1,75 @@
-import type { BaseModel, Binding, BindingId, Identifier, IdentifierId, ReferenceModel } from '../model.js'
+import { getStandardModule } from '@language'
+import type { BaseModel, Binding, BindingId, Identifier, IdentifierId, Import, ImportId, ReferenceModel, Resolution } from '../model.js'
 import { findBindingAt } from '../query.js'
 
 export function computeReferenceModel (model: BaseModel): ReferenceModel {
-  const lookup = buildBindingLookup(model)
+  const resolutions = new Map<IdentifierId, Resolution>()
+  const bindingReferences = new Map<BindingId, Identifier[]>()
+  const importReferences = new Map<ImportId, Identifier[]>()
 
-  const identifierBindingMap = new Map<IdentifierId, Binding>()
-  const referenceMap = new Map<BindingId, Identifier[]>()
+  const lookup = buildBindingLookup(model)
 
   for (const identifier of model.identifiers) {
     const binding = resolveDefinitionBinding(identifier, model, lookup)
-    if (binding == null) {
+
+    // If we have a binding, use that as the resolution.
+    if (binding != null) {
+      resolutions.set(identifier.id, { kind: 'binding', binding })
+      addReference(bindingReferences, binding.id, identifier)
       continue
     }
 
-    identifierBindingMap.set(identifier.id, binding)
-
-    const references = referenceMap.get(binding.id)
-    if (references == null) {
-      referenceMap.set(binding.id, [identifier])
-      continue
+    // Otherwise, for plain identifiers, we might have a reference to a default-imported symbol.
+    if (identifier.kind === 'plain' && identifier.previousSibling == null) {
+      const imp = resolveDefaultImport(lookup, identifier.name)
+      if (imp != null) {
+        resolutions.set(identifier.id, { kind: 'import', import: imp })
+        addReference(importReferences, imp.id, identifier)
+      }
     }
-
-    references.push(identifier)
   }
 
-  for (const references of referenceMap.values()) {
+  sortReferences(bindingReferences)
+  sortReferences(importReferences)
+
+  return { resolutions, bindingReferences, importReferences }
+}
+
+function addReference<Id> (map: Map<Id, Identifier[]>, id: Id, reference: Identifier): void {
+  const references = map.get(id)
+  if (references == null) {
+    map.set(id, [reference])
+    return
+  }
+
+  references.push(reference)
+}
+
+function sortReferences<Id> (map: Map<Id, Identifier[]>): void {
+  for (const references of map.values()) {
     references.sort((a, b) => a.range.offset - b.range.offset)
   }
-
-  return { identifierBindingMap, referenceMap }
 }
 
 interface BindingLookup {
-  readonly useAliases: ReadonlyMap<string, Binding>
+  readonly namedImports: ReadonlyMap<string, Binding>
+  readonly defaultImports: ReadonlyMap<string, Import>
   readonly buses: ReadonlyMap<string, Binding>
   readonly byScopeAndName: ReadonlyMap<string, ReadonlyMap<string, Binding>>
   readonly parentScopes: ReadonlyMap<string, string>
 }
 
 function buildBindingLookup (model: BaseModel): BindingLookup {
-  const useAliases = new Map<string, Binding>()
+  const namedImports = new Map<string, Binding>()
+  const defaultImports = new Map<string, Import>()
   const buses = new Map<string, Binding>()
   const byScopeAndName = new Map<string, Map<string, Binding>>()
 
   for (const binding of model.bindings) {
     switch (binding.kind) {
       case 'use-alias':
-        if (!useAliases.has(binding.name)) {
-          useAliases.set(binding.name, binding)
+        if (!namedImports.has(binding.name)) {
+          namedImports.set(binding.name, binding)
         }
         break
 
@@ -70,6 +92,12 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
     scopeMap.set(binding.name, binding)
   }
 
+  for (const imp of model.imports) {
+    if (imp.alias == null && !defaultImports.has(imp.moduleName)) {
+      defaultImports.set(imp.moduleName, imp)
+    }
+  }
+
   const parentScopes = new Map<string, string>()
   for (const scope of model.scopes) {
     if (scope.parentId != null) {
@@ -77,7 +105,7 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
     }
   }
 
-  return { useAliases, buses, byScopeAndName, parentScopes }
+  return { namedImports, defaultImports, buses, byScopeAndName, parentScopes }
 }
 
 function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, lookup: BindingLookup): Binding | undefined {
@@ -106,7 +134,7 @@ function findRegularBinding (occurrence: Identifier, lookup: BindingLookup): Bin
   }
 
   // Prefer alias imports over other types of bindings.
-  const useAliasBinding = lookup.useAliases.get(occurrence.name)
+  const useAliasBinding = lookup.namedImports.get(occurrence.name)
   if (useAliasBinding != null) {
     return useAliasBinding
   }
@@ -129,4 +157,34 @@ function isExplicitBusReference (identifier: Identifier): boolean {
   return identifier.previousSibling != null &&
     identifier.previousSibling.name === 'bus' &&
     identifier.previousSibling.previousSibling == null
+}
+
+const importCache = new WeakMap<BindingLookup, Map<string, Import | undefined>>()
+
+function resolveDefaultImport (lookup: BindingLookup, name: string): Import | undefined {
+  const cache = importCache.get(lookup)
+
+  if (cache?.has(name) === true) {
+    return cache.get(name)
+  }
+
+  const imp = findDefaultImport(lookup, name)
+
+  if (cache == null) {
+    importCache.set(lookup, new Map([[name, imp]]))
+  } else {
+    cache.set(name, imp)
+  }
+
+  return imp
+}
+
+function findDefaultImport (lookup: BindingLookup, name: string): Import | undefined {
+  for (const [moduleName, imp] of lookup.defaultImports) {
+    if (getStandardModule(moduleName)?.exports.has(name) === true) {
+      return imp
+    }
+  }
+
+  return undefined
 }

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -12,8 +12,9 @@ export interface BaseModel {
 }
 
 export interface ReferenceModel {
-  readonly identifierBindingMap: ReadonlyMap<IdentifierId, Binding>
-  readonly referenceMap: ReadonlyMap<BindingId, readonly Identifier[]>
+  readonly resolutions: ReadonlyMap<IdentifierId, Resolution>
+  readonly bindingReferences: ReadonlyMap<BindingId, readonly Identifier[]>
+  readonly importReferences: ReadonlyMap<ImportId, readonly Identifier[]>
 }
 
 export interface KnownValueModel {
@@ -83,6 +84,27 @@ export interface Import {
   readonly alias?: string
   readonly aliasRange?: SourceRange
 }
+
+// resolution
+
+export type Resolution = {
+  readonly kind: ResolutionKind
+  readonly binding?: Binding
+  readonly import?: Import
+} & (
+  // Resolved to a binding (variable, use-alias, etc.)
+  {
+    readonly kind: 'binding'
+    readonly binding: Binding
+  } |
+  // Resolved to a default import (e.g. "loop" in "use 'patterns' as *")
+  {
+    readonly kind: 'import'
+    readonly import: Import
+  }
+)
+
+export type ResolutionKind = 'binding' | 'import'
 
 // known values
 

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -12,7 +12,7 @@ function isUnused (binding: Binding, model: ReferenceModel): boolean {
     return false
   }
 
-  const references = model.referenceMap.get(binding.id)
+  const references = model.bindingReferences.get(binding.id)
 
   // At most one reference, which would be the definition itself.
   return references == null || references.length <= 1

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -145,4 +145,53 @@ describe('highlight-occurrences/operation.ts', () => {
       ]
     )
   })
+
+  it('highlights occurrences of a default-imported symbol', () => {
+    const source = [
+      'use "patterns" as *',
+      'pattern1 = loop([x---])',
+      'pattern2 = loop([x-x-])',
+      ''
+    ].join('\n')
+
+    const position = source.indexOf('loop([x---])') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('loop([x---])'), 'loop'.length),
+        getRangeAt(source, source.indexOf('loop([x-x-])'), 'loop'.length)
+      ]
+    )
+  })
+
+  it('highlights only identical default-imported symbols', () => {
+    const source = [
+      'use "effects" as *',
+      'foo = delay',
+      'bar = reverb',
+      'baz = delay',
+      'qux = reverb',
+      ''
+    ].join('\n')
+
+    const delayPosition = source.indexOf('delay') + 1
+    const reverbPosition = source.indexOf('reverb') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, delayPosition),
+      [
+        getRangeAt(source, source.indexOf('delay'), 'delay'.length),
+        getRangeAt(source, source.lastIndexOf('delay'), 'delay'.length)
+      ]
+    )
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, reverbPosition),
+      [
+        getRangeAt(source, source.indexOf('reverb'), 'reverb'.length),
+        getRangeAt(source, source.lastIndexOf('reverb'), 'reverb'.length)
+      ]
+    )
+  })
 })

--- a/packages/language-support/test/model/analysis/known-values.test.ts
+++ b/packages/language-support/test/model/analysis/known-values.test.ts
@@ -83,4 +83,27 @@ describe('model/analysis/known-values.ts', () => {
     assert.strictEqual(gainProperty?.kind, 'property-name')
     assert.strictEqual(model.knownValues.get(gainProperty.id), undefined)
   })
+
+  it('does not set known values for nested identifiers', () => {
+    const source = [
+      'use "effects" as fx',
+      'foo = fx.pan.gain',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+
+    const panIdentifier = findIdentifierAt(model, source.indexOf('pan'))
+    assert.strictEqual(panIdentifier?.name, 'pan')
+    assert.deepStrictEqual(model.knownValues.get(panIdentifier.id), {
+      moduleName: 'effects',
+      exportName: 'pan'
+    })
+
+    // This test ensures that the resolution uses the previous sibling instead of
+    // the access chain's root, which would incorrectly treat "fx.pan.gain" as "fx.gain".
+    const gainIdentifier = findIdentifierAt(model, source.indexOf('gain'))
+    assert.strictEqual(gainIdentifier?.name, 'gain')
+    assert.strictEqual(model.knownValues.get(gainIdentifier.id), undefined)
+  })
 })

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -30,13 +30,15 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.name === 'kick')
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier.id)
-    assert.ok(binding != null)
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
     assert.strictEqual(binding.kind, 'regular')
     assert.strictEqual(binding.name, 'kick')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('kick ='), 'kick'.length))
 
-    const references = model.referenceMap.get(binding.id)
+    const references = model.bindingReferences.get(binding.id)
     assert.deepStrictEqual(references, [identifier])
   })
 
@@ -57,13 +59,15 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier.id)
-    assert.ok(binding != null)
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
     assert.strictEqual(binding.kind, 'regular')
     assert.strictEqual(binding.name, 'kick')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('kick ='), 'kick'.length))
 
-    const references = model.referenceMap.get(binding.id)
+    const references = model.bindingReferences.get(binding.id)
     assert.ok(references != null)
     assert.ok(references.includes(identifier))
   })
@@ -87,13 +91,15 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier.id)
-    assert.ok(binding != null)
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
     assert.strictEqual(binding.kind, 'bus')
     assert.strictEqual(binding.name, 'foo')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('bus foo') + 'bus '.length, 'foo'.length))
 
-    const references = model.referenceMap.get(binding.id)
+    const references = model.bindingReferences.get(binding.id)
     assert.ok(references != null)
     assert.ok(references.includes(identifier))
   })
@@ -111,7 +117,7 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier.id)
+    const binding = model.resolutions.get(identifier.id)
     assert.strictEqual(binding, undefined)
   })
 
@@ -134,7 +140,7 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier.id)
+    const binding = model.resolutions.get(identifier.id)
     assert.strictEqual(binding, undefined)
   })
 
@@ -157,7 +163,7 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier.id)
+    const binding = model.resolutions.get(identifier.id)
     assert.strictEqual(binding, undefined)
   })
 
@@ -175,10 +181,93 @@ describe('model/analysis/references.ts', () => {
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)
 
-    const binding = model.identifierBindingMap.get(identifier.id)
-    assert.ok(binding != null)
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
     assert.strictEqual(binding.kind, 'use-alias')
     assert.strictEqual(binding.name, 'fx')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('as fx') + 'as '.length, 'fx'.length))
+  })
+
+  it('resolves default imports', () => {
+    const source = [
+      'use "patterns" as *',
+      'track {',
+      '  part main {',
+      '    kick << loop([x---])',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('loop')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'import')
+
+    const imp = resolution.import
+    assert.strictEqual(imp.moduleName, 'patterns')
+    assert.strictEqual(imp.alias, undefined)
+  })
+
+  it('prefers local variables over default imports', () => {
+    const source = [
+      'use "patterns" as *',
+      'loop = [x---]',
+      'track {',
+      '  part main {',
+      '    kick << loop',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('loop')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+  })
+
+  it('does not resolve default imports for property names', () => {
+    const source = [
+      'use "patterns" as *',
+      'foo = bar(loop: 4)',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('loop:')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution, undefined)
+  })
+
+  it('does not resolve default imports for member accesses', () => {
+    const source = [
+      'use "patterns" as *',
+      'foo = bar.loop',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('bar.loop') + 'bar.'.length
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution, undefined)
   })
 })


### PR DESCRIPTION
The "highlight occurrences" feature works by finding all references to the same symbol that is referenced at the caret position. Previously, this only worked for bindings (local variables, import aliases), i.e., anything with a declaration identifier. Now, default-imported symbols are included as well. For example:

```
use "patterns" as *

kick = loop([x---])
hat = loop([x-x-])
```

In this code, if the caret is on `loop` in the first line, both `loop` references will now be highlighted.