### PR TITLE
feat: Propagate gain metering throughout the graph

### DIFF
--- a/packages/audiograph/src/builder.ts
+++ b/packages/audiograph/src/builder.ts
@@ -1,5 +1,6 @@
 import type { Numeric } from '@utility'
-import type { AnyNode, AudioGraph, Edge, NodeId, NoteOptions } from './graph.js'
+import type { AnyNode, AudioGraph, Edge, Meters, NodeId, NoteOptions } from './graph.js'
+import type { EntityKey } from './entities.js'
 
 export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
   readonly addNode: <T extends TNode> (type: T['type'], node: Omit<T, 'id' | 'type'>) => T
@@ -10,6 +11,8 @@ export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
   readonly setOutput: (nodeId: NodeId) => void
 
   readonly addNoteEvents: (nodeId: NodeId, events: readonly NoteOptions[]) => void
+
+  readonly addMeters: (key: EntityKey, meters: Meters) => void
 
   readonly graph: () => AudioGraph<TNode>
 }
@@ -30,6 +33,7 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
   const edges: Edge[] = []
   const outputIds: NodeId[] = []
   const noteEvents = new Map<NodeId, readonly NoteOptions[]>()
+  const meters = new Map<EntityKey, Meters>()
 
   let nextId = 1 as NodeId
 
@@ -70,13 +74,18 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
     noteEvents.set(nodeId, [...existing, ...events])
   }
 
+  const addMeters: AudioGraphBuilder<TNode>['addMeters'] = (key, value) => {
+    meters.set(key, value)
+  }
+
   const graph: AudioGraphBuilder<TNode>['graph'] = () => ({
     nodes,
     edges,
     outputIds,
     tempo: meta.tempo,
     length: meta.length,
-    noteEvents
+    noteEvents,
+    meters
   })
 
   return {
@@ -85,6 +94,7 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
     addEdges,
     setOutput,
     addNoteEvents,
+    addMeters,
     graph
   }
 }

--- a/packages/audiograph/src/entities.ts
+++ b/packages/audiograph/src/entities.ts
@@ -1,0 +1,28 @@
+import type { BusId, InstrumentId } from '@core'
+import type { Brand } from '@utility'
+
+export type Entity = BusEntity | InstrumentEntity | OutputEntity
+
+interface BusEntity {
+  readonly type: 'bus'
+  readonly id: BusId
+}
+
+interface InstrumentEntity {
+  readonly type: 'instrument'
+  readonly id: InstrumentId
+}
+
+interface OutputEntity {
+  readonly type: 'output'
+}
+
+export type EntityKey = Brand<string, 'audiograph.EntityKey'>
+
+export function createEntityKey (entity: Entity): EntityKey {
+  if (entity.type === 'output') {
+    return 'output' as EntityKey
+  }
+
+  return `${entity.type}:${entity.id}` as EntityKey
+}

--- a/packages/audiograph/src/graph.ts
+++ b/packages/audiograph/src/graph.ts
@@ -1,5 +1,19 @@
 import type { MidiNote } from '@core'
 import type { Brand, Numeric } from '@utility'
+import type { EntityKey } from './entities.js'
+
+export interface AudioGraph<TNode = AnyNode> {
+  readonly nodes: ReadonlyMap<NodeId, TNode>
+  readonly edges: readonly Edge[]
+  readonly outputIds: readonly NodeId[]
+
+  readonly tempo: Numeric<'bpm'>
+  readonly length: Numeric<'beats'>
+
+  readonly noteEvents: ReadonlyMap<NodeId, readonly NoteOptions[]>
+
+  readonly meters: ReadonlyMap<EntityKey, Meters>
+}
 
 export type NodeId = Brand<number, 'audiograph.NodeId'>
 
@@ -20,13 +34,6 @@ export interface NoteOptions {
   readonly duration?: number
 }
 
