### PR TITLE
feat!: Use '~[]' instead of 'curve []' for curves

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -39,7 +39,7 @@ track (120.bpm) {
     snare << snare_pattern
     synth << arp_intro
 
-    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]
+    automate synth.gain as ~[hold(-60.db):3 lin(0.db):1]
   }
 
   part main (8.bars) {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -11,6 +11,7 @@
   stringEscape { "\\" $[.] }
   stringContent { !["\\{] }
 
+  "~["
   "[" "]"
   "<" ">"
   "{" "}"
@@ -95,8 +96,7 @@ step {
 }
 
 Curve {
-  kw<"curve">
-  "["
+  "~["
   (curveSegment | interpolationExpression)*
   "]"
 }

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -74,7 +74,7 @@ describe('go-to-definition/operation.ts', () => {
     const source = [
       'track (120.bpm) {',
       '  part foo {',
-      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '    automate bus.foo.gain as ~[hold(-60.db):3 lin(0.db):1]',
       '  }',
       '}',
       'mixer {',
@@ -113,7 +113,7 @@ describe('go-to-definition/operation.ts', () => {
       '',
       'track (120.bpm) {',
       '  part p {',
-      '    automate synth.gain as curve [hold(-60.db) lin(-60.db, 0.db)]',
+      '    automate synth.gain as ~[hold(-60.db) lin(-60.db, 0.db)]',
       '  }',
       '}',
       ''

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -35,7 +35,7 @@ describe('highlight-occurrences/operation.ts', () => {
     const source = [
       'track (120.bpm) {',
       '  part foo {',
-      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '    automate bus.foo.gain as ~[hold(-60.db):3 lin(0.db):1]',
       '  }',
       '}',
       'mixer {',
@@ -75,7 +75,7 @@ describe('highlight-occurrences/operation.ts', () => {
       'synth = sample("...")',
       'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '    automate synth.gain as ~[hold(-60.db):3 lin(0.db):1]',
       '  }',
       '}',
       ''

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -74,7 +74,7 @@ describe('language-support.ts', () => {
       'instrument = sample("kick-{tempo}")',
       'track (tempo: 140.bpm) {',
       '  part drums {',
-      '    automate lib.gain as curve [hold(-60.db) lin(-60.db, 0.db)]',
+      '    automate lib.gain as ~[hold(-60.db) lin(-60.db, 0.db)]',
       '  }',
       '}',
       'mixer {',

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -27,7 +27,7 @@ describe('model/analysis/base.ts', () => {
       'track (tempo: tempo) {',
       '  part intro (4.bars) {',
       '    kick << p.loop([x---])',
-      '    automate kick.gain as curve [hold(-60.db)]',
+      '    automate kick.gain as ~[hold(-60.db)]',
       '  }',
       '}',
       '',

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -76,7 +76,7 @@ describe('model/analysis/references.ts', () => {
     const source = [
       'track (120.bpm) {',
       '  part foo (4.bars) {',
-      '    automate bus.foo.gain as curve [hold(0.db)]',
+      '    automate bus.foo.gain as ~[hold(0.db)]',
       '  }',
       '}',
       'mixer {',
@@ -128,7 +128,7 @@ describe('model/analysis/references.ts', () => {
       'synth = sample("...", gain: gain)',
       'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as curve [hold(0.db)]',
+      '    automate synth.gain as ~[hold(0.db)]',
       '  }',
       '}',
       ''
@@ -148,7 +148,7 @@ describe('model/analysis/references.ts', () => {
     const source = [
       'track (120.bpm) {',
       '  part main (4.bars) {',
-      '    automate bus.foo.gain as curve [hold(0.db)]',
+      '    automate bus.foo.gain as ~[hold(0.db)]',
       '  }',
       '}',
       'mixer {',

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -55,7 +55,7 @@ describe('unused-variable/operation.ts', () => {
       'synth = sample("...")',
       'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '    automate synth.gain as ~[hold(-60.db):3 lin(0.db):1]',
       '  }',
       '}',
       ''
@@ -72,7 +72,7 @@ describe('unused-variable/operation.ts', () => {
       'foo = sample("...")',
       'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate bus.foo.gain as curve [hold(-60.db):3 lin(0.db):1]',
+      '    automate bus.foo.gain as ~[hold(-60.db):3 lin(0.db):1]',
       '  }',
       '}',
       'mixer {',

--- a/packages/language/src/lexer/lexer.ts
+++ b/packages/language/src/lexer/lexer.ts
@@ -36,6 +36,7 @@ const commonRules: Rules = [
 
   { name: '"', push: stringLexer },
 
+  { name: '~[' },
   { name: '[' },
   { name: ']' },
   { name: '(' },

--- a/packages/language/src/parser/constants.ts
+++ b/packages/language/src/parser/constants.ts
@@ -7,8 +7,7 @@ export const keywords = Object.freeze([
   'mixer',
   'bus',
   'effect',
-  'automate',
-  'curve'
+  'automate'
 ] as const)
 
 export type Keyword = (typeof keywords)[number]

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -332,17 +332,14 @@ const curveSegment_: p.Parser<Token, unknown, ast.CurveSegment> = p.ab(
   }
 )
 
-const curve_: p.Parser<Token, unknown, ast.Curve> = p.ab(
-  keyword('curve'),
-  combine3(
-    expectLiteral('['),
-    p.many(
-      p.eitherOr(curveSegment_, patternInterpolation_)
-    ),
-    expectLiteral(']')
+const curve_: p.Parser<Token, unknown, ast.Curve> = p.abc(
+  literal('~['),
+  p.many(
+    p.eitherOr(curveSegment_, patternInterpolation_)
   ),
-  (_curve, [_l, children, _r]) => {
-    return ast.make('Curve', combineSourceRanges(_curve, _r), { children })
+  expectLiteral(']'),
+  (_l, children, _r) => {
+    return ast.make('Curve', combineSourceRanges(_l, _r), { children })
   }
 )
 

--- a/packages/language/test/compiler/checker.test.ts
+++ b/packages/language/test/compiler/checker.test.ts
@@ -160,26 +160,26 @@ describe('compiler/checker.ts', () => {
     })
 
     it('should accept lin curves', () => {
-      assertValid('my_curve = curve[lin((-60).db, 0.db)]')
+      assertValid('my_curve = ~[lin((-60).db, 0.db)]')
     })
 
     it('should accept curves with weighted segments', () => {
-      assertValid('my_curve = curve[hold((-60).db):3 lin((-60).db, 0.db):1]')
+      assertValid('my_curve = ~[hold((-60).db):3 lin((-60).db, 0.db):1]')
     })
 
     it('should accept lin curves that omit the start after the first segment', () => {
-      assertValid('my_curve = curve[hold((-60).db):3 lin(0.db):1]')
+      assertValid('my_curve = ~[hold((-60).db):3 lin(0.db):1]')
     })
 
     it('should accept hold curves that omit the value after the first segment', () => {
-      assertValid('my_curve = curve[lin((-60).db, (-30).db):3 hold:1]')
+      assertValid('my_curve = ~[lin((-60).db, (-30).db):3 hold:1]')
     })
 
     it('should accept bus gain automation via explicit namespace', () => {
       const source = [
         'track {',
         '  part intro (4.bars) {',
-        '    automate bus.main.gain as curve[lin((-20).db, 0.db)]',
+        '    automate bus.main.gain as ~[lin((-20).db, 0.db)]',
         '  }',
         '}',
         'mixer {',
@@ -280,25 +280,25 @@ describe('compiler/checker.ts', () => {
     })
 
     it('should reject curves with non-numeric parameters', () => {
-      assertErrorMessages('my_curve = curve[hold("not a number")]', [
+      assertErrorMessages('my_curve = ~[hold("not a number")]', [
         'Expected type number, got string'
       ])
     })
 
     it('should reject lin curves that omit the start for the first segment', () => {
-      assertErrorMessages('my_curve = curve[lin(0.db)]', [
+      assertErrorMessages('my_curve = ~[lin(0.db)]', [
         'First curve segment cannot omit its first parameter'
       ])
     })
 
     it('should reject hold curves that omit the value for the first segment', () => {
-      assertErrorMessages('my_curve = curve[hold]', [
+      assertErrorMessages('my_curve = ~[hold]', [
         'First curve segment cannot omit its first parameter'
       ])
     })
 
     it('should reject omitted lin starts when the inherited and explicit units differ', () => {
-      assertErrorMessages('my_curve = curve[hold((-60).db) lin(120.bpm)]', [
+      assertErrorMessages('my_curve = ~[hold((-60).db) lin(120.bpm)]', [
         'Expected type number(db), got number(bpm)'
       ])
     })
@@ -308,7 +308,7 @@ describe('compiler/checker.ts', () => {
         'some_value = ""',
         'track {',
         '  part intro (4.bars) {',
-        '    automate some_value as curve[hold(-60)]',
+        '    automate some_value as ~[hold(-60)]',
         '  }',
         '}'
       ].join('\n')

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -131,7 +131,7 @@ describe('compiler/generator.ts', () => {
       'synth = sample("synth.wav")',
       'track {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as curve[lin((-60).db, 0.db)]',
+      '    automate synth.gain as ~[lin((-60).db, 0.db)]',
       '  }',
       '}'
     ].join('\n')
@@ -152,7 +152,7 @@ describe('compiler/generator.ts', () => {
       'synth = sample("synth.wav")',
       'track {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as curve[lin((-60).db, (-30).db) lin((-30).db, 0.db)]',
+      '    automate synth.gain as ~[lin((-60).db, (-30).db) lin((-30).db, 0.db)]',
       '  }',
       '}'
     ].join('\n')
@@ -174,7 +174,7 @@ describe('compiler/generator.ts', () => {
       'synth = sample("synth.wav")',
       'track {',
       '  part intro (8.bars) {',
-      '    automate synth.gain as curve[hold((-60).db):3 lin((-60).db, 0.db):1]',
+      '    automate synth.gain as ~[hold((-60).db):3 lin((-60).db, 0.db):1]',
       '  }',
       '}'
     ].join('\n')
@@ -196,7 +196,7 @@ describe('compiler/generator.ts', () => {
       'synth = sample("synth.wav")',
       'track {',
       '  part intro (8.bars) {',
-      '    automate synth.gain as curve[hold((-60).db):3 lin(0.db):1]',
+      '    automate synth.gain as ~[hold((-60).db):3 lin(0.db):1]',
       '  }',
       '}'
     ].join('\n')
@@ -218,7 +218,7 @@ describe('compiler/generator.ts', () => {
       'synth = sample("synth.wav")',
       'track {',
       '  part intro (8.bars) {',
-      '    automate synth.gain as curve[lin((-60).db, (-30).db):3 hold:1]',
+      '    automate synth.gain as ~[lin((-60).db, (-30).db):3 hold:1]',
       '  }',
       '}'
     ].join('\n')
@@ -240,7 +240,7 @@ describe('compiler/generator.ts', () => {
       'synth = sample("synth.wav")',
       'track {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as curve[hold((-60).db):(-2) lin((-60).db, (-30).db):0 lin((-30).db, 0.db):1]',
+      '    automate synth.gain as ~[hold((-60).db):(-2) lin((-60).db, (-30).db):0 lin((-30).db, 0.db):1]',
       '  }',
       '}'
     ].join('\n')
@@ -260,7 +260,7 @@ describe('compiler/generator.ts', () => {
     const source = [
       'track {',
       '  part intro (4.bars) {',
-      '    automate bus.main.gain as curve[lin((-20).db, 0.db)]',
+      '    automate bus.main.gain as ~[lin((-20).db, 0.db)]',
       '  }',
       '}',
       'mixer {',
@@ -285,7 +285,7 @@ describe('compiler/generator.ts', () => {
       'lp = fx.lowpass(123.hz)',
       'track {',
       '  part intro (4.bars) {',
-      '    automate lp.frequency as curve[lin(500.hz, 1000.hz)]',
+      '    automate lp.frequency as ~[lin(500.hz, 1000.hz)]',
       '  }',
       '}',
       'mixer {',

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -302,4 +302,28 @@ describe('lexer/lexer.ts', () => {
       ]
     })
   })
+
+  it('should lex curves', () => {
+    const result = lex('~[hold(0.db)]')
+    assert.deepStrictEqual(stripTokenMeta(result), {
+      complete: true,
+      value: [
+        { name: '~[', text: '~[' },
+
+        { name: 'word', text: 'hold' },
+        { name: '(', text: '(' },
+        { name: 'number', text: '0' },
+        { name: '.', text: '.' },
+        { name: 'word', text: 'db' },
+        { name: ')', text: ')' },
+
+        { name: ']', text: ']' }
+      ]
+    })
+  })
+
+  it('should not lex curves when tilde and bracket are separated by whitespace', () => {
+    const result = lex('~ [hold(0.db)]')
+    assert.strictEqual(result.complete, false)
+  })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -411,7 +411,7 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse curve expressions', () => {
-    const result = parse(lexSource('foo = curve[hold(0) lin(0, 1)]'))
+    const result = parse(lexSource('foo = ~[hold(0) lin(0, 1)]'))
     assertResultComplete(result)
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -443,7 +443,7 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse curve segment lengths', () => {
-    const result = parse(lexSource('foo = curve[hold(0):3 lin(0, 1):1]'))
+    const result = parse(lexSource('foo = ~[hold(0):3 lin(0, 1):1]'))
     assertResultComplete(result)
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -477,7 +477,7 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse curve segments without parameters', () => {
-    const result = parse(lexSource('foo = curve[hold hold:2]'))
+    const result = parse(lexSource('foo = ~[hold hold:2]'))
     assertResultComplete(result)
 
     assert.deepStrictEqual(stripRanges(result.value.children), [


### PR DESCRIPTION
This patch updates the syntax for defining automation curves, replacing `curve [...]` ("curve" as a keyword) with `~[...]` (using the tilde symbol). Reasoning: The new syntax is shorter, and not having "curve" as a keyword better visually distinguishes the curve literal from other constructs. For instance, in `automate foo as curve [...]`, it was not readily apparent that `curve [...]` was a single unit instead of `curve` belonging to the automation statement itself.

BREAKING CHANGE: The syntax has changed incompatibly.