### PR TITLE
feat: Add 'fill' function for patterns

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -3,7 +3,7 @@ export const demoCode = `
 
 // Import some functions from the standard library.
 use "instruments" as *  // sample
-use "patterns" as *     // loop
+use "patterns" as *     // loop, fill
 use "effects" as fx
 
 sample_collection = "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master"
@@ -24,7 +24,7 @@ snare_pattern = loop([-x])
 
 // Patterns can also define pitches (note and octave) for melodic instruments.
 // Division and multiplication (/, *) change pattern timing. Here, /4 creates 16th notes.
-arp_intro   = loop([-], 8) + loop([D3:3 D4:3 F4 -] / 4, 4)
+arp_intro   = fill([-], 2.bars) + loop([D3:3 D4:3 F4 -] / 4, 4)
 arp_main    = ([D3:3 D4:3 G4 G4] + [D3:3 D4:2 G5 G4 F4]) / 4
 
 // Steps can have custom lengths. The hit below is 8 times the default step length.

--- a/packages/core/src/pattern.ts
+++ b/packages/core/src/pattern.ts
@@ -259,14 +259,20 @@ export function loopPattern (pattern: Pattern, duration?: Numeric<'beats'>): Pat
 
       do {
         for (const event of pattern.evaluate()) {
-          if (offset + event.time.value >= duration.value) {
+          const eventTime = offset + event.time.value
+          if (eventTime >= duration.value) {
             return
           }
+
+          const remainingDuration = duration.value - eventTime
 
           hasEvents = true
           yield {
             ...event,
-            time: numeric('beats', event.time.value + offset)
+            time: numeric('beats', eventTime),
+            gate: event.gate != null && event.gate.value > remainingDuration
+              ? numeric('beats', remainingDuration)
+              : event.gate
           }
         }
 
@@ -334,7 +340,14 @@ export function renderPatternEvents (pattern: Pattern, end: Numeric<'beats'>): r
     if (event.time.value >= end.value) {
       break
     }
-    events.push(event)
+
+    const remainingDuration = end.value - event.time.value
+    events.push({
+      ...event,
+      gate: event.gate != null && event.gate.value > remainingDuration
+        ? numeric('beats', remainingDuration)
+        : event.gate
+    })
   }
 
   return events

--- a/packages/core/test/pattern.test.ts
+++ b/packages/core/test/pattern.test.ts
@@ -316,6 +316,22 @@ describe('pattern.ts', () => {
       ])
     })
 
+    it('should trim gates that extend beyond the target duration', () => {
+      const pattern = createSerialPattern([
+        { value: 'A4', gate: numeric(undefined, 3) },
+        { value: 'B4', gate: numeric(undefined, 5) }
+      ], 1)
+      const looped = loopPattern(pattern, beats(4))
+
+      assert.strictEqual(looped.length?.value, 4)
+      assert.deepStrictEqual([...looped.evaluate()], [
+        { time: beats(0), gate: beats(3), pitch: 'A4' },
+        { time: beats(1), gate: beats(3), pitch: 'B4' },
+        { time: beats(2), gate: beats(2), pitch: 'A4' },
+        { time: beats(3), gate: beats(1), pitch: 'B4' }
+      ])
+    })
+
     it('should return the same pattern if it is infinite and no duration is provided', () => {
       const pattern = loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }], 1))
       const looped = loopPattern(pattern)
@@ -493,6 +509,21 @@ describe('pattern.ts', () => {
         renderPatternEvents(pattern, beats(2)),
         [
           { time: beats(0), gate: beats(1) }
+        ]
+      )
+    })
+
+    it('should trim gates that extend beyond the render end', () => {
+      const pattern = createSerialPattern([
+        { value: 'A4', gate: numeric(undefined, 3) },
+        { value: 'B4', gate: numeric(undefined, 5) }
+      ], 1)
+
+      assert.deepStrictEqual(
+        renderPatternEvents(pattern, beats(2)),
+        [
+          { time: beats(0), gate: beats(2), pitch: 'A4' },
+          { time: beats(1), gate: beats(1), pitch: 'B4' }
         ]
       )
     })

--- a/packages/language/src/compiler/modules/patterns.ts
+++ b/packages/language/src/compiler/modules/patterns.ts
@@ -22,11 +22,29 @@ const loop = FunctionType.of({
     }
 
     if (pattern.length == null) {
-    // infinite pattern multiplied by finite factor remains infinite
+      // infinite pattern multiplied by finite factor remains infinite
       return PatternType.of(loopPattern(pattern))
     }
 
     const duration = numeric('beats', pattern.length.value * factor)
+
+    return PatternType.of(loopPattern(pattern, duration))
+  }
+})
+
+const fill = FunctionType.of({
+  summary: 'Repeats a pattern until it fills the specified duration. Longer patterns are truncated.',
+  arguments: [
+    { name: 'pattern', type: PatternType, required: true },
+    { name: 'duration', type: NumberType.with('beats'), required: true }
+  ],
+
+  returnType: PatternType,
+
+  invoke: (_context, { pattern, duration }) => {
+    if (duration.value <= 0 || !Number.isFinite(duration.value)) {
+      return PatternType.of(createSerialPattern([], 1))
+    }
 
     return PatternType.of(loopPattern(pattern, duration))
   }
@@ -37,6 +55,7 @@ export const patternsModule = ModuleType.of({
   summary: 'Functions for creating and manipulating patterns.',
 
   exports: new Map<string, Value>([
-    ['loop', loop]
+    ['loop', loop],
+    ['fill', fill]
   ])
 })

--- a/packages/language/test/compiler/modules/patterns.test.ts
+++ b/packages/language/test/compiler/modules/patterns.test.ts
@@ -1,4 +1,4 @@
-import { createSerialPattern, renderPatternEvents } from '@core'
+import { createSerialPattern, loopPattern, renderPatternEvents } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -47,11 +47,11 @@ describe('compiler/modules/patterns.ts', () => {
     })
 
     it('should keep infinite patterns infinite', () => {
-      const pattern = createSerialPattern([
+      const pattern = loopPattern(createSerialPattern([
         { value: 'x' },
         { value: '-' },
         { value: 'C4' }
-      ], 2)
+      ], 2))
       const context = createFunctionContext()
 
       const result = loop.data.invoke(context, { pattern })
@@ -163,6 +163,155 @@ describe('compiler/modules/patterns.ts', () => {
 
       assert.deepStrictEqual(events, [
         { time: beats(0), gate: beats(0.5) }
+      ])
+    })
+  })
+
+  describe('fill', () => {
+    const fill = patterns.exports.get('fill')
+    assert.ok(fill != null && FunctionType.is(fill))
+
+    it('should loop finite patterns until the duration is filled', () => {
+      const pattern = createSerialPattern([
+        { value: 'x' },
+        { value: '-' },
+        { value: 'C4' }
+      ], 2)
+      const context = createFunctionContext()
+
+      const result = fill.data.invoke(context, {
+        pattern,
+        duration: beats(2.0)
+      })
+      const resultPattern = PatternType.cast(result)
+      assert.deepStrictEqual(resultPattern.data.length, beats(2.0))
+
+      const events = renderPatternEvents(resultPattern.data, beats(5.0))
+
+      assert.deepStrictEqual(events, [
+        { time: beats(0), gate: beats(0.5) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4' },
+        { time: beats(1.5), gate: beats(0.5) }
+      ])
+    })
+
+    it('should truncate infinite patterns to the requested duration', () => {
+      const pattern = loopPattern(createSerialPattern([
+        { value: 'x' },
+        { value: '-' },
+        { value: 'C4' }
+      ], 2))
+      const context = createFunctionContext()
+
+      const result = fill.data.invoke(context, {
+        pattern,
+        duration: beats(2.0)
+      })
+      const resultPattern = PatternType.cast(result)
+      assert.deepStrictEqual(resultPattern.data.length, beats(2.0))
+
+      const events = renderPatternEvents(resultPattern.data, beats(5.0))
+
+      assert.deepStrictEqual(events, [
+        { time: beats(0), gate: beats(0.5) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4' },
+        { time: beats(1.5), gate: beats(0.5) }
+      ])
+    })
+
+    it('should return empty pattern when filling an empty pattern', () => {
+      const pattern = createSerialPattern([], 4)
+      const context = createFunctionContext()
+
+      const result = fill.data.invoke(context, {
+        pattern,
+        duration: beats(2.0)
+      })
+      const resultPattern = PatternType.cast(result)
+      assert.deepStrictEqual(resultPattern.data.length?.value, 0)
+
+      const events = renderPatternEvents(resultPattern.data, beats(2.0))
+      assert.deepStrictEqual(events, [])
+    })
+
+    it('should return empty pattern when duration is zero', () => {
+      const pattern = createSerialPattern([
+        { value: 'x' },
+        { value: '-' },
+        { value: 'C4' }
+      ], 2)
+      const context = createFunctionContext()
+
+      const result = fill.data.invoke(context, {
+        pattern,
+        duration: beats(0)
+      })
+      const resultPattern = PatternType.cast(result)
+      assert.deepStrictEqual(resultPattern.data.length?.value, 0)
+
+      const events = renderPatternEvents(resultPattern.data, beats(2.0))
+      assert.deepStrictEqual(events, [])
+    })
+
+    it('should treat negative duration as empty', () => {
+      const pattern = createSerialPattern([
+        { value: 'x' },
+        { value: '-' },
+        { value: 'C4' }
+      ], 2)
+      const context = createFunctionContext()
+
+      const result = fill.data.invoke(context, {
+        pattern,
+        duration: beats(-2.0)
+      })
+      const resultPattern = PatternType.cast(result)
+      assert.deepStrictEqual(resultPattern.data.length?.value, 0)
+
+      const events = renderPatternEvents(resultPattern.data, beats(2.0))
+      assert.deepStrictEqual(events, [])
+    })
+
+    it('should treat non-finite duration as empty', () => {
+      const pattern = createSerialPattern([
+        { value: 'x' },
+        { value: '-' },
+        { value: 'C4' }
+      ], 2)
+      const context = createFunctionContext()
+
+      const result = fill.data.invoke(context, {
+        pattern,
+        duration: beats(Number.POSITIVE_INFINITY)
+      })
+      const resultPattern = PatternType.cast(result)
+      assert.deepStrictEqual(resultPattern.data.length?.value, 0)
+
+      const events = renderPatternEvents(resultPattern.data, beats(2.0))
+      assert.deepStrictEqual(events, [])
+    })
+
+    it('should trim notes with gate that extends beyond the duration', () => {
+      const pattern = createSerialPattern([
+        { value: 'A4', gate: numeric(undefined, 3) },
+        { value: 'B4', gate: numeric(undefined, 5) }
+      ], 1)
+      const context = createFunctionContext()
+
+      const result = fill.data.invoke(context, {
+        pattern,
+        duration: beats(4.0)
+      })
+      const resultPattern = PatternType.cast(result)
+      assert.deepStrictEqual(resultPattern.data.length, beats(4.0))
+
+      const events = renderPatternEvents(resultPattern.data, beats(4.0))
+
+      assert.deepStrictEqual(events, [
+        { time: beats(0), gate: beats(3.0), pitch: 'A4' },
+        { time: beats(1), gate: beats(3.0), pitch: 'B4' },
+        { time: beats(2), gate: beats(2.0), pitch: 'A4' },
+        { time: beats(3), gate: beats(1.0), pitch: 'B4' }
       ])
     })
   })


### PR DESCRIPTION
Adds a 'fill' function to the "patterns" module, which repeats a pattern until a specified duration is reached. Longer patterns are truncated to fit. Especially for odd-length patterns, 'fill' provides better control over note placement than 'loop', where one may have to specify an awkard multiple to get the desired result.