### PR TITLE
feat: Implement unused default import analysis

### DIFF
--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -1,5 +1,5 @@
-import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import { parseStringLiteral } from '@language'
+import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import type { SourceRange } from '../../utilities/range.js'
 import type { TextLike } from '../../utilities/text.js'
 import { toSourceRange } from '../../utilities/text.js'
@@ -72,7 +72,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         }
 
         const { alias, aliasRange, moduleName } = statement
-        if (alias != null && aliasRange != null) {
+        if (alias != null) {
           addIdentifier({ kind: 'definition', scopeId, name: alias, range: aliasRange })
           addBinding({ kind: 'use-alias', scopeId, name: alias, range: aliasRange, moduleName })
         }
@@ -287,14 +287,16 @@ function parseUseStatement (document: TextLike, node: SyntaxNode): Omit<Import, 
     } while (cursor.nextSibling())
   }
 
-  if (moduleName == null || alias == null) {
+  if (moduleName == null || alias == null || aliasRange == null) {
     return undefined
   }
 
-  const result = { moduleName, range: toSourceRange(document, node.from, node.to) }
+  const range = toSourceRange(document, node.from, node.to)
+
+  const result = { moduleName, range, aliasRange }
   if (alias === '*') {
     return result
   }
 
-  return { ...result, alias, aliasRange }
+  return { ...result, alias }
 }

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -82,7 +82,7 @@ export interface Import {
   readonly moduleName: string
   readonly range: SourceRange
   readonly alias?: string
-  readonly aliasRange?: SourceRange
+  readonly aliasRange: SourceRange
 }
 
 // resolution

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -1,12 +1,35 @@
-import type { Binding, ReferenceModel } from '../model/model.js'
+import type { Binding, Import, Model, ReferenceModel } from '../model/model.js'
 import type { LanguageDiagnostic } from '../utilities/diagnostic.js'
 import type { SemanticOperation } from '../utilities/operations.js'
 
 export const findUnusedVariables: SemanticOperation<[], readonly LanguageDiagnostic[]> = (model) => {
-  return model.bindings.filter((binding) => isUnused(binding, model)).map(toDiagnostic)
+  return [
+    ...getUnusedVariables(model),
+    ...getUnusedImports(model)
+  ].sort((a, b) => a.range.offset - b.range.offset)
 }
 
-function isUnused (binding: Binding, model: ReferenceModel): boolean {
+function getUnusedVariables (model: Model): readonly LanguageDiagnostic[] {
+  return model.bindings
+    .filter((binding) => isUnusedBinding(binding, model))
+    .map((binding) => ({
+      name: binding.name,
+      message: `Unused ${binding.kind === 'use-alias' ? 'import' : 'variable'} "${binding.name}"`,
+      range: binding.range
+    }))
+}
+
+function getUnusedImports (model: Model): readonly LanguageDiagnostic[] {
+  return model.imports
+    .filter((statement) => isUnusedImport(statement, model))
+    .map((statement) => ({
+      name: statement.moduleName,
+      message: `Unused import from "${statement.moduleName}"`,
+      range: statement.aliasRange
+    }))
+}
+
+function isUnusedBinding (binding: Binding, model: ReferenceModel): boolean {
   // Buses and parts are implicitly used by the runtime.
   if (binding.kind === 'bus' || binding.kind === 'part') {
     return false
@@ -18,12 +41,12 @@ function isUnused (binding: Binding, model: ReferenceModel): boolean {
   return references == null || references.length <= 1
 }
 
-function toDiagnostic (binding: Binding): LanguageDiagnostic {
-  const type = binding.kind === 'use-alias' ? 'import' : 'variable'
-
-  return {
-    name: binding.name,
-    message: `Unused ${type} "${binding.name}"`,
-    range: binding.range
+function isUnusedImport (statement: Import, model: ReferenceModel): boolean {
+  if (statement.alias != null) {
+    // handled by binding references
+    return false
   }
+
+  const references = model.importReferences.get(statement.id)
+  return references == null || references.length === 0
 }

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -340,7 +340,7 @@ describe('model/analysis/base.ts', () => {
           moduleName: 'patterns',
           range: getRangeAt(source, source.indexOf('use "patterns" as *'), 'use "patterns" as *'.length),
           alias: undefined,
-          aliasRange: undefined
+          aliasRange: getRangeAt(source, source.indexOf('as *') + 'as '.length, '*'.length)
         }
       ]
     )

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -93,9 +93,16 @@ describe('unused-variable/operation.ts', () => {
     )
   })
 
-  it('reports unused imports', () => {
+  it('reports unused named imports', () => {
     const source = [
       'use "patterns" as patterns',
+      'use "effects" as fx',
+      '',
+      'mixer {',
+      '  bus drums {',
+      '    effect fx.gain(0.db)',
+      '  }',
+      '}',
       ''
     ].join('\n')
 
@@ -106,6 +113,31 @@ describe('unused-variable/operation.ts', () => {
           name: 'patterns',
           message: 'Unused import "patterns"',
           range: getRangeAt(source, source.indexOf('as patterns') + 'as '.length, 'patterns'.length)
+        }
+      ]
+    )
+  })
+
+  it('reports unused default imports', () => {
+    const source = [
+      'use "patterns" as *',
+      'use "effects" as *',
+      '',
+      'mixer {',
+      '  bus drums {',
+      '    effect gain(0.db)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      [
+        {
+          name: 'patterns',
+          message: 'Unused import from "patterns"',
+          range: getRangeAt(source, source.indexOf('as *') + 'as '.length, '*'.length)
         }
       ]
     )


### PR DESCRIPTION
In addition to highlighting unused local variables and unused named imports, the analysis now also identifies and highlights unused default imports. For example, for `use "patterns" as *`, if none of the pattern module's exports are used, a diagnostic will now be generated.