### PR TITLE
feat: Make envelope a core instrument property

### DIFF
--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, MidiNote, MixerRouting, Oscillator, Program, Sample, Track } from '@core'
+import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MidiNote, MixerRouting, Oscillator, Program, Sample, Track } from '@core'
 import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
@@ -121,13 +121,39 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
     ? convertPitchToMidi(instrument.rootNote)
     : DEFAULT_ROOT_NOTE
 
+  const envelope = (() => {
+    const a = instrument.envelope.attack.value
+    const d = instrument.envelope.decay.value
+    const s = instrument.envelope.sustain.value
+    const r = instrument.envelope.release.value
+
+    const clampDuration = (value: number): Numeric<'s'> => {
+      return Number.isFinite(value) && value >= 0
+        ? numeric('s', value)
+        : numeric('s', 0)
+    }
+
+    const clampSustain = (value: number): Numeric<undefined> => {
+      return Number.isNaN(value)
+        ? numeric(undefined, 0)
+        : numeric(undefined, Math.max(0, Math.min(1, s)))
+    }
+
+    return {
+      attack: clampDuration(a),
+      decay: clampDuration(d),
+      sustain: clampSustain(s),
+      release: clampDuration(r)
+    }
+  })()
+
   const source = (() => {
     switch (instrument.source.type) {
       case 'sample':
-        return createSampleSource(instrument.source, rootNote, builder)
+        return createSampleSource(instrument.source, rootNote, envelope, builder)
 
       case 'oscillator':
-        return createOscillatorSource(instrument.source, rootNote, builder)
+        return createOscillatorSource(instrument.source, rootNote, envelope, builder)
     }
   })()
 
@@ -144,7 +170,7 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
   }
 }
 
-function createSampleSource (sample: Sample, rootNote: MidiNote, builder: Builder): Node {
+function createSampleSource (sample: Sample, rootNote: MidiNote, envelope: Envelope, builder: Builder): Node {
   const length = (() => {
     if (sample.length == null) {
       return undefined
@@ -158,11 +184,11 @@ function createSampleSource (sample: Sample, rootNote: MidiNote, builder: Builde
     return value < 0 ? numeric('s', 0) : !Number.isFinite(value) ? undefined : numeric('s', value)
   })()
 
-  return builder.addNode<SampleNode>('sample', { rootNote, url: sample.url, length })
+  return builder.addNode<SampleNode>('sample', { rootNote, envelope, url: sample.url, length })
 }
 
-function createOscillatorSource (oscillator: Oscillator, rootNote: MidiNote, builder: Builder): Node {
-  return builder.addNode<OscillatorNode>('oscillator', { rootNote, shape: oscillator.shape })
+function createOscillatorSource (oscillator: Oscillator, rootNote: MidiNote, envelope: Envelope, builder: Builder): Node {
+  return builder.addNode<OscillatorNode>('oscillator', { rootNote, envelope, shape: oscillator.shape })
 }
 
 function createEffect (program: Program, effect: Effect, builder: Builder): SubGraph {

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -1,4 +1,4 @@
-import type { MidiNote } from '@core'
+import type { Envelope, MidiNote } from '@core'
 import type { Numeric } from '@utility'
 import type { TimeVariant } from './automation.js'
 import type { EntityKey } from './entities.js'
@@ -68,6 +68,7 @@ export interface ReverbNode extends AnyNode {
 export interface SampleNode extends AnyNode {
   readonly type: 'sample'
   readonly rootNote: MidiNote
+  readonly envelope: Envelope
   readonly url: string
   readonly length?: Numeric<'s'>
 }
@@ -75,6 +76,7 @@ export interface SampleNode extends AnyNode {
 export interface OscillatorNode extends AnyNode {
   readonly type: 'oscillator'
   readonly rootNote: MidiNote
+  readonly envelope: Envelope
   readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
 }
 

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, InstrumentRouting, MidiNote, MixerRouting, ParameterId, Pitch, Program, Track } from '@core'
+import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, InstrumentRouting, MidiNote, MixerRouting, ParameterId, Pitch, Program, Track } from '@core'
 import { beatsToSeconds, createSerialPattern } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
@@ -8,6 +8,13 @@ import { createEntityKey } from '../src/entities.js'
 import type { NodeId } from '../src/graph.js'
 import { createAudioGraph } from '../src/lowering.js'
 import type { DelayNode, GainNode, IdentityNode, Node, ReverbNode, SampleNode } from '../src/nodes.js'
+
+const defaultEnvelope: Envelope = {
+  attack: numeric('s', 0.01),
+  decay: numeric('s', 0.1),
+  sustain: numeric(undefined, 0.8),
+  release: numeric('s', 0.5)
+}
 
 function compareIds (a: Node, b: Node): number {
   return a.id - b.id
@@ -131,7 +138,8 @@ describe('lowering.ts', () => {
             source: {
               type: 'sample',
               url: 'foo.wav'
-            }
+            },
+            envelope: defaultEnvelope
           } satisfies Instrument
         ]
       ]),
@@ -204,8 +212,9 @@ describe('lowering.ts', () => {
       } satisfies GainNode,
       {
         id: 3 as NodeId,
-        length: undefined,
         type: 'sample',
+        envelope: defaultEnvelope,
+        length: undefined,
         url: 'foo.wav',
         rootNote: 72 as MidiNote // C5
       } satisfies SampleNode,
@@ -248,7 +257,8 @@ describe('lowering.ts', () => {
             source: {
               type: 'sample',
               url: 'foo.wav'
-            }
+            },
+            envelope: defaultEnvelope
           } satisfies Instrument
         ]
       ]),
@@ -338,7 +348,8 @@ describe('lowering.ts', () => {
             source: {
               type: 'sample',
               url: 'foo.wav'
-            }
+            },
+            envelope: defaultEnvelope
           } satisfies Instrument
         ]
       ]),
