### PR TITLE
feat: Make filter frequency time-varying

### DIFF
--- a/packages/audiograph/src/automation.ts
+++ b/packages/audiograph/src/automation.ts
@@ -83,3 +83,19 @@ export const panTransform: Transform<undefined, undefined> = {
 
   transformCurve: (curve) => curve
 }
+
+export const frequencyTransform: Transform<'hz', 'hz'> = {
+  transformValue: (value) => {
+    if (!Number.isFinite(value.value)) {
+      throw new Error(`Invalid frequency: ${value.value}`)
+    }
+
+    if (value.value < 0) {
+      return numeric('hz', 0)
+    }
+
+    return value
+  },
+
+  transformCurve: (curve) => curve
+}

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -2,7 +2,7 @@ import type { Bus, BusId, Effect, Instrument, InstrumentId, MidiNote, MixerRouti
 import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
-import { gainTransform, panTransform, timeVariant, toTimeVariant } from './automation.js'
+import { frequencyTransform, gainTransform, panTransform, timeVariant, toTimeVariant } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
 import { DEFAULT_ROOT_NOTE } from './constants.js'
@@ -180,28 +180,18 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
     }
 
     case 'lowpass': {
-      if (!Number.isFinite(effect.frequency.value)) {
-        throw new Error(`Invalid frequency: ${effect.frequency.value}`)
-      }
-
       return toSubGraph(builder.addNode<BiquadNode>('biquad', {
         filterType: 'lowpass',
-        // TODO time variant
-        frequency: effect.frequency,
+        frequency: toTimeVariant(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
         rolloffPerOctave: numeric('db', 12)
       }))
     }
 
     case 'highpass': {
-      if (!Number.isFinite(effect.frequency.value)) {
-        throw new Error(`Invalid frequency: ${effect.frequency.value}`)
-      }
-
       return toSubGraph(builder.addNode<BiquadNode>('biquad', {
         filterType: 'highpass',
-        // TODO time variant
-        frequency: effect.frequency,
+        frequency: toTimeVariant(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
         rolloffPerOctave: numeric('db', 12)
       }))

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -44,7 +44,7 @@ export interface PanNode extends AnyNode {
 export interface BiquadNode extends AnyNode {
   readonly type: 'biquad'
   readonly filterType: 'lowpass' | 'highpass'
-  readonly frequency: Numeric<'hz'>
+  readonly frequency: TimeVariant<'hz'>
   readonly rolloffPerOctave: Numeric<'db'>
 }
 

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -641,25 +641,37 @@ describe('lowering.ts', () => {
       it('should handle lowpass', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'lowpass',
-          frequency: numeric('hz', 1000)
+          frequency: {
+            id: 600 as ParameterId,
+            initial: numeric('hz', 1000)
+          }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           id: 2 as NodeId,
           type: 'biquad',
           filterType: 'lowpass',
-          frequency: numeric('hz', 1000),
+          frequency: {
+            initial: numeric('hz', 1000),
+            points: []
+          },
           rolloffPerOctave: numeric('db', 12)
         })
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'lowpass',
-          frequency: numeric('hz', -100)
+          frequency: {
+            id: 600 as ParameterId,
+            initial: numeric('hz', -100)
+          }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           id: 2 as NodeId,
           type: 'biquad',
           filterType: 'lowpass',
-          frequency: numeric('hz', -100),
+          frequency: {
+            initial: numeric('hz', 0),
+            points: []
+          },
           rolloffPerOctave: numeric('db', 12)
         })
       })
@@ -668,7 +680,10 @@ describe('lowering.ts', () => {
         for (const frequency of [Infinity, -Infinity, Number.NaN]) {
           assert.throws(() => createAudioGraph(createProgramWithEffect({
             type: 'lowpass',
-            frequency: numeric('hz', frequency)
+            frequency: {
+              id: 600 as ParameterId,
+              initial: numeric('hz', frequency)
+            }
           })), /Invalid frequency/, `should throw for frequency: ${frequency}`)
         }
       })
@@ -678,25 +693,37 @@ describe('lowering.ts', () => {
       it('should handle highpass', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'highpass',
-          frequency: numeric('hz', 500)
+          frequency: {
+            id: 600 as ParameterId,
+            initial: numeric('hz', 500)
+          }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           id: 2 as NodeId,
           type: 'biquad',
           filterType: 'highpass',
-          frequency: numeric('hz', 500),
+          frequency: {
+            initial: numeric('hz', 500),
+            points: []
+          },
           rolloffPerOctave: numeric('db', 12)
         })
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'highpass',
-          frequency: numeric('hz', -100)
+          frequency: {
+            id: 600 as ParameterId,
+            initial: numeric('hz', -100)
+          }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           id: 2 as NodeId,
           type: 'biquad',
           filterType: 'highpass',
-          frequency: numeric('hz', -100),
+          frequency: {
+            initial: numeric('hz', 0),
+            points: []
+          },
           rolloffPerOctave: numeric('db', 12)
         })
       })
