### PR TITLE
feat: Make part name optional

### DIFF
--- a/packages/app/src/components/timeline/Timeline.tsx
+++ b/packages/app/src/components/timeline/Timeline.tsx
@@ -317,7 +317,7 @@ const TimelinePart: FunctionComponent<{
         ref={setContainer}
         onClick={openPopover}
       >
-        {part.name}
+        {part.name ?? '(unnamed)'}
 
         <div className='text-content-100'>
           {lengthShort}
@@ -326,7 +326,7 @@ const TimelinePart: FunctionComponent<{
 
       {popoverOpen && (
         <Popover anchor={container} onClose={closePopover}>
-          <div className='font-bold'>{`part.${part.name}`}</div>
+          <div className='font-bold'>{part.name != null ? `part.${part.name}` : '(unnamed part)'}</div>
           <div>length: {lengthLong}</div>
         </Popover>
       )}

--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -130,7 +130,7 @@ export interface TrackStatement extends ASTNode {
 
 export interface PartStatement extends ASTNode {
   readonly type: 'PartStatement'
-  readonly name: Identifier
+  readonly name?: Identifier
   readonly properties: ArgumentList
   readonly routings: readonly Routing[]
   readonly automations: readonly AutomateStatement[]

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -117,7 +117,7 @@ export interface Track {
 }
 
 export interface Part {
-  readonly name: string
+  readonly name?: string
   readonly length: Numeric<'beats'>
   readonly routings: readonly InstrumentRouting[]
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -183,7 +183,8 @@ TrackStatement {
 }
 
 PartStatement {
-  kw<"part"> VariableDefinition
+  kw<"part">
+  VariableDefinition?
   ("(" argumentList? ")")?
   PartBlock[group=Block] {
     "{" (Routing | Automation)* "}"

--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -228,16 +228,18 @@ function checkTrack (context: MutableContext, track: ast.TrackStatement): readon
   const seenParts = new Set<string>()
 
   for (const part of track.parts) {
-    if (seenParts.has(part.name.name)) {
-      errors.push(new CompileError(`Duplicate part named "${part.name.name}"`, part.range))
-    } else if (trackContext.resolutions.has(part.name.name)) {
-      errors.push(new CompileError(`Part name "${part.name.name}" conflicts with existing identifier`, part.name.range))
+    if (part.name != null) {
+      if (seenParts.has(part.name.name)) {
+        errors.push(new CompileError(`Duplicate part named "${part.name.name}"`, part.range))
+      } else if (trackContext.resolutions.has(part.name.name)) {
+        errors.push(new CompileError(`Part name "${part.name.name}" conflicts with existing identifier`, part.name.range))
+      }
+
+      seenParts.add(part.name.name)
+
+      // Reserve the name in the local scope
+      trackContext.resolutions.set(part.name.name, PartFacet.type())
     }
-
-    seenParts.add(part.name.name)
-
-    // Reserve the name in the local scope
-    trackContext.resolutions.set(part.name.name, PartFacet.type())
 
     errors.push(...checkPart(trackContext, part))
   }

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -178,8 +178,10 @@ function generateTrack (context: Context, track: ast.TrackStatement): Track {
     const part = generatePart(trackContext, partStatement, currentTime)
     parts.push(part)
 
-    assert(!trackContext.resolutions.has(part.name))
-    trackContext.resolutions.set(part.name, PartFacet.type().of(part))
+    if (part.name != null) {
+      assert(!trackContext.resolutions.has(part.name))
+      trackContext.resolutions.set(part.name, PartFacet.type().of(part))
+    }
 
     currentTime = numeric('beats', currentTime.value + part.length.value)
   }
@@ -194,7 +196,7 @@ function generateTrack (context: Context, track: ast.TrackStatement): Track {
 }
 
 function generatePart (context: Context, part: ast.PartStatement, startTime: Numeric<'beats'>): Part {
-  const name = part.name.name
+  const name = part.name?.name
   const properties = resolveArgumentList(context, part.properties, partSchema)
 
   const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -542,7 +542,7 @@ const automateStatement_: p.Parser<Token, unknown, ast.AutomateStatement> = p.ab
 const partStatement_: p.Parser<Token, unknown, ast.PartStatement> = p.abc(
   combine2(
     keyword('part'),
-    expect(identifier_, 'part name')
+    p.option(identifier_, undefined)
   ),
   p.option(
     combine3(

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -621,10 +621,30 @@ describe('parser/parser.ts', () => {
     ])
   })
 
-  it('should reject unnamed parts', () => {
-    const result = parse(lexSource('track { part (4 bars) {} }'))
-    assert.strictEqual(result.complete, false)
-    assert.strictEqual(result.error.message, 'Unexpected "("; expected part name')
+  it('should allow unnamed parts', () => {
+    const result = parse(lexSource('track { part (4.bars) {} }'))
+    assert.strictEqual(result.complete, true)
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'TrackStatement',
+        properties: [],
+        parts: [
+          {
+            type: 'PartStatement',
+            name: undefined,
+            properties: [
+              {
+                type: 'PropertyAccess',
+                object: { type: 'Number', value: 4 },
+                property: { type: 'Identifier', name: 'bars' }
+              }
+            ],
+            routings: [],
+            automations: []
+          }
+        ]
+      }
+    ])
   })
 
   it('should reject unnamed buses', () => {


### PR DESCRIPTION
This patch removes the requirement for parts to have names. There are occasions where a part provides meaningful track structure without any need to refer to it by name, and in fact, inventing a name could feel awkward. Hence, this can now be omitted.