@@ -414,7 +425,8 @@ describe('lowering.ts', () => {
       source: {
         type: 'sample',
         url: 'foo.wav'
-      }
+      },
+      envelope: defaultEnvelope
     })
 
     assert.doesNotThrow(() => createAudioGraph(program))
@@ -431,7 +443,8 @@ describe('lowering.ts', () => {
         source: {
           type: 'sample',
           url: 'foo.wav'
-        }
+        },
+        envelope: defaultEnvelope
       })
 
       assert.throws(() => createAudioGraph(program), /Invalid gain/, `should throw for gain: ${gain}`)
@@ -450,7 +463,8 @@ describe('lowering.ts', () => {
         source: {
           type: 'sample',
           url: 'foo.wav'
-        }
+        },
+        envelope: defaultEnvelope
       })
 
       assert.throws(() => createAudioGraph(program), /Invalid pitch/, `should throw for root note: ${rootNote}`)
@@ -468,13 +482,15 @@ describe('lowering.ts', () => {
         type: 'sample',
         url: 'foo.wav',
         length: numeric('s', -1)
-      }
+      },
+      envelope: defaultEnvelope
     })
 
     const graph = createAudioGraph(program)
     assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
       id: 2 as NodeId,
       type: 'sample',
+      envelope: defaultEnvelope,
       url: 'foo.wav',
       rootNote: 72 as MidiNote,
       length: numeric('s', 0)
@@ -492,13 +508,15 @@ describe('lowering.ts', () => {
         type: 'sample',
         url: 'foo.wav',
         length: numeric('s', Infinity)
-      }
+      },
+      envelope: defaultEnvelope
     })
 
     const graph = createAudioGraph(program)
     assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
       id: 2 as NodeId,
       type: 'sample',
+      envelope: defaultEnvelope,
       url: 'foo.wav',
       rootNote: 72 as MidiNote,
       length: undefined
@@ -516,10 +534,89 @@ describe('lowering.ts', () => {
         type: 'sample',
         url: 'foo.wav',
         length: numeric('s', Number.NaN)
-      }
+      },
+      envelope: defaultEnvelope
     })
 
     assert.throws(() => createAudioGraph(program), /Invalid length/)
