### PR TITLE
fix: Load audio worklet module from separate file

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -27,7 +27,15 @@ const config = defineConfig({
     }
   },
   build: {
-    outDir: 'dist'
+    outDir: 'dist',
+
+    // Exclude audio worklet processors from inlining, as the Content Security Policy
+    // may prevent loading them from base64-encoded data URLs.
+    assetsInlineLimit: (filePath) => {
+      if (filePath.endsWith('.worklet.js')) {
+        return false
+      }
+    }
   }
 })
 

--- a/packages/webaudio/src/time-tracker/time-tracker.worklet.js
+++ b/packages/webaudio/src/time-tracker/time-tracker.worklet.js
@@ -1,0 +1,56 @@
+/**
+ * @import { AudioWorkletGlobalScope, AudioWorkletProcessInputs, AudioWorkletProcessOutputs } from '../worklets/types.js'
+ */
+
+const workletScope = /** @type {AudioWorkletGlobalScope} */ (/** @type {unknown} */ (globalThis))
+
+class CadenceTimeTrackerProcessor extends workletScope.AudioWorkletProcessor {
+  #framesUntilPost
+  #postIntervalFrames
+
+  constructor () {
+    super()
+
+    this.#postIntervalFrames = 1200 // ~25ms at 48kHz
+    this.#framesUntilPost = 0
+
+    /**
+     * @param {MessageEvent} event
+     */
+    this.port.onmessage = (event) => {
+      if (event.data == null || typeof event.data !== 'object' || event.data.type !== 'init') {
+        return
+      }
+
+      const { postIntervalFrames } = event.data
+      if (typeof postIntervalFrames !== 'number') {
+        return
+      }
+
+      this.#postIntervalFrames = Math.max(1, Math.floor(postIntervalFrames))
+      this.#framesUntilPost = 0
+    }
+  }
+
+  /**
+   * @param {AudioWorkletProcessInputs} inputs
+   * @param {AudioWorkletProcessOutputs} outputs
+   */
+  process (inputs, outputs) {
+    const output = outputs[0]
+    if (output?.[0] == null) {
+      return true
+    }
+
+    this.#framesUntilPost -= output[0].length
+
+    if (this.#framesUntilPost <= 0) {
+      this.#framesUntilPost += this.#postIntervalFrames
+      this.port.postMessage({ type: 'time', currentTime: workletScope.currentTime })
+    }
+
+    return true
+  }
+}
+
+workletScope.registerProcessor('cadence-time-tracker', CadenceTimeTrackerProcessor)

--- a/packages/webaudio/src/time-tracker/worklet.ts
+++ b/packages/webaudio/src/time-tracker/worklet.ts
@@ -1,8 +1,9 @@
-import { numeric, MutableObservable } from '@utility'
+import { MutableObservable, numeric } from '@utility'
+import { addWorkletModule } from '../worklets/loader.js'
 import type { TimeTracker, TimeTrackerOptions } from './common.js'
 
 const PROCESSOR_NAME = 'cadence-time-tracker'
