### PR TITLE
refactor: Replace BusType with specific resolution

### DIFF
--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -9,20 +9,20 @@ import { ModuleFacet } from '../type-system/base/module.js'
 import { NumberFacet } from '../type-system/base/number.js'
 import { RecordFacet } from '../type-system/base/record.js'
 import { StringFacet } from '../type-system/base/string.js'
+import { BusFacet } from '../type-system/domain/bus.js'
 import { CurveFacet } from '../type-system/domain/curve.js'
 import { EffectFacet } from '../type-system/domain/effect.js'
 import { InstrumentFacet } from '../type-system/domain/instrument.js'
 import { ParameterFacet } from '../type-system/domain/parameter.js'
 import { PartFacet } from '../type-system/domain/part.js'
 import { PatternFacet } from '../type-system/domain/pattern.js'
-import { makeUnion } from '../type-system/factory.js'
+import { makeType, makeUnion } from '../type-system/factory.js'
 import type { Schema, SchemaItem } from '../type-system/schema.js'
 import type { FacetType, Type, Value } from '../type-system/types.js'
 import { busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from './common.js'
 import { getCurveSegmentType } from './curves.js'
 import { CompileError } from './error.js'
 import { checkCyclicRoutings } from './routings.js'
-import { BusType } from '../type-system/helpers.js'
 import { isSyntaxUnit, toBaseUnit } from './units.js'
 
 export type CheckedProgram = Brand<ast.Program, 'language.CheckedProgram'>
@@ -48,26 +48,19 @@ export function check (program: ast.Program): CheckResult {
   const tracks = program.children.filter((c) => c.type === 'TrackStatement')
   const mixers = program.children.filter((c) => c.type === 'MixerStatement')
 
-  const top = createGlobalScope({
+  const globalScope = createGlobalScope({
     resolutions: importResult.result,
     buses: new Map()
   })
 
-  const context = createLocalScope(top)
+  const scope = createLocalScope(globalScope)
 
   const errors: CompileError[] = []
 
-  errors.push(...checkAssignments(context, assignments))
-
-  // Check mixers before tracks so that tracks can reference buses defined in the mixer
-  errors.push(...checkMixers(context, mixers))
-  for (const mixer of mixers) {
-    for (const bus of mixer.buses) {
-      context.buses.set(bus.name.name, BusType)
-    }
-  }
-
-  errors.push(...checkTracks(context, tracks))
+  // Order matters, as assignments and mixers populate the scope
+  errors.push(...checkAssignments(scope, assignments))
+  errors.push(...checkMixers(scope, mixers))
+  errors.push(...checkTracks(scope, tracks))
 
   return errors.length === 0 ? success(program as CheckedProgram) : failure(errors)
 }
@@ -324,60 +317,81 @@ function checkAutomation (context: Context, automation: ast.AutomateStatement): 
   const curveCheck = checkExpression(context, automation.curve)
   errors.push(...curveCheck.errors)
 
-  if (curveCheck.result != null) {
-    let curveType = CurveFacet.type()
-
-    if (targetCheck.result != null && ParameterFacet.is(targetCheck.result)) {
-      const parameterType = ParameterFacet.detail(targetCheck.result)
-      curveType = CurveFacet.with(parameterType).type()
-    }
-
-    errors.push(...checkType(curveType, curveCheck.result, automation.curve.range))
+  if (curveCheck.result == null) {
+    return errors
   }
+
+  let curveType = CurveFacet.type()
+
+  if (targetCheck.result != null && ParameterFacet.is(targetCheck.result)) {
+    const parameterType = ParameterFacet.detail(targetCheck.result)
+    curveType = CurveFacet.with(parameterType).type()
+  }
+
+  errors.push(...checkType(curveType, curveCheck.result, automation.curve.range))
 
   return errors
 }
 
-function checkMixers (context: Context, mixers: readonly ast.MixerStatement[]): readonly CompileError[] {
+function checkMixers (context: MutableContext, mixers: readonly ast.MixerStatement[]): readonly CompileError[] {
   const errors: CompileError[] = []
 
   for (const mixer of mixers) {
     if (mixers.length > 1) {
       errors.push(new CompileError('Multiple mixer definitions', mixer.range))
     }
-    errors.push(...checkMixer(context, mixer))
+
+    const mixerCheck = checkMixer(context, mixer)
+    errors.push(...mixerCheck.errors)
+
+    for (const [name, type] of mixerCheck.result?.buses.entries() ?? []) {
+      context.buses.set(name, type)
+    }
   }
 
   return errors
 }
 
-function checkMixer (context: Context, mixer: ast.MixerStatement): readonly CompileError[] {
-  const mixerContext = createLocalScope(context)
+interface MixerDetail {
+  readonly buses: ReadonlyMap<string, FacetType>
+}
+
+function checkMixer (context: Context, mixer: ast.MixerStatement): Checked<MixerDetail> {
+  const mixerScope = createLocalScope(context)
 
   const errors: CompileError[] = []
 
-  const propertiesCheck = checkArgumentList(mixerContext, mixer.properties, mixerSchema, mixer.range, 'property')
+  const propertiesCheck = checkArgumentList(mixerScope, mixer.properties, mixerSchema, mixer.range, 'property')
   errors.push(...propertiesCheck.errors)
 
-  const seenBuses = new Set<string>()
+  const seenBuses = new Map<string, FacetType>()
+
+  const declareBus = (name: string, type: FacetType): void => {
+    seenBuses.set(name, type)
+    mixerScope.resolutions.set(name, type)
+    mixerScope.buses.set(name, type)
+  }
 
   // Build up the list of buses first
   for (const bus of mixer.buses) {
     if (seenBuses.has(bus.name.name)) {
       errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
-    } else if (mixerContext.resolutions.has(bus.name.name)) {
+    } else if (mixerScope.resolutions.has(bus.name.name)) {
       errors.push(new CompileError(`Bus name "${bus.name.name}" conflicts with existing identifier`, bus.name.range))
     }
 
-    seenBuses.add(bus.name.name)
-
-    mixerContext.resolutions.set(bus.name.name, BusType)
-    mixerContext.buses.set(bus.name.name, BusType)
+    // reserve a generic type first
+    declareBus(bus.name.name, BusFacet.type())
   }
 
   // Now that all buses are known, we can check the routings
   for (const bus of mixer.buses) {
-    errors.push(...checkBus(mixerContext, bus))
+    const busCheck = checkBus(mixerScope, bus)
+    errors.push(...busCheck.errors)
+
+    if (busCheck.result != null) {
+      declareBus(bus.name.name, busCheck.result)
+    }
   }
 
   errors.push(...checkCyclicRoutings(mixer.buses.map((bus) => ({
@@ -386,10 +400,10 @@ function checkMixer (context: Context, mixer: ast.MixerStatement): readonly Comp
     range: bus.name.range
   }))))
 
-  return errors
+  return { errors, result: { buses: seenBuses } }
 }
 
-function checkBus (context: Context, bus: ast.BusStatement): readonly CompileError[] {
+function checkBus (context: Context, bus: ast.BusStatement): Checked<FacetType> {
   const errors: CompileError[] = []
 
   const propertiesCheck = checkArgumentList(context, bus.properties, busSchema, bus.range, 'property')
@@ -401,7 +415,7 @@ function checkBus (context: Context, bus: ast.BusStatement): readonly CompileErr
     errors.push(...sourceCheck.errors)
 
     if (sourceCheck.result != null) {
-      const options = makeUnion(InstrumentFacet.type(), BusType)
+      const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
       errors.push(...checkType(options, sourceCheck.result, source.range))
     }
   }
@@ -416,7 +430,12 @@ function checkBus (context: Context, bus: ast.BusStatement): readonly CompileErr
     }
   }
 
-  return errors
+  const type = makeType(BusFacet, RecordFacet.with({
+    gain: ParameterFacet.with('db').type(),
+    pan: ParameterFacet.with(undefined).type()
+  }))
+
+  return { errors, result: type }
 }
 
 function checkExpression (context: Context, expression: ast.Expression): Checked<FacetType> {

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -17,6 +17,8 @@ import { InstrumentFacet } from '../type-system/domain/instrument.js'
 import { ParameterFacet } from '../type-system/domain/parameter.js'
 import { PartFacet } from '../type-system/domain/part.js'
 import { PatternFacet } from '../type-system/domain/pattern.js'
+import { makeType } from '../type-system/factory.js'
+import { Numbers, Parameters } from '../type-system/helpers.js'
 import type { InferSchema, Schema } from '../type-system/schema.js'
 import type { FacetType, Value } from '../type-system/types.js'
 import type { CheckedProgram } from './checker.js'
@@ -27,7 +29,6 @@ import { CompileError } from './error.js'
 import type { GenerateOptions } from './options.js'
 import type { GlobalScope, MutableScope, Scope } from './scopes.js'
 import { createGlobalScope, createLocalScope, resolveInScope } from './scopes.js'
-import { BusType, Numbers, Parameters } from '../type-system/helpers.js'
 import { isSyntaxUnit, toNumberValue } from './units.js'
 
 /**
@@ -195,24 +196,8 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
 function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
   const mixerScope = createLocalScope(scope)
 
-  const buses = mixer?.buses.map((bus, index) => generateBus(mixerScope, bus, index as BusId)) ?? []
-  const routings: MixerRouting[] = []
-
-  if (mixer != null) {
-    for (const bus of buses) {
-      assert(!mixerScope.resolutions.has(bus.name))
-      const busValue = BusType.of(bus, {
-        gain: Parameters.of(bus.gain),
-        pan: Parameters.of(bus.pan)
-      })
-      mixerScope.resolutions.set(bus.name, busValue)
-      scope.top.buses.set(bus.name, busValue)
-    }
-
-    for (const bus of mixer.buses) {
-      routings.push(...generateBusRoutings(mixerScope, bus, buses))
-    }
-  }
+  const buses = mixer?.buses.map((bus) => generateBus(mixerScope, bus)) ?? []
+  const routings = mixer?.buses.flatMap((bus) => generateBusRoutings(mixerScope, bus)) ?? []
 
   // Implicit output routings for unrouted buses and instruments
   const unroutedBuses = new Set<BusId>(buses.map((b) => b.id))
@@ -244,7 +229,7 @@ function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
   return { buses, routings }
 }
 
-function generateBus (scope: Scope, bus: ast.BusStatement, id: BusId): Bus {
+function generateBus (scope: MutableScope, bus: ast.BusStatement): Bus {
   const name = bus.name.name
   const properties = resolveArgumentList(scope, bus.properties, busSchema)
 
@@ -260,11 +245,29 @@ function generateBus (scope: Scope, bus: ast.BusStatement, id: BusId): Bus {
   const gain = scope.top.allocateParameter(gainData)
   const pan = scope.top.allocateParameter(panData)
 
-  return { id, name, gain, pan, effects }
+  const data = scope.top.allocateBus({ name, gain, pan, effects })
+
+  const type = makeType(BusFacet, RecordFacet.with({
+    gain: ParameterFacet.with('db').type(),
+    pan: ParameterFacet.with(undefined).type()
+  }))
+
+  const value = type.of(data, {
+    gain: Parameters.of(gain),
+    pan: Parameters.of(pan)
+  })
+
+  assert(!scope.resolutions.has(name))
+  scope.resolutions.set(name, value)
+
+  assert(!scope.top.busValues.has(name))
+  scope.top.busValues.set(name, value)
+
+  return data
 }
 
-function generateBusRoutings (mixerScope: Scope, bus: ast.BusStatement, buses: readonly Bus[]): readonly MixerRouting[] {
-  const destination = nonNull(buses.find((b) => b.name === bus.name.name))
+function generateBusRoutings (mixerScope: Scope, bus: ast.BusStatement): readonly MixerRouting[] {
+  const destination = nonNull(mixerScope.top.buses.get(bus.name.name))
 
   return bus.sources.map((identifier) => {
     const source = resolve(mixerScope, identifier)
@@ -541,7 +544,7 @@ function computeDivide (left: Value, right: Value): Value {
 function resolvePropertyAccess (scope: Scope, expression: ast.PropertyAccess): Value {
   // Special case: "bus" namespace
   if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
-    return nonNull(scope.top.buses.get(expression.property.name))
+    return nonNull(scope.top.busValues.get(expression.property.name))
   }
 
   const object = resolve(scope, expression.object)

--- a/packages/language/src/compiler/scopes.ts
+++ b/packages/language/src/compiler/scopes.ts
@@ -1,9 +1,15 @@
-import type { Automation, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
+import type { Automation, Bus, BusId, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
 import type { Numeric, Unit } from '@utility'
-import type { GenerateOptions } from './options.js'
 import type { Value } from '../type-system/types.js'
+import type { GenerateOptions } from './options.js'
 
 // scope aspects
+
+type Context = BusContext & ParameterContext & InstrumentContext
+
+export interface BusContext {
+  readonly allocateBus: (data: Omit<Bus, 'id'>) => Bus
+}
 
 export interface ParameterContext {
   readonly allocateParameter: <U extends Unit>(initial: Numeric<U>) => Parameter<U>
@@ -22,10 +28,13 @@ export interface Scope {
   readonly resolutions: ReadonlyMap<string, Value>
 }
 
-export interface GlobalScope extends Scope, ParameterContext, InstrumentContext {
+export interface GlobalScope extends Scope, Context {
   readonly options: GenerateOptions
 
-  readonly buses: Map<string, Value>
+  // TODO generalize this to avoid the "bus" namespace special-case
+  readonly buses: Map<string, Bus>
+  readonly busValues: Map<string, Value>
+
   readonly instruments: Map<InstrumentId, Instrument>
   readonly automations: Map<ParameterId, Automation>
 }
@@ -46,9 +55,13 @@ export function createGlobalScope (options: GenerateOptions, initialResolutions:
 
     // from GlobalScope
     options,
-    instruments: new Map(),
     buses: new Map(),
+    busValues: new Map(),
+    instruments: new Map(),
     automations: new Map(),
+
+    // from BusContext
+    allocateBus: (data) => allocateBus(scope, data),
 
     // from ParameterContext
     allocateParameter: (initial) => allocateParameter(scope, initial),
@@ -85,6 +98,15 @@ export function resolveInScope (scope: Scope, name: string): Value | undefined {
 }
 
 // out-of-line implementations
+
+function allocateBus (scope: GlobalScope, data: Omit<Bus, 'id'>): Bus {
+  const id = scope.buses.size as BusId
+
+  const bus = { ...data, id }
+  scope.buses.set(bus.name, bus)
+
+  return bus
+}
 
 function allocateParameter<U extends Unit> (scope: GlobalScope, initial: Numeric<U>): Parameter<U> {
   const currentMaxId = Math.max(0, ...Array.from(scope.automations.keys()))

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -6,7 +6,6 @@ import type { Module } from './base/module.js'
 import { ModuleFacet } from './base/module.js'
 import { NumberFacet } from './base/number.js'
 import { RecordFacet } from './base/record.js'
-import { BusFacet } from './domain/bus.js'
 import { ParameterFacet } from './domain/parameter.js'
 import { makeType } from './factory.js'
 import type { Schema } from './schema.js'
@@ -54,8 +53,3 @@ export const Parameters = {
     return ParameterFacet.with(value.initial.unit).type().of(value)
   }
 }
-
-export const BusType = makeType(BusFacet, RecordFacet.with({
-  gain: ParameterFacet.with('db').type(),
-  pan: ParameterFacet.with(undefined).type()
-}))

--- a/packages/language/test/compiler/scopes.test.ts
+++ b/packages/language/test/compiler/scopes.test.ts
@@ -1,22 +1,23 @@
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
+import type { GenerateOptions } from '../../src/compiler/options.js'
 import { createGlobalScope, createLocalScope, resolveInScope } from '../../src/compiler/scopes.js'
 import { Numbers } from '../../src/type-system/helpers.js'
+
+const options: GenerateOptions = {
+  beatsPerBar: 4,
+  tempo: {
+    default: 120,
+    minimum: 20,
+    maximum: 300
+  }
+}
 
 describe('compiler/scopes.ts', () => {
   describe('createGlobalScope()', () => {
     it('should create a global scope with the provided options and initial resolutions', () => {
       const foo = Numbers.of(numeric('db', 12))
-
-      const options = {
-        beatsPerBar: 4,
-        tempo: {
-          default: 120,
-          minimum: 20,
-          maximum: 300
-        }
-      }
 
       const result = createGlobalScope(options, new Map([['foo', foo]]))
 
@@ -31,15 +32,37 @@ describe('compiler/scopes.ts', () => {
       assert.strictEqual(result.automations.size, 0)
     })
 
+    it('should allocate buses with unique IDs', () => {
+      const scope = createGlobalScope(options, new Map())
+
+      const bus1 = {
+        name: 'bus1',
+        gain: scope.allocateParameter(numeric('db', 0)),
+        pan: scope.allocateParameter(numeric(undefined, 0)),
+        effects: []
+      } as const
+
+      const bus2 = {
+        name: 'bus2',
+        gain: scope.allocateParameter(numeric('db', -3)),
+        pan: scope.allocateParameter(numeric(undefined, -0.5)),
+        effects: []
+      } as const
+
+      const allocated1 = scope.allocateBus(bus1)
+      const allocated2 = scope.allocateBus(bus2)
+
+      assert.strictEqual(allocated1.id, 0)
+      assert.strictEqual(allocated2.id, 1)
+
+      assert.deepStrictEqual([...scope.buses], [
+        ['bus1', { ...bus1, id: 0 }],
+        ['bus2', { ...bus2, id: 1 }]
+      ])
+    })
+
     it('should allocate parameters with unique IDs', () => {
-      const scope = createGlobalScope({
-        beatsPerBar: 4,
-        tempo: {
-          default: 120,
-          minimum: 20,
-          maximum: 300
-        }
-      }, new Map())
+      const scope = createGlobalScope(options, new Map())
 
       const param1 = scope.allocateParameter(numeric('db', 12))
       const param2 = scope.allocateParameter(numeric('db', 6))
@@ -54,14 +77,7 @@ describe('compiler/scopes.ts', () => {
     })
 
     it('should allocate instruments with unique IDs', () => {
-      const scope = createGlobalScope({
-        beatsPerBar: 4,
-        tempo: {
-          default: 120,
-          minimum: 20,
-          maximum: 300
-        }
-      }, new Map())
+      const scope = createGlobalScope(options, new Map())
 
       const instrument1 = {
         gain: scope.allocateParameter(numeric('db', -6)),
@@ -106,14 +122,7 @@ describe('compiler/scopes.ts', () => {
 
   describe('createLocalScope()', () => {
     it('should create a local scope with the provided parent and empty resolutions', () => {
-      const globalScope = createGlobalScope({
-        beatsPerBar: 4,
-        tempo: {
-          default: 120,
-          minimum: 20,
-          maximum: 300
-        }
-      }, new Map([
+      const globalScope = createGlobalScope(options, new Map([
         ['foo', Numbers.of(numeric('db', 12))]
       ]))
 
@@ -145,14 +154,7 @@ describe('compiler/scopes.ts', () => {
       const globalBaz = Numbers.of(numeric('db', 3))
       const localBaz = Numbers.of(numeric('db', 4))
 
-      const globalScope = createGlobalScope({
-        beatsPerBar: 4,
-        tempo: {
-          default: 120,
-          minimum: 20,
-          maximum: 300
-        }
-      }, new Map([
+      const globalScope = createGlobalScope(options, new Map([
         ['foo', globalFoo],
         ['baz', globalBaz]
       ]))


### PR DESCRIPTION
The checker and generator are now prepared to handle buses that diverge from the default type, which could be necessary to support user-defined properties on buses.