### PR TITLE
feat: Add concrete type system facets

### DIFF
--- a/packages/language/src/type-system/base/function.ts
+++ b/packages/language/src/type-system/base/function.ts
@@ -1,0 +1,55 @@
+import { makeFacet } from '../factory.js'
+import type { InferSchema, Schema } from '../schema.js'
+import type { CustomComparable, FacetType, ValueForType } from '../types.js'
+
+export interface Function<S extends Schema = Schema, R extends FacetType = FacetType> {
+  readonly parameters: S
+  readonly returnType: R
+  readonly invoke: (context: unknown, args: InferSchema<S>) => ValueForType<R>
+
+  // documentation
+  readonly summary?: string
+}
+
+interface FunctionSpec<S extends Schema = Schema, R extends FacetType = FacetType> {
+  readonly parameters: S
+  readonly returnType: R
+}
+
+interface FunctionSpecGeneric extends CustomComparable {
+  readonly value: FunctionSpec
+}
+
+const FACET_NAME = 'function'
+
+export const FunctionFacet = {
+  ...makeFacet<typeof FACET_NAME, Function>(FACET_NAME, {}),
+
+  with: <const S extends Schema, const R extends FacetType> (spec: FunctionSpec<S, R>) => {
+    const generic: FunctionSpecGeneric = {
+      value: spec,
+
+      // identity check for now; if we ever want to support structural compatibility for functions,
+      // the schema and return type would have to be checked for assignability
+      checkAssignableFrom: (other: unknown): boolean => {
+        if (typeof other !== 'object' || other == null || !('value' in other)) {
+          return false
+        }
+
+        const otherSpec = (other as FunctionSpecGeneric).value
+        return spec === otherSpec
+      }
+    }
+
+    return makeFacet<typeof FACET_NAME, Function<S, R>>(FACET_NAME, { spec: generic })
+  },
+
+  detail: (type: FacetType): FunctionSpec => {
+    const { generics } = type.getFacet(FACET_NAME)
+    if (!('spec' in generics)) {
+      throw new Error(`Invalid generics for ${FACET_NAME} facet`)
+    }
+
+    return (generics.spec as FunctionSpecGeneric).value
+  }
+}

--- a/packages/language/src/type-system/base/module.ts
+++ b/packages/language/src/type-system/base/module.ts
@@ -1,0 +1,47 @@
+import { makeFacet } from '../factory.js'
+import type { CustomComparable, FacetType, Value } from '../types.js'
+
+export interface Module {
+  readonly name: string
+  readonly exports: ReadonlyMap<string, Value>
+
+  // documentation
+  readonly summary?: string
+}
+
+interface ModuleGeneric extends CustomComparable {
+  readonly value: Module
+}
+
+const FACET_NAME = 'module'
+
+export const ModuleFacet = {
+  ...makeFacet<typeof FACET_NAME, Module>(FACET_NAME, {}),
+
+  with: (value: Module) => {
+    const generic: ModuleGeneric = {
+      value,
+      checkAssignableFrom: (other: unknown): boolean => {
+        if (typeof other !== 'object' || other == null || !('value' in other)) {
+          return false
+        }
+
+        const otherValue = (other as ModuleGeneric).value
+        return value === otherValue
+      }
+    }
+
+    return makeFacet<typeof FACET_NAME, Module>(FACET_NAME, { spec: generic }, {
+      format: () => `${FACET_NAME}("${value.name}")`
+    })
+  },
+
+  detail: (type: FacetType): Module => {
+    const { generics } = type.getFacet(FACET_NAME)
+    if (!('spec' in generics)) {
+      throw new Error(`Invalid generics for ${FACET_NAME} facet`)
+    }
+
+    return (generics.spec as ModuleGeneric).value
+  }
+}

--- a/packages/language/src/type-system/base/number.ts
+++ b/packages/language/src/type-system/base/number.ts
@@ -1,0 +1,24 @@
+import type { Numeric, Unit } from '@utility'
+import { makeFacet } from '../factory.js'
+import type { FacetType } from '../types.js'
+
+const FACET_NAME = 'number'
+
+export const NumberFacet = {
+  ...makeFacet<typeof FACET_NAME, Numeric<Unit>>(FACET_NAME, {}),
+
+  with: <const U extends Unit> (unit: U) => {
+    return makeFacet<typeof FACET_NAME, Numeric<U>>(FACET_NAME, { unit }, {
+      format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
+    })
+  },
+
+  detail: (type: FacetType): Unit => {
+    const { generics } = type.getFacet(FACET_NAME)
+    if (!('unit' in generics)) {
+      throw new Error(`Invalid generics for ${FACET_NAME} facet`)
+    }
+
+    return generics.unit as Unit
+  }
+}

