### PR TITLE
test: Shorten parser tests

### DIFF
--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -1,32 +1,19 @@
 import type { Token } from 'leac'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
+import { lex } from '../../src/lexer/lexer.js'
 import { parse } from '../../src/parser/parser.js'
-import { parseStringLiteral } from '../../src/parser/string.js'
+import { assertResultComplete } from '../test-utils.js'
 
 /**
- * Helper function to create an array of tokens with automatically assigned source ranges
+ * Lex the given string and return the resulting tokens. This assumes that the lexer
+ * is implemented correctly.
  */
-function makeTokens (tokens: ReadonlyArray<Readonly<{ name: string, text?: string }>>, filePath?: string): Token[] {
-  let offset = 0
+function lexSource (input: string, filePath?: string): Token[] {
+  const result = lex(input, filePath)
+  assert.ok(result.complete, result.complete ? undefined : result.error)
 
-  return tokens.map(({ name, text }) => {
-    const tokenText = text ?? name
-    const token = {
-      name,
-      text: tokenText,
-      offset,
-      len: tokenText.length,
-      line: 1,
-      column: offset + 1,
-      filePath,
-      state: ''
-    }
-
-    offset += tokenText.length + 1 // +1 for space
-
-    return token
-  })
+  return result.value
 }
 
 /**
@@ -49,14 +36,9 @@ function stripRanges (node: unknown): unknown {
 }
 
 describe('parser/parser.ts', () => {
-  it('parses plain string literals with language escape rules', () => {
-    assert.strictEqual(parseStringLiteral('"effects\\{main\\}"'), 'effects{main}')
-    assert.strictEqual(parseStringLiteral('"effects\\nmain"'), 'effects\nmain')
-    assert.strictEqual(parseStringLiteral('"effects{main}"'), undefined)
-  })
-
   it('should accept empty input', () => {
-    const result = parse(makeTokens([]))
+    const result = parse([])
+
     assert.deepStrictEqual(stripRanges(result), {
       complete: true,
       value: {
@@ -68,546 +50,332 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse use statements', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'use' },
-      { name: '"' },
-      { name: 'stringContent', text: 'mylib' },
-      { name: '"' },
-      { name: 'word', text: 'as' },
-      { name: 'word', text: 'myalias' },
-      { name: 'word', text: 'use' },
-      { name: '"' },
-      { name: 'stringContent', text: 'otherlib' },
-      { name: '"' },
-      { name: 'word', text: 'as' },
-      { name: '*' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [
-          {
-            type: 'UseStatement',
-            library: {
-              type: 'String',
-              parts: ['mylib']
-            },
-            alias: 'myalias'
-          },
-          {
-            type: 'UseStatement',
-            library: {
-              type: 'String',
-              parts: ['otherlib']
-            }
-          }
-        ],
-        children: []
+    const source = [
+      'use "mylib" as myalias',
+      'use "otherlib" as *'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.imports), [
+      {
+        type: 'UseStatement',
+        library: {
+          type: 'String',
+          parts: ['mylib']
+        },
+        alias: 'myalias'
+      },
+      {
+        type: 'UseStatement',
+        library: {
+          type: 'String',
+          parts: ['otherlib']
+        }
       }
-    })
+    ])
   })
 
   it('should reject use statements after other statements', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: 'number', text: '42' },
-      { name: 'word', text: 'use' },
-      { name: '"' },
-      { name: 'stringContent', text: 'mylib' },
-      { name: '"' },
-      { name: 'word', text: 'as' },
-      { name: 'word', text: 'myalias' }
-    ]))
+    const source = [
+      'foo = 42',
+      'use "mylib" as myalias'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+
     assert.strictEqual(result.complete, false)
+    assert.strictEqual(result.error.message, 'Unexpected statement beginning with "use"')
   })
 
   it('should parse a simple assignment', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: 'number', text: '42' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'foo' },
-            value: { type: 'Number', value: 42 }
-          }
-        ]
+    const result = parse(lexSource('foo = 42'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'foo' },
+        value: { type: 'Number', value: 42 }
       }
-    })
+    ])
   })
 
   it('should parse unit suffixes', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'offset' },
-      { name: '=' },
-      { name: '-' },
-      { name: 'number', text: '1.5' },
-      { name: '.' },
-      { name: 'word', text: 'ms' },
-      { name: 'word', text: 'gain' },
-      { name: '=' },
-      { name: '(' },
-      { name: '-' },
-      { name: 'number', text: '6' },
-      { name: '+' },
-      { name: 'number', text: '3' },
-      { name: ')' },
-      { name: '.' },
-      { name: 'word', text: 'db' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'offset' },
-            value: {
-              type: 'UnaryExpression',
-              operator: '-',
-              argument: {
-                type: 'PropertyAccess',
-                object: { type: 'Number', value: 1.5 },
-                property: { type: 'Identifier', name: 'ms' }
-              }
-            }
-          },
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'gain' },
-            value: {
-              type: 'PropertyAccess',
-              object: {
-                type: 'BinaryExpression',
-                operator: '+',
-                left: { type: 'Number', value: -6 },
-                right: { type: 'Number', value: 3 }
-              },
-              property: { type: 'Identifier', name: 'db' }
-            }
+    const source = [
+      'offset = -1.5.ms',
+      'gain = (-6 + 3).db'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'offset' },
+        value: {
+          type: 'UnaryExpression',
+          operator: '-',
+          argument: {
+            type: 'PropertyAccess',
+            object: { type: 'Number', value: 1.5 },
+            property: { type: 'Identifier', name: 'ms' }
           }
-        ]
+        }
+      },
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'gain' },
+        value: {
+          type: 'PropertyAccess',
+          object: {
+            type: 'BinaryExpression',
+            operator: '+',
+            left: { type: 'Number', value: -6 },
+            right: { type: 'Number', value: 3 }
+          },
+          property: { type: 'Identifier', name: 'db' }
+        }
       }
-    })
+    ])
   })
 
   it('should parse explicit bus parameter access', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'target' },
-      { name: '=' },
-      { name: 'word', text: 'bus' },
-      { name: '.' },
-      { name: 'word', text: 'main' },
-      { name: '.' },
-      { name: 'word', text: 'gain' }
-    ]))
+    const result = parse(lexSource('target = bus.main.gain'))
+    assertResultComplete(result)
 
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'target' },
-            value: {
-              type: 'PropertyAccess',
-              object: {
-                type: 'PropertyAccess',
-                object: { type: 'Identifier', name: 'bus' },
-                property: { type: 'Identifier', name: 'main' }
-              },
-              property: { type: 'Identifier', name: 'gain' }
-            }
-          }
-        ]
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'target' },
+        value: {
+          type: 'PropertyAccess',
+          object: {
+            type: 'PropertyAccess',
+            object: { type: 'Identifier', name: 'bus' },
+            property: { type: 'Identifier', name: 'main' }
+          },
+          property: { type: 'Identifier', name: 'gain' }
+        }
       }
-    })
+    ])
   })
 
   it('should parse string literals with escapes and interpolations', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: '"' },
-      { name: 'stringContent', text: 'a ' },
-      { name: 'stringEscape', text: '\\{' },
-      { name: 'stringContent', text: ' b ' },
-      { name: '{' },
-      { name: 'word', text: 'x' },
-      { name: '}' },
-      { name: 'stringContent', text: ' c' },
-      { name: '"' }
-    ]))
+    const result = parse(lexSource('foo = "a \\{ b {x} c"'))
+    assertResultComplete(result)
 
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'foo' },
-            value: {
-              type: 'String',
-              parts: ['a { b ', { type: 'Identifier', name: 'x' }, ' c']
-            }
-          }
-        ]
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'foo' },
+        value: {
+          type: 'String',
+          parts: [
+            'a { b ',
+            { type: 'Identifier', name: 'x' },
+            ' c'
+          ]
+        }
       }
-    })
+    ])
   })
 
   it('should parse a serial pattern', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: '[' },
-      { name: 'word', text: 'xx' },
-      { name: '-' },
-      { name: 'word', text: 'D4' },
-      { name: ':' },
-      { name: 'number', text: '0.5' },
-      { name: '-' },
-      { name: 'word', text: 'G4' },
-      { name: ']' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'foo' },
-            value: {
-              type: 'Pattern',
-              mode: 'serial',
-              children: [
-                { type: 'Step', value: 'x', parameters: [] },
-                { type: 'Step', value: 'x', parameters: [] },
-                { type: 'Step', value: '-', parameters: [] },
-                {
-                  type: 'Step',
-                  value: 'D4',
-                  length: { type: 'Number', value: 0.5 },
-                  parameters: []
-                },
-                { type: 'Step', value: '-', parameters: [] },
-                { type: 'Step', value: 'G4', parameters: [] }
-              ]
-            }
-          }
-        ]
+    const result = parse(lexSource('foo = [xx-D4:0.5-G4]'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'foo' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            { type: 'Step', value: 'x', parameters: [] },
+            { type: 'Step', value: 'x', parameters: [] },
+            { type: 'Step', value: '-', parameters: [] },
+            { type: 'Step', value: 'D4', length: { type: 'Number', value: 0.5 }, parameters: [] },
+            { type: 'Step', value: '-', parameters: [] },
+            { type: 'Step', value: 'G4', parameters: [] }
+          ]
+        }
       }
-    })
+    ])
   })
 
   it('should parse an empty serial pattern', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: '[' },
-      { name: ']' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'foo' },
-            value: {
-              type: 'Pattern',
-              mode: 'serial',
-              children: []
-            }
-          }
-        ]
+    const result = parse(lexSource('foo = []'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'foo' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: []
+        }
       }
-    })
+    ])
   })
 
   it('should parse a pattern with gate', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'pattern' },
-      { name: '=' },
-      { name: '[' },
-      { name: 'word', text: 'C4' },
-      { name: '(' },
-      { name: 'number', text: '2.0' },
-      { name: ')' },
-      { name: '-' },
-      { name: ']' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'pattern' },
-            value: {
-              type: 'Pattern',
-              mode: 'serial',
-              children: [
-                {
-                  type: 'Step',
-                  value: 'C4',
-                  parameters: [
-                    { type: 'Number', value: 2.0 }
-                  ]
-                },
-                { type: 'Step', value: '-', parameters: [] }
-              ]
-            }
-          }
-        ]
+    const result = parse(lexSource('pattern = [C4(2.0)-]'))
+    assertResultComplete(result)
+
+    const gate = { type: 'Number', value: 2.0 }
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'pattern' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            { type: 'Step', value: 'C4', parameters: [gate] },
+            { type: 'Step', value: '-', parameters: [] }
+          ]
+        }
       }
-    })
+    ])
   })
 
   it('should parse a pattern with gate and length', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'pattern' },
-      { name: '=' },
-      { name: '[' },
-      { name: 'word', text: 'C4' },
-      { name: '(' },
-      { name: 'number', text: '2.0' },
-      { name: ')' },
-      { name: ':' },
-      { name: 'number', text: '1.5' },
-      { name: '-' },
-      { name: ']' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'pattern' },
-            value: {
-              type: 'Pattern',
-              mode: 'serial',
-              children: [
-                {
-                  type: 'Step',
-                  value: 'C4',
-                  length: { type: 'Number', value: 1.5 },
-                  parameters: [
-                    { type: 'Number', value: 2.0 }
-                  ]
-                },
-                { type: 'Step', value: '-', parameters: [] }
-              ]
-            }
-          }
-        ]
+    const result = parse(lexSource('pattern = [C4(2.0):1.5-]'))
+    assertResultComplete(result)
+
+    const gate = { type: 'Number', value: 2.0 }
+    const length = { type: 'Number', value: 1.5 }
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'pattern' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            { type: 'Step', value: 'C4', length, parameters: [gate] },
+            { type: 'Step', value: '-', parameters: [] }
+          ]
+        }
       }
-    })
+    ])
   })
 
   it('should parse a pattern with named arguments', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'pattern' },
-      { name: '=' },
-      { name: '[' },
-      { name: 'word', text: 'C4' },
-      { name: '(' },
-      { name: 'word', text: 'gate' },
-      { name: ':' },
-      { name: 'number', text: '2.0' },
-      { name: ')' },
-      { name: ':' },
-      { name: 'number', text: '1.5' },
-      { name: '-' },
-      { name: ']' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'pattern' },
-            value: {
+    const result = parse(lexSource('pattern = [C4(gate: 2.0):1.5-]'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'pattern' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            {
+              type: 'Step',
+              value: 'C4',
+              length: { type: 'Number', value: 1.5 },
+              parameters: [
+                {
+                  type: 'Property',
+                  key: { type: 'Identifier', name: 'gate' },
+                  value: { type: 'Number', value: 2.0 }
+                }
+              ]
+            },
+            { type: 'Step', value: '-', parameters: [] }
+          ]
+        }
+      }
+    ])
+  })
+
+  it('should parse a pattern with parallel steps', () => {
+    const result = parse(lexSource('pattern = [<C4:0.75-:0.25>E4]'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'pattern' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            {
               type: 'Pattern',
-              mode: 'serial',
+              mode: 'parallel',
               children: [
                 {
                   type: 'Step',
                   value: 'C4',
-                  length: { type: 'Number', value: 1.5 },
-                  parameters: [
-                    {
-                      type: 'Property',
-                      key: { type: 'Identifier', name: 'gate' },
-                      value: { type: 'Number', value: 2.0 }
-                    }
-                  ]
-                },
-                { type: 'Step', value: '-', parameters: [] }
-              ]
-            }
-          }
-        ]
-      }
-    })
-  })
-
-  it('should parse a pattern with parallel steps', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'pattern' },
-      { name: '=' },
-      { name: '[' },
-      { name: '<' },
-      { name: 'word', text: 'C4' },
-      { name: ':' },
-      { name: 'number', text: '0.75' },
-      { name: '-' },
-      { name: ':' },
-      { name: 'number', text: '0.25' },
-      { name: '>' },
-      { name: 'word', text: 'E4' },
-      { name: ']' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'pattern' },
-            value: {
-              type: 'Pattern',
-              mode: 'serial',
-              children: [
-                {
-                  type: 'Pattern',
-                  mode: 'parallel',
-                  children: [
-                    {
-                      type: 'Step',
-                      value: 'C4',
-                      length: { type: 'Number', value: 0.75 },
-                      parameters: []
-                    },
-                    {
-                      type: 'Step',
-                      value: '-',
-                      length: { type: 'Number', value: 0.25 },
-                      parameters: []
-                    }
-                  ]
+                  length: { type: 'Number', value: 0.75 },
+                  parameters: []
                 },
                 {
                   type: 'Step',
-                  value: 'E4',
+                  value: '-',
+                  length: { type: 'Number', value: 0.25 },
                   parameters: []
                 }
               ]
+            },
+            {
+              type: 'Step',
+              value: 'E4',
+              parameters: []
             }
-          }
-        ]
+          ]
+        }
       }
-    })
+    ])
   })
 
   it('should reject empty parallel patterns', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'pattern' },
-      { name: '=' },
-      { name: '[' },
-      { name: '<' },
-      { name: '>' },
-      { name: ']' }
-    ]))
+    const result = parse(lexSource('pattern = [<>]'))
     assert.strictEqual(result.complete, false)
+    assert.strictEqual(result.error.message, 'Unexpected "<"; expected "]"')
   })
 
   it('should parse patterns with interpolations', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'pattern' },
-      { name: '=' },
-      { name: '[' },
-      { name: 'word', text: 'C4' },
-      { name: '-' },
-      { name: '{' },
-      { name: 'word', text: 'some_pattern' },
-      { name: '*' },
-      { name: 'number', text: '2' },
-      { name: '}' },
-      { name: ']' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'pattern' },
-            value: {
-              type: 'Pattern',
-              mode: 'serial',
-              children: [
-                { type: 'Step', value: 'C4', parameters: [] },
-                { type: 'Step', value: '-', parameters: [] },
-                {
-                  type: 'BinaryExpression',
-                  operator: '*',
-                  left: { type: 'Identifier', name: 'some_pattern' },
-                  right: { type: 'Number', value: 2 }
-                }
-              ]
+    const result = parse(lexSource('pattern = [C4-{some_pattern * 2}]'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'pattern' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            { type: 'Step', value: 'C4', parameters: [] },
+            { type: 'Step', value: '-', parameters: [] },
+            {
+              type: 'BinaryExpression',
+              operator: '*',
+              left: { type: 'Identifier', name: 'some_pattern' },
+              right: { type: 'Number', value: 2 }
             }
-          }
-        ]
+          ]
+        }
       }
-    })
+    ])
   })
 
   it('should preserve file paths in split pattern step ranges', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'pattern' },
-      { name: '=' },
-      { name: '[' },
-      { name: 'word', text: 'xx' },
-      { name: ':' },
-      { name: 'number', text: '1' },
-      { name: ']' }
-    ], 'track.cadence'))
-
-    if (!result.complete) {
-      assert.fail(`Expected parse to succeed, got: ${result.error.message}`)
-    }
+    const result = parse(lexSource('pattern = [xx:1]', 'track.cadence'))
+    assertResultComplete(result)
 
     const assignment = result.value.children[0]
     assert.strictEqual(assignment.type, 'Assignment')
@@ -616,452 +384,251 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse property access expressions', () => {
-    // x = object.foo.bar
-    const nonParenthesized = makeTokens([
-      { name: 'word', text: 'x' },
-      { name: '=' },
-      { name: 'word', text: 'object' },
-      { name: '.' },
-      { name: 'word', text: 'foo' },
-      { name: '.' },
-      { name: 'word', text: 'bar' }
-    ])
+    const nonParenthesized = 'x = object.foo.bar'
 
-    // x = (object.foo).bar
-    const parenthesized = makeTokens([
-      { name: 'word', text: 'x' },
-      { name: '=' },
-      { name: '(' },
-      { name: 'word', text: 'object' },
-      { name: '.' },
-      { name: 'word', text: 'foo' },
-      { name: ')' },
-      { name: '.' },
-      { name: 'word', text: 'bar' }
-    ])
+    const parenthesized = 'x = (object.foo).bar'
 
-    // both should produce the same AST
-    for (const tokens of [nonParenthesized, parenthesized]) {
-      const result = parse(tokens)
-      assert.deepStrictEqual(stripRanges(result), {
-        complete: true,
-        value: {
-          type: 'Program',
-          imports: [],
-          children: [
-            {
-              type: 'Assignment',
-              key: { type: 'Identifier', name: 'x' },
-              value: {
-                type: 'PropertyAccess',
-                object: {
-                  type: 'PropertyAccess',
-                  object: {
-                    type: 'Identifier',
-                    name: 'object'
-                  },
-                  property: {
-                    type: 'Identifier',
-                    name: 'foo'
-                  }
-                },
-                property: {
-                  type: 'Identifier',
-                  name: 'bar'
-                }
-              }
-            }
-          ]
+    for (const source of [nonParenthesized, parenthesized]) {
+      const result = parse(lexSource(source))
+      assertResultComplete(result)
+
+      assert.deepStrictEqual(stripRanges(result.value.children), [
+        {
+          type: 'Assignment',
+          key: { type: 'Identifier', name: 'x' },
+          value: {
+            type: 'PropertyAccess',
+            object: {
+              type: 'PropertyAccess',
+              object: { type: 'Identifier', name: 'object' },
+              property: { type: 'Identifier', name: 'foo' }
+            },
+            property: { type: 'Identifier', name: 'bar' }
+          }
         }
-      })
+      ])
     }
   })
 
   it('should parse curve expressions', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: 'word', text: 'curve' },
-      { name: '[' },
-      { name: 'word', text: 'hold' },
-      { name: '(' },
-      { name: 'number', text: '0' },
-      { name: ')' },
-      { name: 'word', text: 'lin' },
-      { name: '(' },
-      { name: 'number', text: '0' },
-      { name: ',' },
-      { name: 'number', text: '1' },
-      { name: ')' },
-      { name: ']' }
-    ]))
+    const result = parse(lexSource('foo = curve[hold(0) lin(0, 1)]'))
+    assertResultComplete(result)
 
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'foo' },
-            value: {
-              type: 'Curve',
-              children: [
-                {
-                  type: 'CurveSegment',
-                  curveType: 'hold',
-                  parameters: [
-                    { type: 'Number', value: 0 }
-                  ]
-                },
-                {
-                  type: 'CurveSegment',
-                  curveType: 'lin',
-                  parameters: [
-                    { type: 'Number', value: 0 },
-                    { type: 'Number', value: 1 }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    })
-  })
-
-  it('should parse curve segment lengths', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: 'word', text: 'curve' },
-      { name: '[' },
-      { name: 'word', text: 'hold' },
-      { name: '(' },
-      { name: 'number', text: '0' },
-      { name: ')' },
-      { name: ':' },
-      { name: 'number', text: '3' },
-      { name: 'word', text: 'lin' },
-      { name: '(' },
-      { name: 'number', text: '0' },
-      { name: ',' },
-      { name: 'number', text: '1' },
-      { name: ')' },
-      { name: ':' },
-      { name: 'number', text: '1' },
-      { name: ']' }
-    ]))
-
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'foo' },
-            value: {
-              type: 'Curve',
-              children: [
-                {
-                  type: 'CurveSegment',
-                  curveType: 'hold',
-                  parameters: [
-                    { type: 'Number', value: 0 }
-                  ],
-                  length: { type: 'Number', value: 3 }
-                },
-                {
-                  type: 'CurveSegment',
-                  curveType: 'lin',
-                  parameters: [
-                    { type: 'Number', value: 0 },
-                    { type: 'Number', value: 1 }
-                  ],
-                  length: { type: 'Number', value: 1 }
-                }
-              ]
-            }
-          }
-        ]
-      }
-    })
-  })
-
-  it('should parse curve segments without parameters', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'foo' },
-      { name: '=' },
-      { name: 'word', text: 'curve' },
-      { name: '[' },
-      { name: 'word', text: 'hold' },
-      { name: 'word', text: 'hold' },
-      { name: ':' },
-      { name: 'number', text: '2' },
-      { name: ']' }
-    ]))
-
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'foo' },
-            value: {
-              type: 'Curve',
-              children: [
-                {
-                  type: 'CurveSegment',
-                  curveType: 'hold',
-                  parameters: []
-                },
-                {
-                  type: 'CurveSegment',
-                  curveType: 'hold',
-                  parameters: [],
-                  length: { type: 'Number', value: 2 }
-                }
-              ]
-            }
-          }
-        ]
-      }
-    })
-  })
-
-  it('should parse property access with function calls', () => {
-    // x = object.method1().method2()
-    const nonParenthesized = makeTokens([
-      { name: 'word', text: 'x' },
-      { name: '=' },
-      { name: 'word', text: 'object' },
-      { name: '.' },
-      { name: 'word', text: 'method1' },
-      { name: '(' },
-      { name: ')' },
-      { name: '.' },
-      { name: 'word', text: 'method2' },
-      { name: '(' },
-      { name: ')' }
-    ])
-
-    // x = (object.method1()).method2()
-    const parenthesized = makeTokens([
-      { name: 'word', text: 'x' },
-      { name: '=' },
-      { name: '(' },
-      { name: 'word', text: 'object' },
-      { name: '.' },
-      { name: 'word', text: 'method1' },
-      { name: '(' },
-      { name: ')' },
-      { name: '.' },
-      { name: 'word', text: 'method2' },
-      { name: ')' },
-      { name: '(' },
-      { name: ')' }
-    ])
-
-    for (const tokens of [nonParenthesized, parenthesized]) {
-      const result = parse(tokens)
-      assert.deepStrictEqual(stripRanges(result), {
-        complete: true,
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'foo' },
         value: {
-          type: 'Program',
-          imports: [],
+          type: 'Curve',
           children: [
             {
-              type: 'Assignment',
-              key: { type: 'Identifier', name: 'x' },
-              value: {
-                type: 'Call',
-                callee: {
-                  type: 'PropertyAccess',
-                  object: {
-                    type: 'Call',
-                    callee: {
-                      type: 'PropertyAccess',
-                      object: {
-                        type: 'Identifier',
-                        name: 'object'
-                      },
-                      property: {
-                        type: 'Identifier',
-                        name: 'method1'
-                      }
-                    },
-                    arguments: []
-                  },
-                  property: {
-                    type: 'Identifier',
-                    name: 'method2'
-                  }
-                },
-                arguments: []
-              }
+              type: 'CurveSegment',
+              curveType: 'hold',
+              parameters: [
+                { type: 'Number', value: 0 }
+              ]
+            },
+            {
+              type: 'CurveSegment',
+              curveType: 'lin',
+              parameters: [
+                { type: 'Number', value: 0 },
+                { type: 'Number', value: 1 }
+              ]
             }
           ]
         }
-      })
+      }
+    ])
+  })
+
+  it('should parse curve segment lengths', () => {
+    const result = parse(lexSource('foo = curve[hold(0):3 lin(0, 1):1]'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'foo' },
+        value: {
+          type: 'Curve',
+          children: [
+            {
+              type: 'CurveSegment',
+              curveType: 'hold',
+              parameters: [
+                { type: 'Number', value: 0 }
+              ],
+              length: { type: 'Number', value: 3 }
+            },
+            {
+              type: 'CurveSegment',
+              curveType: 'lin',
+              parameters: [
+                { type: 'Number', value: 0 },
+                { type: 'Number', value: 1 }
+              ],
+              length: { type: 'Number', value: 1 }
+            }
+          ]
+        }
+      }
+    ])
+  })
+
+  it('should parse curve segments without parameters', () => {
+    const result = parse(lexSource('foo = curve[hold hold:2]'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'foo' },
+        value: {
+          type: 'Curve',
+          children: [
+            {
+              type: 'CurveSegment',
+              curveType: 'hold',
+              parameters: []
+            },
+            {
+              type: 'CurveSegment',
+              curveType: 'hold',
+              parameters: [],
+              length: { type: 'Number', value: 2 }
+            }
+          ]
+        }
+      }
+    ])
+  })
+
+  it('should parse property access with function calls', () => {
+    const nonParenthesized = 'x = object.method1().method2()'
+    const parenthesized = 'x = (object.method1()).method2()'
+
+    for (const source of [nonParenthesized, parenthesized]) {
+      const result = parse(lexSource(source))
+      assertResultComplete(result)
+
+      assert.deepStrictEqual(stripRanges(result.value.children), [
+        {
+          type: 'Assignment',
+          key: { type: 'Identifier', name: 'x' },
+          value: {
+            type: 'Call',
+            callee: {
+              type: 'PropertyAccess',
+              object: {
+                type: 'Call',
+                callee: {
+                  type: 'PropertyAccess',
+                  object: { type: 'Identifier', name: 'object' },
+                  property: { type: 'Identifier', name: 'method1' }
+                },
+                arguments: []
+              },
+              property: { type: 'Identifier', name: 'method2' }
+            },
+            arguments: []
+          }
+        }
+      ])
     }
   })
 
   it('should parse calling the result of a call', () => {
-    // x = factory()(arg1, arg2)
-    const result = parse(makeTokens([
-      { name: 'word', text: 'x' },
-      { name: '=' },
-      { name: 'word', text: 'factory' },
-      { name: '(' },
-      { name: ')' },
-      { name: '(' },
-      { name: 'word', text: 'arg1' },
-      { name: ',' },
-      { name: 'word', text: 'arg2' },
-      { name: ')' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
-          {
-            type: 'Assignment',
-            key: { type: 'Identifier', name: 'x' },
-            value: {
-              type: 'Call',
-              callee: {
-                type: 'Call',
-                callee: {
-                  type: 'Identifier',
-                  name: 'factory'
-                },
-                arguments: []
-              },
-              arguments: [
-                { type: 'Identifier', name: 'arg1' },
-                { type: 'Identifier', name: 'arg2' }
-              ]
-            }
-          }
-        ]
+    const result = parse(lexSource('x = factory()(arg1, arg2)'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'x' },
+        value: {
+          type: 'Call',
+          callee: {
+            type: 'Call',
+            callee: { type: 'Identifier', name: 'factory' },
+            arguments: []
+          },
+          arguments: [
+            { type: 'Identifier', name: 'arg1' },
+            { type: 'Identifier', name: 'arg2' }
+          ]
+        }
       }
-    })
+    ])
   })
 
   it('should parse mixer buses', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'mixer' },
-      { name: '{' },
-      { name: 'word', text: 'bus' },
-      { name: 'word', text: 'mybus' },
-      { name: '(' },
-      { name: 'word', text: 'gain' },
-      { name: ':' },
-      { name: 'number', text: '-3' },
-      { name: '.' },
-      { name: 'word', text: 'db' },
-      { name: ')' },
-      { name: '{' },
-      { name: 'word', text: 'kick' },
-      { name: 'word', text: 'snare' },
-      { name: 'word', text: 'hihat' },
-      { name: 'word', text: 'effect' },
-      { name: 'word', text: 'fx' },
-      { name: '.' },
-      { name: 'word', text: 'pan' },
-      { name: '(' },
-      { name: 'number', text: '0.5' },
-      { name: ')' },
-      { name: '}' },
-      { name: '}' }
-    ]))
-    assert.deepStrictEqual(stripRanges(result), {
-      complete: true,
-      value: {
-        type: 'Program',
-        imports: [],
-        children: [
+    const source = [
+      'mixer {',
+      '  bus mybus(gain: (-3).db) {',
+      '    kick snare hihat',
+      '    effect fx.pan(0.5)',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'MixerStatement',
+        properties: [],
+        buses: [
           {
-            type: 'MixerStatement',
-            properties: [],
-            buses: [
+            type: 'BusStatement',
+            name: { type: 'Identifier', name: 'mybus' },
+            properties: [
               {
-                type: 'BusStatement',
-                name: { type: 'Identifier', name: 'mybus' },
-                properties: [
-                  {
-                    type: 'Property',
-                    key: { type: 'Identifier', name: 'gain' },
-                    value: {
-                      type: 'PropertyAccess',
-                      object: { type: 'Number', value: -3 },
-                      property: { type: 'Identifier', name: 'db' }
-                    }
-                  }
-                ],
-                sources: [
-                  { type: 'Identifier', name: 'kick' },
-                  { type: 'Identifier', name: 'snare' },
-                  { type: 'Identifier', name: 'hihat' }
-                ],
-                effects: [
-                  {
-                    type: 'EffectStatement',
-                    expression: {
-                      type: 'Call',
-                      callee: {
-                        type: 'PropertyAccess',
-                        object: { type: 'Identifier', name: 'fx' },
-                        property: { type: 'Identifier', name: 'pan' }
-                      },
-                      arguments: [
-                        { type: 'Number', value: 0.5 }
-                      ]
-                    }
-                  }
-                ]
+                type: 'Property',
+                key: { type: 'Identifier', name: 'gain' },
+                value: {
+                  type: 'PropertyAccess',
+                  object: { type: 'Number', value: -3 },
+                  property: { type: 'Identifier', name: 'db' }
+                }
+              }
+            ],
+            sources: [
+              { type: 'Identifier', name: 'kick' },
+              { type: 'Identifier', name: 'snare' },
+              { type: 'Identifier', name: 'hihat' }
+            ],
+            effects: [
+              {
+                type: 'EffectStatement',
+                expression: {
+                  type: 'Call',
+                  callee: {
+                    type: 'PropertyAccess',
+                    object: { type: 'Identifier', name: 'fx' },
+                    property: { type: 'Identifier', name: 'pan' }
+                  },
+                  arguments: [
+                    { type: 'Number', value: 0.5 }
+                  ]
+                }
               }
             ]
           }
         ]
       }
-    })
+    ])
   })
 
   it('should reject unnamed parts', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'track' },
-      { name: '{' },
-      { name: 'word', text: 'part' },
-      { name: '(' },
-      { name: 'number', text: '4' },
-      { name: 'word', text: 'bars' },
-      { name: ')' },
-      { name: '{' },
-      { name: '}' },
-      { name: '}' }
-    ]))
+    const result = parse(lexSource('track { part (4 bars) {} }'))
     assert.strictEqual(result.complete, false)
     assert.strictEqual(result.error.message, 'Unexpected "("; expected part name')
   })
 
   it('should reject unnamed buses', () => {
-    const result = parse(makeTokens([
-      { name: 'word', text: 'mixer' },
-      { name: '{' },
-      { name: 'word', text: 'bus' },
-      { name: '{' },
-      { name: '}' },
-      { name: '}' }
-    ]))
+    const result = parse(lexSource('mixer { bus {} }'))
     assert.strictEqual(result.complete, false)
     assert.strictEqual(result.error.message, 'Unexpected "{"; expected bus name')
   })

--- a/packages/language/test/test-utils.ts
+++ b/packages/language/test/test-utils.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-parameters */
 
+import type { Result, SuccessResult } from '../src/result/result.js'
+import assert from 'node:assert'
+
 export type Equals<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends
   (<T>() => T extends Y ? 1 : 2) ? true : false
@@ -7,4 +10,10 @@ export type Equals<X, Y> =
 // Passes typechecking iff types X and Y are exactly equal (no arguments)
 export function expectTypeEquals<X, Y> (..._args: [Equals<X, Y>] extends [true] ? [] : ['Types are not equal']): void {
   // no-op
+}
+
+export function assertResultComplete<TValue, TError extends Error> (
+  result: Result<TValue, TError>
+): asserts result is SuccessResult<TValue> {
+  assert.ok(result.complete, result.complete ? undefined : result.error)
 }


### PR DESCRIPTION
1. Assume the lexer produces correct tokens, as covered by lexer tests. This allows us to use source strings in parser tests instead of hand-crafting verbose token arrays.
2. Shorten assertions to check primarily the AST structure rather than the full return value hierarchy, unless relevant to the test case.