### PR TITLE
feat: Add saw, square, and triangle oscillators

### DIFF
--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -75,7 +75,7 @@ export interface SampleNode extends AnyNode {
 export interface OscillatorNode extends AnyNode {
   readonly type: 'oscillator'
   readonly rootNote: MidiNote
-  readonly shape: 'sine'
+  readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
 }
 
 // metering

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -100,7 +100,7 @@ export interface Sample {
 
 export interface Oscillator {
   readonly type: 'oscillator'
-  readonly shape: 'sine'
+  readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
 }
 
 export interface Track {

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -1,7 +1,8 @@
+import type { Oscillator } from '@core'
 import { isPitch } from '@core'
 import { numeric } from '@utility'
 import { allocateInstrument, allocateParameter } from '../functions.js'
-import type { Value } from '../types.js'
+import type { FunctionValue, Value } from '../types.js'
 import { FunctionType, InstrumentType, ModuleType, NumberType, StringType } from '../types.js'
 
 const UNITY_GAIN = numeric('db', 0)
@@ -34,26 +35,33 @@ const sample = FunctionType.of({
   }
 })
 
-const sine = FunctionType.of({
-  summary: 'Creates an instrument that produces a sine wave.',
-  arguments: [
-    { name: 'gain', type: NumberType.with('db'), required: false }
-  ],
+function createOscillatorFunction (shape: Oscillator['shape']): FunctionValue {
+  return FunctionType.of({
+    summary: `Creates an instrument that produces a ${shape} wave.`,
+    arguments: [
+      { name: 'gain', type: NumberType.with('db'), required: false }
+    ],
 
-  returnType: InstrumentType,
+    returnType: InstrumentType,
 
-  invoke: (context, { gain }) => {
-    const gainParameter = allocateParameter(context, gain ?? UNITY_GAIN)
+    invoke: (context, { gain }) => {
+      const gainParameter = allocateParameter(context, gain ?? UNITY_GAIN)
 
-    return allocateInstrument(context, {
-      gain: gainParameter,
-      source: {
-        type: 'oscillator',
-        shape: 'sine'
-      }
-    })
-  }
-})
+      return allocateInstrument(context, {
+        gain: gainParameter,
+        source: {
+          type: 'oscillator',
+          shape
+        }
+      })
+    }
+  })
+}
+
+const sine = createOscillatorFunction('sine')
+const square = createOscillatorFunction('square')
+const saw = createOscillatorFunction('saw')
+const triangle = createOscillatorFunction('triangle')
 
 export const instrumentsModule = ModuleType.of({
   name: 'instruments',
@@ -61,6 +69,9 @@ export const instrumentsModule = ModuleType.of({
 
   exports: new Map<string, Value>([
     ['sample', sample],
-    ['sine', sine]
+    ['sine', sine],
+    ['square', square],
+    ['saw', saw],
+    ['triangle', triangle]
   ])
 })

--- a/packages/language/test/compiler/modules/instruments.test.ts
+++ b/packages/language/test/compiler/modules/instruments.test.ts
@@ -32,10 +32,7 @@ describe('compiler/modules/instruments.ts', () => {
       assert.deepStrictEqual(result.data, {
         id: 1,
         rootNote: 'C4',
-        gain: {
-          id: 1,
-          initial: numeric('db', -3)
-        },
+        gain: { id: 1, initial: numeric('db', -3) },
         source: {
           type: 'sample',
           url: 'https://example.com/kick.wav',
@@ -43,37 +40,22 @@ describe('compiler/modules/instruments.ts', () => {
         }
       })
 
-      assert.strictEqual(context.instruments.size, 1)
-      const instrument = [...context.instruments.values()][0]
-
-      assert.strictEqual(instrument, result.data)
+      assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })
 
     it('should create instrument with default values', () => {
+      const url = 'https://example.com/snare.wav'
+
       const context = createFunctionContext()
 
-      const result = sample.data.invoke(context, {
-        url: 'https://example.com/snare.wav'
-      })
-
+      const result = sample.data.invoke(context, { url })
       assert.deepStrictEqual(result.data, {
         id: 1,
         rootNote: undefined,
-        gain: {
-          id: 1,
-          initial: numeric('db', 0)
-        },
-        source: {
-          type: 'sample',
-          url: 'https://example.com/snare.wav',
-          length: undefined
-        }
+        gain: { id: 1, initial: numeric('db', 0) },
+        source: { type: 'sample', url, length: undefined }
       })
-
-      assert.strictEqual(context.instruments.size, 1)
-      const instrument = [...context.instruments.values()][0]
-
-      assert.strictEqual(instrument, result.data)
+      assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })
   })
 
@@ -85,23 +67,63 @@ describe('compiler/modules/instruments.ts', () => {
       const context = createFunctionContext()
 
       const result = sine.data.invoke(context, {})
-
       assert.deepStrictEqual(result.data, {
         id: 1,
-        gain: {
-          id: 1,
-          initial: numeric('db', 0)
-        },
-        source: {
-          type: 'oscillator',
-          shape: 'sine'
-        }
+        gain: { id: 1, initial: numeric('db', 0) },
+        source: { type: 'oscillator', shape: 'sine' }
       })
+      assert.deepStrictEqual([...context.instruments.values()], [result.data])
+    })
+  })
 
-      assert.strictEqual(context.instruments.size, 1)
-      const instrument = [...context.instruments.values()][0]
+  describe('square', () => {
+    const square = instruments.exports.get('square')
+    assert.ok(square != null && FunctionType.is(square))
 
-      assert.strictEqual(instrument, result.data)
+    it('should create oscillator instrument', () => {
+      const context = createFunctionContext()
+
+      const result = square.data.invoke(context, {})
+      assert.deepStrictEqual(result.data, {
+        id: 1,
+        gain: { id: 1, initial: numeric('db', 0) },
+        source: { type: 'oscillator', shape: 'square' }
+      })
+      assert.deepStrictEqual([...context.instruments.values()], [result.data])
+    })
+  })
+
+  describe('saw', () => {
+    const saw = instruments.exports.get('saw')
+    assert.ok(saw != null && FunctionType.is(saw))
+
+    it('should create oscillator instrument', () => {
+      const context = createFunctionContext()
+
+      const result = saw.data.invoke(context, {})
+      assert.deepStrictEqual(result.data, {
+        id: 1,
+        gain: { id: 1, initial: numeric('db', 0) },
+        source: { type: 'oscillator', shape: 'saw' }
+      })
+      assert.deepStrictEqual([...context.instruments.values()], [result.data])
+    })
+  })
+
+  describe('triangle', () => {
+    const triangle = instruments.exports.get('triangle')
+    assert.ok(triangle != null && FunctionType.is(triangle))
+
+    it('should create oscillator instrument', () => {
+      const context = createFunctionContext()
+
+      const result = triangle.data.invoke(context, {})
+      assert.deepStrictEqual(result.data, {
+        id: 1,
+        gain: { id: 1, initial: numeric('db', 0) },
+        source: { type: 'oscillator', shape: 'triangle' }
+      })
+      assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })
   })
 })