+  })
+
+  it('should clamp envelope parameters to valid ranges', () => {
+    const createEnvelope = (adsr: [number, number, number, number]): Envelope => ({
+      attack: numeric('s', adsr[0]),
+      decay: numeric('s', adsr[1]),
+      sustain: numeric(undefined, adsr[2]),
+      release: numeric('s', adsr[3])
+    })
+
+    const testCases: Array<{ envelope: Envelope, expected: Envelope }> = [
+      {
+        envelope: createEnvelope([-1, 0, 1, 0]),
+        expected: createEnvelope([0, 0, 1, 0])
+      },
+      {
+        envelope: createEnvelope([0, -1, 1, 0]),
+        expected: createEnvelope([0, 0, 1, 0])
+      },
+      {
+        envelope: createEnvelope([0, 0, -1, 0]),
+        expected: createEnvelope([0, 0, 0, 0])
+      },
+      {
+        envelope: createEnvelope([0, 0, 2, 0]),
+        expected: createEnvelope([0, 0, 1, 0])
+      },
+      {
+        envelope: createEnvelope([0, 0, 1, -1]),
+        expected: createEnvelope([0, 0, 1, 0])
+      },
+      {
+        envelope: createEnvelope([Infinity, 0, 1, 0]),
+        expected: createEnvelope([0, 0, 1, 0])
+      },
+      {
+        envelope: createEnvelope([0, Infinity, 1, 0]),
+        expected: createEnvelope([0, 0, 1, 0])
+      },
+      {
+        envelope: createEnvelope([0, 0, Number.NaN, 0]),
+        expected: createEnvelope([0, 0, 0, 0])
+      },
+      {
+        envelope: createEnvelope([0, 0, Infinity, 0]),
+        expected: createEnvelope([0, 0, 1, 0])
+      },
+      {
+        envelope: createEnvelope([0, 0, 1, Infinity]),
+        expected: createEnvelope([0, 0, 1, 0])
+      }
+    ]
+
+    for (const { envelope, expected } of testCases) {
+      const program = createProgramWithInstrument({
+        id: 100 as InstrumentId,
+        gain: {
+          id: 200 as ParameterId,
+          initial: numeric('db', -6)
+        },
+        source: {
+          type: 'sample',
+          url: 'foo.wav'
+        },
+        envelope
+      })
+
+      const graph = createAudioGraph(program)
+
+      assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
+        id: 2 as NodeId,
+        type: 'sample',
+        url: 'foo.wav',
+        rootNote: 72 as MidiNote,
+        length: undefined,
+        envelope: expected
+      } satisfies SampleNode, `test case: ${JSON.stringify(envelope)}`)
+    }
   })
 
   describe('effects', () => {
@@ -1060,7 +1157,8 @@ describe('lowering.ts', () => {
         source: {
           type: 'sample',
           url: 'foo.wav'
-        }
+        },
+        envelope: defaultEnvelope
       }))
 
       assert.strictEqual(graph.meters.size, 0)
@@ -1084,7 +1182,8 @@ describe('lowering.ts', () => {
               source: {
                 type: 'sample',
                 url: 'foo.wav'
-              }
+              },
+              envelope: defaultEnvelope
             } satisfies Instrument
           ]
         ]),
@@ -1180,7 +1279,8 @@ describe('lowering.ts', () => {
       source: {
         type: 'sample',
         url: 'foo.wav'
-      }
+      },
+      envelope: defaultEnvelope
     })
 
     for (const interval of [Infinity, -Infinity, Number.NaN, 0, -1]) {

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -88,6 +88,7 @@ export interface Instrument {
   readonly rootNote?: Pitch
   readonly gain: Parameter<'db'>
   readonly source: Source
+  readonly envelope: Envelope
 }
 
 export type Source = Sample | Oscillator
@@ -101,6 +102,13 @@ export interface Sample {
 export interface Oscillator {
   readonly type: 'oscillator'
   readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
+}
+
+export interface Envelope {
+  readonly attack: Numeric<'s'>
+  readonly decay: Numeric<'s'>
+  readonly sustain: Numeric<undefined>
+  readonly release: Numeric<'s'>
 }
 
 export interface Track {

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -1,4 +1,4 @@
-import type { Oscillator } from '@core'
+import type { Envelope, Oscillator } from '@core'
 import { isPitch } from '@core'
 import { numeric } from '@utility'
 import { allocateInstrument, allocateParameter } from '../functions.js'
@@ -6,6 +6,13 @@ import type { FunctionValue, Value } from '../types.js'
 import { FunctionType, InstrumentType, ModuleType, NumberType, StringType } from '../types.js'
 
 const UNITY_GAIN = numeric('db', 0)
+
+const ENVELOPE_DECLICK: Envelope = {
+  attack: numeric('s', 0.003),
+  decay: numeric('s', 0),
+  sustain: numeric(undefined, 1),
+  release: numeric('s', 0.003)
+}
 
 const sample = FunctionType.of({
   summary: 'Creates a sample-backed instrument from a URL.',
@@ -30,7 +37,8 @@ const sample = FunctionType.of({
         type: 'sample',
         url,
         length
-      }
+      },
+      envelope: ENVELOPE_DECLICK
     })
   }
 })