-export interface AudioGraph<TNode = AnyNode> {
-  readonly nodes: ReadonlyMap<NodeId, TNode>
-  readonly edges: readonly Edge[]
-  readonly outputIds: readonly NodeId[]
-
-  readonly tempo: Numeric<'bpm'>
-  readonly length: Numeric<'beats'>
-
-  readonly noteEvents: ReadonlyMap<NodeId, readonly NoteOptions[]>
+export interface Meters {
+  readonly gainMeterId: NodeId
 }

--- a/packages/audiograph/src/index.ts
+++ b/packages/audiograph/src/index.ts
@@ -5,5 +5,6 @@ export { dbToGain } from './constants.js'
 
 export type * from './graph.js'
 export type * from './nodes.js'
+export * from './entities.js'
 
 export * from './lowering.js'

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,16 +1,31 @@
 import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Program, Track } from '@core'
 import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents, timeToSeconds } from '@core'
+import type { Numeric } from '@utility'
 import { numeric } from '@utility'
 import { gainTransform, timeVariant, toTimeVariant } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
 import { DEFAULT_ROOT_NOTE } from './constants.js'
+import type { EntityKey } from './entities.js'
+import { createEntityKey } from './entities.js'
 import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
-import type { BiquadNode, DelayNode, GainNode, IdentityNode, Node, PanNode, ReverbNode, SampleNode, WidthNode } from './nodes.js'
+import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, Node, PanNode, ReverbNode, SampleNode, WidthNode } from './nodes.js'
 
 type Builder = AudioGraphBuilder<Node>
 
