### PR TITLE
feat: Add 'wet' parameter to reverb and delay

### DIFF
--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -5,7 +5,7 @@ import { numeric } from '@utility'
 import { frequencyTransform, gainTransform, panTransform, timeVariant, toTimeVariant } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
-import { DEFAULT_ROOT_NOTE } from './constants.js'
+import { dbToGain, DEFAULT_ROOT_NOTE } from './constants.js'
 import type { EntityKey } from './entities.js'
 import { createEntityKey } from './entities.js'
 import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
@@ -260,7 +260,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         builder.addEdge(feedbackGain.id, delayNode.id)
       }
 
-      return createDryWetMix(delayNode, effect.mix.value, builder)
+      return createDryWetMix(delayNode, effect.mix.value, effect.wet, builder)
     }
 
     case 'reverb': {
@@ -278,12 +278,12 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         decay: timeToSeconds(effect.decay, program.track.tempo)
       })
 
-      return createDryWetMix(reverb, mix, builder)
+      return createDryWetMix(reverb, mix, effect.wet, builder)
     }
   }
 }
 
-function createDryWetMix (effect: Node, mix: number, builder: Builder): SubGraph {
+function createDryWetMix (effect: Node, mix: number, wetGain: Numeric<'db'>, builder: Builder): SubGraph {
   if (Number.isNaN(mix)) {
     throw new Error(`Invalid mix: ${mix}`)
   }
@@ -292,8 +292,19 @@ function createDryWetMix (effect: Node, mix: number, builder: Builder): SubGraph
     return toSubGraph(builder.addNode<IdentityNode>('identity', {}))
   }
 
+  const wetLevel = createOptionalGainNode(wetGain, builder)
+
   if (mix >= 1) {
-    return toSubGraph(effect)
+    if (wetLevel == null) {
+      return toSubGraph(effect)
+    }
+
+    builder.addEdge(effect.id, wetLevel.id)
+
+    return {
+      inputs: [effect.id],
+      outputs: [wetLevel.id]
+    }
   }
 
   // dry: 0.0...0.5 -> 100%,   0.75: 50%,         1.0:   0%
@@ -309,12 +320,30 @@ function createDryWetMix (effect: Node, mix: number, builder: Builder): SubGraph
     gain: timeVariant(numeric(undefined, wet), [])
   })
 
-  builder.addEdge(effect.id, wetNode.id)
+  const wetInput = wetLevel ?? effect
+  if (wetLevel != null) {
+    builder.addEdge(effect.id, wetLevel.id)
+  }
+
+  builder.addEdge(wetInput.id, wetNode.id)
 
   return {
     inputs: [dryNode.id, effect.id],
     outputs: [dryNode.id, wetNode.id]
   }
