### PR TITLE
feat: Add sine wave instrument

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -56,10 +56,17 @@ function getNodeLabel ({ data }: MixerFlowNode): string {
   switch (data.type) {
     case 'output':
       return 'Main Output'
+
     case 'bus':
       return data.object.name
+
     case 'instrument': {
-      return data.object.sampleUrl.split('/').pop() ?? data.object.sampleUrl
+      switch (data.object.source.type) {
+        case 'sample':
+          return data.object.source.url.split('/').pop() ?? data.object.source.url
+        case 'oscillator':
+          return data.object.source.shape
+      }
     }
   }
 }
@@ -247,7 +254,15 @@ const InstrumentNodeInfo: FunctionComponent<{
   return (
     <>
       <div className='font-bold'>(Instrument)</div>
-      <div className='max-w-96'>url: {object.sampleUrl}</div>
+      <div>type: {object.source.type}</div>
+      {object.source.type === 'sample' && (
+        <div className='max-w-96'>url: {object.source.url}</div>
+      )}
+      {object.source.type === 'oscillator' && (
+        <div>shape: {object.source.shape}</div>
+      )}
+      <div>root_note: {object.rootNote ?? 'undefined'}</div>
+      <div>gain: {object.gain.initial.value.toFixed(2)} {object.gain.initial.unit}</div>
     </>
   )
 }

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Program, Track } from '@core'
+import type { Bus, BusId, Effect, Instrument, InstrumentId, MidiNote, MixerRouting, Oscillator, Program, Sample, Track } from '@core'
 import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
@@ -9,7 +9,7 @@ import { DEFAULT_ROOT_NOTE } from './constants.js'
 import type { EntityKey } from './entities.js'
 import { createEntityKey } from './entities.js'
 import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
-import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, Node, PanNode, ReverbNode, SampleNode, WidthNode } from './nodes.js'
+import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, Node, OscillatorNode, PanNode, ReverbNode, SampleNode, WidthNode } from './nodes.js'
 
 type Builder = AudioGraphBuilder<Node>
 
@@ -121,24 +121,15 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
     ? convertPitchToMidi(instrument.rootNote)
     : DEFAULT_ROOT_NOTE
 
