### PR TITLE
feat: Show gain meters in mixer graph

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -1,13 +1,17 @@
+import { createEntityKey } from '@audiograph'
 import type { Bus, Instrument } from '@core'
 import type { PanelProps } from '@editor'
-import { useNonNullValue } from '@editor'
+import { useNonNullValue, useService } from '@editor'
 import { Flowchart } from '@flowchart'
+import type { GainMeasurement } from '@webaudio'
 import clsx from 'clsx'
 import type { CSSProperties, FunctionComponent, PropsWithChildren } from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
 import { Popover } from '../../components/popover/Popover.js'
 import { pluralize } from '../../utilities/format.js'
+import type { MeteringService } from '../playback/services/metering.js'
+import { METERING_SERVICE_ID } from '../playback/services/metering.js'
 import type { MixerFlowchartOptions, MixerFlowNode } from './flowchart.js'
 import { createMixerFlowchart } from './flowchart.js'
 
@@ -153,22 +157,55 @@ const MixerNode: FunctionComponent<{
   const openPopover = useCallback(() => setPopover(true), [])
   const closePopover = useCallback(() => setPopover(false), [])
 
+  const [measurement, setMeasurement] = useState<GainMeasurement>({ peak: [0, 0], rms: [0, 0] })
+
+  const meteringService = useService<MeteringService>(METERING_SERVICE_ID)
+
+  const entityKey = useMemo(() => {
+    switch (node.data.type) {
+      case 'output':
+        return createEntityKey({ type: node.data.type })
+      case 'bus':
+        return createEntityKey({ type: node.data.type, id: node.data.object.id })
+      case 'instrument':
+        return createEntityKey({ type: node.data.type, id: node.data.object.id })
+    }
+  }, [node.data])
+
+  useEffect(() => {
+    return meteringService?.subscribeToGain(entityKey, setMeasurement)
+  }, [meteringService, entityKey])
+
+  const { peak, rms } = measurement
+
   return (
     <>
       <button
         type='button'
         className={clsx(
-          'w-full h-full px-2 py-1 flex flex-col justify-center text-start leading-snug text-sm rounded-md border cursor-pointer',
+          'w-full h-full px-2 py-1 flex leading-snug text-sm rounded-md border cursor-pointer',
           highlight ? 'bg-surface-300 border-accent-200 ring-1 ring-accent-200' : 'bg-surface-200 border-frame-200'
         )}
         ref={setContainer}
         onClick={openPopover}
       >
-        <div className='text-content-100'>
-          {getNodeTypeLabel(node.data.type)}
-        </div>
-        <div className='text-content-300 whitespace-nowrap text-ellipsis overflow-hidden'>
-          {getNodeLabel(node)}
+        {/* vertical stereo peak/RMS meters */}
+        <svg className='w-3.5 h-full mr-2 shrink-0'>
+          <rect x='0' y='0' width='6' height='100%' fill='var(--color-surface-100)' />
+          <rect x='8' y='0' width='6' height='100%' fill='var(--color-surface-100)' />
+          <rect x='0' y={(1 - rms[0]) * 100 + '%'} width='6' height={rms[0] * 100 + '%'} fill='var(--color-accent-100)' className='transition-all duration-100' />
+          <rect x='8' y={(1 - rms[1]) * 100 + '%'} width='6' height={rms[1] * 100 + '%'} fill='var(--color-accent-100)' className='transition-all duration-100' />
+          <rect x='0' y={(1 - peak[0]) * 100 + '%'} width='6' height='2' fill={peak[0] > 1 ? 'var(--color-error-surface)' : 'var(--color-content-300)'} />
+          <rect x='8' y={(1 - peak[1]) * 100 + '%'} width='6' height='2' fill={peak[1] > 1 ? 'var(--color-error-surface)' : 'var(--color-content-300)'} />
+        </svg>
+        {/* node info */}
+        <div className='grow min-w-0 flex flex-col justify-center text-start'>
+          <div className='text-content-100'>
+            {getNodeTypeLabel(node.data.type)}
+          </div>
+          <div className='text-content-300 whitespace-nowrap text-ellipsis overflow-hidden'>
+            {getNodeLabel(node)}
+          </div>
         </div>
       </button>
 
@@ -185,7 +222,7 @@ const MixerNode: FunctionComponent<{
 
 const OutputNodeInfo: FunctionComponent = () => {
   return (
-    <div>(Output)</div>
+    <div className='font-bold'>(Output)</div>
   )
 }
 

--- a/packages/app/src/modules/playback/index.ts
+++ b/packages/app/src/modules/playback/index.ts
@@ -1,6 +1,7 @@
+import type { AudioGraphOptions } from '@audiograph'
 import { createAudioGraph } from '@audiograph'
 import type { CommandId, MenuSectionId, Module, ModuleId, PanelId, Problem } from '@editor'
-import { activateTabOfType, useLatestRef, useLayoutDispatch, useNotificationService, useObservable, useProvideProblems, useRegisterCommand } from '@editor'
+import { activateTabOfType, useLatestRef, useLayoutDispatch, useNotificationService, useObservable, useProvideProblems, useRegisterCommand, useRegisterService } from '@editor'
 import { numeric } from '@utility'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
@@ -11,9 +12,16 @@ import { PlaybackControls } from './components/PlaybackControls.js'
 import { TimelinePanel } from './components/TimelinePanel.js'
 import { usePlaybackSettingsSync } from './persistence.js'
 import { PlaybackProvider, useAudioEngine } from './provider.js'
+import { METERING_SERVICE_ID, MeteringService } from './services/metering.js'
 
 const PLAYBACK_ERROR_MESSAGE = 'Cannot play: Program contains errors.'
 const PLAYBACK_ERROR_TIMEOUT = numeric('s', 5)
+
+const AUDIO_GRAPH_OPTIONS: AudioGraphOptions = {
+  metering: {
+    interval: numeric('s', 0.1)
+  }
+}
 
 const moduleId = 'playback' as ModuleId
 export const timelinePanelId = `${moduleId}.timeline` as PanelId
@@ -82,7 +90,7 @@ const GlobalHooks: FunctionComponent = () => {
       }
 
       try {
-        audioEngine.play(createAudioGraph(program))
+        audioEngine.play(createAudioGraph(program, AUDIO_GRAPH_OPTIONS))
         setGraphErrors([])
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Unknown error'
@@ -100,6 +108,12 @@ const GlobalHooks: FunctionComponent = () => {
   }), [audioEngine, showErrorNotification])
 
   useProvideProblems(problems)
+
+  useRegisterService<MeteringService>(METERING_SERVICE_ID, {
+    subscribeToGain: (key, observer) => {
+      return audioEngine.meters.subscribeToGain(key, observer)
+    }
+  }, [audioEngine])
 
   return null
 }

--- a/packages/app/src/modules/playback/services/metering.ts
+++ b/packages/app/src/modules/playback/services/metering.ts
@@ -1,0 +1,10 @@
+import type { EntityKey } from '@audiograph'
+import type { ServiceId } from '@editor'
+import type { Observer, UnsubscribeFn } from '@utility'
+import type { GainMeasurement } from '@webaudio'
+
+export const METERING_SERVICE_ID = 'playback.metering' as ServiceId
+
+export interface MeteringService {
+  readonly subscribeToGain: (key: EntityKey, observer: Observer<GainMeasurement>) => UnsubscribeFn
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -34,6 +34,7 @@ export type { TabTitleProps } from './layout/components/TabTitle.js'
 // modules
 export type * from './modules/types.js'
 export * from './modules/components/ModuleContext.js'
+export * from './modules/components/ServiceContext.js'
 
 // notifications
 export type * from './notifications/types.js'

--- a/packages/editor/src/modules/components/ModuleContext.tsx
+++ b/packages/editor/src/modules/components/ModuleContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, Fragment, type FunctionComponent, type PropsWithChildren, type ReactNode } from 'react'
+import type { FunctionComponent, PropsWithChildren, ReactNode } from 'react'
+import { createContext, Fragment } from 'react'
 import { useSafeContext } from '../../hooks/safe-context.js'
 import type { Module } from '../types.js'
 

--- a/packages/editor/src/modules/components/ServiceContext.tsx
+++ b/packages/editor/src/modules/components/ServiceContext.tsx
@@ -1,0 +1,53 @@
+import type { DependencyList, FunctionComponent, PropsWithChildren } from 'react'
+import { createContext, useCallback, useEffect, useMemo, useState } from 'react'
+import { useSafeContext } from '../../hooks/safe-context.js'
+import type { ServiceId } from '../types.js'
+
+type Unregister = () => void
+
+interface ServiceContextValue {
+  readonly services: ReadonlyMap<ServiceId, unknown>
+  readonly registerService: (id: ServiceId, service: unknown) => Unregister
+}
+
+const ServiceContext = createContext<ServiceContextValue | undefined>(undefined)
+
+export const ServiceProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const [services, setServices] = useState<ReadonlyMap<ServiceId, unknown>>(new Map())
+
+  const registerService = useCallback((id: ServiceId, service: unknown): Unregister => {
+    setServices((prev) => new Map(prev).set(id, service))
+
+    return () => setServices((prev) => {
+      const copy = new Map(prev)
+      copy.delete(id)
+      return copy
+    })
+  }, [])
+
+  const value = useMemo(() => ({
+    services,
+    registerService
+  }), [services, registerService])
+
+  return (
+    <ServiceContext value={value}>
+      {children}
+    </ServiceContext>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+export function useService<T> (id: ServiceId): T | undefined {
+  const context = useSafeContext(ServiceContext, 'ServiceContext')
+  return context.services.get(id) as T | undefined
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+export function useRegisterService<T> (id: ServiceId, service: T, deps: DependencyList = []): void {
+  const { registerService } = useSafeContext(ServiceContext, 'ServiceContext')
+
+  const instance = useMemo(() => service, deps)
+
+  useEffect(() => registerService(id, instance), [id, instance, registerService])
+}

--- a/packages/editor/src/modules/types.ts
+++ b/packages/editor/src/modules/types.ts
@@ -9,6 +9,8 @@ export type ModuleProviderComponent = ComponentType<PropsWithChildren>
 
 export type ModuleId = Brand<string, 'editor.ModuleId'>
 
+export type ServiceId = Brand<string, 'editor.ServiceId'>
+
 export interface Module {
   readonly id: ModuleId
   readonly Provider?: ModuleProviderComponent

--- a/packages/editor/src/provider/CommonProvider.tsx
+++ b/packages/editor/src/provider/CommonProvider.tsx
@@ -4,6 +4,7 @@ import { MenuProvider } from '../commands/components/MenuContext.js'
 import { DialogProvider } from '../dialogs/components/DialogContext.js'
 import { LayoutProvider } from '../layout/components/LayoutContext.js'
 import { ModuleProvider } from '../modules/components/ModuleContext.js'
+import { ServiceProvider } from '../modules/components/ServiceContext.js'
 import type { Module } from '../modules/types.js'
 import { NotificationProvider } from '../notifications/components/NotificationContext.js'
 import { PersistenceProvider } from '../persistence/components/PersistenceContext.js'
@@ -21,15 +22,17 @@ export const CommonProvider: FunctionComponent<PropsWithChildren<{
         <LayoutProvider>
           <DialogProvider>
             <NotificationProvider>
-              <CommandRegistryProvider>
-                <MenuProvider>
-                  <ProblemProvider>
-                    <ModuleProvider modules={modules}>
-                      {children}
-                    </ModuleProvider>
-                  </ProblemProvider>
-                </MenuProvider>
-              </CommandRegistryProvider>
+              <ServiceProvider>
+                <CommandRegistryProvider>
+                  <MenuProvider>
+                    <ProblemProvider>
+                      <ModuleProvider modules={modules}>
+                        {children}
+                      </ModuleProvider>
+                    </ProblemProvider>
+                  </MenuProvider>
+                </CommandRegistryProvider>
+              </ServiceProvider>
             </NotificationProvider>
           </DialogProvider>
         </LayoutProvider>


### PR DESCRIPTION
The peak and RMS stereo levels are now visualized as vertical bars on each node in the mixer graph. This provides a quick signal level view for instruments, buses, and the main output.

The implementation uses a new module-level "service" concept, by which the mixer module can attach itself to data owned by the playback module.