@@ -52,7 +60,8 @@ function createOscillatorFunction (shape: Oscillator['shape']): FunctionValue {
         source: {
           type: 'oscillator',
           shape
-        }
+        },
+        envelope: ENVELOPE_DECLICK
       })
     }
   })

--- a/packages/language/test/compiler/modules/instruments.test.ts
+++ b/packages/language/test/compiler/modules/instruments.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test'
 import type { FunctionContext } from '../../../src/compiler/functions.js'
 import { instrumentsModule } from '../../../src/compiler/modules/instruments.js'
 import { FunctionType } from '../../../src/compiler/types.js'
+import type { Envelope } from '@core'
 
 function createFunctionContext (): FunctionContext {
   return {
@@ -14,6 +15,13 @@ function createFunctionContext (): FunctionContext {
 
 describe('compiler/modules/instruments.ts', () => {
   const instruments = instrumentsModule.data
+
+  const declickEnvelope: Envelope = {
+    attack: numeric('s', 0.003),
+    decay: numeric('s', 0),
+    sustain: numeric(undefined, 1),
+    release: numeric('s', 0.003)
+  }
 
   describe('sample', () => {
     const sample = instruments.exports.get('sample')
@@ -37,7 +45,8 @@ describe('compiler/modules/instruments.ts', () => {
           type: 'sample',
           url: 'https://example.com/kick.wav',
           length: numeric('s', 1.5)
-        }
+        },
+        envelope: declickEnvelope
       })
 
       assert.deepStrictEqual([...context.instruments.values()], [result.data])
@@ -53,7 +62,8 @@ describe('compiler/modules/instruments.ts', () => {
         id: 1,
         rootNote: undefined,
         gain: { id: 1, initial: numeric('db', 0) },
-        source: { type: 'sample', url, length: undefined }
+        source: { type: 'sample', url, length: undefined },
+        envelope: declickEnvelope
       })
       assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })
@@ -70,7 +80,8 @@ describe('compiler/modules/instruments.ts', () => {
       assert.deepStrictEqual(result.data, {
         id: 1,
         gain: { id: 1, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'sine' }
+        source: { type: 'oscillator', shape: 'sine' },
+        envelope: declickEnvelope
       })
       assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })
@@ -87,7 +98,8 @@ describe('compiler/modules/instruments.ts', () => {
       assert.deepStrictEqual(result.data, {
         id: 1,
         gain: { id: 1, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'square' }
+        source: { type: 'oscillator', shape: 'square' },
+        envelope: declickEnvelope
       })
       assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })
@@ -104,7 +116,8 @@ describe('compiler/modules/instruments.ts', () => {
       assert.deepStrictEqual(result.data, {
         id: 1,
         gain: { id: 1, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'saw' }
+        source: { type: 'oscillator', shape: 'saw' },
+        envelope: declickEnvelope
       })
       assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })
@@ -121,7 +134,8 @@ describe('compiler/modules/instruments.ts', () => {
       assert.deepStrictEqual(result.data, {
         id: 1,
         gain: { id: 1, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'triangle' }
+        source: { type: 'oscillator', shape: 'triangle' },
+        envelope: declickEnvelope
       })
       assert.deepStrictEqual([...context.instruments.values()], [result.data])
     })

--- a/packages/language/test/compiler/types.test.ts
+++ b/packages/language/test/compiler/types.test.ts
@@ -593,6 +593,12 @@ describe('compiler/types.ts', () => {
           source: {
             type: 'sample',
             url: 'sample.wav'
+          },
+          envelope: {
+            attack: numeric('s', 0.01),
+            decay: numeric('s', 0.1),
+            sustain: numeric(undefined, 0.8),
+            release: numeric('s', 0.5)
           }
         })
 

--- a/packages/webaudio/src/graph/instruments/common.ts
+++ b/packages/webaudio/src/graph/instruments/common.ts
@@ -1,28 +1,27 @@
 import type { NoteOptions } from '@audiograph'
-import type { MidiNote } from '@core'
+import type { Envelope, MidiNote } from '@core'
 import type { Numeric } from '@utility'
 import { createMultimap } from '@utility'
 import type { Transport } from '../../transport/transport.js'
 import type { Instance } from '../instance.js'
+import { applyEnvelope } from './envelope.js'
 
 export type CreateSource = (note: NoteOptions) => AudioScheduledSourceNode
 
 export interface InstrumentOptions {
+  readonly envelope: Envelope
   readonly rootNote: MidiNote
   readonly length?: Numeric<'s'>
 }
 
-export function createInstrumentInstance (transport: Transport, createSource: CreateSource, options: InstrumentOptions): Instance {
+export function createInstrumentInstance (
+  transport: Transport,
+  createSource: CreateSource,
+  options: InstrumentOptions
+): Instance {
   const { ctx } = transport
 
-  // declick
-  const envelope = {
-    attack: 0.005,
-    release: 0.005
-  }
-
   const sourcesByMidi = createMultimap<MidiNote, ActiveSource>()
-
   const output = ctx.createGain()
 
   const dispose = () => {
@@ -39,7 +38,7 @@ export function createInstrumentInstance (transport: Transport, createSource: Cr
       return
     }
 
-    const duration = (() => {
+    const holdDuration = (() => {
       if (note.duration == null || options.length == null) {
         return note.duration ?? options.length?.value
       }
@@ -47,20 +46,21 @@ export function createInstrumentInstance (transport: Transport, createSource: Cr
       return Math.min(note.duration, options.length.value)
     })()
 
-    if (duration != null && duration <= 0) {
+    if (holdDuration != null && holdDuration <= 0) {
       return
     }
 
     const midi = note.pitch ?? options.rootNote
-    const targetGain = Math.max(0, Math.min(1, note.velocity))
+    const velocity = Math.max(0, Math.min(1, note.velocity))
 
     const sourceNode = createSource(note)
     const gainNode = ctx.createGain()
 
+    sourceNode.connect(gainNode).connect(output)
+
     const source: ActiveSource = {
       sourceNode,
       gainNode,
-      targetGain,
       disposed: false
     }
     sourcesByMidi.add(midi, source)
@@ -72,20 +72,12 @@ export function createInstrumentInstance (transport: Transport, createSource: Cr
       }
     }, { once: true })
 
-    gainNode.gain.setValueAtTime(0, time)
-    gainNode.gain.linearRampToValueAtTime(targetGain, time + envelope.attack)
+    const { envelope } = options
+    applyEnvelope(envelope, gainNode.gain, { time, velocity, holdDuration })
 
-    sourceNode.connect(gainNode).connect(output)
     sourceNode.start(time)
-
-    if (duration != null) {
-      const releaseStartTime = time + duration
-      const releaseEndTime = releaseStartTime + envelope.release
-
-      gainNode.gain.setValueAtTime(targetGain, releaseStartTime)
-      gainNode.gain.linearRampToValueAtTime(0, releaseEndTime)
-
-      sourceNode.stop(releaseEndTime)
+    if (holdDuration != null) {
+      sourceNode.stop(time + holdDuration + envelope.release.value)
     }
   })
 
@@ -95,7 +87,6 @@ export function createInstrumentInstance (transport: Transport, createSource: Cr
 interface ActiveSource {
   readonly sourceNode: AudioScheduledSourceNode
   readonly gainNode: GainNode
-  readonly targetGain: number
   disposed: boolean
 }
 

--- a/packages/webaudio/src/graph/instruments/envelope.ts
+++ b/packages/webaudio/src/graph/instruments/envelope.ts
@@ -1,0 +1,76 @@
+import type { Envelope } from '@core'
+
+export interface EnvelopeTarget {
+  cancelScheduledValues(time: number): void
+  setValueAtTime(value: number, time: number): void
+  linearRampToValueAtTime(value: number, time: number): void
+}
+
+export interface EnvelopeOptions {
+  readonly time: number
+  readonly velocity: number
+  readonly holdDuration?: number
+}
+
+export function applyEnvelope (envelope: Envelope, target: EnvelopeTarget, options: EnvelopeOptions): void {
+  const { time, velocity, holdDuration } = options
+
+  const attack = envelope.attack.value
+  const decay = envelope.decay.value
+  const sustain = envelope.sustain.value
+  const release = envelope.release.value
+
+  const sustainLevel = velocity * sustain
+
+  const attackStartTime = time
+  const attackEndTime = time + attack
+
+  const decayEndTime = attackEndTime + decay
+
+  // attack
+  if (attackEndTime > attackStartTime) {
+    target.setValueAtTime(0, attackStartTime)
+    target.linearRampToValueAtTime(velocity, attackEndTime)
+  } else {
+    target.setValueAtTime(velocity, attackStartTime)
+  }
+
+  // decay and sustain
+  if (decayEndTime > attackEndTime) {
+    target.linearRampToValueAtTime(sustainLevel, decayEndTime)
+  } else {
+    target.setValueAtTime(sustainLevel, attackEndTime)
+  }
+
+  // release
+  if (holdDuration != null) {
+    const releaseStartTime = time + holdDuration
+    const releaseEndTime = releaseStartTime + release
+
+    const releaseStartLevel = (() => {
+      // in sustain phase
+      if (releaseStartTime >= decayEndTime) {
+        return sustainLevel
+      }
+
+      // in decay phase
+      if (decay > 0 && releaseStartTime >= attackEndTime) {
+        const decayProgress = (releaseStartTime - attackEndTime) / decay
+        return velocity + ((sustainLevel - velocity) * decayProgress)
+      }
+
+      // in attack phase
+      const attackProgress = (releaseStartTime - attackStartTime) / attack
+      return velocity * attackProgress
+    })()
+
+    target.cancelScheduledValues(releaseStartTime)
+
+    if (releaseEndTime > releaseStartTime) {
+      target.setValueAtTime(releaseStartLevel, releaseStartTime)
+      target.linearRampToValueAtTime(0, releaseEndTime)
+    } else {
+      target.setValueAtTime(0, releaseStartTime)
+    }
+  }
+}

--- a/packages/webaudio/src/graph/instruments/oscillator.ts
+++ b/packages/webaudio/src/graph/instruments/oscillator.ts
@@ -23,6 +23,7 @@ export async function createOscillatorInstance (node: OscillatorNode, transport:
   }
 
   return createInstrumentInstance(transport, createSource, {
+    envelope: node.envelope,
     rootNote: node.rootNote,
     length: undefined
   })

--- a/packages/webaudio/src/graph/instruments/sample.ts
+++ b/packages/webaudio/src/graph/instruments/sample.ts
@@ -18,6 +18,7 @@ export async function createSampleInstance (node: SampleNode, transport: Transpo
   }
 
   return createInstrumentInstance(transport, createSource, {
+    envelope: node.envelope,
     rootNote: node.rootNote,
     length: node.length
   })

--- a/packages/webaudio/test/graph/instruments/envelope.test.ts
+++ b/packages/webaudio/test/graph/instruments/envelope.test.ts
@@ -1,0 +1,146 @@
+import type { Envelope } from '@core'
+import { numeric } from '@utility'
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import type { EnvelopeTarget } from '../../../src/graph/instruments/envelope.js'
+import { applyEnvelope } from '../../../src/graph/instruments/envelope.js'
+
+type EnvelopeEvent =
+  { type: 'cancel', time: number } |
+  { type: 'set' | 'ramp', value: number, time: number }
+
+class MockEnvelopeTarget implements EnvelopeTarget {
+  readonly events: EnvelopeEvent[] = []
+
+  cancelScheduledValues (time: number): void {
+    this.events.push({ type: 'cancel', time })
+  }
+
+  setValueAtTime (value: number, time: number): void {
+    this.events.push({ type: 'set', value, time })
+  }
+
+  linearRampToValueAtTime (value: number, time: number): void {
+    this.events.push({ type: 'ramp', value, time })
+  }
+}
+
+function createEnvelope (values: { attack: number, decay: number, sustain: number, release: number }): Envelope {
+  return {
+    attack: numeric('s', values.attack),
+    decay: numeric('s', values.decay),
+    sustain: numeric(undefined, values.sustain),
+    release: numeric('s', values.release)
+  }
+}
+
+describe('graph/instruments/envelope.ts', () => {
+  describe('applyEnvelope()', () => {
+    it('schedules attack and decay without release when hold duration is absent', () => {
+      const target = new MockEnvelopeTarget()
+
+      applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 3 }), target, {
+        time: 10,
+        velocity: 1
+      })
+
+      assert.deepStrictEqual(target.events, [
+        { type: 'set', value: 0, time: 10 },
+        { type: 'ramp', value: 1, time: 11 },
+        { type: 'ramp', value: 0.5, time: 13 }
+      ])
+    })
+
+    it('handles zero-length attack by setting the peak immediately before decay', () => {
+      const target = new MockEnvelopeTarget()
+
+      applyEnvelope(createEnvelope({ attack: 0, decay: 2, sustain: 0.5, release: 3 }), target, {
+        time: 10,
+        velocity: 1
+      })
+
+      assert.deepStrictEqual(target.events, [
+        { type: 'set', value: 1, time: 10 },
+        { type: 'ramp', value: 0.5, time: 12 }
+      ])
+    })
+
+    it('handles zero-length decay by setting the sustain level immediately after attack', () => {
+      const target = new MockEnvelopeTarget()
+
+      applyEnvelope(createEnvelope({ attack: 1, decay: 0, sustain: 0.5, release: 3 }), target, {
+        time: 10,
+        velocity: 1
+      })
+
+      assert.deepStrictEqual(target.events, [
+        { type: 'set', value: 0, time: 10 },
+        { type: 'ramp', value: 1, time: 11 },
+        { type: 'set', value: 0.5, time: 11 }
+      ])
+    })
+
+    it('starts release from the current attack level when the note ends during attack', () => {
+      const target = new MockEnvelopeTarget()
+
+      applyEnvelope(createEnvelope({ attack: 4, decay: 2, sustain: 0.5, release: 1 }), target, {
+        time: 3,
+        velocity: 1,
+        holdDuration: 1
+      })
+
+      assert.deepStrictEqual(target.events.slice(-3), [
+        { type: 'cancel', time: 4 },
+        { type: 'set', value: 0.25, time: 4 },
+        { type: 'ramp', value: 0, time: 5 }
+      ])
+    })
+
+    it('starts release from the current decay level when the note ends during decay', () => {
+      const target = new MockEnvelopeTarget()
+
+      applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 1 }), target, {
+        time: 10,
+        velocity: 1,
+        holdDuration: 2
+      })
+
+      assert.deepStrictEqual(target.events.slice(-3), [
+        { type: 'cancel', time: 12 },
+        { type: 'set', value: 0.75, time: 12 },
+        { type: 'ramp', value: 0, time: 13 }
+      ])
+    })
+
+    it('starts release from sustain when the note ends after decay', () => {
+      const target = new MockEnvelopeTarget()
+
+      applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 4 }), target, {
+        time: 10,
+        velocity: 0.8,
+        holdDuration: 5
+      })
+
+      assert.deepStrictEqual(target.events.slice(-3), [
+        { type: 'cancel', time: 15 },
+        { type: 'set', value: 0.4, time: 15 },
+        { type: 'ramp', value: 0, time: 19 }
+      ])
+    })
+
+    it('handles zero-length release by setting the value to 0 immediately after hold duration', () => {
+      const target = new MockEnvelopeTarget()
+
+      applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 0 }), target, {
+        time: 10,
+        velocity: 1,
+        holdDuration: 5
+      })
+
+      assert.deepStrictEqual(target.events.slice(-2), [
+        { type: 'cancel', time: 15 },
+        { type: 'set', value: 0, time: 15 }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
This patch generalizes the envelope implementation to full ADSR, and adds the envelope as a property of the core Instrument type. From there, it flows through lowering and into the Web Audio graph. The constructors set a fixed envelope with a short attack and release time to prevent audible clicks. Customization is not yet implemented.