+}
+
+function createOptionalGainNode (wetGain: Numeric<'db'>, builder: Builder): Node | undefined {
+  if (wetGain.value === 0) {
+    return undefined
+  }
+
+  const gain = dbToGain(wetGain.value)
+
+  return builder.addNode<GainNode>('gain', {
+    // TODO time variant
+    gain: timeVariant(numeric(undefined, gain), [])
+  })
 }
 
 function createRoutings (

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -887,48 +887,49 @@ describe('lowering.ts', () => {
           type: 'delay',
           mix: numeric(undefined, 0.25),
           time: numeric('beats', 0.5),
-          feedback: numeric(undefined, 0.4)
+          feedback: numeric(undefined, 0.4),
+          wet: numeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
-        // output node
-        {
-          id: 1 as NodeId,
-          type: 'identity'
-        } satisfies IdentityNode,
-        // delay node
-        {
-          id: 2 as NodeId,
-          type: 'delay',
-          time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
-        } satisfies DelayNode,
-        // feedback gain node
-        {
-          id: 3 as NodeId,
-          type: 'gain',
-          gain: {
-            initial: numeric(undefined, 0.4),
-            points: []
-          }
-        } satisfies GainNode,
-        // dry gain node
-        {
-          id: 4 as NodeId,
-          type: 'gain',
-          gain: {
-            initial: numeric(undefined, 1.0),
-            points: []
-          }
-        } satisfies GainNode,
-        // wet gain node
-        {
-          id: 5 as NodeId,
-          type: 'gain',
-          gain: {
-            initial: numeric(undefined, 0.5),
-            points: []
-          }
-        } satisfies GainNode
+          // output node
+          {
+            id: 1 as NodeId,
+            type: 'identity'
+          } satisfies IdentityNode,
+          // delay node
+          {
+            id: 2 as NodeId,
+            type: 'delay',
+            time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+          } satisfies DelayNode,
+          // feedback gain node
+          {
+            id: 3 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 0.4),
+              points: []
+            }
+          } satisfies GainNode,
+          // dry gain node
+          {
+            id: 4 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 1.0),
+              points: []
+            }
+          } satisfies GainNode,
+          // wet gain node
+          {
+            id: 5 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 0.5),
+              points: []
+            }
+          } satisfies GainNode
         ])
 
         assert.deepStrictEqual(graph.edges, [
@@ -938,7 +939,7 @@ describe('lowering.ts', () => {
           { from: 3 as NodeId, to: 2 as NodeId },
           // delay to wet
           { from: 2 as NodeId, to: 5 as NodeId },
-          // input to dry
+          // input to output (dry)
           { from: 4 as NodeId, to: 1 as NodeId },
           // wet to output
           { from: 5 as NodeId, to: 1 as NodeId }
@@ -950,7 +951,8 @@ describe('lowering.ts', () => {
           type: 'delay',
           mix: numeric(undefined, Infinity),
           time: numeric('beats', 0.5),
-          feedback: numeric(undefined, 0.4)
+          feedback: numeric(undefined, 0.4),
+          wet: numeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
@@ -982,7 +984,8 @@ describe('lowering.ts', () => {
           type: 'delay',
           mix: numeric(undefined, Number.NaN),
           time: numeric('beats', 0.5),
-          feedback: numeric(undefined, 0.4)
+          feedback: numeric(undefined, 0.4),
+          wet: numeric('db', 0)
         })), /Invalid mix/)
       })
 
@@ -992,7 +995,8 @@ describe('lowering.ts', () => {
             type: 'delay',
             mix: numeric(undefined, 0.25),
             time: numeric('beats', time),
-            feedback: numeric(undefined, 0.4)
+            feedback: numeric(undefined, 0.4),
+            wet: numeric('db', 0)
           })), /Invalid time/, `should throw for time: ${time}`)
         }
       })
@@ -1002,7 +1006,8 @@ describe('lowering.ts', () => {
           type: 'delay',
           mix: numeric(undefined, 0.25),
           time: numeric('beats', 0.5),
-          feedback: numeric(undefined, Infinity)
+          feedback: numeric(undefined, Infinity),
+          wet: numeric('db', 0)
         }))
 
         assert.deepStrictEqual(graph.nodes.get(3 as NodeId), {
@@ -1020,7 +1025,8 @@ describe('lowering.ts', () => {
           type: 'delay',
           mix: numeric(undefined, 0.25),
           time: numeric('beats', 0.5),
-          feedback: numeric(undefined, Number.NaN)
+          feedback: numeric(undefined, Number.NaN),
+          wet: numeric('db', 0)
         })), /Invalid feedback/)
       })
 
@@ -1029,7 +1035,8 @@ describe('lowering.ts', () => {
           type: 'delay',
           mix: numeric(undefined, 0.25),
           time: numeric('s', 1.5),
-          feedback: numeric(undefined, 0.4)
+          feedback: numeric(undefined, 0.4),
+          wet: numeric('db', 0)
         }))
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
@@ -1038,6 +1045,96 @@ describe('lowering.ts', () => {
           time: numeric('s', 1.5)
         } satisfies DelayNode)
       })