--- a/packages/webaudio/src/graph/instruments/oscillator.ts
+++ b/packages/webaudio/src/graph/instruments/oscillator.ts
@@ -5,12 +5,19 @@ import type { Instance } from '../instance.js'
 import type { CreateSource } from './common.js'
 import { createInstrumentInstance } from './common.js'
 
+const oscillatorTypeMap: Record<OscillatorNode['shape'], OscillatorType> = {
+  sine: 'sine',
+  square: 'square',
+  saw: 'sawtooth',
+  triangle: 'triangle'
+}
+
 export async function createOscillatorInstance (node: OscillatorNode, transport: Transport): Promise<Instance> {
   const { ctx } = transport
 
   const createSource: CreateSource = (note) => {
     const oscillator = ctx.createOscillator()
-    oscillator.type = node.shape
+    oscillator.type = oscillatorTypeMap[node.shape]
     oscillator.frequency.value = getMidiFrequency(note.pitch ?? node.rootNote)
     return oscillator
   }


### PR DESCRIPTION
This patch follows up on PR #515 by adding saw, square, and triangle oscillator instruments in addition to the existing sine oscillator. These are all available from the "instruments" module:

```
use "instruments" as *

synth_sine = sine()
synth_saw = saw()
synth_square = square()
synth_triangle = triangle()
```