--- a/packages/language/src/type-system/base/record.ts
+++ b/packages/language/src/type-system/base/record.ts
@@ -1,0 +1,24 @@
+import { makeFacet } from '../factory.js'
+import type { FacetType, ValueForType } from '../types.js'
+
+type RecordGenerics = Readonly<Partial<Record<string, FacetType>>>
+
+type RecordDataForFields<Fields extends RecordGenerics> = {
+  readonly [K in keyof Fields]: ValueForType<Fields[K]>
+}
+
+const FACET_NAME = 'record'
+
+export const RecordFacet = {
+  ...makeFacet<typeof FACET_NAME, RecordDataForFields<RecordGenerics>>(FACET_NAME, {}),
+
+  with: <const Fields extends RecordGenerics> (fields: Fields) => {
+    return makeFacet<typeof FACET_NAME, RecordDataForFields<Fields>>(FACET_NAME, fields, {
+      format: () => `${FACET_NAME}(${Object.keys(fields).join(', ')})`
+    })
+  },
+
+  detail: (type: FacetType): RecordGenerics => {
+    return type.getFacet(FACET_NAME).generics as RecordGenerics
+  }
+}

--- a/packages/language/src/type-system/base/string.ts
+++ b/packages/language/src/type-system/base/string.ts
@@ -1,0 +1,5 @@
+import { makeFacet } from '../factory.js'
+
+const FACET_NAME = 'string'
+
+export const StringFacet = makeFacet<typeof FACET_NAME, string>(FACET_NAME, {})

--- a/packages/language/src/type-system/domain/bus.ts
+++ b/packages/language/src/type-system/domain/bus.ts
@@ -1,0 +1,6 @@
+import type { Bus } from '@core'
+import { makeFacet } from '../factory.js'
+
+const FACET_NAME = 'bus'
+
+export const BusFacet = makeFacet<typeof FACET_NAME, Bus>(FACET_NAME, {})

--- a/packages/language/src/type-system/domain/curve.ts
+++ b/packages/language/src/type-system/domain/curve.ts
@@ -1,0 +1,46 @@
+import type { Numeric, Unit } from '@utility'
+import { makeFacet } from '../factory.js'
+import type { FacetType } from '../types.js'
+
+export interface Curve<U extends Unit> {
+  readonly unit: U
+  readonly segments: ReadonlyArray<CurveSegment<U>>
+}
+
+export type CurveSegment<U extends Unit> = HoldCurveSegment<U> | LinearCurveSegment<U>
+
+export interface HoldCurveSegment<U extends Unit> {
+  readonly type: 'hold'
+  readonly length: Numeric<undefined>
+  readonly unit: U
+  readonly value: Numeric<U>
+}
+
+export interface LinearCurveSegment<U extends Unit> {
+  readonly type: 'lin'
+  readonly length: Numeric<undefined>
+  readonly unit: U
+  readonly start: Numeric<U>
+  readonly end: Numeric<U>
+}
+
+const FACET_NAME = 'curve'
+
+export const CurveFacet = {
+  ...makeFacet<typeof FACET_NAME, Curve<Unit>>(FACET_NAME, {}),
+
+  with: <const U extends Unit> (unit: U) => {
+    return makeFacet<typeof FACET_NAME, Curve<U>>(FACET_NAME, { unit }, {
+      format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
+    })
+  },
+
+  detail: (type: FacetType): Unit => {
+    const { generics } = type.getFacet(FACET_NAME)
+    if (!('unit' in generics)) {
+      throw new Error(`Invalid generics for ${FACET_NAME} facet`)
+    }
+
+    return generics.unit as Unit
+  }
+}

--- a/packages/language/src/type-system/domain/effect.ts
+++ b/packages/language/src/type-system/domain/effect.ts
@@ -1,0 +1,6 @@
+import type { Effect } from '@core'
+import { makeFacet } from '../factory.js'
+
+const FACET_NAME = 'effect'
+
+export const EffectFacet = makeFacet<typeof FACET_NAME, Effect>(FACET_NAME, {})

