### PR TITLE
feat: Implement gain meter node

### DIFF
--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -5,13 +5,20 @@ import type { AnyNode } from './graph.js'
 
 export interface NodeTypeMap {
   readonly identity: IdentityNode
+
+  // effects
   readonly gain: GainNode
   readonly pan: PanNode
   readonly biquad: BiquadNode
   readonly width: WidthNode
   readonly delay: DelayNode
   readonly reverb: ReverbNode
+
+  // sources
   readonly sample: SampleNode
+
+  // metering
+  readonly gain_meter: GainMeterNode
 }
 
 export type Node = NodeTypeMap[keyof NodeTypeMap]
@@ -19,6 +26,8 @@ export type Node = NodeTypeMap[keyof NodeTypeMap]
 export interface IdentityNode extends AnyNode {
   readonly type: 'identity'
 }
+
+// effects
 
 export interface GainNode extends AnyNode {
   readonly type: 'gain'
@@ -52,9 +61,22 @@ export interface ReverbNode extends AnyNode {
   readonly decay: Numeric<'s'>
 }
 
+// sources
+
 export interface SampleNode extends AnyNode {
   readonly type: 'sample'
   readonly sampleUrl: string
   readonly rootNote: MidiNote
   readonly length?: Numeric<'s'>
+}
+
+// metering
+
+export interface GainMeterNode extends AnyNode {
+  readonly type: 'gain_meter'
+
+  /**
+   * The approximate interval, in seconds, at which the gain meter should post updates.
+   */
+  readonly interval: Numeric<'s'>
 }

--- a/packages/webaudio/src/graph/factory.ts
+++ b/packages/webaudio/src/graph/factory.ts
@@ -3,11 +3,13 @@ import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
 import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance, createWidthInstance } from './effect.js'
 import type { Instance } from './instance.js'
