### PR TITLE
fix: Wait for worklet ready before processing

### DIFF
--- a/packages/webaudio/src/worklets/metering/factory.ts
+++ b/packages/webaudio/src/worklets/metering/factory.ts
@@ -17,7 +17,7 @@ export async function createMeter<T> (
 ): Promise<MeterInstance<T | undefined>> {
   await addWorkletModule(ctx, url.href)
 
-  const measurements = new MutableObservable<T | undefined>(undefined)
+  let disposed = false
 
   const node = new AudioWorkletNode(ctx, processor, {
     numberOfInputs: 1,
@@ -25,9 +25,19 @@ export async function createMeter<T> (
     outputChannelCount: [1]
   })
 
-  let disposed = false
+  // Wait for configuration to be acknowledged before processing begins
+  const readyPromise = new Promise<void>((resolve) => {
+    node.port.onmessage = (event: MessageEvent) => {
+      if (event.data === 'ready') {
+        resolve()
+      }
+    }
+  })
 
   node.port.postMessage(configuration)
+  await readyPromise
+
+  const measurements = new MutableObservable<T | undefined>(undefined)
 
   node.port.onmessage = (event: MessageEvent<T>) => {
     if (!disposed) {

--- a/packages/webaudio/src/worklets/metering/time-meter.worklet.js
+++ b/packages/webaudio/src/worklets/metering/time-meter.worklet.js
@@ -18,6 +18,8 @@ class TimeMeterProcessor extends workletScope.AudioWorkletProcessor {
     this.port.onmessage = (event) => {
       this.#interval = event.data.interval
       this.#counter = 0
+
+      this.port.postMessage('ready')
     }
   }
 


### PR DESCRIPTION
Fixes a potential race condition where the audio context could start processing before the worklet's configuration is applied, which would lead to lost measurements.