### PR TITLE
chore: Exclude worklets from TSConfig

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,7 +165,11 @@ export default defineConfig([
   {
     ignores: [
       'dist',
-      'packages/*/dist'
+      'packages/*/dist',
+
+      // TypeScript treats worklets as global scripts which interfere with one another.
+      // They must be excluded from the TSConfig, and therefore also from ESLint, which relies on the TSConfig.
+      'packages/webaudio/src/**/*.worklet.js'
     ]
   },
   {

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -10,5 +10,8 @@
     "./packages/*/test-browser",
     "./packages/*/vite.config.ts",
     "./packages/*/vitest.config.ts"
+  ],
+  "exclude": [
+    "./packages/webaudio/src/**/*.worklet.js"
   ]
 }


### PR DESCRIPTION
TypeScript treats worklets as "scripts" rather than "modules", meaning that once a second worklet is added, they will be typechecked together. This causes issues with duplicate declarations. Due to lack of a proper solution, the best option is to exclude worklets from typechecking.