### PR TITLE
feat: Add 'clip' effect

### DIFF
--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -9,7 +9,7 @@ import { dbToGain, DEFAULT_ROOT_NOTE } from './constants.js'
 import type { EntityKey } from './entities.js'
 import { createEntityKey } from './entities.js'
 import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
-import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, Node, OscillatorNode, PanNode, ReverbNode, SampleNode, WidthNode } from './nodes.js'
+import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, Node, OscillatorNode, PanNode, ReverbNode, SampleNode, WaveShaperNode, WidthNode } from './nodes.js'
 
 type Builder = AudioGraphBuilder<Node>
 
@@ -276,6 +276,45 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
       })
 
       return createDryWetMix(reverb, mix, effect.wet, builder)
+    }
+
+    case 'clip': {
+      // The wave shaper curve is not time-variant. Hence, we use two gain nodes to implement the threshold,
+      // one in front of the wave shaper with gain of -threshold, and one after with gain of +threshold to compensate.
+      // If the threshold is -Infinity, we must of course not apply a +Infinity gain, which would be illegal.
+
+      const invert = (value: Numeric<undefined>): Numeric<undefined> => {
+        if (value.value === 0) {
+          throw new Error('Invalid gain')
+        }
+
+        return numeric(undefined, 1 / value.value)
+      }
+
+      const thresholdGain = toTimeVariant(effect.threshold, program, gainTransform)
+
+      const input = builder.addNode<GainNode>('gain', {
+        gain: {
+          initial: invert(thresholdGain.initial),
+          points: thresholdGain.points.map(({ time, value, curve }) => ({ time, value: invert(value), curve }))
+        }
+      })
+
+      const waveShaper = builder.addNode<WaveShaperNode>('wave_shaper', {
+        curve: new Float32Array([-1, 0, 1])
+      })
+
+      const output = builder.addNode<GainNode>('gain', {
+        gain: thresholdGain
+      })
+
+      builder.addEdge(input.id, waveShaper.id)
+      builder.addEdge(waveShaper.id, output.id)
+
+      return {
+        inputs: [input.id],
+        outputs: [output.id]
+      }
     }
   }
 }

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -14,6 +14,7 @@ export interface NodeTypeMap {
   readonly width: WidthNode
   readonly delay: DelayNode
   readonly reverb: ReverbNode
+  readonly wave_shaper: WaveShaperNode
 
   // sources
   readonly sample: SampleNode
@@ -61,6 +62,11 @@ export interface DelayNode extends AnyNode {
 export interface ReverbNode extends AnyNode {
   readonly type: 'reverb'
   readonly decay: Numeric<'s'>
+}
+
+export interface WaveShaperNode extends AnyNode {
+  readonly type: 'wave_shaper'
+  readonly curve: Float32Array<ArrayBuffer>
 }
 
 // sources

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -7,7 +7,7 @@ import { dbToGain } from '../src/constants.js'
 import { createEntityKey } from '../src/entities.js'
 import type { NodeId } from '../src/graph.js'
 import { createAudioGraph } from '../src/lowering.js'
-import type { DelayNode, GainNode, IdentityNode, Node, ReverbNode, SampleNode } from '../src/nodes.js'
+import type { DelayNode, GainNode, IdentityNode, Node, ReverbNode, SampleNode, WaveShaperNode } from '../src/nodes.js'
 
 const defaultEnvelope: Envelope = {
   attack: numeric('s', 0.01),
@@ -1345,6 +1345,73 @@ describe('lowering.ts', () => {
             decay: numeric('s', 2),
             wet: numeric('db', wet)
           })), /Invalid gain/, `should throw for wet level: ${wet}`)
+        }
+      })
+    })
+
+    describe('clip effect', () => {
+      it('should create gain, wave shaper, and makeup nodes', () => {
+        const threshold = numeric('db', -6)
+
+        const graph = createAudioGraph(createProgramWithEffect({
+          type: 'clip',
+          threshold: {
+            id: 400 as ParameterId,
+            initial: threshold
+          }
+        }))
+
+        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+          // output node
+          {
+            id: 1 as NodeId,
+            type: 'identity'
+          } satisfies IdentityNode,
+          // pre-gain to set the threshold
+          {
+            id: 2 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, 1 / dbToGain(threshold.value)),
+              points: []
+            }
+          } satisfies GainNode,
+          // wave shaper
+          {
+            id: 3 as NodeId,
+            type: 'wave_shaper',
+            curve: new Float32Array([-1, 0, 1])
+          } satisfies WaveShaperNode,
+          // makeup gain
+          {
+            id: 4 as NodeId,
+            type: 'gain',
+            gain: {
+              initial: numeric(undefined, dbToGain(threshold.value)),
+              points: []
+            }
+          } satisfies GainNode
+        ])
+
+        assert.deepStrictEqual(graph.edges, [
+          // pre-gain to wave shaper
+          { from: 2 as NodeId, to: 3 as NodeId },
+          // wave shaper to makeup gain
+          { from: 3 as NodeId, to: 4 as NodeId },
+          // makeup gain to output
+          { from: 4 as NodeId, to: 1 as NodeId }
+        ])
+      })
+
+      it('should throw for invalid clip threshold', () => {
+        for (const threshold of [-Infinity, Infinity, Number.NaN]) {
+          assert.throws(() => createAudioGraph(createProgramWithEffect({
+            type: 'clip',
+            threshold: {
+              id: 400 as ParameterId,
+              initial: numeric('db', threshold)
+            }
+          })), /Invalid gain/, `should throw for threshold: ${threshold}`)
         }
       })
     })

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -156,7 +156,8 @@ export type Effect =
   HighpassEffect |
   WidthEffect |
   DelayEffect |
