### PR TITLE
fix: Prevent prototype access on record facets

### DIFF
--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -747,7 +747,7 @@ function checkPropertyAccess (context: Context, expression: ast.PropertyAccess):
 
   if (RecordFacet.is(object)) {
     const record = RecordFacet.detail(object)
-    if (record[property.name] != null) {
+    if (Object.hasOwn(record, property.name)) {
       return { errors: [], result: record[property.name] }
     }
 

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -609,7 +609,8 @@ function resolvePropertyAccess (context: Context, expression: ast.PropertyAccess
   }
 
   if (RecordFacet.has(object)) {
-    return nonNull(RecordFacet.get(object)[property])
+    const record = RecordFacet.get(object)
+    return nonNull(Object.hasOwn(record, property) ? record[property] : undefined)
   }
 
   assert(false)

--- a/packages/language/src/compiler/type-helpers.ts
+++ b/packages/language/src/compiler/type-helpers.ts
@@ -25,8 +25,8 @@ export const Functions = {
 
 export const Modules = {
   of: (value: Module): Value => {
-    const exportTypes: Record<string, FacetType> = {}
-    const exportValues: Record<string, Value> = {}
+    const exportTypes: Record<string, FacetType> = Object.create(null)
+    const exportValues: Record<string, Value> = Object.create(null)
 
     for (const [name, exportValue] of value.exports) {
       exportTypes[name] = exportValue.type

--- a/packages/language/src/type-system/base/record.ts
+++ b/packages/language/src/type-system/base/record.ts
@@ -9,12 +9,41 @@ type RecordDataForFields<Fields extends RecordGenerics> = {
 
 const FACET_NAME = 'record'
 
+function cloneOwnProperties<const T extends Record<string, unknown>> (value: T): T {
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`Expected ${FACET_NAME} facet data to use a plain object or null prototype`)
+  }
+
+  const clone = Object.create(null) as T
+  for (const key of Object.keys(value) as Array<keyof T>) {
+    clone[key] = value[key]
+  }
+
+  return clone
+}
+
+function normalizeRecordData<Fields extends RecordGenerics> (data: unknown): RecordDataForFields<Fields> {
+  if (typeof data !== 'object' || data == null) {
+    throw new Error(`Expected ${FACET_NAME} facet data to be an object`)
+  }
+
+  return cloneOwnProperties(data as RecordDataForFields<Fields> & Record<string, unknown>) as RecordDataForFields<Fields>
+}
+
+const EMPTY_RECORD_GENERICS = cloneOwnProperties({} as Record<string, unknown>) as RecordGenerics
+
 export const RecordFacet = {
-  ...makeFacet<typeof FACET_NAME, RecordDataForFields<RecordGenerics>>(FACET_NAME, {}),
+  ...makeFacet<typeof FACET_NAME, RecordDataForFields<RecordGenerics>>(FACET_NAME, EMPTY_RECORD_GENERICS, {
+    normalize: (data) => normalizeRecordData<RecordGenerics>(data)
+  }),
 
   with: <const Fields extends RecordGenerics> (fields: Fields) => {
-    return makeFacet<typeof FACET_NAME, RecordDataForFields<Fields>>(FACET_NAME, fields, {
-      format: () => `${FACET_NAME}(${Object.keys(fields).join(', ')})`
+    const safeFields = cloneOwnProperties(fields)
+
+    return makeFacet<typeof FACET_NAME, RecordDataForFields<Fields>>(FACET_NAME, safeFields, {
+      format: () => `${FACET_NAME}(${Object.keys(safeFields).join(', ')})`,
+      normalize: (data) => normalizeRecordData<Fields>(data)
     })
   },
 

--- a/packages/language/src/type-system/factory.ts
+++ b/packages/language/src/type-system/factory.ts
@@ -1,14 +1,15 @@
 import { isFacetAssignableFromFacet, isFacetAssignableFromType, isTypeAssignableFromType } from './assignability.js'
 import type { DataForFacets, Facet, FacetType, Generics, SpecificFacetDataForValue, Type, UnionType, Value, ValueForType } from './types.js'
 
-export interface FacetOptions {
+export interface FacetOptions<Data = unknown> {
   readonly format?: () => string
+  readonly normalize?: (data: unknown) => Data
 }
 
 export function makeFacet<const Name extends string, Data> (
   name: Name,
   generics: Generics,
-  options?: FacetOptions
+  options?: FacetOptions<Data>
 ): Facet<Name, Data> {
   let cachedType: FacetType<[Facet<Name, Data>]> | undefined = undefined
 
@@ -41,7 +42,9 @@ export function makeFacet<const Name extends string, Data> (
     type: () => {
       cachedType ??= makeType(facet)
       return cachedType
-    }
+    },
+
+    normalize: options?.normalize
   }
 
   return facet
@@ -78,7 +81,10 @@ export function makeType<const Facets extends readonly Facet[]> (
 
     of: (...data: DataForFacets<Facets>): ValueForType<FacetType<Facets>> => {
       const dataMap = new Map<string, unknown>(
-        Array.from(type.facets.entries(), ([name], index) => [name, data[index]])
+        Array.from(type.facets.entries(), ([name, facet], index) => [
+          name,
+          facet.normalize == null ? data[index] : facet.normalize(data[index])
+        ])
       )
 
       return { type, data: dataMap }

--- a/packages/language/src/type-system/types.ts
+++ b/packages/language/src/type-system/types.ts
@@ -31,6 +31,8 @@ export interface Facet<Name extends string = string, Data = unknown> {
 
   readonly type: () => FacetType<[Facet<Name, Data>]>
 
+  readonly normalize?: (data: unknown) => Data
+
   // used for type inference of facet data, not actually present at runtime
   readonly [facetDataType]?: Data
 }

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -376,5 +376,26 @@ describe('compiler/checker.ts', () => {
         'Expected type pattern, got number'
       ])
     })
+
+    it('should reject accessing prototype', () => {
+      const source = [
+        'use "instruments" as inst',
+        'module_proto = inst.__proto__',
+        'instrument_proto = inst.sample("piano.wav").__proto__',
+        'module_constructor = inst.constructor',
+        'instrument_constructor = inst.sample("piano.wav").constructor',
+        'module_tostring = inst.toString',
+        'instrument_tostring = inst.sample("piano.wav").toString'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Module "instruments" has no export named "__proto__"',
+        'Type instrument + record(gain) has no property named "__proto__"',
+        'Module "instruments" has no export named "constructor"',
+        'Type instrument + record(gain) has no property named "constructor"',
+        'Module "instruments" has no export named "toString"',
+        'Type instrument + record(gain) has no property named "toString"'
+      ])
+    })
   })
 })

--- a/packages/language/test/compiler/type-helpers.test.ts
+++ b/packages/language/test/compiler/type-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test'
+import { Modules } from '../../src/compiler/type-helpers.js'
+import { StringFacet } from '../../src/type-system/base/string.js'
+import { ModuleFacet } from '../../src/type-system/base/module.js'
+import assert from 'node:assert'
+import { RecordFacet } from '../../src/type-system/base/record.js'
+
+describe('compiler/type-helpers.ts', () => {
+  describe('Modules', () => {
+    it('should not pollute the prototype with modules that export __proto__', () => {
+      const protoValue = StringFacet.type().of('malicious')
+
+      const module = Modules.of({
+        name: 'foobar',
+        exports: new Map([
+          ['__proto__', protoValue]
+        ])
+      })
+
+      const moduleData = ModuleFacet.get(module)
+      assert.strictEqual(moduleData.name, 'foobar')
+      assert.strictEqual(moduleData.exports.get('__proto__'), protoValue)
+
+      const recordData = RecordFacet.get(module)
+      assert.strictEqual(Object.getPrototypeOf(recordData), null)
+      assert.strictEqual(recordData.__proto__, protoValue)
+    })
+  })
+})

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -134,6 +134,36 @@ describe('type-system/base', () => {
       assert.strictEqual(StringFacet.get(recordData.label), 'lead')
     })
 
+    it('should reject non-plain objects for record fields', () => {
+      assert.throws(
+        () => RecordFacet.with({ __proto__: NumberFacet.type() } as Record<string, any>),
+        /Expected record facet data to use a plain object or null prototype/
+      )
+    })
+
+    it('should not expose object prototype properties', () => {
+      const recordFacet = RecordFacet.with({ gain: NumberFacet.type() })
+      const recordType = recordFacet.type()
+      const recordValue = recordType.of({ gain: NumberFacet.with('db').type().of(numeric('db', -9)) })
+      const recordData = recordFacet.get(recordValue)
+
+      assert.strictEqual(Object.getPrototypeOf(RecordFacet.detail(recordType)), null)
+      assert.strictEqual(Object.getPrototypeOf(recordData), null)
+
+      assert.strictEqual(RecordFacet.detail(recordType).__proto__, undefined)
+      assert.strictEqual((recordData as Record<string, unknown>).constructor, undefined)
+
+      const genericRecordType = RecordFacet.type()
+      const genericRecordValue = genericRecordType.of({ gain: NumberFacet.with('db').type().of(numeric('db', -9)) })
+      const genericRecordData = RecordFacet.get(genericRecordValue)
+
+      assert.strictEqual(Object.getPrototypeOf(RecordFacet.detail(genericRecordType)), null)
+      assert.strictEqual(Object.getPrototypeOf(genericRecordData), null)
+
+      assert.strictEqual(RecordFacet.detail(genericRecordType).__proto__, undefined)
+      assert.strictEqual((genericRecordData as Record<string, unknown>).constructor, undefined)
+    })
+
     it('should compare records based on field assignability', () => {
       const broadRecordFacet = RecordFacet.with({ gain: NumberFacet.type() })
       const narrowRecordFacet = RecordFacet.with({ gain: NumberFacet.with('db').type() })


### PR DESCRIPTION
This patch fixes a gap in the record facet implementation that allowed it to be constructed with data that had access to the object prototype. Specifically, the checker would allow accessing properties such as `toString` and `__proto__` on record-typed values, while the generator would crash due to the unexpected types of these properties.

A layered approach was taken to address this issue. First, the facet ensures that both its generic and its value are created with the null prototype. Second, the objects are normalized and cloned to remove non- own properties. Third, the checker and generator use `Object.hasOwn` when accessing properties on the record data. Fourth, the modules helper is also prepared to handle dangerous module exports, although at this time, users are not yet able to define their own modules.