@@ -705,7 +732,10 @@ describe('lowering.ts', () => {
         for (const frequency of [Infinity, -Infinity, Number.NaN]) {
           assert.throws(() => createAudioGraph(createProgramWithEffect({
             type: 'highpass',
-            frequency: numeric('hz', frequency)
+            frequency: {
+              id: 600 as ParameterId,
+              initial: numeric('hz', frequency)
+            }
           })), /Invalid frequency/, `should throw for frequency: ${frequency}`)
         }
       })

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -162,12 +162,12 @@ export interface PanEffect {
 
 export interface LowpassEffect {
   readonly type: 'lowpass'
-  readonly frequency: Numeric<'hz'>
+  readonly frequency: Parameter<'hz'>
 }
 
 export interface HighpassEffect {
   readonly type: 'highpass'
-  readonly frequency: Numeric<'hz'>
+  readonly frequency: Parameter<'hz'>
 }
 
 export interface WidthEffect {

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -41,14 +41,14 @@ const lowpass = createEffectConstructor('Filters out frequencies above the cutof
   { name: 'frequency', type: NumberType.with('hz'), required: true }
 ], (context, args) => ({
   type: 'lowpass',
-  frequency: args.frequency
+  frequency: allocateParameter(context, args.frequency)
 }))
 
 const highpass = createEffectConstructor('Filters out frequencies below the cutoff.', [
   { name: 'frequency', type: NumberType.with('hz'), required: true }
 ], (context, args) => ({
   type: 'highpass',
-  frequency: args.frequency
+  frequency: allocateParameter(context, args.frequency)
 }))
 
 const width = createEffectConstructor('Adjusts the stereo width of the signal.', [

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -71,7 +71,10 @@ describe('compiler/modules/effects.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         type: 'lowpass',
-        frequency: numeric('hz', 1000)
+        frequency: {
+          id: 1,
+          initial: numeric('hz', 1000)
+        }
       })
     })
   })
@@ -88,7 +91,10 @@ describe('compiler/modules/effects.ts', () => {
 
       assert.deepStrictEqual(result.data, {
         type: 'highpass',
-        frequency: numeric('hz', 200)
+        frequency: {
+          id: 1,
+          initial: numeric('hz', 200)
+        }
       })
     })
   })

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -24,7 +24,7 @@ export function createPanInstance (node: PanNode, transport: Transport): Instanc
 export function createBiquadInstance (node: BiquadNode, transport: Transport): Instance {
   const audioNode = transport.ctx.createBiquadFilter()
   audioNode.type = node.filterType
-  audioNode.frequency.value = node.frequency.value
+  automate(transport, audioNode.frequency, node.frequency)
   audioNode.Q.value = -node.rolloffPerOctave.value
   return toInstance(audioNode)
 }


### PR DESCRIPTION
This lets the frequency become a parameter instead of plain numeric value, paving the way for automation, though this is not yet implemented in this commit as it requires type system changes first.