+
+      it('should add a gain node for non-zero wet level', () => {
+        const graph = createAudioGraph(createProgramWithEffect({
+          type: 'delay',
+          mix: numeric(undefined, 0.25),
+          time: numeric('beats', 0.5),
+          feedback: numeric(undefined, 0.4),
+          wet: numeric('db', -6)
+        }))
+
+        // Note: There already is a wet gain node to handle the mix level,
+        // but it cannot be reused as there may be separate automations for the mix and wet parameters,
+        // which would unnecessarily complicate the calculations.
+        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+          // output node
+          {
+            id: 1 as NodeId,
+            type: 'identity'
+          } satisfies IdentityNode,
+          // delay node
+          {
+            id: 2 as NodeId,
+            type: 'delay',
+            time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+          } satisfies DelayNode,
+          // feedback gain node
+          {
+            id: 3 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 0.4),
+              points: []
+            }
+          } satisfies GainNode,
+          // wet gain node for wet level
+          {
+            id: 4 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, dbToGain(-6)),
+              points: []
+            }
+          } satisfies GainNode,
+          // dry gain node (mix)
+          {
+            id: 5 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 1.0),
+              points: []
+            }
+          } satisfies GainNode,
+          // wet gain node (mix)
+          {
+            id: 6 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 0.5),
+              points: []
+            }
+          } satisfies GainNode
+        ])
+
+        assert.deepStrictEqual(graph.edges, [
+          // delay to feedback
+          { from: 2 as NodeId, to: 3 as NodeId },
+          // feedback to delay
+          { from: 3 as NodeId, to: 2 as NodeId },
+          // delay to wet level
+          { from: 2 as NodeId, to: 4 as NodeId },
+          // wet level to wet mix
+          { from: 4 as NodeId, to: 6 as NodeId },
+          // input to output (dry)
+          { from: 5 as NodeId, to: 1 as NodeId },
+          // wet mix to output
+          { from: 6 as NodeId, to: 1 as NodeId }
+        ])
+      })
+
+      it('should throw for invalid wet level', () => {
+        for (const wet of [Infinity, Number.NaN]) {
+          assert.throws(() => createAudioGraph(createProgramWithEffect({
+            type: 'delay',
+            mix: numeric(undefined, 0.25),
+            time: numeric('beats', 0.5),
+            feedback: numeric(undefined, 0.4),
+            wet: numeric('db', wet)
+          })), /Invalid gain/, `should throw for wet level: ${wet}`)
+        }
+      })
     })
 
     describe('reverb effect', () => {
@@ -1045,7 +1142,8 @@ describe('lowering.ts', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'reverb',
           mix: numeric(undefined, 0.75),
-          decay: numeric('s', 2)
+          decay: numeric('s', 2),
+          wet: numeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
@@ -1094,7 +1192,8 @@ describe('lowering.ts', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'reverb',
           mix: numeric(undefined, 1.5),
-          decay: numeric('s', 2)
+          decay: numeric('s', 2),
+          wet: numeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
@@ -1116,7 +1215,8 @@ describe('lowering.ts', () => {
         assert.throws(() => createAudioGraph(createProgramWithEffect({
           type: 'reverb',
           mix: numeric(undefined, Number.NaN),
-          decay: numeric('s', 2)
+          decay: numeric('s', 2),
+          wet: numeric('db', 0)
         })), /Invalid mix/)
       })
 
@@ -1125,7 +1225,8 @@ describe('lowering.ts', () => {
           assert.throws(() => createAudioGraph(createProgramWithEffect({
             type: 'reverb',
             mix: numeric(undefined, 0.75),
-            decay: numeric('s', decay)
+            decay: numeric('s', decay),
+            wet: numeric('db', 0)
           })), /Invalid decay/, `should throw for decay: ${decay}`)
         }
       })
@@ -1134,7 +1235,8 @@ describe('lowering.ts', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'reverb',
           mix: numeric(undefined, 0.75),
-          decay: numeric('beats', 2)
+          decay: numeric('beats', 2),
+          wet: numeric('db', 0)
         }))
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
@@ -1142,6 +1244,81 @@ describe('lowering.ts', () => {
           type: 'reverb',
           decay: beatsToSeconds(numeric('beats', 2), numeric('bpm', 120))
         } satisfies ReverbNode)
+      })
+
+      it('should add a gain node for non-zero wet level', () => {
+        const graph = createAudioGraph(createProgramWithEffect({
+          type: 'reverb',
+          mix: numeric(undefined, 0.25),
+          decay: numeric('s', 2),
+          wet: numeric('db', -6)
+        }))
+
+        // Note: There already is a wet gain node to handle the mix level,
+        // but it cannot be reused as there may be separate automations for the mix and wet parameters,
+        // which would unnecessarily complicate the calculations.
+        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+          // output node
+          {
+            id: 1 as NodeId,
+            type: 'identity'
+          } satisfies IdentityNode,
+          // reverb node
+          {
+            id: 2 as NodeId,
+            type: 'reverb',
+            decay: numeric('s', 2)
+          } satisfies ReverbNode,
+          // wet gain node for wet level
+          {
+            id: 3 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, dbToGain(-6)),
+              points: []
+            }
+          } satisfies GainNode,
+          // dry gain node (mix)
+          {
+            id: 4 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 1.0),
+              points: []
+            }
+          } satisfies GainNode,
+          // wet gain node (mix)
+          {
+            id: 5 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 0.5),
+              points: []
+            }
+          } satisfies GainNode
+        ])
+
+        assert.deepStrictEqual(graph.edges, [
+          // reverb to wet
+          { from: 2 as NodeId, to: 3 as NodeId },
+          // wet level to wet mix
+          { from: 3 as NodeId, to: 5 as NodeId },
+          // dry to output
+          { from: 4 as NodeId, to: 1 as NodeId },
+          // wet mix to output
+          { from: 5 as NodeId, to: 1 as NodeId }
+        ])
+      })
+
+      it('should throw for invalid wet level', () => {
+        for (const wet of [Infinity, Number.NaN]) {
+          assert.throws(() => createAudioGraph(createProgramWithEffect({
+            type: 'reverb',
+            mix: numeric(undefined, 0.75),
+            decay: numeric('s', 2),
+            wet: numeric('db', wet)
+          })), /Invalid gain/, `should throw for wet level: ${wet}`)
+        }
       })
     })
   })

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -188,12 +188,14 @@ export interface DelayEffect {
   readonly mix: Numeric<undefined>
   readonly time: Numeric<'beats'> | Numeric<'s'>
   readonly feedback: Numeric<undefined>
+  readonly wet: Numeric<'db'>
 }
 
 export interface ReverbEffect {
   readonly type: 'reverb'
   readonly mix: Numeric<undefined>
   readonly decay: Numeric<'beats'> | Numeric<'s'>
+  readonly wet: Numeric<'db'>
 }
 
 export interface MixerRouting {

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -72,7 +72,7 @@ describe('hover/operation.ts', () => {
       applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, delayPosition),
       {
         range: getRangeAt(source, source.indexOf('delay('), 'delay'.length),
-        title: 'delay(mix: number, time: number(beats) | number(s), feedback: number) -> effect',
+        title: 'delay(mix: number, time: number(beats) | number(s), feedback: number, wet?: number(db)) -> effect',
         summary: 'Adds echoes with configurable mix, time, and feedback.'
       }
     )
@@ -81,7 +81,7 @@ describe('hover/operation.ts', () => {
       applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, reverbPosition),
       {
         range: getRangeAt(source, source.indexOf('reverb('), 'reverb'.length),
-        title: 'reverb(mix: number, decay: number(beats) | number(s)) -> effect',
+        title: 'reverb(mix: number, decay: number(beats) | number(s), wet?: number(db)) -> effect',
         summary: 'Adds reverberation with configurable mix and decay.'
       }
     )

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -1,4 +1,5 @@
 import type { Effect } from '@core'
+import { numeric } from '@utility'
 import { NumberFacet } from '../../type-system/base/number.js'
 import { RecordFacet } from '../../type-system/base/record.js'
 import { EffectFacet } from '../../type-system/domain/effect.js'
@@ -8,6 +9,8 @@ import type { Value } from '../../type-system/types.js'
 import type { FunctionContext } from '../functions.js'
 import { allocateParameter } from '../functions.js'
 import { Functions, Modules, Parameters } from '../type-helpers.js'
+
+const UNITY_GAIN = numeric('db', 0)
 
 // types
 
@@ -142,7 +145,8 @@ const delay = Functions.of({
   parameters: [
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'time', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
-    { name: 'feedback', type: NumberFacet.with(undefined).type(), required: true }
+    { name: 'feedback', type: NumberFacet.with(undefined).type(), required: true },
+    { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ],
 
   returnType: DelayEffectType,
@@ -152,7 +156,8 @@ const delay = Functions.of({
       type: 'delay',
       mix: NumberFacet.get(args.mix),
       time: NumberFacet.get(args.time),
-      feedback: NumberFacet.get(args.feedback)
+      feedback: NumberFacet.get(args.feedback),
+      wet: args.wet != null ? NumberFacet.get(args.wet) : UNITY_GAIN
     }
 
     return DelayEffectType.of(effect)
@@ -164,7 +169,8 @@ const reverb = Functions.of({
 
   parameters: [
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
-    { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true }
+    { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
+    { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ],
 
   returnType: ReverbEffectType,
@@ -173,7 +179,8 @@ const reverb = Functions.of({
     const effect: Effect = {
       type: 'reverb',
       mix: NumberFacet.get(args.mix),
-      decay: NumberFacet.get(args.decay)
+      decay: NumberFacet.get(args.decay),
+      wet: args.wet != null ? NumberFacet.get(args.wet) : UNITY_GAIN
     }
 
     return ReverbEffectType.of(effect)

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -364,7 +364,8 @@ describe('compiler/generator.ts', () => {
       type: 'delay',
       mix: numeric(undefined, 0.25),
       time: numeric('s', 1.5),
-      feedback: numeric(undefined, 0.4)
+      feedback: numeric(undefined, 0.4),
+      wet: numeric('db', 0)
     })
   })
 
@@ -382,7 +383,8 @@ describe('compiler/generator.ts', () => {
     assert.deepStrictEqual(result.mixer.buses[0].effects[0], {
       type: 'reverb',
       mix: numeric(undefined, 0.25),
-      decay: numeric('beats', 2)
+      decay: numeric('beats', 2),
+      wet: numeric('db', 0)
     })
   })
 

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -152,7 +152,8 @@ describe('compiler/modules/effects.ts', () => {
         type: 'delay',
         mix: numeric(undefined, 0.5),
         time: beats(0.5),
-        feedback: numeric(undefined, 0.3)
+        feedback: numeric(undefined, 0.3),
+        wet: numeric('db', 0)
       })
 
       assert.strictEqual(RecordFacet.has(result), false)
@@ -170,10 +171,25 @@ describe('compiler/modules/effects.ts', () => {
         type: 'delay',
         mix: numeric(undefined, 0.5),
         time: seconds(1.5),
-        feedback: numeric(undefined, 0.3)
+        feedback: numeric(undefined, 0.3),
+        wet: numeric('db', 0)
       })
 
       assert.strictEqual(RecordFacet.has(result), false)
+    })
+
+    it('should accept optional wet parameter', () => {
+      const context = createFunctionContext()
+      const result = delay.invoke(context, {
+        mix: Numbers.of(numeric(undefined, 0.5)),
+        time: Numbers.of(beats(0.5)),
+        feedback: Numbers.of(numeric(undefined, 0.3)),
+        wet: Numbers.of(numeric('db', 3))
+      })
+
+      const effect = EffectFacet.get(result)
+      assert.strictEqual(effect.type, 'delay')
+      assert.deepStrictEqual(effect.wet, numeric('db', 3))
     })
   })
 
@@ -192,7 +208,8 @@ describe('compiler/modules/effects.ts', () => {
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'reverb',
         decay: numeric('s', 2.0),
-        mix: numeric(undefined, 0.4)
+        mix: numeric(undefined, 0.4),
+        wet: numeric('db', 0)
       })
 
       assert.strictEqual(RecordFacet.has(result), false)
@@ -208,10 +225,24 @@ describe('compiler/modules/effects.ts', () => {
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'reverb',
         decay: beats(2),
-        mix: numeric(undefined, 0.4)
+        mix: numeric(undefined, 0.4),
+        wet: numeric('db', 0)
       })
 
       assert.strictEqual(RecordFacet.has(result), false)
+    })
+
+    it('should accept optional wet parameter', () => {
+      const context = createFunctionContext()
+      const result = reverb.invoke(context, {
+        decay: Numbers.of(numeric('s', 2.0)),
+        mix: Numbers.of(numeric(undefined, 0.4)),
+        wet: Numbers.of(numeric('db', -3))
+      })
+
+      const effect = EffectFacet.get(result)
+      assert.strictEqual(effect.type, 'reverb')
+      assert.deepStrictEqual(effect.wet, numeric('db', -3))
     })
   })
 })


### PR DESCRIPTION
The wet gain sits between the effect processor and the dry/wet mixer, so that the wet signal can be attenuated without affecting the dry signal. This allows for more flexible control over the effect than with just the mix parameter alone. For example, to achieve an intense reverb effect, you would previously need to use a high mix value (decreasing the dry), followed by a separate gain effect to boost the overall level. Now, the wet signal can be boosted directly.