-  ReverbEffect
+  ReverbEffect |
+  ClipEffect
 
 export interface GainEffect {
   readonly type: 'gain'
@@ -196,6 +197,11 @@ export interface ReverbEffect {
   readonly mix: Numeric<undefined>
   readonly decay: Numeric<'beats'> | Numeric<'s'>
   readonly wet: Numeric<'db'>
+}
+
+export interface ClipEffect {
+  readonly type: 'clip'
+  readonly threshold: Parameter<'db'>
 }
 
 export interface MixerRouting {

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -38,6 +38,10 @@ const DelayEffectType = makeType(EffectFacet, RecordFacet.with({
 
 const ReverbEffectType = makeType(EffectFacet)
 
+const ClipEffectType = makeType(EffectFacet, RecordFacet.with({
+  threshold: ParameterFacet.with('db').type()
+}))
+
 // factories
 
 const gain = Functions.of({
@@ -193,6 +197,27 @@ const reverb = Functions.of({
   }
 })
 
+const clip = Functions.of({
+  summary: 'Applies hard clipping to the signal at the specified threshold.',
+
+  parameters: [
+    { name: 'threshold', type: NumberFacet.with('db').type(), required: true }
+  ],
+
+  returnType: ClipEffectType,
+
+  invoke: (context, args) => {
+    const effect: Effect = {
+      type: 'clip',
+      threshold: allocateParameter(context as FunctionContext, NumberFacet.get(args.threshold))
+    }
+
+    return ClipEffectType.of(effect, {
+      threshold: Parameters.of(effect.threshold)
+    })
+  }
+})
+
 // module
 
 export const effectsModule = Modules.of({
@@ -207,6 +232,7 @@ export const effectsModule = Modules.of({
     ['highpass', highpass],
     ['width', width],
     ['delay', delay],
-    ['reverb', reverb]
+    ['reverb', reverb],
+    ['clip', clip]
   ])
 })

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -252,4 +252,27 @@ describe('compiler/modules/effects.ts', () => {
       assert.deepStrictEqual(effect.wet, numeric('db', -3))
     })
   })
+
+  describe('clip', () => {
+    const clipValue = effects.exports.get('clip')
+    assert.ok(clipValue != null && FunctionFacet.has(clipValue))
+    const clip = FunctionFacet.get(clipValue)
+
+    it('should create clip effect', () => {
+      const context = createFunctionContext()
+      const result = clip.invoke(context, {
+        threshold: Numbers.of(numeric(undefined, 0.8))
+      })
+
+      assert.deepStrictEqual(EffectFacet.get(result), {
+        type: 'clip',
+        threshold: {
+          id: 1 as ParameterId,
+          initial: numeric(undefined, 0.8)
+        }
+      })
+
+      assert.deepStrictEqual(Object.keys(RecordFacet.get(result)), ['threshold'])
+    })
+  })
 })

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -1,4 +1,4 @@
-import type { BiquadNode, DelayNode, GainNode, IdentityNode, PanNode, ReverbNode, WidthNode } from '@audiograph'
+import type { BiquadNode, DelayNode, GainNode, IdentityNode, PanNode, ReverbNode, WaveShaperNode, WidthNode } from '@audiograph'
 import type { Transport } from '../transport/transport.js'
 import { automate } from './automation.js'
 import type { Instance } from './instance.js'
@@ -102,6 +102,12 @@ export function createReverbInstance (node: ReverbNode, transport: Transport): I
     decay: node.decay
   })
 
+  return toInstance(audioNode)
+}
+
+export function createWaveShaperInstance (node: WaveShaperNode, transport: Transport): Instance {
+  const audioNode = transport.ctx.createWaveShaper()
+  audioNode.curve = node.curve
   return toInstance(audioNode)
 }
 

--- a/packages/webaudio/src/graph/factory.ts
+++ b/packages/webaudio/src/graph/factory.ts
@@ -2,11 +2,11 @@ import type { Node } from '@audiograph'
 import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
 import type { GainMeasurement } from '../worklets/metering/messages.js'
-import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance, createWidthInstance } from './effect.js'
+import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance, createWaveShaperInstance, createWidthInstance } from './effect.js'
 import type { Instance } from './instance.js'
-import { createGainMeterInstance } from './metering.js'
 import { createOscillatorInstance } from './instruments/oscillator.js'
 import { createSampleInstance } from './instruments/sample.js'
+import { createGainMeterInstance } from './metering.js'
 
 const factories = Object.freeze({
   identity: createIdentityInstance,
@@ -18,6 +18,7 @@ const factories = Object.freeze({
   width: createWidthInstance,
   delay: createDelayInstance,
   reverb: createReverbInstance,
+  wave_shaper: createWaveShaperInstance,
 
   // sources
   sample: createSampleInstance,


### PR DESCRIPTION
The effects module now exports a `clip(threshold: number(db))` function that clips the input signal to the specified threshold. In the graph, this is implemented using a pre-gain by the inverse of the threshold, followed by a wave shaper with a curve that clips the signal to the range [-1, +1], followed by a post-gain to compensate for the pre-gain. A threshold of -Infinity is not supported, as it would require an infinite pre-gain. The threshold can be automated.