--- a/packages/language/src/type-system/domain/instrument.ts
+++ b/packages/language/src/type-system/domain/instrument.ts
@@ -1,0 +1,6 @@
+import type { Instrument } from '@core'
+import { makeFacet } from '../factory.js'
+
+const FACET_NAME = 'instrument'
+
+export const InstrumentFacet = makeFacet<typeof FACET_NAME, Instrument>(FACET_NAME, {})

--- a/packages/language/src/type-system/domain/parameter.ts
+++ b/packages/language/src/type-system/domain/parameter.ts
@@ -1,0 +1,25 @@
+import type { Parameter } from '@core'
+import type { Unit } from '@utility'
+import { makeFacet } from '../factory.js'
+import type { FacetType } from '../types.js'
+
+const FACET_NAME = 'parameter'
+
+export const ParameterFacet = {
+  ...makeFacet<typeof FACET_NAME, Parameter<Unit>>(FACET_NAME, {}),
+
+  with: <const U extends Unit> (unit: U) => {
+    return makeFacet<typeof FACET_NAME, Parameter<U>>(FACET_NAME, { unit }, {
+      format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
+    })
+  },
+
+  detail: (type: FacetType): Unit => {
+    const { generics } = type.getFacet(FACET_NAME)
+    if (!('unit' in generics)) {
+      throw new Error(`Invalid generics for ${FACET_NAME} facet`)
+    }
+
+    return generics.unit as Unit
+  }
+}

--- a/packages/language/src/type-system/domain/part.ts
+++ b/packages/language/src/type-system/domain/part.ts
@@ -1,0 +1,6 @@
+import type { Part } from '@core'
+import { makeFacet } from '../factory.js'
+
+const FACET_NAME = 'part'
+
+export const PartFacet = makeFacet<typeof FACET_NAME, Part>(FACET_NAME, {})

