### PR TITLE
refactor: Use lowercase type in program, flowchart

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -37,13 +37,24 @@ const FLOWCHART_OPTIONS: MixerFlowchartOptions = {
   }
 }
 
+function getNodeTypeLabel (type: MixerFlowNode['data']['type']): string {
+  switch (type) {
+    case 'output':
+      return 'Output'
+    case 'bus':
+      return 'Bus'
+    case 'instrument':
+      return 'Instrument'
+  }
+}
+
 function getNodeLabel ({ data }: MixerFlowNode): string {
   switch (data.type) {
-    case 'Output':
+    case 'output':
       return 'Main Output'
-    case 'Bus':
+    case 'bus':
       return data.object.name
-    case 'Instrument': {
+    case 'instrument': {
       return data.object.sampleUrl.split('/').pop() ?? data.object.sampleUrl
     }
   }
@@ -154,7 +165,7 @@ const MixerNode: FunctionComponent<{
         onClick={openPopover}
       >
         <div className='text-content-100'>
-          {node.data.type}
+          {getNodeTypeLabel(node.data.type)}
         </div>
         <div className='text-content-300 whitespace-nowrap text-ellipsis overflow-hidden'>
           {getNodeLabel(node)}
@@ -163,9 +174,9 @@ const MixerNode: FunctionComponent<{
 
       {popover && (
         <Popover anchor={container} onClose={closePopover}>
-          {node.data.type === 'Output' && (<OutputNodeInfo />)}
-          {node.data.type === 'Bus' && (<BusNodeInfo object={node.data.object} />)}
-          {node.data.type === 'Instrument' && (<InstrumentNodeInfo object={node.data.object} />)}
+          {node.data.type === 'output' && (<OutputNodeInfo />)}
+          {node.data.type === 'bus' && (<BusNodeInfo object={node.data.object} />)}
+          {node.data.type === 'instrument' && (<InstrumentNodeInfo object={node.data.object} />)}
         </Popover>
       )}
     </>

--- a/packages/app/src/modules/mixer/flowchart.ts
+++ b/packages/app/src/modules/mixer/flowchart.ts
@@ -1,19 +1,19 @@
 import type { Bus, BusId, Instrument, InstrumentId, Program } from '@core'
 import type { FlowEdge, FlowEdgeId, FlowEdgeStyle, FlowNode, FlowNodeId } from '@flowchart'
 
-const mixerObjectTypes = ['Bus', 'Instrument'] as const
+const mixerObjectTypes = ['bus', 'instrument'] as const
 type MixerObjectType = typeof mixerObjectTypes[number]
 type MixerObjectId = BusId | InstrumentId
 type MixerObject = Bus | Instrument
 
 type MixerNodeData = {
-  readonly type: 'Output'
+  readonly type: 'output'
   readonly object?: undefined
 } | {
-  readonly type: 'Bus'
+  readonly type: 'bus'
   readonly object: Bus
 } | {
-  readonly type: 'Instrument'
+  readonly type: 'instrument'
   readonly object: Instrument
 }
 
@@ -21,9 +21,9 @@ interface MixerEdgeData {}
 
 function getObjectsOfType (program: Program, type: MixerObjectType): Iterable<[MixerObjectId, MixerObject]> {
   switch (type) {
-    case 'Bus':
+    case 'bus':
       return program.mixer.buses.map((bus) => [bus.id, bus])
-    case 'Instrument':
+    case 'instrument':
       return program.instruments.entries()
   }
 }
@@ -69,7 +69,7 @@ function createNodes (program: Program, options: MixerFlowchartOptions): Nodes {
     data
   })
 
-  const output = createNode({ type: 'Output' })
+  const output = createNode({ type: 'output' })
   all.push(output)
 
   for (const type of mixerObjectTypes) {
@@ -93,7 +93,7 @@ function createEdges (program: Program, options: MixerFlowchartOptions, nodes: N
     const from = nodes.byObject[sourceType].get(routing.source.id)?.id
 
     const destinationType = routing.destination.type
-    const to = destinationType === 'Output'
+    const to = destinationType === 'output'
       ? nodes.output.id
       : nodes.byObject[destinationType].get(routing.destination.id)?.id
 

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -302,18 +302,18 @@ function createRoutings (
 ): void {
   const findSource = (item: MixerRouting['source']): SubGraph | undefined => {
     switch (item.type) {
-      case 'Bus':
+      case 'bus':
         return busSubgraphs.get(item.id)
-      case 'Instrument':
+      case 'instrument':
         return instrumentSubgraphs.get(item.id)
     }
   }
 
   const findDestination = (item: MixerRouting['destination']): SubGraph | undefined => {
     switch (item.type) {
-      case 'Output':
+      case 'output':
         return { inputs: [outputId], outputs: [outputId] }
-      case 'Bus':
+      case 'bus':
         return busSubgraphs.get(item.id)
     }
   }

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -28,11 +28,11 @@ function createProgramWithInstrument (instrument: Instrument): Program {
         {
           implicit: true,
           source: {
-            type: 'Instrument',
+            type: 'instrument',
             id: instrument.id
           },
           destination: {
-            type: 'Output'
+            type: 'output'
           }
         }
       ]
@@ -65,11 +65,11 @@ function createProgramWithEffect (effect: Effect): Program {
         {
           implicit: false,
           source: {
-            type: 'Bus',
+            type: 'bus',
             id: 100 as BusId
           },
           destination: {
-            type: 'Output'
+            type: 'output'
           }
         }
       ]
@@ -153,11 +153,11 @@ describe('lowering.ts', () => {
           {
             implicit: false,
             source: {
-              type: 'Instrument',
+              type: 'instrument',
               id: instrumentId
             },
             destination: {
-              type: 'Bus',
+              type: 'bus',
               id: busId
             }
           } satisfies MixerRouting,
@@ -165,11 +165,11 @@ describe('lowering.ts', () => {
           {
             implicit: true,
             source: {
-              type: 'Bus',
+              type: 'bus',
               id: busId
             },
             destination: {
-              type: 'Output'
+              type: 'output'
             }
           } satisfies MixerRouting
         ]
@@ -272,11 +272,11 @@ describe('lowering.ts', () => {
           {
             implicit: true,
             source: {
-              type: 'Instrument',
+              type: 'instrument',
               id: instrumentId
             },
             destination: {
-              type: 'Output'
+              type: 'output'
             }
           } satisfies MixerRouting
         ]
@@ -337,11 +337,11 @@ describe('lowering.ts', () => {
             routings: [
               {
                 source: {
-                  type: 'Pattern',
+                  type: 'pattern',
                   value: createSerialPattern([{ value: 'C4' }, { value: 'E4' }], 1)
                 },
                 destination: {
-                  type: 'Instrument',
+                  type: 'instrument',
                   id: instrumentId
                 }
               } satisfies InstrumentRouting
@@ -353,11 +353,11 @@ describe('lowering.ts', () => {
             routings: [
               {
                 source: {
-                  type: 'Pattern',
+                  type: 'pattern',
                   value: createSerialPattern([{ value: 'G4' }, { value: 'B4' }], 1)
                 },
                 destination: {
-                  type: 'Instrument',
+                  type: 'instrument',
                   id: instrumentId
                 }
               } satisfies InstrumentRouting
@@ -1017,22 +1017,22 @@ describe('lowering.ts', () => {
             {
               implicit: false,
               source: {
-                type: 'Instrument',
+                type: 'instrument',
                 id: instrumentId
               },
               destination: {
-                type: 'Bus',
+                type: 'bus',
                 id: busId
               }
             } satisfies MixerRouting,
             {
               implicit: true,
               source: {
-                type: 'Bus',
+                type: 'bus',
                 id: busId
               },
               destination: {
-                type: 'Output'
+                type: 'output'
               }
             } satisfies MixerRouting
           ]

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -104,12 +104,12 @@ export interface Part {
 
 export interface InstrumentRouting {
   readonly source: {
-    readonly type: 'Pattern'
+    readonly type: 'pattern'
     readonly value: Pattern
   }
 
   readonly destination: {
-    readonly type: 'Instrument'
+    readonly type: 'instrument'
     readonly id: InstrumentId
   }
 }
@@ -180,17 +180,17 @@ export interface MixerRouting {
   readonly implicit: boolean
 
   readonly source: {
-    readonly type: 'Instrument'
+    readonly type: 'instrument'
     readonly id: InstrumentId
   } | {
-    readonly type: 'Bus'
+    readonly type: 'bus'
     readonly id: BusId
   }
 
   readonly destination: {
-    readonly type: 'Output'
+    readonly type: 'output'
   } | {
-    readonly type: 'Bus'
+    readonly type: 'bus'
     readonly id: BusId
   }
 }

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -199,12 +199,12 @@ function generatePart (context: Context, part: ast.PartStatement, startTime: Num
 
     return {
       source: {
-        type: 'Pattern',
+        type: 'pattern',
         value: source.data
       },
 
       destination: {
-        type: 'Instrument',
+        type: 'instrument',
         id: instrument.data.id
       }
     }
@@ -254,25 +254,25 @@ function generateMixer (context: Context, mixer: ast.MixerStatement): Mixer {
 
   for (const routing of routings) {
     switch (routing.source.type) {
-      case 'Bus':
+      case 'bus':
         unroutedBuses.delete(routing.source.id)
         break
-      case 'Instrument':
+      case 'instrument':
         unroutedInstruments.delete(routing.source.id)
         break
     }
   }
 
   const createImplicitRouting = (source: MixerRouting['source']) => {
-    routings.push({ implicit: true, source, destination: { type: 'Output' } })
+    routings.push({ implicit: true, source, destination: { type: 'output' } })
   }
 
   for (const busId of unroutedBuses) {
-    createImplicitRouting({ type: 'Bus', id: busId })
+    createImplicitRouting({ type: 'bus', id: busId })
   }
 
   for (const instrumentId of unroutedInstruments) {
-    createImplicitRouting({ type: 'Instrument', id: instrumentId })
+    createImplicitRouting({ type: 'instrument', id: instrumentId })
   }
 
   return { buses, routings }
@@ -303,9 +303,9 @@ function generateBusRoutings (mixerContext: Context, bus: ast.BusStatement, buse
     const toRouting = (src: { type: Type['name'], id: InstrumentId | BusId }): MixerRouting => ({
       implicit: false,
       source: src.type === 'instrument'
-        ? { type: 'Instrument', id: src.id as InstrumentId }
-        : { type: 'Bus', id: src.id as BusId },
-      destination: { type: 'Bus', id: destination.id }
+        ? { type: 'instrument', id: src.id as InstrumentId }
+        : { type: 'bus', id: src.id as BusId },
+      destination: { type: 'bus', id: destination.id }
     })
 
     if (InstrumentType.is(source)) {

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -288,13 +288,13 @@ describe('compiler/generator.ts', () => {
     assert.deepStrictEqual(result.mixer.routings, [
       {
         implicit: false,
-        destination: { type: 'Bus', id: 0 },
-        source: { type: 'Bus', id: 1 }
+        destination: { type: 'bus', id: 0 },
+        source: { type: 'bus', id: 1 }
       },
       {
         implicit: true,
-        destination: { type: 'Output' },
-        source: { type: 'Bus', id: 0 }
+        destination: { type: 'output' },
+        source: { type: 'bus', id: 0 }
       }
     ])
   })


### PR DESCRIPTION
Specifically the routables were using capitalized type strings, which was slightly inconsistent.