-const moduleLoadPromises = new WeakMap<BaseAudioContext, Promise<void>>()
+const PROCESSOR_MODULE_URL = new URL('./time-tracker.worklet.js', import.meta.url)
 
 export async function createWorkletTimeTracker (
   ctx: BaseAudioContext,
@@ -13,7 +14,7 @@ export async function createWorkletTimeTracker (
 
   const time = new MutableObservable(numeric('s', 0))
 
-  await ensureModuleLoaded(ctx)
+  await addWorkletModule(ctx, PROCESSOR_MODULE_URL.href)
 
   const node = new AudioWorkletNode(ctx, PROCESSOR_NAME, {
     numberOfInputs: 0,
@@ -51,81 +52,4 @@ export async function createWorkletTimeTracker (
   }
 
   return { time, dispose }
-}
-
-async function ensureModuleLoaded (ctx: BaseAudioContext): Promise<void> {
-  if (!('audioWorklet' in ctx) || (ctx as any).audioWorklet == null) {
-    throw new Error('AudioWorklet not available')
-  }
-
-  const existing = moduleLoadPromises.get(ctx)
-  if (existing != null) {
-    await existing
-    return
-  }
-
-  try {
-    const promise = (async () => {
-      const source = createProcessorModuleSource()
-      const url = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))
-
-      try {
-        await (ctx as any).audioWorklet.addModule(url)
-      } finally {
-        URL.revokeObjectURL(url)
-      }
-    })()
-
-    moduleLoadPromises.set(ctx, promise)
-    await promise
-  } catch (err: unknown) {
-    moduleLoadPromises.delete(ctx)
-    throw err
-  }
-}
-
-function createProcessorModuleSource (): string {
-  return `
-class CadenceTimeTrackerProcessor extends AudioWorkletProcessor {
-  #framesUntilPost
-  #postIntervalFrames
-
-  constructor () {
-    super()
-
-    this.#framesUntilPost = 0
-    this.#postIntervalFrames = 1200 // ~25ms at 48kHz
-
-    this.port.onmessage = (event) => {
-      if (event == null || event.data == null || typeof event.data !== 'object' || event.data.type !== 'init') {
-        return
-      }
-
-      const { postIntervalFrames } = event.data
-
-      this.#postIntervalFrames = Math.max(1, Math.floor(postIntervalFrames))
-      this.#framesUntilPost = 0
-    }
-  }
-
-  process (inputs, outputs) {
-    const output = outputs[0]
-    if (output == null || output[0] == null) {
-      return true
-    }
-
-    const frames = output[0].length
-    this.#framesUntilPost -= frames
-
-    if (this.#framesUntilPost <= 0) {
-      this.#framesUntilPost += this.#postIntervalFrames
-      this.port.postMessage({ type: 'time', currentTime })
-    }
-
-    return true
-  }
-}
-
-registerProcessor('${PROCESSOR_NAME}', CadenceTimeTrackerProcessor);
-`.trimStart()
 }

--- a/packages/webaudio/src/worklets/loader.ts
+++ b/packages/webaudio/src/worklets/loader.ts
@@ -1,0 +1,60 @@
+import { numeric } from '@utility'
+
+interface AudioContextWithWorklet extends BaseAudioContext {
+  readonly audioWorklet: AudioWorklet
+}
+
+const LOAD_TIMEOUT = numeric('s', 30)
+
+const workletCache = new WeakMap<BaseAudioContext, Map<string, Promise<void>>>()
+
+export async function addWorkletModule (ctx: BaseAudioContext, moduleUrl: string): Promise<void> {
+  const cached = workletCache.get(ctx)?.get(moduleUrl)
+
+  if (cached != null) {
+    try {
+      await cached
+      return
+    } catch {
+      // Failed to load previously, try again
+    }
+  }
+
+  const promise = add(ctx, moduleUrl, AbortSignal.timeout(LOAD_TIMEOUT.value * 1000))
+
+  let ctxCache = workletCache.get(ctx)
+  if (ctxCache == null) {
+    ctxCache = new Map()
+    workletCache.set(ctx, ctxCache)
+  }
+
+  ctxCache.set(moduleUrl, promise)
+
+  try {
+    await promise
+  } catch (err) {
+    ctxCache.delete(moduleUrl)
+    throw err
+  }
+}
+
+async function add (ctx: BaseAudioContext, moduleUrl: string, signal: AbortSignal): Promise<void> {
+  if (!('audioWorklet' in ctx) || (ctx as any).audioWorklet == null) {
+    throw new Error('AudioWorklet not available')
+  }
+
+  const load = (ctx as AudioContextWithWorklet).audioWorklet.addModule(moduleUrl)
+
+  const abort = new Promise<void>((resolve, reject) => {
+    const onAbort = () => reject(new Error('Loading AudioWorklet module aborted'))
+
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
+  await Promise.race([load, abort])
+}

--- a/packages/webaudio/src/worklets/types.ts
+++ b/packages/webaudio/src/worklets/types.ts
@@ -1,0 +1,20 @@
+export type AudioWorkletProcessInputs = ReadonlyArray<readonly Float32Array[]>
+
+export type AudioWorkletProcessOutputs = Array<Array<Float32Array | undefined> | undefined>
+
+export interface AudioWorkletProcessor {
+  readonly port: MessagePort
+  process(
+    inputs: AudioWorkletProcessInputs,
+    outputs: AudioWorkletProcessOutputs,
+    parameters: Record<string, Float32Array>
+  ): boolean
+}
+
+type AudioWorkletProcessorConstructor = new () => AudioWorkletProcessor
+
+export interface AudioWorkletGlobalScope {
+  readonly AudioWorkletProcessor: AudioWorkletProcessorConstructor
+  readonly currentTime: number
+  registerProcessor(name: string, processorCtor: AudioWorkletProcessorConstructor): void
+}


### PR DESCRIPTION
This patch refactors the loader code of the time tracker worklet to increase reusability, and moves the worklet processor code to a separate file. This has the benefit of improved maintainability (e.g. syntax highlighting and linting work properly) and also allows us to load the worklet module without inlining.