-export function createAudioGraph (program: Program): AudioGraph<Node> {
+export interface AudioGraphOptions {
+  /**
+   * If specified, the graph will include additional nodes for metering with the given interval.
+   * One node will be added for each instrument, bus, and the output.
+   */
+  readonly metering?: MeteringOptions
+}
+
+interface MeteringOptions {
+  readonly interval: Numeric<'s'>
+}
+
+export function createAudioGraph (program: Program, options?: AudioGraphOptions): AudioGraph<Node> {
   const builder = createAudioGraphBuilder<Node>({
     tempo: program.track.tempo,
     length: calculateTotalLength(program)
@@ -38,6 +53,10 @@ export function createAudioGraph (program: Program): AudioGraph<Node> {
   createRoutings(program, busSubgraphs, instrumentSubgraphs, output.id, builder)
 
   createNoteEvents(program.track, instruments, builder)
+
+  if (options?.metering != null) {
+    createMeteringNodes(busSubgraphs, instrumentSubgraphs, output.id, builder, options.metering)
+  }
 
   return builder.graph()
 }
@@ -332,5 +351,46 @@ function createNoteEvents (track: Track, instruments: ReadonlyMap<InstrumentId, 
     }
 
     offsetBeats += part.length.value
+  }
+}
+
+function createMeteringNodes (
+  busSubgraphs: ReadonlyMap<BusId, SubGraph>,
+  instrumentSubgraphs: ReadonlyMap<InstrumentId, SubGraph>,
+  outputId: NodeId,
+  builder: Builder,
+  options: MeteringOptions
+): void {
+  const intervalSeconds = options.interval.value
+  if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) {
+    throw new Error(`Invalid metering interval: ${options.interval.value}`)
+  }
+
+  const createMeters = (key: EntityKey, sources: readonly NodeId[]): void => {
+    const gainMeter = builder.addNode<GainMeterNode>('gain_meter', {
+      key,
+      interval: options.interval
+    })
+
+    builder.addMeters(key, {
+      gainMeterId: gainMeter.id
+    })
+
+    builder.addEdges(sources, [gainMeter.id])
+  }
+
+  {
+    const key = createEntityKey({ type: 'output' })
+    createMeters(key, [outputId])
+  }
+
+  for (const [busId, subgraph] of busSubgraphs) {
+    const key = createEntityKey({ type: 'bus', id: busId })
+    createMeters(key, subgraph.outputs)
+  }
+
+  for (const [instrumentId, subgraph] of instrumentSubgraphs) {
+    const key = createEntityKey({ type: 'instrument', id: instrumentId })
+    createMeters(key, subgraph.outputs)
   }
 }

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -1,6 +1,7 @@
 import type { MidiNote } from '@core'
 import type { Numeric } from '@utility'
 import type { TimeVariant } from './automation.js'
+import type { EntityKey } from './entities.js'
 import type { AnyNode } from './graph.js'
 
 export interface NodeTypeMap {
@@ -74,6 +75,11 @@ export interface SampleNode extends AnyNode {
 
 export interface GainMeterNode extends AnyNode {
   readonly type: 'gain_meter'
+
+  /**
+   * The entity for which this gain meter is measuring the gain.
+   */
+  readonly key: EntityKey
 
   /**
    * The approximate interval, in seconds, at which the gain meter should post updates.

--- a/packages/audiograph/test/builder.test.ts
+++ b/packages/audiograph/test/builder.test.ts
@@ -1,8 +1,10 @@
+import type { BusId, InstrumentId, MidiNote } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { createAudioGraphBuilder } from '../src/builder.js'
-import type { MidiNote } from '@core'
+import { createEntityKey } from '../src/entities.js'
+import type { NodeId } from '../src/graph.js'
 
 describe('builder.ts', () => {
   const tempo = numeric('bpm', 120)
@@ -190,5 +192,38 @@ describe('builder.ts', () => {
     assert.throws(() => builder.addNoteEvents(node1.id, [
       { time: 0, pitch: 60 as MidiNote, velocity: 0.8, duration: Number.NaN }
     ]))
+  })
+
+  it('should add meters', () => {
+    const builder = createAudioGraphBuilder({ tempo, length })
+
+    // output
+    const outputKey = createEntityKey({ type: 'output' })
+    const outputMeters = {
+      gainMeterId: 100 as NodeId
+    }
+    builder.addMeters(outputKey, outputMeters)
+
+    // bus
+    const busKey = createEntityKey({ type: 'bus', id: 1 as BusId })
+    const busMeters = {
+      gainMeterId: 200 as NodeId
+    }
+    builder.addMeters(busKey, busMeters)
+
+    // instrument
+    const instrumentKey = createEntityKey({ type: 'instrument', id: 2 as InstrumentId })
+    const instrumentMeters = {
+      gainMeterId: 300 as NodeId
+    }
+    builder.addMeters(instrumentKey, instrumentMeters)
+
+    const graph = builder.graph()
+
+    assert.deepStrictEqual([...graph.meters.entries()], [
+      [outputKey, outputMeters],
+      [busKey, busMeters],
+      [instrumentKey, instrumentMeters]
+    ])
   })
 })

--- a/packages/audiograph/test/entities.test.ts
+++ b/packages/audiograph/test/entities.test.ts
@@ -1,0 +1,36 @@
+import type { BusId, InstrumentId } from '@core'
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { createEntityKey } from '../src/entities.js'
+
+describe('entities.ts', () => {
+  it('should create unique entity keys', () => {
+    const key1 = createEntityKey({ type: 'bus', id: 1 as BusId })
+    const key2 = createEntityKey({ type: 'bus', id: 2 as BusId })
+    const key3 = createEntityKey({ type: 'instrument', id: 1 as InstrumentId })
+    const key4 = createEntityKey({ type: 'instrument', id: 2 as InstrumentId })
+    const key5 = createEntityKey({ type: 'output' })
+
+    const keys = [key1, key2, key3, key4, key5]
+    const uniqueKeys = new Set(keys)
+
+    assert.strictEqual(uniqueKeys.size, keys.length)
+  })
+
+  it('should create the same key for the same entity', () => {
+    const output1 = createEntityKey({ type: 'output' })
+    const output2 = createEntityKey({ type: 'output' })
+
+    assert.strictEqual(output1, output2)
+
+    const bus1 = createEntityKey({ type: 'bus', id: 1 as BusId })
+    const bus2 = createEntityKey({ type: 'bus', id: 1 as BusId })
+
+    assert.strictEqual(bus1, bus2)
+
+    const instrument1 = createEntityKey({ type: 'instrument', id: 1 as InstrumentId })
+    const instrument2 = createEntityKey({ type: 'instrument', id: 1 as InstrumentId })
+
+    assert.strictEqual(instrument1, instrument2)
+  })
+})

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -4,6 +4,7 @@ import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { dbToGain } from '../src/constants.js'
+import { createEntityKey } from '../src/entities.js'
 import type { NodeId } from '../src/graph.js'
 import { createAudioGraph } from '../src/lowering.js'
 import type { DelayNode, GainNode, IdentityNode, Node, ReverbNode, SampleNode } from '../src/nodes.js'
@@ -960,5 +961,141 @@ describe('lowering.ts', () => {
         } satisfies ReverbNode)
       })
     })
+  })
+
+  describe('metering', () => {
+    it('should not add metering by default', () => {
+      const graph = createAudioGraph(createProgramWithInstrument({
+        id: 100 as InstrumentId,
+        sampleUrl: 'foo.wav',
+        gain: {
+          id: 200 as ParameterId,
+          initial: numeric('db', -6)
+        }
+      }))
+
+      assert.strictEqual(graph.meters.size, 0)
+    })
+
+    it('should add meters when enabled', () => {
+      const instrumentId = 100 as InstrumentId
+      const busId = 200 as BusId
+
+      const program: Program = {
+        beatsPerBar: 4,
+        instruments: new Map([
+          [
+            instrumentId,
+            {
+              id: instrumentId,
+              sampleUrl: 'foo.wav',
+              gain: {
+                id: 200 as ParameterId,
+                initial: numeric('db', -6)
+              }
+            } satisfies Instrument
+          ]
+        ]),
+        automations: new Map(),
+        track: {
+          tempo: numeric('bpm', 120),
+          parts: []
+        },
+        mixer: {
+          buses: [
+            {
+              id: busId,
+              name: 'Bus 1',
+              gain: {
+                id: 201 as ParameterId,
+                initial: numeric('db', -3)
+              },
+              effects: []
+            } satisfies Bus
+          ],
+          routings: [
+            {
+              implicit: false,
+              source: {
+                type: 'Instrument',
+                id: instrumentId
+              },
+              destination: {
+                type: 'Bus',
+                id: busId
+              }
+            } satisfies MixerRouting,
+            {
+              implicit: true,
+              source: {
+                type: 'Bus',
+                id: busId
+              },
+              destination: {
+                type: 'Output'
+              }
+            } satisfies MixerRouting
+          ]
+        }
+      }
+
+      const interval = numeric('s', 0.123)
+
+      const graph = createAudioGraph(program, {
+        metering: { interval }
+      })
+
+      const outputKey = createEntityKey({ type: 'output' })
+      const outputMeters = graph.meters.get(outputKey)
+      assert.ok(outputMeters)
+
+      const outputGainMeter = graph.nodes.get(outputMeters.gainMeterId)
+      assert.strictEqual(outputGainMeter?.type, 'gain_meter')
+      assert.deepStrictEqual(outputGainMeter.key, outputKey)
+      assert.deepStrictEqual(outputGainMeter.interval, interval)
+
+      const busKey = createEntityKey({ type: 'bus', id: busId })
+      const busMeters = graph.meters.get(busKey)
+      assert.ok(busMeters)
+
+      const busGainMeter = graph.nodes.get(busMeters.gainMeterId)
+      assert.strictEqual(busGainMeter?.type, 'gain_meter')
+      assert.deepStrictEqual(busGainMeter.key, busKey)
+      assert.deepStrictEqual(busGainMeter.interval, interval)
+
+      const instrumentKey = createEntityKey({ type: 'instrument', id: instrumentId })
+      const instrumentMeters = graph.meters.get(instrumentKey)
+      assert.ok(instrumentMeters)
+
+      const instrumentGainMeter = graph.nodes.get(instrumentMeters.gainMeterId)
+      assert.strictEqual(instrumentGainMeter?.type, 'gain_meter')
+      assert.deepStrictEqual(instrumentGainMeter.key, instrumentKey)
+      assert.deepStrictEqual(instrumentGainMeter.interval, interval)
+    })
+  })
+
+  it('should throw for invalid metering interval', () => {
+    const program = createProgramWithInstrument({
+      id: 100 as InstrumentId,
+      sampleUrl: 'foo.wav',
+      gain: {
+        id: 200 as ParameterId,
+        initial: numeric('db', -6)
+      }
+    })
+
+    for (const interval of [Infinity, -Infinity, Number.NaN, 0, -1]) {
+      const options = {
+        metering: {
+          interval: numeric('s', interval)
+        }
+      }
+
+      assert.throws(
+        () => createAudioGraph(program, options),
+        /Invalid metering interval/,
+        `should throw for interval: ${interval}`
+      )
+    }
   })
 })

--- a/packages/utility/src/observable/observable.ts
+++ b/packages/utility/src/observable/observable.ts
@@ -1,6 +1,6 @@
-type UnsubscribeFn = () => void
+export type UnsubscribeFn = () => void
 
-type Observer<T> = (value: T) => void
+export type Observer<T> = (value: T) => void
 
 export interface Observable<T> {
   readonly get: () => T
@@ -34,5 +34,9 @@ export class MutableObservable<T> implements Observable<T> {
     return () => {
       this.observers.delete(observer)
     }
+  }
+
+  get observerCount (): number {
+    return this.observers.size
   }
 }

--- a/packages/utility/test/observable/observable.test.ts
+++ b/packages/utility/test/observable/observable.test.ts
@@ -51,5 +51,22 @@ describe('observable/observable.ts', () => {
 
       assert.deepStrictEqual(notifiedValues, [0, 0, 1, 1, 2, 2])
     })
+
+    it('should update observerCount correctly', () => {
+      const obs = new MutableObservable(0)
+      assert.strictEqual(obs.observerCount, 0)
+
+      const unsubscribe1 = obs.subscribe(() => {})
+      assert.strictEqual(obs.observerCount, 1)
+
+      const unsubscribe2 = obs.subscribe(() => {})
+      assert.strictEqual(obs.observerCount, 2)
+
+      unsubscribe1()
+      assert.strictEqual(obs.observerCount, 1)
+
+      unsubscribe2()
+      assert.strictEqual(obs.observerCount, 0)
+    })
   })
 })

--- a/packages/webaudio/src/engine/engine.ts
+++ b/packages/webaudio/src/engine/engine.ts
@@ -1,8 +1,13 @@
-import type { AudioGraph, Node } from '@audiograph'
+import type { AudioGraph, EntityKey, Node } from '@audiograph'
 import type { BeatRange } from '@core'
-import { DisposeStack, MutableObservable, numeric, type Numeric, type Observable } from '@utility'
-import { createAudioFetcher, type CacheLimits } from '../assets/fetcher.js'
-import { createAudioSession, type AudioSession } from './session.js'
+import type { Numeric, Observable, Observer, UnsubscribeFn } from '@utility'
+import { DisposeStack, MutableObservable, numeric } from '@utility'
+import type { CacheLimits } from '../assets/fetcher.js'
+import { createAudioFetcher } from '../assets/fetcher.js'
+import type { MeterCallbacks } from '../graph/factory.js'
+import type { GainMeasurement } from './engine.js'
+import type { AudioSession } from './session.js'
+import { createAudioSession } from './session.js'
 
 export interface AudioEngineOptions {
   readonly outputGain: Numeric<'db'>
@@ -20,7 +25,13 @@ export interface AudioEngine {
   readonly range: MutableObservable<BeatRange>
   readonly position: Observable<Numeric<'beats'>>
   readonly errors: Observable<readonly Error[]>
+
+  readonly meters: {
+    readonly subscribeToGain: (key: EntityKey, observer: Observer<GainMeasurement>) => UnsubscribeFn
+  }
 }
+
+export type { GainMeasurement } from '../worklets/metering/messages.js'
 
 export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
   const outputGain = new MutableObservable(options.outputGain)
@@ -34,6 +45,18 @@ export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
   const position = new MutableObservable(range.get().start)
   const errors = new MutableObservable<readonly Error[]>([])
 
+  const gainMeters = new Map<string, MutableObservable<GainMeasurement>>()
+
+  const meterCallbacks: MeterCallbacks = {
+    onGain: (key, measurement) => gainMeters.get(key)?.set(measurement)
+  }
+
+  const resetMeters = () => {
+    for (const meter of gainMeters.values()) {
+      meter.set({ peak: [0, 0], rms: [0, 0] })
+    }
+  }
+
   let session: AudioSession | undefined
   let stopSession: (() => void) | undefined
 
@@ -44,7 +67,7 @@ export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
 
     const disposeStack = new DisposeStack()
 
-    const thisSession = session = createAudioSession(graph, range.get(), outputGain, fetcher)
+    const thisSession = session = createAudioSession(graph, range.get(), outputGain, fetcher, meterCallbacks)
     disposeStack.pushDisposable(thisSession)
 
     const stopThisSession = stopSession = () => {
@@ -53,6 +76,7 @@ export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
       if (session === thisSession) {
         session = undefined
         playing.set(false)
+        resetMeters()
       }
 
       if (stopSession === stopThisSession) {
@@ -74,6 +98,8 @@ export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
       }
     }))
 
+    resetMeters()
+
     thisSession.start()
     playing.set(true)
   }
@@ -82,5 +108,25 @@ export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
     stopSession?.()
   }
 
-  return { outputGain, playing, play, stop, range, position, errors }
+  const meters = {
+    subscribeToGain: (key: EntityKey, observer: Observer<GainMeasurement>): UnsubscribeFn => {
+      let meter = gainMeters.get(key)
+      if (meter == null) {
+        meter = new MutableObservable<GainMeasurement>({ peak: [0, 0], rms: [0, 0] })
+        gainMeters.set(key, meter)
+      }
+
+      const unsubscribe = meter.subscribe(observer)
+
+      return () => {
+        unsubscribe()
+
+        if (meter.observerCount <= 0) {
+          gainMeters.delete(key)
+        }
+      }
+    }
+  }
+
+  return { outputGain, playing, play, stop, range, position, errors, meters }
 }

--- a/packages/webaudio/src/engine/session.ts
+++ b/packages/webaudio/src/engine/session.ts
@@ -1,8 +1,11 @@
 import type { AudioGraph, Node } from '@audiograph'
 import { dbToGain } from '@audiograph'
-import { type BeatRange, beatsToSeconds } from '@core'
-import { DisposeStack, MutableObservable, numeric, type Numeric, type Observable } from '@utility'
+import type { BeatRange } from '@core'
+import { beatsToSeconds } from '@core'
+import type { Numeric, Observable } from '@utility'
+import { DisposeStack, MutableObservable, numeric } from '@utility'
 import type { AudioFetcher } from '../assets/fetcher.js'
+import type { MeterCallbacks } from '../graph/factory.js'
 import { createWebAudioGraph } from '../graph/graph.js'
 import { createOnlineTransport } from '../transport/transport.js'
 
@@ -18,7 +21,8 @@ export function createAudioSession (
   graph: AudioGraph<Node>,
   range: BeatRange,
   outputGain: Observable<Numeric<'db'>>,
-  fetcher: AudioFetcher
+  fetcher: AudioFetcher,
+  meterCallbacks: MeterCallbacks
 ): AudioSession {
   const disposeStack = new DisposeStack()
 
@@ -45,7 +49,7 @@ export function createAudioSession (
   const position = new MutableObservable(range.start)
   const errors = new MutableObservable<readonly Error[]>([])
 
-  const webAudioGraphPromise = createWebAudioGraph(graph, transport, fetcher)
+  const webAudioGraphPromise = createWebAudioGraph(graph, transport, fetcher, meterCallbacks)
     .then((webAudioGraph) => {
       disposeStack.pushDisposable(webAudioGraph)
       return webAudioGraph

--- a/packages/webaudio/src/graph/factory.ts
+++ b/packages/webaudio/src/graph/factory.ts
@@ -1,6 +1,7 @@
 import type { Node } from '@audiograph'
 import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
+import type { GainMeasurement } from '../worklets/metering/messages.js'
 import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance, createWidthInstance } from './effect.js'
 import type { Instance } from './instance.js'
 import { createGainMeterInstance } from './metering.js'
@@ -24,6 +25,16 @@ const factories = Object.freeze({
   gain_meter: createGainMeterInstance
 })
 
-export async function createNodeInstance (node: Node, transport: Transport, fetcher: AudioFetcher): Promise<Instance> {
-  return factories[node.type](node as any, transport, fetcher)
+type NodeFactoryArguments = readonly [
+  transport: Transport,
+  fetcher: AudioFetcher,
+  meterCallbacks?: MeterCallbacks
+]
+
+export interface MeterCallbacks {
+  readonly onGain: (key: string, measurement: GainMeasurement) => void
+}
+
+export async function createNodeInstance (node: Node, ...args: NodeFactoryArguments): Promise<Instance> {
+  return factories[node.type](node as any, ...args)
 }

--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -1,6 +1,7 @@
 import type { AudioGraph, Node, NodeId } from '@audiograph'
 import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
+import type { MeterCallbacks } from './factory.js'
 import { createNodeInstance } from './factory.js'
 import type { Instance } from './instance.js'
 
@@ -8,20 +9,27 @@ export interface WebAudioGraph {
   readonly dispose: () => void
 }
 
-export async function createWebAudioGraph (graph: AudioGraph<Node>, transport: Transport, fetcher: AudioFetcher): Promise<WebAudioGraph> {
+export async function createWebAudioGraph (
+  graph: AudioGraph<Node>,
+  transport: Transport,
+  fetcher: AudioFetcher,
+  meterCallbacks?: MeterCallbacks
+): Promise<WebAudioGraph> {
   const instances = new Map<NodeId, Instance>()
   let disposed = false
 
   const promises = new Map<NodeId, Promise<void>>()
   for (const node of graph.nodes.values()) {
-    promises.set(node.id, createNodeInstance(node, transport, fetcher).then((instance) => {
+    const promise = createNodeInstance(node, transport, fetcher, meterCallbacks).then((instance) => {
       if (disposed) {
         instance.dispose()
         return
       }
 
       instances.set(node.id, instance)
-    }))
+    })
+
+    promises.set(node.id, promise)
   }
 
   try {

--- a/packages/webaudio/src/graph/metering.ts
+++ b/packages/webaudio/src/graph/metering.ts
@@ -1,17 +1,35 @@
 import type { GainMeterNode } from '@audiograph'
+import type { UnsubscribeFn } from '@utility'
+import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
-import type { Instance } from './instance.js'
 import { createGainMeter } from '../worklets/metering/factory.js'
+import type { MeterCallbacks } from './factory.js'
+import type { Instance } from './instance.js'
 
-export async function createGainMeterInstance (node: GainMeterNode, transport: Transport): Promise<Instance> {
+export async function createGainMeterInstance (
+  node: GainMeterNode,
+  transport: Transport,
+  fetcher: AudioFetcher,
+  meterCallbacks?: MeterCallbacks
+): Promise<Instance> {
   const instance = await createGainMeter(transport.ctx, {
     interval: node.interval.value * transport.ctx.sampleRate
   })
+
+  let unsubscribe: UnsubscribeFn | undefined
+  if (meterCallbacks != null) {
+    unsubscribe = instance.measurements.subscribe((measurement) => {
+      if (measurement != null) {
+        meterCallbacks.onGain(node.key, measurement)
+      }
+    })
+  }
 
   return {
     input: instance.node,
     output: instance.node,
     dispose: () => {
+      unsubscribe?.()
       instance.dispose()
     }
   }


### PR DESCRIPTION
This patch adds a new `EntityKey` type to identify instruments, buses, and the output. This is then attached to metering nodes in audiograph lowering, such that any measurements done by the node instance can be associated with the relevant entity. The webaudio engine is updated to include metering callbacks that would allow users of the engine (i.e. the app) to subscribe to measurements for any given entity key. This will be part of a future patch.