-  const length = (() => {
-    if (instrument.length == null) {
-      return undefined
-    }
+  const source = (() => {
+    switch (instrument.source.type) {
+      case 'sample':
+        return createSampleSource(instrument.source, rootNote, builder)
 
-    const value = instrument.length.value
-    if (Number.isNaN(value)) {
-      throw new Error(`Invalid length: ${value}`)
+      case 'oscillator':
+        return createOscillatorSource(instrument.source, rootNote, builder)
     }
-
-    return value < 0 ? numeric('s', 0) : !Number.isFinite(value) ? undefined : numeric('s', value)
   })()
-
-  const source = builder.addNode<SampleNode>('sample', {
-    sampleUrl: instrument.sampleUrl,
-    rootNote,
-    length
-  })
 
   const gain = builder.addNode<GainNode>('gain', {
     gain: toTimeVariant(instrument.gain, program, gainTransform)
@@ -151,6 +142,27 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
     outputs: [gain.id],
     instrument: source.id
   }
+}
+
+function createSampleSource (sample: Sample, rootNote: MidiNote, builder: Builder): Node {
+  const length = (() => {
+    if (sample.length == null) {
+      return undefined
+    }
+
+    const value = sample.length.value
+    if (Number.isNaN(value)) {
+      throw new Error(`Invalid length: ${value}`)
+    }
+
+    return value < 0 ? numeric('s', 0) : !Number.isFinite(value) ? undefined : numeric('s', value)
+  })()
+
+  return builder.addNode<SampleNode>('sample', { rootNote, url: sample.url, length })
+}
+
+function createOscillatorSource (oscillator: Oscillator, rootNote: MidiNote, builder: Builder): Node {
+  return builder.addNode<OscillatorNode>('oscillator', { rootNote, shape: oscillator.shape })
 }
 
 function createEffect (program: Program, effect: Effect, builder: Builder): SubGraph {

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -17,6 +17,7 @@ export interface NodeTypeMap {
 
   // sources
   readonly sample: SampleNode
+  readonly oscillator: OscillatorNode
 
   // metering
   readonly gain_meter: GainMeterNode
@@ -66,9 +67,15 @@ export interface ReverbNode extends AnyNode {
 
 export interface SampleNode extends AnyNode {
   readonly type: 'sample'
-  readonly sampleUrl: string
   readonly rootNote: MidiNote
+  readonly url: string
   readonly length?: Numeric<'s'>
+}
+
+export interface OscillatorNode extends AnyNode {
+  readonly type: 'oscillator'
+  readonly rootNote: MidiNote
+  readonly shape: 'sine'
 }
 
 // metering

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -124,10 +124,13 @@ describe('lowering.ts', () => {
           instrumentId,
           {
             id: instrumentId,
-            sampleUrl: 'foo.wav',
             gain: {
               id: instrumentGainId,
               initial: numeric('db', -6)
+            },
+            source: {
+              type: 'sample',
+              url: 'foo.wav'
             }
           } satisfies Instrument
         ]
@@ -203,7 +206,7 @@ describe('lowering.ts', () => {
         id: 3 as NodeId,
         length: undefined,
         type: 'sample',
-        sampleUrl: 'foo.wav',
+        url: 'foo.wav',
         rootNote: 72 as MidiNote // C5
       } satisfies SampleNode,
       {
@@ -238,10 +241,13 @@ describe('lowering.ts', () => {
           instrumentId,
           {
             id: instrumentId,
-            sampleUrl: 'foo.wav',
             gain: {
               id: instrumentGainId,
               initial: numeric('db', -6)
+            },
+            source: {
+              type: 'sample',
+              url: 'foo.wav'
             }
           } satisfies Instrument
         ]
@@ -325,10 +331,13 @@ describe('lowering.ts', () => {
           instrumentId,
           {
             id: instrumentId,
-            sampleUrl: 'foo.wav',
             gain: {
               id: 200 as ParameterId,
               initial: numeric('db', -6)
+            },
+            source: {
+              type: 'sample',
+              url: 'foo.wav'
             }
           } satisfies Instrument
         ]
@@ -398,10 +407,13 @@ describe('lowering.ts', () => {
   it('should allow negative infinity instrument gain', () => {
     const program = createProgramWithInstrument({
       id: 100 as InstrumentId,
-      sampleUrl: 'foo.wav',
       gain: {
         id: 200 as ParameterId,
         initial: numeric('db', -Infinity)
+      },
+      source: {
+        type: 'sample',
+        url: 'foo.wav'
       }
     })
 
@@ -412,10 +424,13 @@ describe('lowering.ts', () => {
     for (const gain of [Infinity, Number.NaN]) {
       const program = createProgramWithInstrument({
         id: 100 as InstrumentId,
-        sampleUrl: 'foo.wav',
         gain: {
           id: 200 as ParameterId,
           initial: numeric('db', gain)
+        },
+        source: {
+          type: 'sample',
+          url: 'foo.wav'
         }
       })
 
@@ -427,12 +442,15 @@ describe('lowering.ts', () => {
     for (const rootNote of ['C-1' as Pitch, 'G10' as Pitch]) {
       const program = createProgramWithInstrument({
         id: 100 as InstrumentId,
-        sampleUrl: 'foo.wav',
+        rootNote,
         gain: {
           id: 200 as ParameterId,
           initial: numeric('db', -6)
         },
-        rootNote
+        source: {
+          type: 'sample',
+          url: 'foo.wav'
+        }
       })
 
       assert.throws(() => createAudioGraph(program), /Invalid pitch/, `should throw for root note: ${rootNote}`)
@@ -442,19 +460,22 @@ describe('lowering.ts', () => {
   it('should clamp negative sample lengths to zero', () => {
     const program = createProgramWithInstrument({
       id: 100 as InstrumentId,
-      sampleUrl: 'foo.wav',
       gain: {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      length: numeric('s', -1)
+      source: {
+        type: 'sample',
+        url: 'foo.wav',
+        length: numeric('s', -1)
+      }
     })
 
     const graph = createAudioGraph(program)
     assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
       id: 2 as NodeId,
       type: 'sample',
-      sampleUrl: 'foo.wav',
+      url: 'foo.wav',
       rootNote: 72 as MidiNote,
       length: numeric('s', 0)
     } satisfies SampleNode)
@@ -463,19 +484,22 @@ describe('lowering.ts', () => {
   it('should treat infinite sample length as valid', () => {
     const program = createProgramWithInstrument({
       id: 100 as InstrumentId,
-      sampleUrl: 'foo.wav',
       gain: {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      length: numeric('s', Infinity)
+      source: {
+        type: 'sample',
+        url: 'foo.wav',
+        length: numeric('s', Infinity)
+      }
     })
 
     const graph = createAudioGraph(program)
     assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
       id: 2 as NodeId,
       type: 'sample',
-      sampleUrl: 'foo.wav',
+      url: 'foo.wav',
       rootNote: 72 as MidiNote,
       length: undefined
     } satisfies SampleNode)
@@ -484,12 +508,15 @@ describe('lowering.ts', () => {
   it('should throw for NaN sample length', () => {
     const program = createProgramWithInstrument({
       id: 100 as InstrumentId,
-      sampleUrl: 'foo.wav',
       gain: {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      length: numeric('s', Number.NaN)
+      source: {
+        type: 'sample',
+        url: 'foo.wav',
+        length: numeric('s', Number.NaN)
+      }
     })
 
     assert.throws(() => createAudioGraph(program), /Invalid length/)
@@ -996,10 +1023,13 @@ describe('lowering.ts', () => {
     it('should not add metering by default', () => {
       const graph = createAudioGraph(createProgramWithInstrument({
         id: 100 as InstrumentId,
-        sampleUrl: 'foo.wav',
         gain: {
           id: 200 as ParameterId,
           initial: numeric('db', -6)
+        },
+        source: {
+          type: 'sample',
+          url: 'foo.wav'
         }
       }))
 
@@ -1017,10 +1047,13 @@ describe('lowering.ts', () => {
             instrumentId,
             {
               id: instrumentId,
-              sampleUrl: 'foo.wav',
               gain: {
                 id: 200 as ParameterId,
                 initial: numeric('db', -6)
+              },
+              source: {
+                type: 'sample',
+                url: 'foo.wav'
               }
             } satisfies Instrument
           ]
@@ -1110,10 +1143,13 @@ describe('lowering.ts', () => {
   it('should throw for invalid metering interval', () => {
     const program = createProgramWithInstrument({
       id: 100 as InstrumentId,
-      sampleUrl: 'foo.wav',
       gain: {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
+      },
+      source: {
+        type: 'sample',
+        url: 'foo.wav'
       }
     })
 

--- a/packages/core/src/midi.ts
+++ b/packages/core/src/midi.ts
@@ -47,3 +47,7 @@ export function convertPitchToMidi (pitch: Pitch): MidiNote {
 
   return midi
 }
+
+export function getMidiFrequency (midi: MidiNote): number {
+  return 440 * Math.pow(2, (midi - 69) / 12)
+}

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -85,10 +85,22 @@ export type InstrumentId = Brand<number, 'core.InstrumentId'>
 
 export interface Instrument {
   readonly id: InstrumentId
-  readonly sampleUrl: string
-  readonly gain: Parameter<'db'>
   readonly rootNote?: Pitch
+  readonly gain: Parameter<'db'>
+  readonly source: Source
+}
+
+export type Source = Sample | Oscillator
+
+export interface Sample {
+  readonly type: 'sample'
+  readonly url: string
   readonly length?: Numeric<'s'>
+}
+
+export interface Oscillator {
+  readonly type: 'oscillator'
+  readonly shape: 'sine'
 }
 
 export interface Track {

--- a/packages/core/test/midi.test.ts
+++ b/packages/core/test/midi.test.ts
@@ -1,14 +1,24 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { convertPitchToMidi } from '../src/midi.js'
+import { convertPitchToMidi, getMidiFrequency, type MidiNote } from '../src/midi.js'
 
 describe('midi.ts', () => {
-  it('maps pitches to standard MIDI note numbers', () => {
-    assert.strictEqual(convertPitchToMidi('C0'), 12)
-    assert.strictEqual(convertPitchToMidi('C#0'), 13)
-    assert.strictEqual(convertPitchToMidi('Db0'), 13)
-    assert.strictEqual(convertPitchToMidi('C4'), 60)
-    assert.strictEqual(convertPitchToMidi('A4'), 69)
-    assert.strictEqual(convertPitchToMidi('C5'), 72)
+  describe('convertPitchToMidi()', () => {
+    it('maps pitches to standard MIDI note numbers', () => {
+      assert.strictEqual(convertPitchToMidi('C0'), 12)
+      assert.strictEqual(convertPitchToMidi('C#0'), 13)
+      assert.strictEqual(convertPitchToMidi('Db0'), 13)
+      assert.strictEqual(convertPitchToMidi('C4'), 60)
+      assert.strictEqual(convertPitchToMidi('A4'), 69)
+      assert.strictEqual(convertPitchToMidi('C5'), 72)
+    })
+  })
+
+  describe('getMidiFrequency()', () => {
+    it('calculates the frequency of MIDI notes', () => {
+      assert.ok(Math.abs(getMidiFrequency(69 as MidiNote) - 440) < 1e-6)
+      assert.ok(Math.abs(getMidiFrequency(60 as MidiNote) - 261.625565) < 1e-6)
+      assert.ok(Math.abs(getMidiFrequency(72 as MidiNote) - 523.251130) < 1e-6)
+    })
   })
 })

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -22,11 +22,35 @@ const sample = FunctionType.of({
     const gainParameter = allocateParameter(context, gain ?? UNITY_GAIN)
 
     return allocateInstrument(context, {
-      sampleUrl: url,
       gain: gainParameter,
       // eslint-disable-next-line camelcase
       rootNote: isPitch(root_note) ? root_note : undefined,
-      length
+      source: {
+        type: 'sample',
+        url,
+        length
+      }
+    })
+  }
+})
+
+const sine = FunctionType.of({
+  summary: 'Creates an instrument that produces a sine wave.',
+  arguments: [
+    { name: 'gain', type: NumberType.with('db'), required: false }
+  ],
+
+  returnType: InstrumentType,
+
+  invoke: (context, { gain }) => {
+    const gainParameter = allocateParameter(context, gain ?? UNITY_GAIN)
+
+    return allocateInstrument(context, {
+      gain: gainParameter,
+      source: {
+        type: 'oscillator',
+        shape: 'sine'
+      }
     })
   }
 })
@@ -36,6 +60,7 @@ export const instrumentsModule = ModuleType.of({
   summary: 'Functions for creating and manipulating instruments.',
 
   exports: new Map<string, Value>([
-    ['sample', sample]
+    ['sample', sample],
+    ['sine', sine]
   ])
 })

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -75,7 +75,9 @@ describe('compiler/generator.ts', () => {
 
     const result = generateSource(source)
     assert.deepStrictEqual(result.instruments.size, 1)
-    assert.deepStrictEqual(result.instruments.get(1 as any)?.sampleUrl, 'kick.wav')
+
+    const instrument = result.instruments.get(1 as any)
+    assert.strictEqual(instrument?.source.type, 'sample')
   })
 
   it('should support import aliases', () => {
@@ -86,7 +88,9 @@ describe('compiler/generator.ts', () => {
 
     const result = generateSource(source)
     assert.deepStrictEqual(result.instruments.size, 1)
-    assert.deepStrictEqual(result.instruments.get(1 as any)?.sampleUrl, 'kick.wav')
+
+    const instrument = result.instruments.get(1 as any)
+    assert.strictEqual(instrument?.source.type, 'sample')
   })
 
   it('should support shadowing of imported names', () => {
@@ -362,8 +366,44 @@ describe('compiler/generator.ts', () => {
 
       const result = generateSource(source)
       assert.deepStrictEqual(result.instruments.size, 2)
-      assert.deepStrictEqual(result.instruments.get(1 as any)?.sampleUrl, 'sample1.wav')
-      assert.deepStrictEqual(result.instruments.get(2 as any)?.sampleUrl, 'sample2.wav')
+
+      const instrument1 = result.instruments.get(1 as any)
+      assert.strictEqual(instrument1?.source.type, 'sample')
+      assert.deepStrictEqual(instrument1.source.url, 'sample1.wav')
+
+      const instrument2 = result.instruments.get(2 as any)
+      assert.strictEqual(instrument2?.source.type, 'sample')
+      assert.deepStrictEqual(instrument2.source.url, 'sample2.wav')
+
+      assert.deepStrictEqual(result.automations.size, 2)
+      assert.deepStrictEqual(result.instruments.get(1 as any)?.gain.id, 1 as any)
+      assert.deepStrictEqual(result.instruments.get(2 as any)?.gain.id, 2 as any)
+      assert.deepStrictEqual(result.automations.get(1 as any)?.parameterId, 1 as any)
+      assert.deepStrictEqual(result.automations.get(2 as any)?.parameterId, 2 as any)
+    })
+  })
+
+  describe('instruments.sine', () => {
+    it('should allocate instrument and parameter IDs correctly', () => {
+      const source = [
+        'use "instruments" as *',
+        'inst1 = sine(gain: -6.db)',
+        'inst2 = sine(gain: -12.db)'
+      ].join('\n')
+
+      const result = generateSource(source)
+      assert.deepStrictEqual(result.instruments.size, 2)
+
+      const instrument1 = result.instruments.get(1 as any)
+      assert.strictEqual(instrument1?.source.type, 'oscillator')
+      assert.strictEqual(instrument1.source.shape, 'sine')
+      assert.deepStrictEqual(instrument1.gain.initial, numeric('db', -6))
+
+      const instrument2 = result.instruments.get(2 as any)
+      assert.strictEqual(instrument2?.source.type, 'oscillator')
+      assert.strictEqual(instrument2.source.shape, 'sine')
+      assert.deepStrictEqual(instrument2.gain.initial, numeric('db', -12))
+
       assert.deepStrictEqual(result.automations.size, 2)
       assert.deepStrictEqual(result.instruments.get(1 as any)?.gain.id, 1 as any)
       assert.deepStrictEqual(result.instruments.get(2 as any)?.gain.id, 2 as any)

--- a/packages/language/test/compiler/modules/instruments.test.ts
+++ b/packages/language/test/compiler/modules/instruments.test.ts
@@ -31,13 +31,16 @@ describe('compiler/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         id: 1,
-        sampleUrl: 'https://example.com/kick.wav',
+        rootNote: 'C4',
         gain: {
           id: 1,
           initial: numeric('db', -3)
         },
-        rootNote: 'C4',
-        length: numeric('s', 1.5)
+        source: {
+          type: 'sample',
+          url: 'https://example.com/kick.wav',
+          length: numeric('s', 1.5)
+        }
       })
 
       assert.strictEqual(context.instruments.size, 1)
@@ -55,13 +58,44 @@ describe('compiler/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         id: 1,
-        sampleUrl: 'https://example.com/snare.wav',
+        rootNote: undefined,
         gain: {
           id: 1,
           initial: numeric('db', 0)
         },
-        rootNote: undefined,
-        length: undefined
+        source: {
+          type: 'sample',
+          url: 'https://example.com/snare.wav',
+          length: undefined
+        }
+      })
+
+      assert.strictEqual(context.instruments.size, 1)
+      const instrument = [...context.instruments.values()][0]
+
+      assert.strictEqual(instrument, result.data)
+    })
+  })
+
+  describe('sine', () => {
+    const sine = instruments.exports.get('sine')
+    assert.ok(sine != null && FunctionType.is(sine))
+
+    it('should create oscillator instrument', () => {
+      const context = createFunctionContext()
+
+      const result = sine.data.invoke(context, {})
+
+      assert.deepStrictEqual(result.data, {
+        id: 1,
+        gain: {
+          id: 1,
+          initial: numeric('db', 0)
+        },
+        source: {
+          type: 'oscillator',
+          shape: 'sine'
+        }
       })
 
       assert.strictEqual(context.instruments.size, 1)

--- a/packages/language/test/compiler/types.test.ts
+++ b/packages/language/test/compiler/types.test.ts
@@ -585,13 +585,15 @@ describe('compiler/types.ts', () => {
       it('should return property values', () => {
         const instrumentValue = InstrumentType.of({
           id: 1 as any,
-          sampleUrl: 'sample.wav',
+          rootNote: undefined,
           gain: {
             id: 2 as ParameterId,
             initial: numeric('db', -3)
           },
-          rootNote: undefined,
-          length: undefined
+          source: {
+            type: 'sample',
+            url: 'sample.wav'
+          }
         })
 
         const gainValue = InstrumentType.propertyValue(instrumentValue, 'gain')

--- a/packages/webaudio/src/graph/factory.ts
+++ b/packages/webaudio/src/graph/factory.ts
@@ -5,7 +5,8 @@ import type { GainMeasurement } from '../worklets/metering/messages.js'
 import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance, createWidthInstance } from './effect.js'
 import type { Instance } from './instance.js'
 import { createGainMeterInstance } from './metering.js'
-import { createSampleInstance } from './sample.js'
+import { createOscillatorInstance } from './instruments/oscillator.js'
+import { createSampleInstance } from './instruments/sample.js'
 
 const factories = Object.freeze({
   identity: createIdentityInstance,
@@ -20,6 +21,7 @@ const factories = Object.freeze({
 
   // sources
   sample: createSampleInstance,
+  oscillator: createOscillatorInstance,
 
   // metering
   gain_meter: createGainMeterInstance

--- a/packages/webaudio/src/graph/instruments/common.ts
+++ b/packages/webaudio/src/graph/instruments/common.ts
@@ -1,11 +1,18 @@
-import type { NoteOptions, SampleNode } from '@audiograph'
+import type { NoteOptions } from '@audiograph'
 import type { MidiNote } from '@core'
+import type { Numeric } from '@utility'
 import { createMultimap } from '@utility'
-import type { AudioFetcher } from '../assets/fetcher.js'
-import type { Transport } from '../transport/transport.js'
-import type { Instance } from './instance.js'
+import type { Transport } from '../../transport/transport.js'
+import type { Instance } from '../instance.js'
 
-export async function createSampleInstance (node: SampleNode, transport: Transport, fetcher: AudioFetcher): Promise<Instance> {
+export type CreateSource = (note: NoteOptions) => AudioScheduledSourceNode
+
+export interface InstrumentOptions {
+  readonly rootNote: MidiNote
+  readonly length?: Numeric<'s'>
+}
+
+export function createInstrumentInstance (transport: Transport, createSource: CreateSource, options: InstrumentOptions): Instance {
   const { ctx } = transport
 
   // declick
@@ -18,8 +25,6 @@ export async function createSampleInstance (node: SampleNode, transport: Transpo
 
   const output = ctx.createGain()
 
-  const sampleBuffer = await fetcher.fetch(ctx, node.sampleUrl)
-
   const dispose = () => {
     output.disconnect()
     for (const sources of sourcesByMidi.values()) {
@@ -29,27 +34,27 @@ export async function createSampleInstance (node: SampleNode, transport: Transpo
     }
   }
 
-  const triggerNote = (options: NoteOptions) => transport.schedule(options.time, (time) => {
+  const triggerNote = (note: NoteOptions) => transport.schedule(note.time, (time) => {
     if (time < 0) {
       return
     }
 
     const duration = (() => {
-      if (options.duration == null || node.length == null) {
-        return options.duration ?? node.length?.value
+      if (note.duration == null || options.length == null) {
+        return note.duration ?? options.length?.value
       }
 
-      return Math.min(options.duration, node.length.value)
+      return Math.min(note.duration, options.length.value)
     })()
 
     if (duration != null && duration <= 0) {
       return
     }
 
-    const midi = options.pitch ?? node.rootNote
-    const targetGain = Math.max(0, Math.min(1, options.velocity))
+    const midi = note.pitch ?? options.rootNote
+    const targetGain = Math.max(0, Math.min(1, note.velocity))
 
-    const sourceNode = ctx.createBufferSource()
+    const sourceNode = createSource(note)
     const gainNode = ctx.createGain()
 
     const source: ActiveSource = {
@@ -66,9 +71,6 @@ export async function createSampleInstance (node: SampleNode, transport: Transpo
         disposeActiveSource(source)
       }
     }, { once: true })
-
-    sourceNode.buffer = sampleBuffer
-    sourceNode.playbackRate.value = Math.pow(2, (midi - node.rootNote) / 12)
 
     gainNode.gain.setValueAtTime(0, time)
     gainNode.gain.linearRampToValueAtTime(targetGain, time + envelope.attack)
@@ -91,7 +93,7 @@ export async function createSampleInstance (node: SampleNode, transport: Transpo
 }
 
 interface ActiveSource {
-  readonly sourceNode: AudioBufferSourceNode
+  readonly sourceNode: AudioScheduledSourceNode
   readonly gainNode: GainNode
   readonly targetGain: number
   disposed: boolean

--- a/packages/webaudio/src/graph/instruments/oscillator.ts
+++ b/packages/webaudio/src/graph/instruments/oscillator.ts
@@ -1,0 +1,22 @@
+import type { OscillatorNode } from '@audiograph'
+import { getMidiFrequency } from '@core'
+import type { Transport } from '../../transport/transport.js'
+import type { Instance } from '../instance.js'
+import type { CreateSource } from './common.js'
+import { createInstrumentInstance } from './common.js'
+
+export async function createOscillatorInstance (node: OscillatorNode, transport: Transport): Promise<Instance> {
+  const { ctx } = transport
+
+  const createSource: CreateSource = (note) => {
+    const oscillator = ctx.createOscillator()
+    oscillator.type = node.shape
+    oscillator.frequency.value = getMidiFrequency(note.pitch ?? node.rootNote)
+    return oscillator
+  }
+
+  return createInstrumentInstance(transport, createSource, {
+    rootNote: node.rootNote,
+    length: undefined
+  })
+}

--- a/packages/webaudio/src/graph/instruments/sample.ts
+++ b/packages/webaudio/src/graph/instruments/sample.ts
@@ -1,0 +1,24 @@
+import type { SampleNode } from '@audiograph'
+import type { AudioFetcher } from '../../assets/fetcher.js'
+import type { Transport } from '../../transport/transport.js'
+import type { Instance } from '../instance.js'
+import type { CreateSource } from './common.js'
+import { createInstrumentInstance } from './common.js'
+
+export async function createSampleInstance (node: SampleNode, transport: Transport, fetcher: AudioFetcher): Promise<Instance> {
+  const { ctx } = transport
+
+  const sampleBuffer = await fetcher.fetch(ctx, node.url)
+
+  const createSource: CreateSource = (note) => {
+    const sourceNode = ctx.createBufferSource()
+    sourceNode.buffer = sampleBuffer
+    sourceNode.playbackRate.value = Math.pow(2, ((note.pitch ?? node.rootNote) - node.rootNote) / 12)
+    return sourceNode
+  }
+
+  return createInstrumentInstance(transport, createSource, {
+    rootNote: node.rootNote,
+    length: node.length
+  })
+}


### PR DESCRIPTION
This patch adds a new oscillator node type to the audio graph, and uses it to implement a second export of the "instruments" module: "sine". As the name suggests, this instrument produces a simple sine wave. The only parameter is gain, which is recommended to be adjusted, as the oscillator output spans the full range of [-1, 1].