### PR TITLE
feat: Make effect parameters accessible

### DIFF
--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -1,88 +1,190 @@
 import type { Effect } from '@core'
 import { NumberFacet } from '../../type-system/base/number.js'
-import { makeUnion } from '../../type-system/factory.js'
-import type { InferSchema, Schema } from '../../type-system/schema.js'
+import { RecordFacet } from '../../type-system/base/record.js'
+import { EffectFacet } from '../../type-system/domain/effect.js'
+import { ParameterFacet } from '../../type-system/domain/parameter.js'
+import { makeType, makeUnion } from '../../type-system/factory.js'
 import type { Value } from '../../type-system/types.js'
 import type { FunctionContext } from '../functions.js'
 import { allocateParameter } from '../functions.js'
-import { Functions, Modules } from '../type-helpers.js'
-import { EffectFacet } from '../../type-system/domain/effect.js'
+import { Functions, Modules, Parameters } from '../type-helpers.js'
 
-// Factory
+// types
 
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-const createEffectConstructor = <T extends Effect, const S extends Schema>(
-  summary: string,
-  schema: S,
-  create: (context: FunctionContext, args: InferSchema<S>) => T
-) => {
-  return Functions.of({
-    summary,
-    parameters: schema,
-    returnType: EffectFacet.type(),
-    invoke: (context, args) => EffectFacet.type().of(create(context as FunctionContext, args))
-  })
-}
-
-// Effects
-
-const gain = createEffectConstructor('Applies a gain adjustment to the signal.', [
-  { name: 'gain', type: NumberFacet.with('db').type(), required: true }
-], (context, args) => ({
-  type: 'gain',
-  gain: allocateParameter(context, NumberFacet.get(args.gain))
+const GainEffectType = makeType(EffectFacet, RecordFacet.with({
+  gain: ParameterFacet.with('db').type()
 }))
 
-const pan = createEffectConstructor('Places the signal in the stereo field.', [
-  { name: 'pan', type: NumberFacet.with(undefined).type(), required: true }
-], (context, args) => ({
-  type: 'pan',
-  pan: allocateParameter(context, NumberFacet.get(args.pan))
+const PanEffectType = makeType(EffectFacet, RecordFacet.with({
+  pan: ParameterFacet.with(undefined).type()
 }))
 
-const lowpass = createEffectConstructor('Filters out frequencies above the cutoff.', [
-  { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
-], (context, args) => ({
-  type: 'lowpass',
-  frequency: allocateParameter(context, NumberFacet.get(args.frequency))
+const LowpassEffectType = makeType(EffectFacet, RecordFacet.with({
+  frequency: ParameterFacet.with('hz').type()
 }))
 
-const highpass = createEffectConstructor('Filters out frequencies below the cutoff.', [
-  { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
-], (context, args) => ({
-  type: 'highpass',
-  frequency: allocateParameter(context, NumberFacet.get(args.frequency))
+const HighpassEffectType = makeType(EffectFacet, RecordFacet.with({
+  frequency: ParameterFacet.with('hz').type()
 }))
 
-const width = createEffectConstructor('Adjusts the stereo width of the signal.', [
-  { name: 'width', type: NumberFacet.with(undefined).type(), required: true }
-], (context, args) => ({
-  type: 'width',
-  width: NumberFacet.get(args.width)
-}))
+const WidthEffectType = makeType(EffectFacet)
+const DelayEffectType = makeType(EffectFacet)
+const ReverbEffectType = makeType(EffectFacet)
 
-const delay = createEffectConstructor('Adds echoes with configurable mix, time, and feedback.', [
-  { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
-  { name: 'time', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
-  { name: 'feedback', type: NumberFacet.with(undefined).type(), required: true }
-], (context, args) => ({
-  type: 'delay',
-  mix: NumberFacet.get(args.mix),
-  time: NumberFacet.get(args.time),
-  feedback: NumberFacet.get(args.feedback)
-}))
+// factories
 
-const reverb = createEffectConstructor('Adds reverberation with configurable mix and decay.', [
-  { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
-  { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true }
-], (context, args) => ({
-  type: 'reverb',
-  mix: NumberFacet.get(args.mix),
-  decay: NumberFacet.get(args.decay)
-}))
+const gain = Functions.of({
+  summary: 'Applies a gain adjustment to the signal.',
+
+  parameters: [
+    { name: 'gain', type: NumberFacet.with('db').type(), required: true }
+  ],
+
+  returnType: GainEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'gain',
+      gain: allocateParameter(context as FunctionContext, NumberFacet.get(args.gain))
+    }
+
+    return GainEffectType.of(effect, {
+      gain: Parameters.of(effect.gain)
+    })
+  }
+})
+
+const pan = Functions.of({
+  summary: 'Places the signal in the stereo field.',
+
+  parameters: [
+    { name: 'pan', type: NumberFacet.with(undefined).type(), required: true }
+  ],
+
+  returnType: PanEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'pan',
+      pan: allocateParameter(context as FunctionContext, NumberFacet.get(args.pan))
+    }
+
+    return PanEffectType.of(effect, {
+      pan: Parameters.of(effect.pan)
+    })
+  }
+})
+
+const lowpass = Functions.of({
+  summary: 'Filters out frequencies above the cutoff.',
+
+  parameters: [
+    { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
+  ],
+
+  returnType: LowpassEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'lowpass',
+      frequency: allocateParameter(context as FunctionContext, NumberFacet.get(args.frequency))
+    }
+
+    return LowpassEffectType.of(effect, {
+      frequency: Parameters.of(effect.frequency)
+    })
+  }
+})
+
+const highpass = Functions.of({
+  summary: 'Filters out frequencies below the cutoff.',
+
+  parameters: [
+    { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
+  ],
+
+  returnType: HighpassEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'highpass',
+      frequency: allocateParameter(context as FunctionContext, NumberFacet.get(args.frequency))
+    }
+
+    return HighpassEffectType.of(effect, {
+      frequency: Parameters.of(effect.frequency)
+    })
+  }
+})
+
+const width = Functions.of({
+  summary: 'Adjusts the stereo width of the signal.',
+
+  parameters: [
+    { name: 'width', type: NumberFacet.with(undefined).type(), required: true }
+  ],
+
+  returnType: WidthEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'width',
+      width: NumberFacet.get(args.width)
+    }
+
+    return WidthEffectType.of(effect)
+  }
+})
+
+const delay = Functions.of({
+  summary: 'Adds echoes with configurable mix, time, and feedback.',
+
+  parameters: [
+    { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
+    { name: 'time', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
+    { name: 'feedback', type: NumberFacet.with(undefined).type(), required: true }
+  ],
+
+  returnType: DelayEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'delay',
+      mix: NumberFacet.get(args.mix),
+      time: NumberFacet.get(args.time),
+      feedback: NumberFacet.get(args.feedback)
+    }
+
+    return DelayEffectType.of(effect)
+  }
+})
+
+const reverb = Functions.of({
+  summary: 'Adds reverberation with configurable mix and decay.',
+
+  parameters: [
+    { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
+    { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true }
+  ],
+
+  returnType: ReverbEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'reverb',
+      mix: NumberFacet.get(args.mix),
+      decay: NumberFacet.get(args.decay)
+    }
+
+    return ReverbEffectType.of(effect)
+  }
+})
+
+// module
 
 export const effectsModule = Modules.of({
   name: 'effects',
+
   summary: 'Effect functions for shaping mixer bus audio.',
 
   exports: new Map<string, Value>([

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -279,6 +279,36 @@ describe('compiler/generator.ts', () => {
     ])
   })
 
+  it('should automate effect parameters', () => {
+    const source = [
+      'use "effects" as fx',
+      'lp = fx.lowpass(123.hz)',
+      'track {',
+      '  part intro (4.bars) {',
+      '    automate lp.frequency as curve[lin(500.hz, 1000.hz)]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus main {',
+      '    effect lp',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    const effect = result.mixer.buses[0].effects[0]
+    assert.strictEqual(effect.type, 'lowpass')
+    assert.deepStrictEqual(effect.frequency.initial, numeric('hz', 123))
+
+    const automation = result.automations.get(effect.frequency.id)
+    assert.ok(automation != null)
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('hz', 500), curve: 'step' },
+      { time: numeric('beats', 16), value: numeric('hz', 1000), curve: 'linear' }
+    ])
+  })
+
   it('should route instruments into the output when no mixer is present', () => {
     const source = [
       'use "instruments" as *',

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -7,6 +7,7 @@ import { Numbers } from '../../../src/compiler/type-helpers.js'
 import { FunctionFacet } from '../../../src/type-system/base/function.js'
 import { ModuleFacet } from '../../../src/type-system/base/module.js'
 import { EffectFacet } from '../../../src/type-system/domain/effect.js'
+import { RecordFacet } from '../../../src/type-system/base/record.js'
 
 function createFunctionContext (): FunctionContext {
   return {
@@ -40,6 +41,8 @@ describe('compiler/modules/effects.ts', () => {
           initial: numeric('db', -6)
         }
       })
+
+      assert.deepStrictEqual(Object.keys(RecordFacet.get(result)), ['gain'])
     })
   })
 
@@ -61,6 +64,8 @@ describe('compiler/modules/effects.ts', () => {
           initial: numeric(undefined, 0.5)
         }
       })
+
+      assert.deepStrictEqual(Object.keys(RecordFacet.get(result)), ['pan'])
     })
   })
 
@@ -82,6 +87,8 @@ describe('compiler/modules/effects.ts', () => {
           initial: numeric('hz', 1000)
         }
       })
+
+      assert.deepStrictEqual(Object.keys(RecordFacet.get(result)), ['frequency'])
     })
   })
 