--- a/packages/language/src/type-system/domain/pattern.ts
+++ b/packages/language/src/type-system/domain/pattern.ts
@@ -1,0 +1,6 @@
+import type { Pattern } from '@core'
+import { makeFacet } from '../factory.js'
+
+const FACET_NAME = 'pattern'
+
+export const PatternFacet = makeFacet<typeof FACET_NAME, Pattern>(FACET_NAME, {})

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -1,0 +1,145 @@
+import type { Numeric } from '@utility'
+import { numeric } from '@utility'
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import type { Function } from '../../src/type-system/base/function.js'
+import { FunctionFacet } from '../../src/type-system/base/function.js'
+import type { Module } from '../../src/type-system/base/module.js'
+import { ModuleFacet } from '../../src/type-system/base/module.js'
+import { NumberFacet } from '../../src/type-system/base/number.js'
+import { RecordFacet } from '../../src/type-system/base/record.js'
+import { StringFacet } from '../../src/type-system/base/string.js'
+import { makeSchema } from '../../src/type-system/schema.js'
+import type { ValueForType } from '../../src/type-system/types.js'
+import { expectTypeEquals } from '../test-utils.js'
+
+describe('type-system/base', () => {
+  describe('StringFacet', () => {
+    it('should format and round-trip string values', () => {
+      const value = StringFacet.type().of('hello')
+
+      assert.strictEqual(StringFacet.format(), 'string')
+      assert.strictEqual(StringFacet.has(value), true)
+      assert.strictEqual(StringFacet.get(value), 'hello')
+    })
+  })
+
+  describe('NumberFacet', () => {
+    it('should support unit-specific facets and detail()', () => {
+      const genericValue = NumberFacet.type().of(numeric('db', -3))
+      const decibelFacet = NumberFacet.with('db')
+      const decibelType = decibelFacet.type()
+      const decibelValue = decibelType.of(numeric('db', -3))
+      const specificData = decibelFacet.get(decibelValue)
+
+      expectTypeEquals<Numeric<'db'>, typeof specificData>()
+      assert.strictEqual(NumberFacet.format(), 'number')
+      assert.strictEqual(NumberFacet.with(undefined).format(), 'number')
+      assert.strictEqual(decibelFacet.format(), 'number(db)')
+      assert.strictEqual(NumberFacet.has(decibelValue), true)
+      assert.strictEqual(decibelFacet.has(genericValue), false)
+      assert.strictEqual(NumberFacet.detail(decibelType), 'db')
+      assert.strictEqual(specificData.unit, 'db')
+      assert.strictEqual(specificData.value, -3)
+      assert.throws(() => NumberFacet.detail(NumberFacet.type()), /Invalid generics for number facet/)
+    })
+  })
+
+  describe('FunctionFacet', () => {
+    it('should preserve function specs through with() and detail()', () => {
+      const amountType = NumberFacet.with('db').type()
+      const returnType = StringFacet.type()
+      const schema = makeSchema([
+        { name: 'amount', type: amountType, required: true },
+        { name: 'label', type: returnType, required: false }
+      ])
+      const spec = { parameters: schema, returnType }
+      const typedFacet = FunctionFacet.with(spec)
+      const typedType = typedFacet.type()
+
+      const func: Function<typeof schema, typeof returnType> = {
+        parameters: schema,
+        returnType,
+        invoke: (_context, args) => args.label ?? returnType.of('fallback'),
+        summary: 'demo function'
+      }
+
+      const value = typedType.of(func)
+      const loadedFunction = typedFacet.get(value)
+      const result = loadedFunction.invoke(undefined, {
+        amount: amountType.of(numeric('db', -6))
+      })
+
+      expectTypeEquals<Function<typeof schema, typeof returnType>, typeof loadedFunction>()
+      expectTypeEquals<ValueForType<typeof returnType>, typeof result>()
+
+      assert.strictEqual(typedFacet.format(), 'function')
+      assert.strictEqual(typedFacet.is(FunctionFacet.with(spec)), true)
+
+      const identicalShapeSpec = { parameters: schema, returnType }
+      assert.strictEqual(typedFacet.is(FunctionFacet.with(identicalShapeSpec)), false)
+
+      assert.strictEqual(FunctionFacet.detail(typedType), spec)
+      assert.strictEqual(StringFacet.get(result), 'fallback')
+      assert.throws(() => FunctionFacet.detail(FunctionFacet.type()), /Invalid generics for function facet/)
+    })
+  })
+
+  describe('ModuleFacet', () => {
+    it('should preserve module identity through with() and detail()', () => {
+      const greeting = StringFacet.type().of('hello')
+      const moduleValue: Module = {
+        name: 'demo',
+        exports: new Map([['greeting', greeting]]),
+        summary: 'demo module'
+      }
+
+      const typedFacet = ModuleFacet.with(moduleValue)
+      const typedType = typedFacet.type()
+      const value = typedType.of(moduleValue)
+      const loadedModule = typedFacet.get(value)
+
+      expectTypeEquals<Module, typeof loadedModule>()
+      assert.strictEqual(typedFacet.format(), 'module("demo")')
+      assert.strictEqual(typedFacet.is(ModuleFacet.with(moduleValue)), true)
+      assert.strictEqual(typedFacet.is(ModuleFacet.with({ ...moduleValue })), false)
+      assert.strictEqual(ModuleFacet.detail(typedType), moduleValue)
+      assert.strictEqual(loadedModule.exports.get('greeting'), greeting)
+      assert.throws(() => ModuleFacet.detail(ModuleFacet.type()), /Invalid generics for module facet/)
+    })
+  })
+
+  describe('RecordFacet', () => {
+    it('should preserve field types and round-trip record values', () => {
+      const gainType = NumberFacet.with('db').type()
+      const labelType = StringFacet.type()
+      const recordFacet = RecordFacet.with({ gain: gainType, label: labelType })
+      const recordType = recordFacet.type()
+      const recordValue = recordType.of({
+        gain: gainType.of(numeric('db', -9)),
+        label: labelType.of('lead')
+      })
+      const recordData = recordFacet.get(recordValue)
+
+      expectTypeEquals<ValueForType<typeof gainType>, typeof recordData.gain>()
+      expectTypeEquals<ValueForType<typeof labelType>, typeof recordData.label>()
+
+      assert.strictEqual(RecordFacet.format(), 'record')
+      assert.strictEqual(recordFacet.format(), 'record(gain, label)')
+      assert.strictEqual(RecordFacet.has(recordValue), true)
+      assert.strictEqual(RecordFacet.detail(recordType).gain, gainType)
+      assert.strictEqual(RecordFacet.detail(recordType).label, labelType)
+      assert.strictEqual(NumberFacet.get(recordData.gain).unit, 'db')
+      assert.strictEqual(NumberFacet.get(recordData.gain).value, -9)
+      assert.strictEqual(StringFacet.get(recordData.label), 'lead')
+    })
+
+    it('should compare records based on field assignability', () => {
+      const broadRecordFacet = RecordFacet.with({ gain: NumberFacet.type() })
+      const narrowRecordFacet = RecordFacet.with({ gain: NumberFacet.with('db').type() })
+
+      assert.strictEqual(broadRecordFacet.is(narrowRecordFacet), true)
+      assert.strictEqual(narrowRecordFacet.is(broadRecordFacet), false)
+    })
+  })
+})

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -1,0 +1,199 @@
+import type { Bus, BusId, Effect, Instrument, InstrumentId, Parameter, ParameterId, Part, Pattern } from '@core'
+import { createSerialPattern } from '@core'
+import { numeric } from '@utility'
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { BusFacet } from '../../src/type-system/domain/bus.js'
+import type { Curve } from '../../src/type-system/domain/curve.js'
+import { CurveFacet } from '../../src/type-system/domain/curve.js'
+import { EffectFacet } from '../../src/type-system/domain/effect.js'
+import { InstrumentFacet } from '../../src/type-system/domain/instrument.js'
+import { ParameterFacet } from '../../src/type-system/domain/parameter.js'
+import { PartFacet } from '../../src/type-system/domain/part.js'
+import { PatternFacet } from '../../src/type-system/domain/pattern.js'
+import { expectTypeEquals } from '../test-utils.js'
+
+const gainParameter: Parameter<'db'> = {
+  id: 1 as ParameterId,
+  initial: numeric('db', -6)
+}
+
+const panParameter: Parameter<undefined> = {
+  id: 2 as ParameterId,
+  initial: numeric(undefined, 0.25)
+}
+
+const pattern: Pattern = createSerialPattern([
+  { value: 'C4' },
+  { value: '-', length: numeric(undefined, 1) },
+  { value: 'E4', gate: numeric(undefined, 0.5) }
+], 4)
+
+const effect: Effect = {
+  type: 'gain',
+  gain: gainParameter
+}
+
+const instrument: Instrument = {
+  id: 1 as InstrumentId,
+  rootNote: 'C4',
+  gain: gainParameter,
+  source: {
+    type: 'oscillator',
+    shape: 'triangle'
+  },
+  envelope: {
+    attack: numeric('s', 0.01),
+    decay: numeric('s', 0.2),
+    sustain: numeric(undefined, 0.8),
+    release: numeric('s', 0.3)
+  }
+}
+
+const part: Part = {
+  name: 'intro',
+  length: numeric('beats', 4),
+  routings: [{
+    source: {
+      type: 'pattern',
+      value: pattern
+    },
+    destination: {
+      type: 'instrument',
+      id: instrument.id
+    }
+  }]
+}
+
+const bus: Bus = {
+  id: 1 as BusId,
+  name: 'main',
+  pan: panParameter,
+  gain: gainParameter,
+  effects: [effect]
+}
+
+describe('type-system/domain', () => {
+  describe('ParameterFacet', () => {
+    it('should support unit-specific parameters and detail()', () => {
+      const genericValue = ParameterFacet.type().of(gainParameter)
+      const decibelFacet = ParameterFacet.with('db')
+      const decibelType = decibelFacet.type()
+      const decibelValue = decibelType.of(gainParameter)
+      const parameterData = decibelFacet.get(decibelValue)
+
+      expectTypeEquals<Parameter<'db'>, typeof parameterData>()
+      assert.strictEqual(ParameterFacet.format(), 'parameter')
+      assert.strictEqual(ParameterFacet.with(undefined).format(), 'parameter')
+      assert.strictEqual(decibelFacet.format(), 'parameter(db)')
+      assert.strictEqual(ParameterFacet.has(decibelValue), true)
+      assert.strictEqual(decibelFacet.has(genericValue), false)
+      assert.strictEqual(ParameterFacet.detail(decibelType), 'db')
+      assert.strictEqual(parameterData.initial.unit, 'db')
+      assert.strictEqual(parameterData.initial.value, -6)
+      assert.throws(() => ParameterFacet.detail(ParameterFacet.type()), /Invalid generics for parameter facet/)
+    })
+  })
+
+  describe('CurveFacet', () => {
+    it('should support unit-specific curves and detail()', () => {
+      const curve: Curve<'db'> = {
+        unit: 'db',
+        segments: [
+          {
+            type: 'hold',
+            length: numeric(undefined, 1),
+            unit: 'db',
+            value: numeric('db', -6)
+          },
+          {
+            type: 'lin',
+            length: numeric(undefined, 2),
+            unit: 'db',
+            start: numeric('db', -6),
+            end: numeric('db', 0)
+          }
+        ]
+      }
+
+      const genericValue = CurveFacet.type().of(curve)
+      const decibelFacet = CurveFacet.with('db')
+      const decibelType = decibelFacet.type()
+      const decibelValue = decibelType.of(curve)
+      const curveData = decibelFacet.get(decibelValue)
+
+      expectTypeEquals<Curve<'db'>, typeof curveData>()
+      assert.strictEqual(CurveFacet.format(), 'curve')
+      assert.strictEqual(CurveFacet.with(undefined).format(), 'curve')
+      assert.strictEqual(decibelFacet.format(), 'curve(db)')
+      assert.strictEqual(CurveFacet.has(decibelValue), true)
+      assert.strictEqual(decibelFacet.has(genericValue), false)
+      assert.strictEqual(CurveFacet.detail(decibelType), 'db')
+      assert.strictEqual(curveData.segments[0]?.unit, 'db')
+      assert.strictEqual(curveData.segments[1]?.type, 'lin')
+      assert.throws(() => CurveFacet.detail(CurveFacet.type()), /Invalid generics for curve facet/)
+    })
+  })
+
+  describe('BusFacet', () => {
+    it('should format and round-trip bus values', () => {
+      const value = BusFacet.type().of(bus)
+      const busData = BusFacet.get(value)
+
+      expectTypeEquals<Bus, typeof busData>()
+      assert.strictEqual(BusFacet.format(), 'bus')
+      assert.strictEqual(BusFacet.has(value), true)
+      assert.strictEqual(busData, bus)
+    })
+  })
+
+  describe('EffectFacet', () => {
+    it('should format and round-trip effect values', () => {
+      const value = EffectFacet.type().of(effect)
+      const effectData = EffectFacet.get(value)
+
+      expectTypeEquals<Effect, typeof effectData>()
+      assert.strictEqual(EffectFacet.format(), 'effect')
+      assert.strictEqual(EffectFacet.has(value), true)
+      assert.strictEqual(effectData, effect)
+    })
+  })
+
+  describe('InstrumentFacet', () => {
+    it('should format and round-trip instrument values', () => {
+      const value = InstrumentFacet.type().of(instrument)
+      const instrumentData = InstrumentFacet.get(value)
+
+      expectTypeEquals<Instrument, typeof instrumentData>()
+      assert.strictEqual(InstrumentFacet.format(), 'instrument')
+      assert.strictEqual(InstrumentFacet.has(value), true)
+      assert.strictEqual(instrumentData, instrument)
+      assert.strictEqual(InstrumentFacet.has(BusFacet.type().of(bus)), false)
+    })
+  })
+
+  describe('PartFacet', () => {
+    it('should format and round-trip part values', () => {
+      const value = PartFacet.type().of(part)
+      const partData = PartFacet.get(value)
+
+      expectTypeEquals<Part, typeof partData>()
+      assert.strictEqual(PartFacet.format(), 'part')
+      assert.strictEqual(PartFacet.has(value), true)
+      assert.strictEqual(partData, part)
+    })
+  })
+
+  describe('PatternFacet', () => {
+    it('should format and round-trip pattern values', () => {
+      const value = PatternFacet.type().of(pattern)
+      const patternData = PatternFacet.get(value)
+
+      expectTypeEquals<Pattern, typeof patternData>()
+      assert.strictEqual(PatternFacet.format(), 'pattern')
+      assert.strictEqual(PatternFacet.has(value), true)
+      assert.strictEqual(patternData, pattern)
+      assert.deepStrictEqual(Array.from(patternData.evaluate()), Array.from(pattern.evaluate()))
+    })
+  })
+})


### PR DESCRIPTION
Follow-up to PR #524, adding individual facet implementations for base types (i.e., not specific to the music domain) and domain types. In total, these suffice to represent all types currently in use in the compiler. Switching from the previous type system to the new one will be done in a separate patch.