### PR TITLE
refactor: Improve function context type safety

### DIFF
--- a/packages/language/src/compiler/functions.ts
+++ b/packages/language/src/compiler/functions.ts
@@ -1,12 +1,17 @@
 import type { Automation, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
 import type { Numeric, Unit } from '@utility'
 
-export interface FunctionContext {
+export type FunctionContext = InstrumentContext & ParameterContext
+
+export interface InstrumentContext {
   readonly instruments: Map<InstrumentId, Instrument>
+}
+
+export interface ParameterContext {
   readonly automations: Map<ParameterId, Automation>
 }
 
-export function allocateInstrument (context: FunctionContext, data: Omit<Instrument, 'id'>): Instrument {
+export function allocateInstrument (context: InstrumentContext, data: Omit<Instrument, 'id'>): Instrument {
   const currentMaxId = Math.max(0, ...Array.from(context.instruments.keys()))
   const id = (currentMaxId + 1) as InstrumentId
 
@@ -16,7 +21,7 @@ export function allocateInstrument (context: FunctionContext, data: Omit<Instrum
   return instrument
 }
 
-export function allocateParameter<U extends Unit> (context: FunctionContext, initial: Numeric<U>): Parameter<U> {
+export function allocateParameter<U extends Unit> (context: ParameterContext, initial: Numeric<U>): Parameter<U> {
   const currentMaxId = Math.max(0, ...Array.from(context.automations.keys()))
   const id = (currentMaxId + 1) as ParameterId
 

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -3,6 +3,7 @@ import type { Automation, Bus, BusId, Instrument, InstrumentId, InstrumentRoutin
 import { concatPatterns, createParallelPattern, createSerialPattern, mergePatterns, multiplyPattern } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
+import type { Function } from '../type-system/base/function.js'
 import { FunctionFacet } from '../type-system/base/function.js'
 import { ModuleFacet } from '../type-system/base/module.js'
 import { NumberFacet } from '../type-system/base/number.js'
@@ -16,11 +17,12 @@ import { ParameterFacet } from '../type-system/domain/parameter.js'
 import { PartFacet } from '../type-system/domain/part.js'
 import { PatternFacet } from '../type-system/domain/pattern.js'
 import type { InferSchema, Schema } from '../type-system/schema.js'
-import type { Value } from '../type-system/types.js'
+import type { FacetType, Value } from '../type-system/types.js'
 import { busSchema, partSchema, stepSchema, trackSchema } from './common.js'
 import type { CurveSegment as GeneratedCurveSegment } from './curves.js'
 import { createCurve, createCurveSegment, getCurveSegmentType, renderCurvePoints } from './curves.js'
 import { CompileError } from './error.js'
+import type { FunctionContext } from './functions.js'
 import { allocateParameter } from './functions.js'
 import { getStandardModuleValue } from './modules.js'
 import { BusType, Numbers, Parameters } from './type-helpers.js'
@@ -619,7 +621,8 @@ function resolvePropertyAccess (context: Context, expression: ast.PropertyAccess
 }
 
 function resolveCall (context: Context, expression: ast.Call): Value {
-  const func = FunctionFacet.get(resolve(context, expression.callee))
+  // cast due to context type
+  const func = FunctionFacet.get(resolve(context, expression.callee)) as Function<Schema, FacetType, FunctionContext>
   const args = resolveArgumentList(context, expression.arguments, func.parameters)
 
   return func.invoke(context.top, args)
@@ -635,9 +638,7 @@ function resolveArgumentList<S extends Schema> (context: Context, args: ast.Argu
       break
     }
 
-    const param = schema.at(i)
-    assert(param != null)
-
+    const param = nonNull(schema.at(i))
     entries.push([param.name, resolve(context, arg)])
   }
 
@@ -646,9 +647,7 @@ function resolveArgumentList<S extends Schema> (context: Context, args: ast.Argu
     const arg = args[i]
     assert(arg.type === 'Property')
 
-    const param = schema.find((s) => s.name === arg.key.name)
-    assert(param != null)
-
+    const param = nonNull(schema.find((s) => s.name === arg.key.name))
     entries.push([param.name, resolve(context, arg.value)])
   }
 

--- a/packages/language/src/compiler/modules/effects.ts
+++ b/packages/language/src/compiler/modules/effects.ts
@@ -6,7 +6,7 @@ import { EffectFacet } from '../../type-system/domain/effect.js'
 import { ParameterFacet } from '../../type-system/domain/parameter.js'
 import { makeType, makeUnion } from '../../type-system/factory.js'
 import type { Value } from '../../type-system/types.js'
-import type { FunctionContext } from '../functions.js'
+import type { ParameterContext } from '../functions.js'
 import { allocateParameter } from '../functions.js'
 import { Functions, Modules, Parameters } from '../type-helpers.js'
 
@@ -53,10 +53,10 @@ const gain = Functions.of({
 
   returnType: GainEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'gain',
-      gain: allocateParameter(context as FunctionContext, NumberFacet.get(args.gain))
+      gain: allocateParameter(context, NumberFacet.get(args.gain))
     }
 
     return GainEffectType.of(effect, {
@@ -74,10 +74,10 @@ const pan = Functions.of({
 
   returnType: PanEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'pan',
-      pan: allocateParameter(context as FunctionContext, NumberFacet.get(args.pan))
+      pan: allocateParameter(context, NumberFacet.get(args.pan))
     }
 
     return PanEffectType.of(effect, {
@@ -95,10 +95,10 @@ const lowpass = Functions.of({
 
   returnType: LowpassEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'lowpass',
-      frequency: allocateParameter(context as FunctionContext, NumberFacet.get(args.frequency))
+      frequency: allocateParameter(context, NumberFacet.get(args.frequency))
     }
 
     return LowpassEffectType.of(effect, {
@@ -116,10 +116,10 @@ const highpass = Functions.of({
 
   returnType: HighpassEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'highpass',
-      frequency: allocateParameter(context as FunctionContext, NumberFacet.get(args.frequency))
+      frequency: allocateParameter(context, NumberFacet.get(args.frequency))
     }
 
     return HighpassEffectType.of(effect, {
@@ -137,7 +137,7 @@ const width = Functions.of({
 
   returnType: WidthEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'width',
       width: NumberFacet.get(args.width)
@@ -159,12 +159,12 @@ const delay = Functions.of({
 
   returnType: DelayEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'delay',
       mix: NumberFacet.get(args.mix),
       time: NumberFacet.get(args.time),
-      feedback: allocateParameter(context as FunctionContext, NumberFacet.get(args.feedback)),
+      feedback: allocateParameter(context, NumberFacet.get(args.feedback)),
       wet: args.wet != null ? NumberFacet.get(args.wet) : UNITY_GAIN
     }
 
@@ -185,7 +185,7 @@ const reverb = Functions.of({
 
   returnType: ReverbEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'reverb',
       mix: NumberFacet.get(args.mix),
@@ -206,10 +206,10 @@ const clip = Functions.of({
 
   returnType: ClipEffectType,
 
-  invoke: (context, args) => {
+  invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'clip',
-      threshold: allocateParameter(context as FunctionContext, NumberFacet.get(args.threshold))
+      threshold: allocateParameter(context, NumberFacet.get(args.threshold))
     }
 
     return ClipEffectType.of(effect, {

--- a/packages/language/src/compiler/modules/instruments.ts
+++ b/packages/language/src/compiler/modules/instruments.ts
@@ -8,7 +8,7 @@ import { InstrumentFacet } from '../../type-system/domain/instrument.js'
 import { ParameterFacet } from '../../type-system/domain/parameter.js'
 import { makeType } from '../../type-system/factory.js'
 import type { Value } from '../../type-system/types.js'
-import type { FunctionContext } from '../functions.js'
+import type { InstrumentContext, ParameterContext } from '../functions.js'
 import { allocateInstrument, allocateParameter } from '../functions.js'
 import { Functions, Modules, Parameters } from '../type-helpers.js'
 
@@ -41,18 +41,16 @@ const sample = Functions.of({
   returnType: SampleInstrumentType,
 
   // eslint-disable-next-line camelcase
-  invoke: (context, { url, gain, root_note, length }) => {
-    const ctx = context as FunctionContext
-
+  invoke: (context: ParameterContext & InstrumentContext, { url, gain, root_note, length }) => {
     const urlValue = StringFacet.get(url)
     const gainValue = gain != null ? NumberFacet.get(gain) : UNITY_GAIN
     // eslint-disable-next-line camelcase
     const rootNoteValue = root_note != null ? StringFacet.get(root_note) : undefined
     const lengthValue = length != null ? NumberFacet.get(length) : undefined
 
-    const gainParameter = allocateParameter(ctx, gainValue)
+    const gainParameter = allocateParameter(context, gainValue)
 
-    const instrument = allocateInstrument(ctx, {
+    const instrument = allocateInstrument(context, {
       gain: gainParameter,
       rootNote: rootNoteValue != null && isPitch(rootNoteValue) ? rootNoteValue : undefined,
       source: {
@@ -78,13 +76,11 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
 
     returnType: OscillatorInstrumentType,
 
-    invoke: (context, { gain }) => {
-      const ctx = context as FunctionContext
-
+    invoke: (context: ParameterContext & InstrumentContext, { gain }) => {
       const gainValue = gain != null ? NumberFacet.get(gain) : UNITY_GAIN
-      const gainParameter = allocateParameter(ctx, gainValue)
+      const gainParameter = allocateParameter(context, gainValue)
 
-      const instrument = allocateInstrument(ctx, {
+      const instrument = allocateInstrument(context, {
         gain: gainParameter,
         source: {
           type: 'oscillator',

--- a/packages/language/src/compiler/modules/patterns.ts
+++ b/packages/language/src/compiler/modules/patterns.ts
@@ -14,7 +14,7 @@ const loop = Functions.of({
 
   returnType: PatternFacet.type(),
 
-  invoke: (_context, { pattern, times }) => {
+  invoke: (context, { pattern, times }) => {
     const patternValue = PatternFacet.get(pattern)
 
     if (times == null) {
@@ -46,7 +46,7 @@ const fill = Functions.of({
 
   returnType: PatternFacet.type(),
 
-  invoke: (_context, { pattern, duration }) => {
+  invoke: (context, { pattern, duration }) => {
     const patternValue = PatternFacet.get(pattern)
     const durationValue = NumberFacet.get(duration)
 

--- a/packages/language/src/compiler/type-helpers.ts
+++ b/packages/language/src/compiler/type-helpers.ts
@@ -13,7 +13,7 @@ import type { Schema } from '../type-system/schema.js'
 import type { Facet, FacetType, Value } from '../type-system/types.js'
 
 export const Functions = {
-  of: <const S extends Schema, const R extends FacetType> (value: Function<S, R>): Value => {
+  of: <const S extends Schema, const R extends FacetType, const Context> (value: Function<S, R, Context>): Value => {
     const type = makeType(FunctionFacet.with({
       parameters: value.parameters,
       returnType: value.returnType

--- a/packages/language/src/type-system/base/function.ts
+++ b/packages/language/src/type-system/base/function.ts
@@ -2,10 +2,10 @@ import { makeFacet } from '../factory.js'
 import type { InferSchema, Schema } from '../schema.js'
 import type { CustomComparable, FacetType, ValueForType } from '../types.js'
 
-export interface Function<S extends Schema = Schema, R extends FacetType = FacetType> {
+export interface Function<S extends Schema = Schema, R extends FacetType = FacetType, Context = never> {
   readonly parameters: S
   readonly returnType: R
-  readonly invoke: (context: unknown, args: InferSchema<S>) => ValueForType<R>
+  readonly invoke: (context: Context, args: InferSchema<S>) => ValueForType<R>
 
   // documentation
   readonly summary?: string

--- a/packages/language/test/compiler/modules/effects.test.ts
+++ b/packages/language/test/compiler/modules/effects.test.ts
@@ -5,10 +5,9 @@ import { describe, it } from 'node:test'
 import type { FunctionContext } from '../../../src/compiler/functions.js'
 import { effectsModule } from '../../../src/compiler/modules/effects.js'
 import { Numbers } from '../../../src/compiler/type-helpers.js'
-import { FunctionFacet } from '../../../src/type-system/base/function.js'
-import { ModuleFacet } from '../../../src/type-system/base/module.js'
 import { RecordFacet } from '../../../src/type-system/base/record.js'
 import { EffectFacet } from '../../../src/type-system/domain/effect.js'
+import { getFunctionExport } from './test-utils.js'
 
 function createFunctionContext (): FunctionContext {
   return {
@@ -22,12 +21,8 @@ describe('compiler/modules/effects.ts', () => {
   const beats = (value: number) => numeric('beats', value)
   const seconds = (value: number) => numeric('s', value)
 
-  const effects = ModuleFacet.get(effectsModule)
-
   describe('gain', () => {
-    const gainValue = effects.exports.get('gain')
-    assert.ok(gainValue != null && FunctionFacet.has(gainValue))
-    const gain = FunctionFacet.get(gainValue)
+    const gain = getFunctionExport(effectsModule, 'gain')
 
     it('should create gain effect', () => {
       const context = createFunctionContext()
@@ -48,9 +43,7 @@ describe('compiler/modules/effects.ts', () => {
   })
 
   describe('pan', () => {
-    const panValue = effects.exports.get('pan')
-    assert.ok(panValue != null && FunctionFacet.has(panValue))
-    const pan = FunctionFacet.get(panValue)
+    const pan = getFunctionExport(effectsModule, 'pan')
 
     it('should create pan effect', () => {
       const context = createFunctionContext()
@@ -71,9 +64,7 @@ describe('compiler/modules/effects.ts', () => {
   })
 
   describe('lowpass', () => {
-    const lowpassValue = effects.exports.get('lowpass')
-    assert.ok(lowpassValue != null && FunctionFacet.has(lowpassValue))
-    const lowpass = FunctionFacet.get(lowpassValue)
+    const lowpass = getFunctionExport(effectsModule, 'lowpass')
 
     it('should create lowpass effect', () => {
       const context = createFunctionContext()
@@ -94,9 +85,7 @@ describe('compiler/modules/effects.ts', () => {
   })
 
   describe('highpass', () => {
-    const highpassValue = effects.exports.get('highpass')
-    assert.ok(highpassValue != null && FunctionFacet.has(highpassValue))
-    const highpass = FunctionFacet.get(highpassValue)
+    const highpass = getFunctionExport(effectsModule, 'highpass')
 
     it('should create highpass effect', () => {
       const context = createFunctionContext()
@@ -117,9 +106,7 @@ describe('compiler/modules/effects.ts', () => {
   })
 
   describe('width', () => {
-    const widthValue = effects.exports.get('width')
-    assert.ok(widthValue != null && FunctionFacet.has(widthValue))
-    const width = FunctionFacet.get(widthValue)
+    const width = getFunctionExport(effectsModule, 'width')
 
     it('should create width effect', () => {
       const context = createFunctionContext()
@@ -137,9 +124,7 @@ describe('compiler/modules/effects.ts', () => {
   })
 
   describe('delay', () => {
-    const delayValue = effects.exports.get('delay')
-    assert.ok(delayValue != null && FunctionFacet.has(delayValue))
-    const delay = FunctionFacet.get(delayValue)
+    const delay = getFunctionExport(effectsModule, 'delay')
 
     it('should create delay effect', () => {
       const context = createFunctionContext()
@@ -201,9 +186,7 @@ describe('compiler/modules/effects.ts', () => {
   })
 
   describe('reverb', () => {
-    const reverbValue = effects.exports.get('reverb')
-    assert.ok(reverbValue != null && FunctionFacet.has(reverbValue))
-    const reverb = FunctionFacet.get(reverbValue)
+    const reverb = getFunctionExport(effectsModule, 'reverb')
 
     it('should create reverb effect', () => {
       const context = createFunctionContext()
@@ -254,9 +237,7 @@ describe('compiler/modules/effects.ts', () => {
   })
 
   describe('clip', () => {
-    const clipValue = effects.exports.get('clip')
-    assert.ok(clipValue != null && FunctionFacet.has(clipValue))
-    const clip = FunctionFacet.get(clipValue)
+    const clip = getFunctionExport(effectsModule, 'clip')
 
     it('should create clip effect', () => {
       const context = createFunctionContext()

--- a/packages/language/test/compiler/modules/instruments.test.ts
+++ b/packages/language/test/compiler/modules/instruments.test.ts
@@ -5,10 +5,9 @@ import { describe, it } from 'node:test'
 import type { FunctionContext } from '../../../src/compiler/functions.js'
 import { instrumentsModule } from '../../../src/compiler/modules/instruments.js'
 import { Numbers } from '../../../src/compiler/type-helpers.js'
-import { FunctionFacet } from '../../../src/type-system/base/function.js'
-import { ModuleFacet } from '../../../src/type-system/base/module.js'
 import { StringFacet } from '../../../src/type-system/base/string.js'
 import { InstrumentFacet } from '../../../src/type-system/domain/instrument.js'
+import { getFunctionExport } from './test-utils.js'
 
 function createFunctionContext (): FunctionContext {
   return {
@@ -18,8 +17,6 @@ function createFunctionContext (): FunctionContext {
 }
 
 describe('compiler/modules/instruments.ts', () => {
-  const instruments = ModuleFacet.get(instrumentsModule)
-
   const declickEnvelope: Envelope = {
     attack: numeric('s', 0.003),
     decay: numeric('s', 0),
@@ -28,9 +25,7 @@ describe('compiler/modules/instruments.ts', () => {
   }
 
   describe('sample', () => {
-    const sampleValue = instruments.exports.get('sample')
-    assert.ok(sampleValue != null && FunctionFacet.has(sampleValue))
-    const sample = FunctionFacet.get(sampleValue)
+    const sample = getFunctionExport(instrumentsModule, 'sample')
 
     it('should create instrument from sample', () => {
       const context = createFunctionContext()
@@ -75,9 +70,7 @@ describe('compiler/modules/instruments.ts', () => {
   })
 
   describe('sine', () => {
-    const sineValue = instruments.exports.get('sine')
-    assert.ok(sineValue != null && FunctionFacet.has(sineValue))
-    const sine = FunctionFacet.get(sineValue)
+    const sine = getFunctionExport(instrumentsModule, 'sine')
 
     it('should create oscillator instrument', () => {
       const context = createFunctionContext()
@@ -94,9 +87,7 @@ describe('compiler/modules/instruments.ts', () => {
   })
 
   describe('square', () => {
-    const squareValue = instruments.exports.get('square')
-    assert.ok(squareValue != null && FunctionFacet.has(squareValue))
-    const square = FunctionFacet.get(squareValue)
+    const square = getFunctionExport(instrumentsModule, 'square')
 
     it('should create oscillator instrument', () => {
       const context = createFunctionContext()
@@ -113,9 +104,7 @@ describe('compiler/modules/instruments.ts', () => {
   })
 
   describe('saw', () => {
-    const sawValue = instruments.exports.get('saw')
-    assert.ok(sawValue != null && FunctionFacet.has(sawValue))
-    const saw = FunctionFacet.get(sawValue)
+    const saw = getFunctionExport(instrumentsModule, 'saw')
 
     it('should create oscillator instrument', () => {
       const context = createFunctionContext()
@@ -132,9 +121,7 @@ describe('compiler/modules/instruments.ts', () => {
   })
 
   describe('triangle', () => {
-    const triangleValue = instruments.exports.get('triangle')
-    assert.ok(triangleValue != null && FunctionFacet.has(triangleValue))
-    const triangle = FunctionFacet.get(triangleValue)
+    const triangle = getFunctionExport(instrumentsModule, 'triangle')
 
     it('should create oscillator instrument', () => {
       const context = createFunctionContext()

--- a/packages/language/test/compiler/modules/patterns.test.ts
+++ b/packages/language/test/compiler/modules/patterns.test.ts
@@ -5,9 +5,8 @@ import { describe, it } from 'node:test'
 import type { FunctionContext } from '../../../src/compiler/functions.js'
 import { patternsModule } from '../../../src/compiler/modules/patterns.js'
 import { Numbers } from '../../../src/compiler/type-helpers.js'
-import { FunctionFacet } from '../../../src/type-system/base/function.js'
-import { ModuleFacet } from '../../../src/type-system/base/module.js'
 import { PatternFacet } from '../../../src/type-system/domain/pattern.js'
+import { getFunctionExport } from './test-utils.js'
 
 function createFunctionContext (): FunctionContext {
   return {
@@ -20,12 +19,8 @@ describe('compiler/modules/patterns.ts', () => {
   // helper to create Numeric<'beats'>
   const beats = (value: number) => numeric('beats', value)
 
-  const patterns = ModuleFacet.get(patternsModule)
-
   describe('loop', () => {
-    const loopValue = patterns.exports.get('loop')
-    assert.ok(loopValue != null && FunctionFacet.has(loopValue))
-    const loop = FunctionFacet.get(loopValue)
+    const loop = getFunctionExport(patternsModule, 'loop')
 
     it('should loop finite patterns infinitely', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
@@ -172,9 +167,7 @@ describe('compiler/modules/patterns.ts', () => {
   })
 
   describe('fill', () => {
-    const fillValue = patterns.exports.get('fill')
-    assert.ok(fillValue != null && FunctionFacet.has(fillValue))
-    const fill = FunctionFacet.get(fillValue)
+    const fill = getFunctionExport(patternsModule, 'fill')
 
     it('should loop finite patterns until the duration is filled', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([

--- a/packages/language/test/compiler/modules/test-utils.ts
+++ b/packages/language/test/compiler/modules/test-utils.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert'
+import type { FunctionContext } from '../../../src/compiler/functions.js'
+import type { Function } from '../../../src/type-system/base/function.js'
+import { FunctionFacet } from '../../../src/type-system/base/function.js'
+import { ModuleFacet } from '../../../src/type-system/base/module.js'
+import type { Schema } from '../../../src/type-system/schema.js'
+import type { FacetType, Value } from '../../../src/type-system/types.js'
+
+export function getModuleExport (moduleValue: Value, exportName: string): Value {
+  const module = ModuleFacet.get(moduleValue)
+
+  const exportValue = module.exports.get(exportName)
+  assert.ok(exportValue != null, `Module '${module.name}' does not export '${exportName}'`)
+
+  return exportValue
+}
+
+export function getFunctionExport (moduleValue: Value, exportName: string): Function<Schema, FacetType, FunctionContext> {
+  const exportValue = getModuleExport(moduleValue, exportName)
+  assert.ok(FunctionFacet.has(exportValue), `Export '${exportName}' is not a function`)
+
+  // cast due to context type
+  return FunctionFacet.get(exportValue) as Function<Schema, FacetType, FunctionContext>
+}

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -66,7 +66,7 @@ describe('type-system/base', () => {
 
       const value = typedType.of(func)
       const loadedFunction = typedFacet.get(value)
-      const result = loadedFunction.invoke(undefined, {
+      const result = loadedFunction.invoke(undefined as never, {
         amount: amountType.of(numeric('db', -6))
       })
 


### PR DESCRIPTION
This patch adds a generic to the `Function` type that represents the invocation context, allowing the function to use it directly without casting. The casting still needs to happen at the call site, however, this is just a single place, instead of one per function definition.