### PR TITLE
fix: Apply final automation value if out of range

### DIFF
--- a/packages/webaudio/src/graph/automation.ts
+++ b/packages/webaudio/src/graph/automation.ts
@@ -41,7 +41,8 @@ export function automate<U extends Unit> (transport: Transport, param: AudioPara
     // If it is still in the past, we need to find the value at time 0
     if (pointTimes[pointIndex] < 0) {
       if (pointIndex + 1 >= points.length) {
-        // Not enough points
+        // Not enough points, but we can at least set the final value
+        param.setValueAtTime(points[pointIndex].value.value, 0)
         return
       }
 


### PR DESCRIPTION
If the automation in its entirety is in the past, we should still apply the final value to ensure that the parameter is set correctly. This is an edge case that can occur when playback is started from the middle of a track with an automation that starts and ends before the current time.