### PR TITLE
refactor: Require string in isPitch/isStepValue

### DIFF
--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -49,11 +49,11 @@ export interface Pattern {
   readonly evaluate: () => Iterable<NoteEvent>
 }
 
-export function isPitch (value: unknown): value is Pitch {
+export function isPitch (value: string): value is Pitch {
   return typeof value === 'string' && /^[A-G][#b]?(?:10|[0-9])$/.test(value)
 }
 
-export function isStepValue (value: unknown): value is StepValue {
+export function isStepValue (value: string): value is StepValue {
   return value === '-' || value === 'x' || isPitch(value)
 }
 

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -32,7 +32,7 @@ const sample = FunctionType.of({
     return allocateInstrument(context, {
       gain: gainParameter,
       // eslint-disable-next-line camelcase
-      rootNote: isPitch(root_note) ? root_note : undefined,
+      rootNote: root_note != null && isPitch(root_note) ? root_note : undefined,
       source: {
         type: 'sample',
         url,


### PR DESCRIPTION
Accepting `unknown` opens up the possibility of passing nonsensical input, such as `Value` objects from the type system that have not been unpacked, without any type errors.