### PR TITLE
refactor: Use async factory for graph instances

### DIFF
--- a/packages/webaudio/src/engine/session.ts
+++ b/packages/webaudio/src/engine/session.ts
@@ -45,13 +45,16 @@ export function createAudioSession (
   const position = new MutableObservable(range.start)
   const errors = new MutableObservable<readonly Error[]>([])
 
-  const webAudioGraph = createWebAudioGraph(graph, transport, fetcher)
-  disposeStack.pushDisposable(webAudioGraph)
+  const webAudioGraphPromise = createWebAudioGraph(graph, transport, fetcher)
+    .then((webAudioGraph) => {
+      disposeStack.pushDisposable(webAudioGraph)
+      return webAudioGraph
+    })
 
   let disposed = false
 
   const start = () => {
-    webAudioGraph.loaded.then(() => {
+    webAudioGraphPromise.then(() => {
       if (disposed) {
         return
       }

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -72,7 +72,6 @@ export function createWidthInstance (node: WidthNode, transport: Transport): Ins
   return {
     input,
     output: merger,
-    loaded: Promise.resolve(),
     dispose: () => {
       input.disconnect()
       splitter.disconnect()
@@ -96,23 +95,20 @@ export function createReverbInstance (node: ReverbNode, transport: Transport): I
 
   const audioNode = ctx.createConvolver()
 
-  const promise = generateReverbImpulseResponse({
+  audioNode.buffer = generateReverbImpulseResponse({
     createBuffer: (options) => new AudioBuffer(options),
     numberOfChannels: ctx.destination.channelCount,
     sampleRate: ctx.sampleRate,
     decay: node.decay
-  }).then((buffer) => {
-    audioNode.buffer = buffer
   })
 
-  return toInstance(audioNode, promise)
+  return toInstance(audioNode)
 }
 
 function toInstance (node: AudioNode, loaded = Promise.resolve()): Instance {
   return {
     input: node,
     output: node,
-    loaded,
     dispose: () => {
       node.disconnect()
     }

--- a/packages/webaudio/src/graph/factory.ts
+++ b/packages/webaudio/src/graph/factory.ts
@@ -18,6 +18,6 @@ const factories = Object.freeze({
   sample: createSampleInstance
 })
 
-export function createNodeInstance (node: Node, transport: Transport, fetcher: AudioFetcher): Instance {
+export async function createNodeInstance (node: Node, transport: Transport, fetcher: AudioFetcher): Promise<Instance> {
   return factories[node.type](node as any, transport, fetcher)
 }

--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -5,36 +5,42 @@ import { createNodeInstance } from './factory.js'
 import type { Instance } from './instance.js'
 
 export interface WebAudioGraph {
-  /**
-   * Resolves once all instances have finished their load attempts.
-   * Rejects if any instance fails to load or the timeout is reached.
-   */
-  readonly loaded: Promise<void>
-
   readonly dispose: () => void
 }
 
-export function createWebAudioGraph (graph: AudioGraph<Node>, transport: Transport, fetcher: AudioFetcher): WebAudioGraph {
-  const instances = createInstances(graph, transport, fetcher)
-  const promises = Array.from(instances.values(), (item) => item.loaded)
+export async function createWebAudioGraph (graph: AudioGraph<Node>, transport: Transport, fetcher: AudioFetcher): Promise<WebAudioGraph> {
+  const instances = new Map<NodeId, Instance>()
+  let disposed = false
+
+  const promises = new Map<NodeId, Promise<void>>()
+  for (const node of graph.nodes.values()) {
+    promises.set(node.id, createNodeInstance(node, transport, fetcher).then((instance) => {
+      if (disposed) {
+        instance.dispose()
+        return
+      }
+
+      instances.set(node.id, instance)
+    }))
+  }
+
+  try {
+    await Promise.all(promises.values())
+  } catch (err: unknown) {
+    disposed = true
+    instances.forEach((instance) => instance.dispose())
+    throw err
+  }
 
   setupRoutings(graph, instances, transport.input)
   scheduleNoteEvents(graph, instances)
 
   return {
-    loaded: Promise.all(promises).then(() => undefined),
-    dispose: () => instances.forEach((instance) => instance.dispose())
+    dispose: () => {
+      disposed = true
+      instances.forEach((instance) => instance.dispose())
+    }
   }
-}
-
-function createInstances (graph: AudioGraph<Node>, transport: Transport, fetcher: AudioFetcher): Map<NodeId, Instance> {
-  const instances = new Map<NodeId, Instance>()
-
-  for (const node of graph.nodes.values()) {
-    instances.set(node.id, createNodeInstance(node, transport, fetcher))
-  }
-
-  return instances
 }
 
 function setupRoutings (graph: AudioGraph<Node>, instances: Map<NodeId, Instance>, output: AudioNode): void {

--- a/packages/webaudio/src/graph/instance.ts
+++ b/packages/webaudio/src/graph/instance.ts
@@ -1,7 +1,6 @@
 import type { NoteOptions } from '@audiograph'
 
 export interface Instance {
-  readonly loaded: Promise<void>
   readonly dispose: () => void
 
   readonly input?: AudioNode

--- a/packages/webaudio/src/graph/noise.ts
+++ b/packages/webaudio/src/graph/noise.ts
@@ -11,7 +11,7 @@ export function generateReverbImpulseResponse (options: {
   readonly numberOfChannels: number
   readonly sampleRate: number
   readonly decay: Numeric<'s'>
-}): Promise<AudioBuffer> {
+}): AudioBuffer {
   const { sampleRate, numberOfChannels, decay, createBuffer } = options
 
   // buffer length must be non-zero
@@ -31,7 +31,7 @@ export function generateReverbImpulseResponse (options: {
     }
   }
 
-  return Promise.resolve(ir)
+  return ir
 }
 
 // 2 seconds at 44.1kHz

--- a/packages/webaudio/src/graph/sample.ts
+++ b/packages/webaudio/src/graph/sample.ts
@@ -5,7 +5,7 @@ import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
 import type { Instance } from './instance.js'
 
-export function createSampleInstance (node: SampleNode, transport: Transport, fetcher: AudioFetcher): Instance {
+export async function createSampleInstance (node: SampleNode, transport: Transport, fetcher: AudioFetcher): Promise<Instance> {
   const { ctx } = transport
 
   // declick
@@ -18,10 +18,7 @@ export function createSampleInstance (node: SampleNode, transport: Transport, fe
 
   const output = ctx.createGain()
 
-  let sampleBuffer: AudioBuffer | undefined
-  const loaded = fetcher.fetch(ctx, node.sampleUrl).then((buffer) => {
-    sampleBuffer = buffer
-  })
+  const sampleBuffer = await fetcher.fetch(ctx, node.sampleUrl)
 
   const dispose = () => {
     output.disconnect()
@@ -33,7 +30,7 @@ export function createSampleInstance (node: SampleNode, transport: Transport, fe
   }
 
   const triggerNote = (options: NoteOptions) => transport.schedule(options.time, (time) => {
-    if (sampleBuffer == null || time < 0) {
+    if (time < 0) {
       return
     }
 
@@ -90,12 +87,7 @@ export function createSampleInstance (node: SampleNode, transport: Transport, fe
     }
   })
 
-  return {
-    loaded,
-    dispose,
-    output,
-    triggerNote
-  }
+  return { dispose, output, triggerNote }
 }
 
 interface ActiveSource {

--- a/packages/webaudio/src/renderer/renderer.ts
+++ b/packages/webaudio/src/renderer/renderer.ts
@@ -44,9 +44,6 @@ export function createAudioRenderer (options: AudioRendererOptions): AudioRender
         duration
       })
 
-      const webAudioGraph = createWebAudioGraph(graph, transport, fetcher)
-      disposeStack.pushDisposable(webAudioGraph)
-
       if (options.onProgress != null) {
         disposeStack.push(transport.time.subscribe((time) => {
           if (time == null) {
@@ -59,7 +56,9 @@ export function createAudioRenderer (options: AudioRendererOptions): AudioRender
       let audioBuffer: AudioBuffer | undefined
 
       try {
-        await webAudioGraph.loaded
+        const webAudioGraph = await createWebAudioGraph(graph, transport, fetcher)
+        disposeStack.pushDisposable(webAudioGraph)
+
         audioBuffer = await transport.render()
       } catch (err: unknown) {
         return {

--- a/packages/webaudio/test/graph/noise.test.ts
+++ b/packages/webaudio/test/graph/noise.test.ts
@@ -37,11 +37,11 @@ class MockAudioBuffer {
 
 describe('graph/noise.ts', () => {
   describe('generateReverbImpulseResponse', () => {
-    it('generates an impulse response with the expected properties', async () => {
+    it('generates an impulse response with the expected properties', () => {
       const sampleRate = 44_100
       const decay = numeric('s', 1.5)
 
-      const ir = await generateReverbImpulseResponse({
+      const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
         numberOfChannels: 4,
         sampleRate,
@@ -55,11 +55,11 @@ describe('graph/noise.ts', () => {
       assert.strictEqual(ir.sampleRate, sampleRate)
     })
 
-    it('generates an impulse response with a decaying envelope', async () => {
+    it('generates an impulse response with a decaying envelope', () => {
       const sampleRate = 44_100
       const decay = numeric('s', 2)
 
-      const ir = await generateReverbImpulseResponse({
+      const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
         numberOfChannels: 1,
         sampleRate,
@@ -76,11 +76,11 @@ describe('graph/noise.ts', () => {
       assert(secondHalfAvg < firstHalfAvg * 0.1, `Expected second half average (${secondHalfAvg}) to be less than 10% of first half average (${firstHalfAvg})`)
     })
 
-    it('generates different noise for different channels', async () => {
+    it('generates different noise for different channels', () => {
       const sampleRate = 44_100
       const decay = numeric('s', 1)
 
-      const ir = await generateReverbImpulseResponse({
+      const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
         numberOfChannels: 2,
         sampleRate,
@@ -94,11 +94,11 @@ describe('graph/noise.ts', () => {
       assert.notDeepStrictEqual(channelData1, channelData2, 'Expected different noise patterns for different channels')
     })
 
-    it('handles long decay times without errors', async () => {
+    it('handles long decay times without errors', () => {
       const sampleRate = 44_100
       const decay = numeric('s', 30)
 
-      const ir = await generateReverbImpulseResponse({
+      const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
         numberOfChannels: 1,
         sampleRate,


### PR DESCRIPTION
Removes the `loaded` promise on the webaudio graph, and each node instance, in favor of using async factories. This is more flexible and simpler in most cases, with a slight disadvantage of not being able to do some work during loading, such as connecting nodes.