### PR TITLE
feat: Add facet-based type system for future use

### DIFF
--- a/packages/language/src/type-system/assignability.ts
+++ b/packages/language/src/type-system/assignability.ts
@@ -1,0 +1,80 @@
+import type { CustomComparable, Facet, GenericValue, Type, UnionType } from './types.js'
+
+const isGenericType = (value: GenericValue): value is Type => {
+  return typeof value === 'object' && ('facets' in value || 'members' in value)
+}
+
+const isCustomComparable = (value: GenericValue): value is CustomComparable => {
+  return typeof value === 'object' && 'checkAssignableFrom' in value
+}
+
+export function isGenericValueAssignableFrom (target: GenericValue, other: GenericValue): boolean {
+  if (target === other) {
+    return true
+  }
+
+  if (isGenericType(target) && isGenericType(other)) {
+    return isTypeAssignableFromType(target, other)
+  }
+
+  if (isCustomComparable(target)) {
+    return target.checkAssignableFrom(other)
+  }
+
+  return false
+}
+
+export function isFacetAssignableFromFacet (target: Facet, other: Facet): boolean {
+  if (other === target) {
+    return true
+  }
+
+  return other.name === target.name && Object.keys(target.generics).every((key) => {
+    if (!(key in other.generics)) {
+      return false
+    }
+
+    return isGenericValueAssignableFrom(target.generics[key], other.generics[key])
+  })
+}
+
+const isUnionType = (type: Type): type is UnionType => {
+  return 'members' in type
+}
+
+export function isFacetAssignableFromType (target: Facet, type: Type): boolean {
+  if (isUnionType(type)) {
+    return type.members.every((member) => isFacetAssignableFromType(target, member))
+  }
+
+  for (const typeFacet of type.facets.values()) {
+    if (isFacetAssignableFromFacet(target, typeFacet)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export function isTypeAssignableFromType (target: Type, other: Type): boolean {
+  if (other === target) {
+    return true
+  }
+
+  if (isUnionType(other)) {
+    return other.members.every((otherMember) => isTypeAssignableFromType(target, otherMember))
+  }
+
+  if (isUnionType(target)) {
+    return target.members.some((targetMember) => isTypeAssignableFromType(targetMember, other))
+  }
+
+  for (const targetFacet of target.facets.values()) {
+    const otherFacet = other.facets.get(targetFacet.name)
+    if (otherFacet == null || !isFacetAssignableFromFacet(targetFacet, otherFacet)) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/packages/language/src/type-system/factory.ts
+++ b/packages/language/src/type-system/factory.ts
@@ -1,0 +1,123 @@
+import { isFacetAssignableFromFacet, isFacetAssignableFromType, isTypeAssignableFromType } from './assignability.js'
+import type { DataForFacets, Facet, FacetType, Generics, SpecificFacetDataForValue, Type, UnionType, Value, ValueForType } from './types.js'
+
+export interface FacetOptions {
+  readonly format?: () => string
+}
+
+export function makeFacet<const Name extends string, Data> (
+  name: Name,
+  generics: Generics,
+  options?: FacetOptions
+): Facet<Name, Data> {
+  let cachedType: FacetType<[Facet<Name, Data>]> | undefined = undefined
+
+  const facet: Facet<Name, Data> = {
+    name,
+    generics,
+
+    format: options?.format ?? (() => name),
+
+    is: (other: Facet | Type): boolean => {
+      if ('name' in other && 'generics' in other) {
+        return isFacetAssignableFromFacet(facet, other)
+      } else {
+        return isFacetAssignableFromType(facet, other)
+      }
+    },
+
+    has: (value: Value): value is Value<Facet<Name, Data>> => {
+      return isFacetAssignableFromType(facet, value.type)
+    },
+
+    get: <const V extends Value>(value: V): SpecificFacetDataForValue<V, Name, Data> => {
+      if (!isFacetAssignableFromType(facet, value.type)) {
+        throw new Error(`Value is not assignable to facet ${facet.name}`)
+      }
+
+      return value.data.get(facet.name) as SpecificFacetDataForValue<V, Name, Data>
+    },
+
+    type: () => {
+      cachedType ??= makeType(facet)
+      return cachedType
+    }
+  }
+
+  return facet
+}
+
+export function makeType<const Facets extends readonly Facet[]> (
+  ...facets: Facets
+): FacetType<Facets> {
+  if (facets.length === 0) {
+    throw new Error('Expected at least one facet')
+  }
+
+  const facetMap = new Map<string, Facet>(
+    facets.map((facet) => [facet.name, facet])
+  )
+  if (facetMap.size !== facets.length) {
+    throw new Error('Duplicate facet names are not allowed in a type')
+  }
+
+  const type = {
+    facets: facetMap,
+
+    format: () => {
+      return facets.map((facet) => facet.format()).join(' + ')
+    },
+
+    is: (other: Type): boolean => {
+      return isTypeAssignableFromType(type, other)
+    },
+
+    has: (value: Value): value is ValueForType<FacetType<Facets>> => {
+      return isTypeAssignableFromType(type, value.type)
+    },
+
+    of: (...data: DataForFacets<Facets>): ValueForType<FacetType<Facets>> => {
+      const dataMap = new Map<string, unknown>(
+        Array.from(type.facets.entries(), ([name], index) => [name, data[index]])
+      )
+
+      return { type, data: dataMap }
+    },
+
+    getFacet: (name: string): Facets[number] => {
+      const facet = type.facets.get(name)
+      if (facet == null) {
+        throw new Error(`Facet ${name} not found in type`)
+      }
+      return facet
+    }
+  } satisfies FacetType<Facets>
+
+  return type
+}
+
+export function makeUnion<const Members extends readonly FacetType[]> (
+  ...members: Members
+): UnionType<Members> {
+  if (members.length === 0) {
+    throw new Error('Expected at least one member')
+  }
+
+  const type = {
+    members,
+
+    format: () => {
+      return members.map((member) => member.format()).join(' | ')
+    },
+
+    is: (other: Type): boolean => {
+      return isTypeAssignableFromType(type, other)
+    },
+
+    has: (value: Value): value is ValueForType<UnionType<Members>> => {
+      return isTypeAssignableFromType(type, value.type)
+    }
+  } satisfies UnionType<Members>
+
+  return type
+}

--- a/packages/language/src/type-system/schema.ts
+++ b/packages/language/src/type-system/schema.ts
@@ -1,0 +1,19 @@
+import type { Type, ValueForType } from './types.js'
+
+export type Schema = readonly SchemaItem[]
+
+export interface SchemaItem<T extends Type = Type> {
+  readonly name: string
+  readonly type: T
+  readonly required: boolean
+}
+
+export type InferSchema<S extends Schema> = {
+  [P in S[number] as P['required'] extends true ? P['name'] : never]: ValueForType<P['type']>
+} & {
+  [P in S[number] as P['required'] extends false ? P['name'] : never]?: ValueForType<P['type']>
+}
+
+export function makeSchema<const S extends Schema> (schema: S): S {
+  return schema
+}

--- a/packages/language/src/type-system/types.ts
+++ b/packages/language/src/type-system/types.ts
@@ -1,0 +1,89 @@
+export type Type = FacetType | UnionType
+
+declare const facetDataType: unique symbol
+
+export interface FacetType<Facets extends readonly Facet[] = readonly Facet[]> {
+  readonly facets: ReadonlyMap<string, Facet>
+
+  readonly format: () => string
+  readonly is: (other: Type) => boolean
+  readonly has: (value: Value) => value is ValueForType<FacetType<Facets>>
+  readonly of: (...data: DataForFacets<Facets>) => ValueForType<FacetType<Facets>>
+  readonly getFacet: (name: string) => Facets[number]
+}
+
+export interface UnionType<Members extends readonly FacetType[] = readonly FacetType[]> {
+  readonly members: Members
+
+  readonly format: () => string
+  readonly is: (other: Type) => boolean
+  readonly has: (value: Value) => value is ValueForType<UnionType<Members>>
+}
+
+export interface Facet<Name extends string = string, Data = unknown> {
+  readonly name: Name
+  readonly generics: Generics
+
+  readonly format: () => string
+  readonly is: (other: Facet | Type) => boolean
+  readonly has: (value: Value) => value is Value<Facet<Name, Data>>
+  readonly get: <const V extends Value>(value: V) => SpecificFacetDataForValue<V, Name, Data>
+
+  readonly type: () => FacetType<[Facet<Name, Data>]>
+
+  // used for type inference of facet data, not actually present at runtime
+  readonly [facetDataType]?: Data
+}
+
+export interface Value<Facets extends Facet = Facet> {
+  readonly type: FacetType
+  readonly data: ReadonlyMap<Facets['name'], unknown>
+}
+
+// helper types for facet generics
+
+export type IdentityComparable = string | number | boolean | undefined
+
+export interface CustomComparable {
+  readonly checkAssignableFrom: (other: unknown) => boolean
+}
+
+export type GenericValue = IdentityComparable | Type | CustomComparable
+export type Generics = Readonly<Record<string, GenericValue>>
+
+// inference helpers
+
+export type DataForFacet<F> = F extends { readonly [facetDataType]?: infer Data } ? Data : never
+
+export type DataForFacets<Facets> =
+  Facets extends readonly [infer F, ...infer R]
+    ? F extends Facet<string, infer Data>
+      ? [Data, ...DataForFacets<R>]
+      : never
+    : []
+
+export type ValueForType<T> =
+  T extends FacetType<infer Facets>
+    ? Value<Facets[number]>
+    : T extends UnionType<infer Members>
+      ? ValueForType<Members[number]>
+      : never
+
+export type FacetByName<Facets, Name extends string> =
+  Extract<Facets, { readonly name: Name }>
+
+export type FacetDataByName<Facets, Name extends string> =
+  DataForFacet<FacetByName<Facets, Name>>
+
+type UntypedFacetDataFallback<Facets, Fallback> =
+  Facets extends { readonly name: string }
+    ? string extends Facets['name']
+      ? Fallback
+      : never
+    : never
+
+export type SpecificFacetDataForValue<V extends Value, Name extends string, Fallback> = V extends Value<infer Facets>
+  ? [FacetDataByName<Facets, Name>] extends [never]
+      ? UntypedFacetDataFallback<Facets, Fallback>
+      : Fallback & FacetDataByName<Facets, Name>
+  : Fallback

--- a/packages/language/test/type-system/type-system.test.ts
+++ b/packages/language/test/type-system/type-system.test.ts
@@ -1,0 +1,306 @@
+import type { Numeric, Unit } from '@utility'
+import { numeric } from '@utility'
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { makeFacet, makeType, makeUnion } from '../../src/type-system/factory.js'
+import type { DataForFacet, DataForFacets, Value, ValueForType } from '../../src/type-system/types.js'
+import { expectTypeEquals } from '../test-utils.js'
+
+const stringFacet = makeFacet<'string', string>('string', {})
+const numberFacet = makeFacet<'number', number>('number', {})
+const numericFacet = makeFacet<'numeric', Numeric<Unit>>('numeric', {})
+const decibelFacet = makeFacet<'numeric', Numeric<'db'>>('numeric', { unit: 'db' }, {
+  format: () => 'numeric(db)'
+})
+const hertzFacet = makeFacet<'numeric', Numeric<'hz'>>('numeric', { unit: 'hz' }, {
+  format: () => 'numeric(hz)'
+})
+
+const stringType = makeType(stringFacet)
+const numberType = makeType(numberFacet)
+const stringAndNumberType = makeType(stringFacet, numberFacet)
+const numericType = makeType(numericFacet)
+const decibelType = makeType(decibelFacet)
+const hertzType = makeType(hertzFacet)
+
+const numericUnion = makeUnion(decibelType, hertzType)
+
+describe('type-system', () => {
+  describe('DataForFacet', () => {
+    it('should infer facet data', () => {
+      expectTypeEquals<string, DataForFacet<typeof stringFacet>>()
+      expectTypeEquals<Numeric<Unit>, DataForFacet<typeof numericFacet>>()
+    })
+  })
+
+  describe('DataForFacets', () => {
+    it('should infer facet data', () => {
+      expectTypeEquals<[string, number], DataForFacets<[typeof stringFacet, typeof numberFacet]>>()
+      expectTypeEquals<[], DataForFacets<[]>>()
+    })
+  })
+
+  describe('ValueForType', () => {
+    it('should infer values for facet types and unions', () => {
+      expectTypeEquals<Value<typeof stringFacet>, ValueForType<typeof stringType>>()
+      expectTypeEquals<ValueForType<typeof decibelType> | ValueForType<typeof hertzType>, ValueForType<typeof numericUnion>>()
+    })
+  })
+
+  describe('get()', () => {
+    it('should infer a more specific data type from the value if available', () => {
+      const specificValue = decibelType.of(numeric('db', 42))
+      const specificData = numericFacet.get(specificValue)
+      expectTypeEquals<Numeric<Unit> & Numeric<'db'>, typeof specificData>()
+      expectTypeEquals<'db', typeof specificData.unit>()
+      assert.strictEqual(specificData.unit, 'db')
+      assert.strictEqual(specificData.value, 42)
+
+      const widenedValue: Value = specificValue
+      const widenedData = numericFacet.get(widenedValue)
+      expectTypeEquals<Numeric<Unit>, typeof widenedData>()
+      expectTypeEquals<Unit, typeof widenedData.unit>()
+      assert.strictEqual(widenedData.unit, 'db')
+      assert.strictEqual(widenedData.value, 42)
+    })
+  })
+
+  describe('Facet', () => {
+    it('should format facets with default and custom formatting', () => {
+      assert.strictEqual(stringFacet.format(), 'string')
+      assert.strictEqual(decibelFacet.format(), 'numeric(db)')
+    })
+
+    it('should compare facets using identity, custom comparable, and type generics', () => {
+      assert.strictEqual(stringFacet.is(stringFacet), true)
+      assert.strictEqual(numberFacet.is(numberFacet), true)
+      assert.strictEqual(stringFacet.is(numberFacet), false)
+      assert.strictEqual(numberFacet.is(stringFacet), false)
+
+      assert.strictEqual(numericFacet.is(decibelFacet), true)
+      assert.strictEqual(decibelFacet.is(numericFacet), false)
+
+      const customComparableFacetA = makeFacet<'custom', unknown>('custom', {
+        foobar: {
+          checkAssignableFrom: (other): boolean => other === customComparableFacetA
+        }
+      })
+      const customComparableFacetB = makeFacet<'custom', unknown>('custom', {
+        foobar: {
+          checkAssignableFrom: (other): boolean => other === customComparableFacetB
+        }
+      })
+
+      assert.strictEqual(customComparableFacetA.is(customComparableFacetA), true)
+      assert.strictEqual(customComparableFacetA.is(customComparableFacetB), false)
+
+      const unionGenericFacetA = makeFacet<'generic', unknown>('generic', {
+        foobar: makeUnion(decibelType, hertzType)
+      })
+      const unionGenericFacetB = makeFacet<'generic', unknown>('generic', {
+        foobar: makeUnion(decibelType, hertzType)
+      })
+
+      assert.strictEqual(unionGenericFacetA.is(unionGenericFacetB), true)
+
+      const simpleGenericFacet = makeFacet<'generic', unknown>('generic', {
+        foobar: decibelType
+      })
+
+      assert.strictEqual(unionGenericFacetA.is(simpleGenericFacet), true)
+      assert.strictEqual(simpleGenericFacet.is(unionGenericFacetA), false)
+    })
+
+    it('should compare facets against types and unions', () => {
+      assert.strictEqual(numericFacet.is(decibelType), true)
+      assert.strictEqual(decibelFacet.is(numericType), false)
+      assert.strictEqual(numericFacet.is(numericUnion), true)
+      assert.strictEqual(decibelFacet.is(numericUnion), false)
+    })
+
+    it('should check values', () => {
+      const pairValue = stringAndNumberType.of('hello', 42)
+      const broadNumericValue = numericType.of(numeric(undefined, 5))
+      const decibelValue = decibelType.of(numeric('db', 42))
+
+      assert.strictEqual(stringFacet.has(pairValue), true)
+      assert.strictEqual(numberFacet.has(pairValue), true)
+      assert.strictEqual(decibelFacet.has(decibelValue), true)
+      assert.strictEqual(numericFacet.has(decibelValue), true)
+      assert.strictEqual(decibelFacet.has(broadNumericValue), false)
+    })
+
+    it('should retrieve facet data', () => {
+      const pairValue = stringAndNumberType.of('hello', 42)
+      const broadNumericValue = numericType.of(numeric(undefined, 5))
+      const decibelValue = decibelType.of(numeric('db', 42))
+
+      assert.strictEqual(stringFacet.get(pairValue), 'hello')
+      assert.strictEqual(numberFacet.get(pairValue), 42)
+      assert.deepStrictEqual(decibelFacet.get(decibelValue), numeric('db', 42))
+
+      assert.throws(() => stringFacet.get(decibelValue), /Value is not assignable to facet string/)
+      assert.throws(() => decibelFacet.get(broadNumericValue), /Value is not assignable to facet numeric/)
+    })
+
+    it('should narrow values through has()', () => {
+      const maybeFacetValue: Value = decibelType.of(numeric('db', 42))
+      if (!numericFacet.has(maybeFacetValue)) {
+        assert.fail('Expected numericFacet.has() to narrow a decibel value')
+      }
+      const narrowedFacetValue: Value<typeof numericFacet> = maybeFacetValue
+      assert.strictEqual(numericFacet.get(narrowedFacetValue).unit, 'db')
+    })
+
+    it('should cache the single-facet type returned by type()', () => {
+      const facetType = stringFacet.type()
+      const facetValue = facetType.of('hello')
+
+      assert.strictEqual(facetType, stringFacet.type())
+      assert.strictEqual(facetType.format(), 'string')
+      assert.strictEqual(facetType.getFacet('string'), stringFacet)
+      assert.strictEqual(facetType.has(facetValue), true)
+    })
+  })
+
+  describe('FacetType', () => {
+    it('should throw if given zero facets', () => {
+      assert.throws(() => makeType(), /Expected at least one facet/)
+    })
+
+    it('should store facets', () => {
+      assert.deepStrictEqual(Array.from(stringAndNumberType.facets.keys()), ['string', 'number'])
+      assert.strictEqual(stringAndNumberType.facets.get('string'), stringFacet)
+      assert.strictEqual(stringAndNumberType.facets.get('number'), numberFacet)
+    })
+
+    it('should format based on facets', () => {
+      assert.strictEqual(stringAndNumberType.format(), 'string + number')
+      assert.strictEqual(decibelType.format(), 'numeric(db)')
+    })
+
+    it('should compare assignability for exact, broader, incompatible, and union types', () => {
+      assert.strictEqual(stringType.is(stringType), true)
+      assert.strictEqual(stringType.is(stringAndNumberType), true)
+      assert.strictEqual(stringAndNumberType.is(stringType), false)
+      assert.strictEqual(stringType.is(numberType), false)
+
+      assert.strictEqual(numericType.is(decibelType), true)
+      assert.strictEqual(decibelType.is(numericType), false)
+      assert.strictEqual(numericType.is(numericUnion), true)
+      assert.strictEqual(decibelType.is(numericUnion), false)
+
+      assert.strictEqual(numericUnion.is(numericUnion), true)
+    })
+
+    it('should create values with data map based on facets', () => {
+      const pairValue = stringAndNumberType.of('hello', 42)
+
+      assert.strictEqual(pairValue.type, stringAndNumberType)
+      assert.deepStrictEqual(Array.from(pairValue.data.entries()), [
+        ['string', 'hello'],
+        ['number', 42]
+      ])
+    })
+
+    it('should check compatibility', () => {
+      const pairValue = stringAndNumberType.of('hello', 42)
+      const stringValue = stringType.of('hello')
+
+      assert.strictEqual(stringAndNumberType.has(pairValue), true)
+      assert.strictEqual(stringType.has(pairValue), true)
+      assert.strictEqual(numberType.has(pairValue), true)
+      assert.strictEqual(stringAndNumberType.has(stringValue), false)
+      assert.strictEqual(numberType.has(stringValue), false)
+    })
+
+    it('should return facets by name', () => {
+      assert.strictEqual(stringAndNumberType.getFacet('string'), stringFacet)
+      assert.strictEqual(stringAndNumberType.getFacet('number'), numberFacet)
+      assert.throws(() => stringAndNumberType.getFacet('missing'), /Facet missing not found in type/)
+    })
+
+    it('should reject missing or duplicate names', () => {
+      const duplicateStringFacet = makeFacet<'string', number>('string', { variant: true })
+
+      assert.throws(() => makeType(stringFacet, duplicateStringFacet), /Duplicate facet names are not allowed in a type/)
+      assert.throws(() => makeType(decibelFacet, hertzFacet), /Duplicate facet names are not allowed in a type/)
+    })
+
+    it('should narrow values through has()', () => {
+      const maybeTypeValue: Value = decibelType.of(numeric('db', 42))
+      if (!decibelType.has(maybeTypeValue)) {
+        assert.fail('Expected decibelType.has() to narrow a decibel value')
+      }
+      const narrowedTypeValue: ValueForType<typeof decibelType> = maybeTypeValue
+      assert.strictEqual(decibelFacet.get(narrowedTypeValue).unit, 'db')
+    })
+  })
+
+  describe('UnionType', () => {
+    it('should throw if given zero members', () => {
+      assert.throws(() => makeUnion(), /Expected at least one member/)
+    })
+
+    it('should store members', () => {
+      const primitiveUnion = makeUnion(stringType, numberType)
+      assert.deepStrictEqual(primitiveUnion.members, [stringType, numberType])
+    })
+
+    it('should format based on members', () => {
+      const primitiveUnion = makeUnion(stringType, numberType)
+      assert.strictEqual(primitiveUnion.format(), 'string | number')
+      assert.strictEqual(numericUnion.format(), 'numeric(db) | numeric(hz)')
+    })
+
+    it('should compare assignability against members and other unions', () => {
+      const primitiveUnion = makeUnion(stringType, numberType)
+      const widerUnion = makeUnion(stringType, numberType, decibelType)
+      const narrowerUnion = makeUnion(stringType)
+
+      assert.strictEqual(primitiveUnion.is(primitiveUnion), true)
+      assert.strictEqual(primitiveUnion.is(stringType), true)
+      assert.strictEqual(primitiveUnion.is(numberType), true)
+      assert.strictEqual(primitiveUnion.is(stringAndNumberType), true)
+      assert.strictEqual(primitiveUnion.is(widerUnion), false)
+      assert.strictEqual(primitiveUnion.is(narrowerUnion), true)
+      assert.strictEqual(narrowerUnion.is(primitiveUnion), false)
+      assert.strictEqual(primitiveUnion.is(decibelType), false)
+    })
+
+    it('should accept values from any compatible member type', () => {
+      const primitiveUnion = makeUnion(stringType, numberType)
+      const stringValue = stringType.of('hello')
+      const pairValue = stringAndNumberType.of('hello', 42)
+      const decibelValue = decibelType.of(numeric('db', 42))
+      const broadNumericValue = numericType.of(numeric(undefined, 5))
+
+      assert.strictEqual(primitiveUnion.has(stringValue), true)
+      assert.strictEqual(primitiveUnion.has(pairValue), true)
+      assert.strictEqual(primitiveUnion.has(decibelValue), false)
+
+      assert.strictEqual(numericUnion.has(decibelValue), true)
+      assert.strictEqual(numericUnion.has(broadNumericValue), false)
+    })
+
+    it('should narrow values through has()', () => {
+      const maybeUnionValue: Value = hertzType.of(numeric('hz', 1000))
+      if (!numericUnion.has(maybeUnionValue)) {
+        assert.fail('Expected numericUnion.has() to narrow a member value')
+      }
+      assert.strictEqual(numericFacet.get(maybeUnionValue).unit, 'hz')
+    })
+  })
+
+  describe('Value', () => {
+    it('should keep its originating type and per-facet data map', () => {
+      const value = stringAndNumberType.of('hello', 42)
+      const data = value.data as ReadonlyMap<string, unknown>
+
+      assert.strictEqual(value.type, stringAndNumberType)
+      assert.strictEqual(value.data.get('string'), 'hello')
+      assert.strictEqual(value.data.get('number'), 42)
+      assert.strictEqual(data.has('missing'), false)
+    })
+  })
+})


### PR DESCRIPTION
This patch introduces a new abstract type system. In contrast to the current, purely nominal type system, this new one deconstructs each type into a set of facets, which represent orthogonal aspects of the type. For example, primitive types like `string` have just a single facet, but more complex types such as instruments could be split into two facets: one to denote the instrument capability itself, and another record-like facet to denote the parameters. This makes it possible to define any number of concrete instrument types that are all assignable to the same instrument facet, while also exposing different properties per type.

Additionally, union types are first-class citizens in this new system, such that property schemas (e.g., function parameters) can accept them directly.

Language-specific facets will be added in a follow-up patch, as well as integration of the new type system into the compiler.