### PR TITLE
feat: Differentiate warnings from errors in the UI

### DIFF
--- a/packages/app/src/components/tab/StyledTabTitle.tsx
+++ b/packages/app/src/components/tab/StyledTabTitle.tsx
@@ -41,13 +41,8 @@ export const StyledTabTitle: FunctionComponent<TabTitleProps> = ({ tab, state, o
       )}
     >
       {macOS && closeButton}
-
       <TitleComponent panelProps={tab.component.props} tabId={tab.id} />
-
-      <div className='px-1 py-0.5 text-xs leading-none bg-error-surface text-error-content border border-error-frame rounded empty:hidden'>
-        <NotificationsComponent panelProps={tab.component.props} tabId={tab.id} />
-      </div>
-
+      <NotificationsComponent panelProps={tab.component.props} tabId={tab.id} />
       {!macOS && closeButton}
     </div>
   )

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -44,10 +44,17 @@ html.dark {
 
   /* var(--color-red-300), var(--color-red-800) */
   --color-error-surface: light-dark(oklch(80.8% 0.114 19.571), oklch(44.4% 0.177 26.899));
-  /* var(--color-red-600), var(--color-red-500) */
-  --color-error-frame: light-dark(oklch(57.7% 0.245 27.325), oklch(63.7% 0.237 25.331));
+  /* var(--color-red-600), var(--color-red-400) */
+  --color-error-frame: light-dark(oklch(57.7% 0.245 27.325), oklch(70.4% 0.191 22.216));
   /* var(--color-black), var(--color-white) */
   --color-error-content: light-dark(#000, #fff);
+
+  /* var(--color-yellow-300), var(--color-yellow-800) */
+  --color-warning-surface: light-dark(oklch(90.5% 0.182 98.111), oklch(47.6% 0.114 61.907));
+  /* var(--color-yellow-600), var(--color-yellow-500) */
+  --color-warning-frame: light-dark(oklch(68.1% 0.162 75.834), oklch(79.5% 0.184 86.047));
+  /* var(--color-black), var(--color-white) */
+  --color-warning-content: light-dark(#000, #fff);
 
   --color-dialog-backdrop: light-dark(hsl(210 6% 0% / 28%), hsl(210 6% 16% / 52%));
 }

--- a/packages/app/src/modules/problems/ProblemsNotifications.tsx
+++ b/packages/app/src/modules/problems/ProblemsNotifications.tsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx'
+import { useProblemCountByKind } from './hooks.js'
+
+export const ProblemsNotifications = () => {
+  const { error, warning } = useProblemCountByKind()
+  const count = error + warning
+
+  if (count === 0) {
+    return null
+  }
+
+  return (
+    <span
+      className={clsx(
+        'px-1 py-0.5 text-xs leading-none border rounded',
+        error === 0
+          ? 'bg-warning-surface text-warning-content border-warning-frame'
+          : 'bg-error-surface text-error-content border-error-frame'
+      )}
+    >
+      {count}
+    </span>
+  )
+}

--- a/packages/app/src/modules/problems/hooks.ts
+++ b/packages/app/src/modules/problems/hooks.ts
@@ -1,0 +1,14 @@
+import type { ProblemKind } from '@editor'
+import { useProblems } from '@editor'
+import { useMemo } from 'react'
+
+export function useProblemCountByKind (): Record<ProblemKind, number> {
+  const problems = useProblems()
+
+  return useMemo(() => {
+    return problems.reduce<Record<ProblemKind, number>>((accumulator, problem) => {
+      ++accumulator[problem.kind]
+      return accumulator
+    }, { error: 0, warning: 0 } satisfies Record<ProblemKind, number>)
+  }, [problems])
+}

--- a/packages/app/src/modules/problems/index.ts
+++ b/packages/app/src/modules/problems/index.ts
@@ -1,8 +1,10 @@
 import type { CommandId, MenuSectionId, Module, ModuleId, PanelId } from '@editor'
-import { activateTabOfType, useLayoutDispatch, useProblems, useRegisterCommand } from '@editor'
+import { activateTabOfType, useLayoutDispatch, useRegisterCommand } from '@editor'
 import type { FunctionComponent } from 'react'
 import { pluralize } from '../../utilities/format.js'
+import { ProblemsNotifications } from './ProblemsNotifications.js'
 import { ProblemsPanel } from './ProblemsPanel.js'
+import { useProblemCountByKind } from './hooks.js'
 
 const moduleId = 'problems' as ModuleId
 export const problemsPanelId = `${moduleId}.problems` as PanelId
@@ -36,10 +38,7 @@ export const problemsModule: Module = {
       closeable: true,
       Panel: ProblemsPanel,
       Title: () => 'Problems',
-      Notifications: () => {
-        const problems = useProblems()
-        return problems.length > 0 ? problems.length : null
-      }
+      Notifications: ProblemsNotifications
     }
   ],
 
@@ -59,8 +58,21 @@ export const problemsModule: Module = {
         commandId: viewProblemsId,
         position: 'start',
         Label: () => {
-          const problems = useProblems()
-          return problems.length === 0 ? 'No errors' : pluralize(problems.length, 'error')
+          const { error, warning } = useProblemCountByKind()
+
+          if (error === 0 && warning === 0) {
+            return 'No problems'
+          }
+
+          if (warning === 0) {
+            return pluralize(error, 'error')
+          }
+
+          if (error === 0) {
+            return pluralize(warning, 'warning')
+          }
+
+          return `${pluralize(error, 'error')}, ${pluralize(warning, 'warning')}`
         }
       }
     ]

--- a/packages/editor/src/layout/components/TabTitle.tsx
+++ b/packages/editor/src/layout/components/TabTitle.tsx
@@ -28,7 +28,7 @@ export function parseTabDropTarget (id: string): TabDropTargetInfo | undefined {
 
 export interface TabTitleProps {
   readonly TitleComponent: ModuleRenderFn<PanelProps, string>
-  readonly NotificationsComponent: ModuleRenderFn<PanelProps, number | null>
+  readonly NotificationsComponent: ModuleRenderFn<PanelProps>
   readonly tab: Tab
   readonly state: TabTitleState
   readonly closeable: boolean

--- a/packages/editor/src/modules/types.ts
+++ b/packages/editor/src/modules/types.ts
@@ -36,7 +36,7 @@ export interface Panel {
   readonly closeable: boolean
   readonly Panel: ComponentType<PanelProps>
   readonly Title: ModuleRenderFn<PanelProps, string>
-  readonly Notifications?: ModuleRenderFn<PanelProps, number | null>
+  readonly Notifications?: ModuleRenderFn<PanelProps>
 }
 
 export interface PanelProps {


### PR DESCRIPTION
The problem count shown as decoration on the "Problems" tab header is now shown in yellow if there are only warnings, and in red if there are errors, instead of red in both cases. Additionally, the wording in the footer now mentions either errors, warnings, or both.