@@ -103,6 +110,8 @@ describe('compiler/modules/effects.ts', () => {
           initial: numeric('hz', 200)
         }
       })
+
+      assert.deepStrictEqual(Object.keys(RecordFacet.get(result)), ['frequency'])
     })
   })
 
@@ -121,6 +130,8 @@ describe('compiler/modules/effects.ts', () => {
         type: 'width',
         width: numeric(undefined, 0.8)
       })
+
+      assert.strictEqual(RecordFacet.has(result), false)
     })
   })
 
@@ -143,6 +154,8 @@ describe('compiler/modules/effects.ts', () => {
         time: beats(0.5),
         feedback: numeric(undefined, 0.3)
       })
+
+      assert.strictEqual(RecordFacet.has(result), false)
     })
 
     it('should create delay effect with seconds', () => {
@@ -159,6 +172,8 @@ describe('compiler/modules/effects.ts', () => {
         time: seconds(1.5),
         feedback: numeric(undefined, 0.3)
       })
+
+      assert.strictEqual(RecordFacet.has(result), false)
     })
   })
 
@@ -179,6 +194,8 @@ describe('compiler/modules/effects.ts', () => {
         decay: numeric('s', 2.0),
         mix: numeric(undefined, 0.4)
       })
+
+      assert.strictEqual(RecordFacet.has(result), false)
     })
 
     it('should create reverb effect with beats', () => {
@@ -193,6 +210,8 @@ describe('compiler/modules/effects.ts', () => {
         decay: beats(2),
         mix: numeric(undefined, 0.4)
       })
+
+      assert.strictEqual(RecordFacet.has(result), false)
     })
   })
 })


### PR DESCRIPTION
This patch extends the effect types to include record facets, allowing parameters to be accessed as properties on effect values. This enables users to write code like `gain_effect.gain` to access the gain parameter of a gain effect, or `lowpass_effect.frequency` to access the filter frequency. This works out-of-the-box with automations, although it requires the effect to be declared in global scope so that it can be resolved in the automation; syntax to access bus effects is needed for better ergonomics.