### PR TITLE
feat: Make pan an automatable parameter

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -233,9 +233,7 @@ const BusNodeInfo: FunctionComponent<{
     <>
       <div className='font-bold'>bus.{object.name}</div>
       <div>gain: {object.gain.initial.value.toFixed(2)} {object.gain.initial.unit}</div>
-      {object.pan != null && (
-        <div>pan: {object.pan.value.toFixed(2)}</div>
-      )}
+      <div>pan: {object.pan.initial.value.toFixed(2)}</div>
       {object.effects.length > 0 && (
         <div>+ {pluralize(object.effects.length, 'effect')}</div>
       )}

--- a/packages/audiograph/src/automation.ts
+++ b/packages/audiograph/src/automation.ts
@@ -1,5 +1,7 @@
-import { beatsToSeconds, type AutomationPoint, type Parameter, type Program } from '@core'
-import { numeric, type Numeric, type Unit } from '@utility'
+import type { AutomationPoint, Parameter, Program } from '@core'
+import { beatsToSeconds } from '@core'
+import type { Numeric, Unit } from '@utility'
+import { numeric } from '@utility'
 import { dbToGain } from './constants.js'
 
 export type Curve = 'step' | 'linear' | 'exponential'
@@ -68,4 +70,16 @@ export const gainTransform: Transform<'db', undefined> = {
         throw new Error()
     }
   }
+}
+
+export const panTransform: Transform<undefined, undefined> = {
+  transformValue: (value) => {
+    if (Number.isNaN(value.value)) {
+      throw new Error(`Invalid pan: ${value.value}`)
+    }
+
+    return numeric(undefined, Math.max(-1, Math.min(1, value.value)))
+  },
+
+  transformCurve: (curve) => curve
 }

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -2,7 +2,7 @@ import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Progra
 import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
-import { gainTransform, timeVariant, toTimeVariant } from './automation.js'
+import { gainTransform, panTransform, timeVariant, toTimeVariant } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
 import { DEFAULT_ROOT_NOTE } from './constants.js'
@@ -88,12 +88,13 @@ function createBus (program: Program, bus: Bus, builder: Builder): SubGraph {
     appendEffect(effect)
   }
 
-  if (bus.pan != null) {
+  // Optimization: Skip adding a node if the value is constant 0.
+  // TODO: Make this more generic and move into appendEffect?
+  if (bus.pan.initial.value !== 0 || program.automations.has(bus.pan.id)) {
     appendEffect({ type: 'pan', pan: bus.pan })
   }
 
-  // Optimization: Skip adding a node if gain is 0 and is not automated.
-  // TODO: Make this more generic and move into appendEffect?
+  // TODO: see above
   if (bus.gain.initial.value !== 0 || program.automations.has(bus.gain.id)) {
     appendEffect({ type: 'gain', gain: bus.gain })
   }
@@ -161,13 +162,8 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
     }
 
     case 'pan': {
-      if (Number.isNaN(effect.pan.value)) {
-        throw new Error(`Invalid pan: ${effect.pan.value}`)
-      }
-
       return toSubGraph(builder.addNode<PanNode>('pan', {
-        // TODO time variant
-        pan: numeric(undefined, Math.max(-1, Math.min(1, effect.pan.value)))
+        pan: toTimeVariant(effect.pan, program, panTransform)
       }))
     }
 

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -37,7 +37,7 @@ export interface GainNode extends AnyNode {
 
 export interface PanNode extends AnyNode {
   readonly type: 'pan'
-  readonly pan: Numeric<undefined>
+  readonly pan: TimeVariant<undefined>
 }
 
 export interface BiquadNode extends AnyNode {

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -58,6 +58,10 @@ function createProgramWithEffect (effect: Effect): Program {
             id: 400 as ParameterId,
             initial: numeric('db', 0)
           },
+          pan: {
+            id: 500 as ParameterId,
+            initial: numeric(undefined, 0)
+          },
           effects: [effect]
         }
       ],
@@ -144,6 +148,10 @@ describe('lowering.ts', () => {
             gain: {
               id: busGainId,
               initial: numeric('db', -3)
+            },
+            pan: {
+              id: 500 as ParameterId,
+              initial: numeric(undefined, 0)
             },
             effects: []
           } satisfies Bus
@@ -542,41 +550,62 @@ describe('lowering.ts', () => {
       it('should handle pan', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'pan',
-          pan: numeric(undefined, 0.5)
+          pan: {
+            id: 500 as ParameterId,
+            initial: numeric(undefined, 0.5)
+          }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           id: 2 as NodeId,
           type: 'pan',
-          pan: numeric(undefined, 0.5)
+          pan: {
+            initial: numeric(undefined, 0.5),
+            points: []
+          }
         })
       })
 
       it('should clamp pan to [-1, 1]', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'pan',
-          pan: numeric(undefined, Infinity)
+          pan: {
+            id: 500 as ParameterId,
+            initial: numeric(undefined, Infinity)
+          }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           id: 2 as NodeId,
           type: 'pan',
-          pan: numeric(undefined, 1)
+          pan: {
+            initial: numeric(undefined, 1),
+            points: []
+          }
         })
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'pan',
-          pan: numeric(undefined, -Infinity)
+          pan: {
+            id: 500 as ParameterId,
+            initial: numeric(undefined, -Infinity)
+          }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           id: 2 as NodeId,
           type: 'pan',
