### PR TITLE
fix: Add implicit routings in absence of mixer

### DIFF
--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -40,9 +40,7 @@ export function generate (program: ast.Program, options: GenerateOptions): Progr
   processAssignments(context, assignments)
 
   // Automations in the track may refer to mixer buses, so the mixer must be generated first.
-  const mixer = mixers.length > 0
-    ? generateMixer(context, mixers[0])
-    : { buses: [], routings: [] }
+  const mixer = generateMixer(context, mixers.at(0))
 
   const track = tracks.length > 0
     ? generateTrack(context, tracks[0])
@@ -230,22 +228,23 @@ function generatePart (context: Context, part: ast.PartStatement, startTime: Num
   return { name, length, routings }
 }
 
-function generateMixer (context: Context, mixer: ast.MixerStatement): Mixer {
+function generateMixer (context: Context, mixer?: ast.MixerStatement): Mixer {
   const mixerContext = createLocalScope(context)
 
-  const buses = mixer.buses.map((bus, index) => generateBus(mixerContext, bus, index as BusId))
-
-  for (const bus of buses) {
-    assert(!mixerContext.resolutions.has(bus.name))
-    const busValue = BusType.of(bus)
-    mixerContext.resolutions.set(bus.name, busValue)
-    context.top.buses.set(bus.name, busValue)
-  }
-
+  const buses = mixer?.buses.map((bus, index) => generateBus(mixerContext, bus, index as BusId)) ?? []
   const routings: MixerRouting[] = []
 
-  for (const bus of mixer.buses) {
-    routings.push(...generateBusRoutings(mixerContext, bus, buses))
+  if (mixer != null) {
+    for (const bus of buses) {
+      assert(!mixerContext.resolutions.has(bus.name))
+      const busValue = BusType.of(bus)
+      mixerContext.resolutions.set(bus.name, busValue)
+      context.top.buses.set(bus.name, busValue)
+    }
+
+    for (const bus of mixer.buses) {
+      routings.push(...generateBusRoutings(mixerContext, bus, buses))
+    }
   }
 
   // Implicit output routings for unrouted buses and instruments

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -275,6 +275,23 @@ describe('compiler/generator.ts', () => {
     ])
   })
 
+  it('should route instruments into the output when no mixer is present', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      ''
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.mixer.routings, [
+      {
+        implicit: true,
+        destination: { type: 'output' },
+        source: { type: 'instrument', id: 1 }
+      }
+    ])
+  })
+
   it('should support buses as sources in mixer', () => {
     const source = [
       'mixer {',


### PR DESCRIPTION
Instruments were only routed to the output if a mixer statement was present, so for input source code without `mixer { ... }`, the output would be silent. This is now fixed.