+import { createGainMeterInstance } from './metering.js'
 import { createSampleInstance } from './sample.js'
 
 const factories = Object.freeze({
   identity: createIdentityInstance,
 
+  // effects
   gain: createGainInstance,
   pan: createPanInstance,
   biquad: createBiquadInstance,
@@ -15,7 +17,11 @@ const factories = Object.freeze({
   delay: createDelayInstance,
   reverb: createReverbInstance,
 
-  sample: createSampleInstance
+  // sources
+  sample: createSampleInstance,
+
+  // metering
+  gain_meter: createGainMeterInstance
 })
 
 export async function createNodeInstance (node: Node, transport: Transport, fetcher: AudioFetcher): Promise<Instance> {

--- a/packages/webaudio/src/graph/metering.ts
+++ b/packages/webaudio/src/graph/metering.ts
@@ -1,0 +1,18 @@
+import type { GainMeterNode } from '@audiograph'
+import type { Transport } from '../transport/transport.js'
+import type { Instance } from './instance.js'
+import { createGainMeter } from '../worklets/metering/factory.js'
+
+export async function createGainMeterInstance (node: GainMeterNode, transport: Transport): Promise<Instance> {
+  const instance = await createGainMeter(transport.ctx, {
+    interval: node.interval.value * transport.ctx.sampleRate
+  })
+
+  return {
+    input: instance.node,
+    output: instance.node,
+    dispose: () => {
+      instance.dispose()
+    }
+  }
+}

--- a/packages/webaudio/src/worklets/metering/factory.ts
+++ b/packages/webaudio/src/worklets/metering/factory.ts
@@ -1,7 +1,7 @@
 import type { Observable } from '@utility'
 import { MutableObservable } from '@utility'
 import { addWorkletModule } from '../loader.js'
-import type { MeterConfiguration, TimeMeasurement } from './messages.js'
+import type { GainMeasurement, MeterConfiguration, TimeMeasurement } from './messages.js'
 
 export interface MeterInstance<T> {
   readonly dispose: () => void
@@ -61,4 +61,9 @@ type MeterFactory<T> = (ctx: BaseAudioContext, configuration: MeterConfiguration
 export const createTimeMeter: MeterFactory<TimeMeasurement> = async (ctx, configuration) => {
   const url = new URL('./time-meter.worklet.js', import.meta.url)
   return await createMeter(ctx, url, 'time_meter', configuration)
+}
+
+export const createGainMeter: MeterFactory<GainMeasurement> = async (ctx, configuration) => {
+  const url = new URL('./gain-meter.worklet.js', import.meta.url)
+  return await createMeter(ctx, url, 'gain_meter', configuration)
 }

--- a/packages/webaudio/src/worklets/metering/gain-meter.worklet.js
+++ b/packages/webaudio/src/worklets/metering/gain-meter.worklet.js
@@ -1,0 +1,88 @@
+/**
+ * @import { AudioWorkletGlobalScope, AudioWorkletProcessInputs, AudioWorkletProcessOutputs } from '../types.js'
+ * @import { MeterConfiguration } from './messages.js'
+ */
+
+const workletScope = /** @type {AudioWorkletGlobalScope} */ (/** @type {unknown} */ (globalThis))
+
+class GainMeterProcessor extends workletScope.AudioWorkletProcessor {
+  #interval = 0
+  #counter = 0
+
+  #peak = [0, 0]
+  #sampleCount = [0, 0]
+  #sumSquares = [0, 0]
+
+  constructor () {
+    super()
+
+    /**
+     * @param {MessageEvent<MeterConfiguration>} event
+     */
+    this.port.onmessage = (event) => {
+      this.#interval = event.data.interval
+      this.#counter = 0
+
+      this.#peak = [0, 0]
+      this.#sampleCount = [0, 0]
+      this.#sumSquares = [0, 0]
+
+      this.port.postMessage('ready')
+    }
+  }
+
+  /**
+   * @param {AudioWorkletProcessInputs} inputs
+   * @param {AudioWorkletProcessOutputs} outputs
+   */
+  process (inputs, outputs) {
+    if (this.#interval <= 0) {
+      return true
+    }
+
+    const channels = inputs[0] ?? []
+    const meterChannels = channels.length === 1 ? [channels[0], channels[0]] : [channels[0], channels[1]]
+
+    for (let channelIndex = 0; channelIndex < 2; ++channelIndex) {
+      const channel = meterChannels[channelIndex]
+      const frameCount = channel?.length ?? 0
+
+      if (frameCount === 0) {
+        continue
+      }
+
+      for (let i = 0; i < frameCount; ++i) {
+        const value = channel[i]
+        const magnitude = Math.abs(value)
+
+        this.#sumSquares[channelIndex] += value * value
+        this.#peak[channelIndex] = Math.max(this.#peak[channelIndex], magnitude)
+      }
+
+      this.#sampleCount[channelIndex] += frameCount
+    }
+
+    const frameCount = channels[0]?.length ?? channels[1]?.length ?? 0
+
+    this.#counter -= frameCount
+
+    if (this.#counter <= 0) {
+      this.#counter += this.#interval
+
+      const rms = [0, 1].map((channelIndex) => {
+        const sampleCount = this.#sampleCount[channelIndex]
+        return sampleCount > 0 ? Math.sqrt(this.#sumSquares[channelIndex] / sampleCount) : 0
+      })
+
+      this.port.postMessage({ peak: this.#peak, rms })
+
+      this.#peak = [0, 0]
+      this.#sampleCount = [0, 0]
+      this.#sumSquares = [0, 0]
+    }
+
+    return true
+  }
+}
+
+workletScope.registerProcessor('gain_meter', GainMeterProcessor)

--- a/packages/webaudio/src/worklets/metering/messages.ts
+++ b/packages/webaudio/src/worklets/metering/messages.ts
@@ -11,3 +11,17 @@ export interface TimeMeasurement {
    */
   readonly time: number
 }
+
+export interface GainMeasurement {
+  /**
+   * The signal's peak values for the left and right channels, each representing the
+   * maximum absolute amplitude over the interval since the last update, in the range [0, 1].
+   */
+  readonly peak: readonly [number, number]
+
+  /**
+   * The signal's root mean square (RMS) values for the left and right channels, each
+   * representing the average power over the interval since the last update, in the range [0, 1].
+   */
+  readonly rms: readonly [number, number]
+}

--- a/packages/webaudio/test-browser/worklets/metering/gain-meter.test.ts
+++ b/packages/webaudio/test-browser/worklets/metering/gain-meter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { createGainMeter } from '../../../src/worklets/metering/factory.js'
+import type { GainMeasurement } from '../../../src/worklets/metering/messages.js'
+
+describe('worklets/metering/gain-meter.worklet.js', () => {
+  it('reports stereo RMS and peak at render-quantum boundaries once the interval has elapsed', async () => {
+    const interval = 192
+    const sampleRate = 48_000
+    const quantum = 128
+    const length = quantum * 4
+    const ctx = new OfflineAudioContext({ sampleRate, length, numberOfChannels: 2 })
+    const instance = await createGainMeter(ctx, { interval })
+    const measurements: GainMeasurement[] = []
+    const unsubscribe = instance.measurements.subscribe((measurement) => {
+      if (measurement != null) {
+        measurements.push(measurement)
+      }
+    })
+
+    try {
+      const input = ctx.createBuffer(2, length, sampleRate)
+      const left = input.getChannelData(0)
+      const right = input.getChannelData(1)
+
+      left.fill(0.5, 0, quantum)
+      left.fill(-1, quantum, quantum * 2)
+      left.fill(0.25, quantum * 2, quantum * 3)
+
+      right.fill(-0.25, 0, quantum)
+      right.fill(0.75, quantum, quantum * 2)
+      right.fill(-0.5, quantum * 2, quantum * 3)
+
+      const source = ctx.createBufferSource()
+      source.buffer = input
+
+      source.connect(instance.node)
+      instance.node.connect(ctx.destination)
+
+      source.start(0)
+      await ctx.startRendering()
+
+      await expect.poll(() => measurements.length).toBe(3)
+      expect(measurements[0]?.rms).toEqual([expect.closeTo(0.5, 6), expect.closeTo(0.25, 6)])
+      expect(measurements[0]?.peak).toEqual([expect.closeTo(0.5, 6), expect.closeTo(0.25, 6)])
+      expect(measurements[1]?.rms).toEqual([expect.closeTo(1, 6), expect.closeTo(0.75, 6)])
+      expect(measurements[1]?.peak).toEqual([expect.closeTo(1, 6), expect.closeTo(0.75, 6)])
+      expect(measurements[2]?.rms).toEqual([expect.closeTo(0.25, 6), expect.closeTo(0.5, 6)])
+      expect(measurements[2]?.peak).toEqual([expect.closeTo(0.25, 6), expect.closeTo(0.5, 6)])
+    } finally {
+      unsubscribe()
+      instance.dispose()
+    }
+  })
+
+  it('mirrors mono input measurements to both reported channels', async () => {
+    const interval = 128
+    const sampleRate = 48_000
+    const length = interval * 2
+    const ctx = new OfflineAudioContext({ sampleRate, length, numberOfChannels: 1 })
+    const instance = await createGainMeter(ctx, { interval })
+    const measurements: GainMeasurement[] = []
+    const unsubscribe = instance.measurements.subscribe((measurement) => {
+      if (measurement != null) {
+        measurements.push(measurement)
+      }
+    })
+
+    try {
+      const input = ctx.createBuffer(1, length, sampleRate)
+      const mono = input.getChannelData(0)
+
+      mono.fill(0.5, 0, interval)
+      mono.fill(-0.25, interval, length)
+
+      const source = ctx.createBufferSource()
+      source.buffer = input
+
+      source.connect(instance.node)
+      instance.node.connect(ctx.destination)
+
+      source.start(0)
+      await ctx.startRendering()
+
+      await expect.poll(() => measurements.length).toBe(2)
+      expect(measurements[0]?.rms).toEqual([expect.closeTo(0.5, 6), expect.closeTo(0.5, 6)])
+      expect(measurements[0]?.peak).toEqual([expect.closeTo(0.5, 6), expect.closeTo(0.5, 6)])
+      expect(measurements[1]?.rms).toEqual([expect.closeTo(0.25, 6), expect.closeTo(0.25, 6)])
+      expect(measurements[1]?.peak).toEqual([expect.closeTo(0.25, 6), expect.closeTo(0.25, 6)])
+    } finally {
+      unsubscribe()
+      instance.dispose()
+    }
+  })
+})


### PR DESCRIPTION
While metering is not yet exposed in the user interface, this commit lays the groundwork for a gain meter node that can be used to monitor the peak and RMS levels at various points in the audio graph.