-          pan: numeric(undefined, -1)
+          pan: {
+            initial: numeric(undefined, -1),
+            points: []
+          }
         })
       })
 
       it('should throw for NaN pan', () => {
         assert.throws(() => createAudioGraph(createProgramWithEffect({
           type: 'pan',
-          pan: numeric(undefined, Number.NaN)
+          pan: {
+            id: 500 as ParameterId,
+            initial: numeric(undefined, Number.NaN)
+          }
         })), /Invalid pan/)
       })
     })
@@ -1009,6 +1038,10 @@ describe('lowering.ts', () => {
               gain: {
                 id: 201 as ParameterId,
                 initial: numeric('db', -3)
+              },
+              pan: {
+                id: 202 as ParameterId,
+                initial: numeric(undefined, 0)
               },
               effects: []
             } satisfies Bus

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -124,7 +124,7 @@ export type BusId = Brand<number, 'core.BusId'>
 export interface Bus {
   readonly id: BusId
   readonly name: string
-  readonly pan?: Numeric<undefined>
+  readonly pan: Parameter<undefined>
   readonly gain: Parameter<'db'>
   readonly effects: readonly Effect[]
 }
@@ -145,7 +145,7 @@ export interface GainEffect {
 
 export interface PanEffect {
   readonly type: 'pan'
-  readonly pan: Numeric<undefined>
+  readonly pan: Parameter<undefined>
 }
 
 export interface LowpassEffect {

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -286,10 +286,10 @@ function generateBus (context: Context, bus: ast.BusStatement, id: BusId): Bus {
     return EffectType.cast(resolve(context, effect.expression)).data
   })
 
-  // Gain must always be allocated even if not explicitly set,
-  // as it could still be automated.
+  // These must always be allocated even if not explicitly set,
+  // as they could still be automated.
   const gain = allocateParameter(context.top, properties.gain ?? numeric('db', 0))
-  const pan = properties.pan
+  const pan = allocateParameter(context.top, properties.pan ?? numeric(undefined, 0))
 
   return { id, name, gain, pan, effects }
 }

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -34,7 +34,7 @@ const pan = createEffectConstructor('Places the signal in the stereo field.', [
   { name: 'pan', type: NumberType.with(undefined), required: true }
 ], (context, args) => ({
   type: 'pan',
-  pan: args.pan
+  pan: allocateParameter(context, args.pan)
 }))
 
 const lowpass = createEffectConstructor('Filters out frequencies above the cutoff.', [

--- a/packages/language/src/compiler/types.ts
+++ b/packages/language/src/compiler/types.ts
@@ -274,6 +274,8 @@ export const BusType = makeType<'bus', {}, BusValue>('bus', undefined, {
     switch (name) {
       case 'gain':
         return ParameterType.with('db')
+      case 'pan':
+        return ParameterType.with(undefined)
       default:
         return undefined
     }
@@ -283,6 +285,8 @@ export const BusType = makeType<'bus', {}, BusValue>('bus', undefined, {
     switch (name) {
       case 'gain':
         return ParameterType.of(value.data.gain)
+      case 'pan':
+        return ParameterType.of(value.data.pan)
       default:
         return undefined
     }

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -266,10 +266,9 @@ describe('compiler/generator.ts', () => {
 
     const result = generateSource(source)
 
-    assert.strictEqual(result.automations.size, 1)
     const busGain = result.mixer.buses[0].gain
     const automation = result.automations.get(busGain.id)
-    assert.ok(automation)
+    assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -20), curve: 'step' },
       { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -51,7 +51,10 @@ describe('compiler/modules/effects.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         type: 'pan',
-        pan: numeric(undefined, 0.5)
+        pan: {
+          id: 1,
+          initial: numeric(undefined, 0.5)
+        }
       })
     })
   })

--- a/packages/language/test/compiler/types.test.ts
+++ b/packages/language/test/compiler/types.test.ts
@@ -628,6 +628,10 @@ describe('compiler/types.ts', () => {
         const gainType = BusType.propertyType('gain')
         assert.strictEqual(gainType?.name, 'parameter')
         assert.deepStrictEqual(gainType.generics, { unit: 'db' })
+
+        const panType = BusType.propertyType('pan')
+        assert.strictEqual(panType?.name, 'parameter')
+        assert.deepStrictEqual(panType.generics, { unit: undefined })
       })
     })
 
@@ -636,7 +640,10 @@ describe('compiler/types.ts', () => {
         const busValue = BusType.of({
           id: 1 as any,
           name: 'main',
-          pan: undefined,
+          pan: {
+            id: 3 as ParameterId,
+            initial: numeric(undefined, 0)
+          },
           gain: {
             id: 2 as ParameterId,
             initial: numeric('db', -3)
@@ -646,6 +653,9 @@ describe('compiler/types.ts', () => {
 
         const gainValue = BusType.propertyValue(busValue, 'gain')
         assert.deepStrictEqual(gainValue?.data, busValue.data.gain)
+
+        const panValue = BusType.propertyValue(busValue, 'pan')
+        assert.deepStrictEqual(panValue?.data, busValue.data.pan)
       })
     })
   })

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -17,7 +17,7 @@ export function createGainInstance (node: GainNode, transport: Transport): Insta
 export function createPanInstance (node: PanNode, transport: Transport): Instance {
   // equal power panning
   const audioNode = transport.ctx.createStereoPanner()
-  audioNode.pan.value = node.pan.value
+  automate(transport, audioNode.pan, node.pan)
   return toInstance(audioNode)
 }
 


### PR DESCRIPTION
This patch turns pan from a simple numeric value into a time-variant parameter, meaning it can now be automated:

```
// pan left to right, then right to left
automate bus.my_bus.pan as curve [lin(-1, 1) lin(1, -1)]
```