### PR TITLE
fix: Avoid O(n) complexity in ID allocation

### DIFF
--- a/packages/language/src/compiler/scopes.ts
+++ b/packages/language/src/compiler/scopes.ts
@@ -109,8 +109,7 @@ function allocateBus (scope: GlobalScope, data: Omit<Bus, 'id'>): Bus {
 }
 
 function allocateParameter<U extends Unit> (scope: GlobalScope, initial: Numeric<U>): Parameter<U> {
-  const currentMaxId = Math.max(0, ...Array.from(scope.automations.keys()))
-  const id = (currentMaxId + 1) as ParameterId
+  const id = scope.automations.size as ParameterId
 
   scope.automations.set(id, {
     parameterId: id,
@@ -121,8 +120,7 @@ function allocateParameter<U extends Unit> (scope: GlobalScope, initial: Numeric
 }
 
 function allocateInstrument (scope: GlobalScope, data: Omit<Instrument, 'id'>): Instrument {
-  const currentMaxId = Math.max(0, ...Array.from(scope.instruments.keys()))
-  const id = (currentMaxId + 1) as InstrumentId
+  const id = scope.instruments.size as InstrumentId
 
   const instrument = { ...data, id }
   scope.instruments.set(instrument.id, instrument)

--- a/packages/language/test/compiler/generator.test.ts
+++ b/packages/language/test/compiler/generator.test.ts
@@ -1,4 +1,4 @@
-import type { ParameterId, Program } from '@core'
+import type { Program } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -76,8 +76,9 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
     assert.deepStrictEqual(result.instruments.size, 1)
 
-    const instrument = result.instruments.get(1 as any)
-    assert.strictEqual(instrument?.source.type, 'sample')
+    const [instrument] = result.instruments.values()
+    assert.strictEqual(instrument.source.type, 'sample')
+    assert.strictEqual(instrument.source.url, 'kick.wav')
   })
 
   it('should support import aliases', () => {
@@ -89,8 +90,9 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
     assert.deepStrictEqual(result.instruments.size, 1)
 
-    const instrument = result.instruments.get(1 as any)
-    assert.strictEqual(instrument?.source.type, 'sample')
+    const [instrument] = result.instruments.values()
+    assert.strictEqual(instrument.source.type, 'sample')
+    assert.strictEqual(instrument.source.url, 'kick.wav')
   })
 
   it('should support shadowing of imported names', () => {
@@ -139,7 +141,8 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
 
     assert.strictEqual(result.automations.size, 1)
-    const automation = [...result.automations.values()][0]
+    const [automation] = result.automations.values()
+
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
       { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
@@ -160,7 +163,8 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
 
     assert.strictEqual(result.automations.size, 1)
-    const automation = [...result.automations.values()][0]
+    const [automation] = result.automations.values()
+
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
       { time: numeric('beats', 8), value: numeric('db', -30), curve: 'linear' },
@@ -182,7 +186,8 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
 
     assert.strictEqual(result.automations.size, 1)
-    const automation = [...result.automations.values()][0]
+    const [automation] = result.automations.values()
+
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
       { time: numeric('beats', 24), value: numeric('db', -60), curve: 'step' },
@@ -204,7 +209,8 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
 
     assert.strictEqual(result.automations.size, 1)
-    const automation = [...result.automations.values()][0]
+    const [automation] = result.automations.values()
+
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
       { time: numeric('beats', 24), value: numeric('db', -60), curve: 'step' },
@@ -226,7 +232,8 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
 
     assert.strictEqual(result.automations.size, 1)
-    const automation = [...result.automations.values()][0]
+    const [automation] = result.automations.values()
+
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
       { time: numeric('beats', 24), value: numeric('db', -30), curve: 'linear' },
@@ -248,7 +255,8 @@ describe('compiler/generator.ts', () => {
     const result = generateSource(source)
 
     assert.strictEqual(result.automations.size, 1)
-    const automation = [...result.automations.values()][0]
+    const [automation] = result.automations.values()
+
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
       { time: numeric('beats', 0), value: numeric('db', -30), curve: 'step' },
@@ -270,8 +278,7 @@ describe('compiler/generator.ts', () => {
 
     const result = generateSource(source)
 
-    const busGain = result.mixer.buses[0].gain
-    const automation = result.automations.get(busGain.id)
+    const automation = result.automations.get(result.mixer.buses[0].gain.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
       { time: numeric('beats', 0), value: numeric('db', -20), curve: 'step' },
@@ -317,11 +324,14 @@ describe('compiler/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
+
+    const [instrument] = result.instruments.values()
+
     assert.deepStrictEqual(result.mixer.routings, [
       {
         implicit: true,
         destination: { type: 'output' },
-        source: { type: 'instrument', id: 1 }
+        source: { type: 'instrument', id: instrument.id }
       }
     ])
   })
@@ -329,22 +339,29 @@ describe('compiler/generator.ts', () => {
   it('should support buses as sources in mixer', () => {
     const source = [
       'mixer {',
-      '  bus bus1 { bus2 }',
-      '  bus bus2 {}',
+      '  bus bus0 { bus1 }',
+      '  bus bus1 {}',
       '}'
     ].join('\n')
 
     const result = generateSource(source)
+
+    const bus0 = result.mixer.buses.find((bus) => bus.name === 'bus0')
+    assert.ok(bus0 != null)
+
+    const bus1 = result.mixer.buses.find((bus) => bus.name === 'bus1')
+    assert.ok(bus1 != null)
+
     assert.deepStrictEqual(result.mixer.routings, [
       {
         implicit: false,
-        destination: { type: 'bus', id: 0 },
-        source: { type: 'bus', id: 1 }
+        destination: { type: 'bus', id: bus0.id },
+        source: { type: 'bus', id: bus1.id }
       },
       {
         implicit: true,
         destination: { type: 'output' },
-        source: { type: 'bus', id: 0 }
+        source: { type: 'bus', id: bus0.id }
       }
     ])
   })
@@ -353,19 +370,23 @@ describe('compiler/generator.ts', () => {
     const source = [
       'use "effects" as fx',
       'mixer {',
-      '  bus bus1 {',
+      '  bus bus0 {',
       '    effect fx.delay(mix: 0.25, time: 1.5.s, feedback: 0.4)',
       '  }',
       '}'
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.mixer.buses[0].effects[0], {
+
+    const effect = result.mixer.buses[0].effects[0]
+    assert.strictEqual(effect.type, 'delay')
+
+    assert.deepStrictEqual(effect, {
       type: 'delay',
       mix: numeric(undefined, 0.25),
       time: numeric('s', 1.5),
       feedback: {
-        id: 1 as ParameterId,
+        id: effect.feedback.id,
         initial: numeric(undefined, 0.4)
       },
       wet: numeric('db', 0)
@@ -376,7 +397,7 @@ describe('compiler/generator.ts', () => {
     const source = [
       'use "effects" as fx',
       'mixer {',
-      '  bus bus1 {',
+      '  bus bus0 {',
       '    effect fx.reverb(mix: 0.25, decay: 2.beats)',
       '  }',
       '}'
@@ -388,62 +409,6 @@ describe('compiler/generator.ts', () => {
       mix: numeric(undefined, 0.25),
       decay: numeric('beats', 2),
       wet: numeric('db', 0)
-    })
-  })
-
-  describe('instruments.sample', () => {
-    it('should allocate instrument and parameter IDs correctly', () => {
-      const source = [
-        'use "instruments" as *',
-        'inst1 = sample(url: "sample1.wav")',
-        'inst2 = sample(url: "sample2.wav")'
-      ].join('\n')
-
-      const result = generateSource(source)
-      assert.deepStrictEqual(result.instruments.size, 2)
-
-      const instrument1 = result.instruments.get(1 as any)
-      assert.strictEqual(instrument1?.source.type, 'sample')
-      assert.deepStrictEqual(instrument1.source.url, 'sample1.wav')
-
-      const instrument2 = result.instruments.get(2 as any)
-      assert.strictEqual(instrument2?.source.type, 'sample')
-      assert.deepStrictEqual(instrument2.source.url, 'sample2.wav')
-
-      assert.deepStrictEqual(result.automations.size, 2)
-      assert.deepStrictEqual(result.instruments.get(1 as any)?.gain.id, 1 as any)
-      assert.deepStrictEqual(result.instruments.get(2 as any)?.gain.id, 2 as any)
-      assert.deepStrictEqual(result.automations.get(1 as any)?.parameterId, 1 as any)
-      assert.deepStrictEqual(result.automations.get(2 as any)?.parameterId, 2 as any)
-    })
-  })
-
-  describe('instruments.sine', () => {
-    it('should allocate instrument and parameter IDs correctly', () => {
-      const source = [
-        'use "instruments" as *',
-        'inst1 = sine(gain: -6.db)',
-        'inst2 = sine(gain: -12.db)'
-      ].join('\n')
-
-      const result = generateSource(source)
-      assert.deepStrictEqual(result.instruments.size, 2)
-
-      const instrument1 = result.instruments.get(1 as any)
-      assert.strictEqual(instrument1?.source.type, 'oscillator')
-      assert.strictEqual(instrument1.source.shape, 'sine')
-      assert.deepStrictEqual(instrument1.gain.initial, numeric('db', -6))
-
-      const instrument2 = result.instruments.get(2 as any)
-      assert.strictEqual(instrument2?.source.type, 'oscillator')
-      assert.strictEqual(instrument2.source.shape, 'sine')
-      assert.deepStrictEqual(instrument2.gain.initial, numeric('db', -12))
-
-      assert.deepStrictEqual(result.automations.size, 2)
-      assert.deepStrictEqual(result.instruments.get(1 as any)?.gain.id, 1 as any)
-      assert.deepStrictEqual(result.instruments.get(2 as any)?.gain.id, 2 as any)
-      assert.deepStrictEqual(result.automations.get(1 as any)?.parameterId, 1 as any)
-      assert.deepStrictEqual(result.automations.get(2 as any)?.parameterId, 2 as any)
     })
   })
 })

--- a/packages/language/test/compiler/scopes.test.ts
+++ b/packages/language/test/compiler/scopes.test.ts
@@ -35,51 +35,51 @@ describe('compiler/scopes.ts', () => {
     it('should allocate buses with unique IDs', () => {
       const scope = createGlobalScope(options, new Map())
 
-      const bus1 = {
-        name: 'bus1',
+      const bus0 = {
+        name: 'bus0',
         gain: scope.allocateParameter(numeric('db', 0)),
         pan: scope.allocateParameter(numeric(undefined, 0)),
         effects: []
       } as const
 
-      const bus2 = {
-        name: 'bus2',
+      const bus1 = {
+        name: 'bus1',
         gain: scope.allocateParameter(numeric('db', -3)),
         pan: scope.allocateParameter(numeric(undefined, -0.5)),
         effects: []
       } as const
 
-      const allocated1 = scope.allocateBus(bus1)
-      const allocated2 = scope.allocateBus(bus2)
+      const allocated1 = scope.allocateBus(bus0)
+      const allocated2 = scope.allocateBus(bus1)
 
       assert.strictEqual(allocated1.id, 0)
       assert.strictEqual(allocated2.id, 1)
 
       assert.deepStrictEqual([...scope.buses], [
-        ['bus1', { ...bus1, id: 0 }],
-        ['bus2', { ...bus2, id: 1 }]
+        ['bus0', { ...bus0, id: 0 }],
+        ['bus1', { ...bus1, id: 1 }]
       ])
     })
 
     it('should allocate parameters with unique IDs', () => {
       const scope = createGlobalScope(options, new Map())
 
-      const param1 = scope.allocateParameter(numeric('db', 12))
-      const param2 = scope.allocateParameter(numeric('db', 6))
+      const parameter0 = scope.allocateParameter(numeric('db', 12))
+      const parameter1 = scope.allocateParameter(numeric('db', 6))
 
-      assert.strictEqual(param1.id, 1)
-      assert.strictEqual(param2.id, 2)
+      assert.strictEqual(parameter0.id, 0)
+      assert.strictEqual(parameter1.id, 1)
 
       assert.deepStrictEqual([...scope.automations], [
-        [1, { parameterId: 1, points: [] }],
-        [2, { parameterId: 2, points: [] }]
+        [0, { parameterId: 0, points: [] }],
+        [1, { parameterId: 1, points: [] }]
       ])
     })
 
     it('should allocate instruments with unique IDs', () => {
       const scope = createGlobalScope(options, new Map())
 
-      const instrument1 = {
+      const instrument0 = {
         gain: scope.allocateParameter(numeric('db', -6)),
         source: {
           type: 'oscillator',
@@ -93,7 +93,7 @@ describe('compiler/scopes.ts', () => {
         }
       } as const
 
-      const instrument2 = {
+      const instrument1 = {
         gain: scope.allocateParameter(numeric('db', -3)),
         source: {
           type: 'oscillator',
@@ -107,15 +107,15 @@ describe('compiler/scopes.ts', () => {
         }
       } as const
 
+      const allocated0 = scope.allocateInstrument(instrument0)
       const allocated1 = scope.allocateInstrument(instrument1)
-      const allocated2 = scope.allocateInstrument(instrument2)
 
+      assert.strictEqual(allocated0.id, 0)
       assert.strictEqual(allocated1.id, 1)
-      assert.strictEqual(allocated2.id, 2)
 
       assert.deepStrictEqual([...scope.instruments], [
-        [1, { ...instrument1, id: 1 }],
-        [2, { ...instrument2, id: 2 }]
+        [0, { ...instrument0, id: 0 }],
+        [1, { ...instrument1, id: 1 }]
       ])
     })
   })

--- a/packages/language/test/library/modules/effects.test.ts
+++ b/packages/language/test/library/modules/effects.test.ts
@@ -1,13 +1,12 @@
-import type { ParameterId } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GlobalScope } from '../../../src/compiler/scopes.js'
 import { createGlobalScope } from '../../../src/compiler/scopes.js'
-import { Numbers } from '../../../src/type-system/helpers.js'
 import { effectsModule } from '../../../src/library/modules/effects.js'
 import { RecordFacet } from '../../../src/type-system/base/record.js'
 import { EffectFacet } from '../../../src/type-system/domain/effect.js'
+import { Numbers } from '../../../src/type-system/helpers.js'
 import { getFunctionExport } from './test-utils.js'
 
 function createFunctionContext (): GlobalScope {
@@ -30,14 +29,18 @@ describe('library/modules/effects.ts', () => {
     const gain = getFunctionExport(effectsModule, 'gain')
 
     it('should create gain effect', () => {
-      const result = gain.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = gain.invoke(context, {
         gain: Numbers.of(numeric('db', -6))
       })
+
+      const [gainId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'gain',
         gain: {
-          id: 1,
+          id: gainId,
           initial: numeric('db', -6)
         }
       })
@@ -50,14 +53,18 @@ describe('library/modules/effects.ts', () => {
     const pan = getFunctionExport(effectsModule, 'pan')
 
     it('should create pan effect', () => {
-      const result = pan.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = pan.invoke(context, {
         pan: Numbers.of(numeric(undefined, 0.5))
       })
+
+      const [panId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'pan',
         pan: {
-          id: 1,
+          id: panId,
           initial: numeric(undefined, 0.5)
         }
       })
@@ -70,14 +77,18 @@ describe('library/modules/effects.ts', () => {
     const lowpass = getFunctionExport(effectsModule, 'lowpass')
 
     it('should create lowpass effect', () => {
-      const result = lowpass.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = lowpass.invoke(context, {
         frequency: Numbers.of(numeric('hz', 1000))
       })
+
+      const [frequencyId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'lowpass',
         frequency: {
-          id: 1,
+          id: frequencyId,
           initial: numeric('hz', 1000)
         }
       })
@@ -90,14 +101,18 @@ describe('library/modules/effects.ts', () => {
     const highpass = getFunctionExport(effectsModule, 'highpass')
 
     it('should create highpass effect', () => {
-      const result = highpass.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = highpass.invoke(context, {
         frequency: Numbers.of(numeric('hz', 200))
       })
+
+      const [frequencyId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'highpass',
         frequency: {
-          id: 1,
+          id: frequencyId,
           initial: numeric('hz', 200)
         }
       })
@@ -110,7 +125,9 @@ describe('library/modules/effects.ts', () => {
     const width = getFunctionExport(effectsModule, 'width')
 
     it('should create width effect', () => {
-      const result = width.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = width.invoke(context, {
         width: Numbers.of(numeric(undefined, 0.8))
       })
 
@@ -127,18 +144,22 @@ describe('library/modules/effects.ts', () => {
     const delay = getFunctionExport(effectsModule, 'delay')
 
     it('should create delay effect', () => {
-      const result = delay.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = delay.invoke(context, {
         mix: Numbers.of(numeric(undefined, 0.5)),
         time: Numbers.of(beats(0.5)),
         feedback: Numbers.of(numeric(undefined, 0.3))
       })
+
+      const [feedbackId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'delay',
         mix: numeric(undefined, 0.5),
         time: beats(0.5),
         feedback: {
-          id: 1 as ParameterId,
+          id: feedbackId,
           initial: numeric(undefined, 0.3)
         },
         wet: numeric('db', 0)
@@ -148,18 +169,22 @@ describe('library/modules/effects.ts', () => {
     })
 
     it('should create delay effect with seconds', () => {
-      const result = delay.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = delay.invoke(context, {
         mix: Numbers.of(numeric(undefined, 0.5)),
         time: Numbers.of(seconds(1.5)),
         feedback: Numbers.of(numeric(undefined, 0.3))
       })
+
+      const [feedbackId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'delay',
         mix: numeric(undefined, 0.5),
         time: seconds(1.5),
         feedback: {
-          id: 1 as ParameterId,
+          id: feedbackId,
           initial: numeric(undefined, 0.3)
         },
         wet: numeric('db', 0)
@@ -169,7 +194,9 @@ describe('library/modules/effects.ts', () => {
     })
 
     it('should accept optional wet parameter', () => {
-      const result = delay.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = delay.invoke(context, {
         mix: Numbers.of(numeric(undefined, 0.5)),
         time: Numbers.of(beats(0.5)),
         feedback: Numbers.of(numeric(undefined, 0.3)),
@@ -186,7 +213,9 @@ describe('library/modules/effects.ts', () => {
     const reverb = getFunctionExport(effectsModule, 'reverb')
 
     it('should create reverb effect', () => {
-      const result = reverb.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = reverb.invoke(context, {
         decay: Numbers.of(numeric('s', 2.0)),
         mix: Numbers.of(numeric(undefined, 0.4))
       })
@@ -202,7 +231,9 @@ describe('library/modules/effects.ts', () => {
     })
 
     it('should create reverb effect with beats', () => {
-      const result = reverb.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = reverb.invoke(context, {
         decay: Numbers.of(beats(2)),
         mix: Numbers.of(numeric(undefined, 0.4))
       })
@@ -218,7 +249,9 @@ describe('library/modules/effects.ts', () => {
     })
 
     it('should accept optional wet parameter', () => {
-      const result = reverb.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = reverb.invoke(context, {
         decay: Numbers.of(numeric('s', 2.0)),
         mix: Numbers.of(numeric(undefined, 0.4)),
         wet: Numbers.of(numeric('db', -3))
@@ -234,14 +267,18 @@ describe('library/modules/effects.ts', () => {
     const clip = getFunctionExport(effectsModule, 'clip')
 
     it('should create clip effect', () => {
-      const result = clip.invoke(createFunctionContext(), {
+      const context = createFunctionContext()
+
+      const result = clip.invoke(context, {
         threshold: Numbers.of(numeric(undefined, 0.8))
       })
+
+      const [thresholdId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'clip',
         threshold: {
-          id: 1 as ParameterId,
+          id: thresholdId,
           initial: numeric(undefined, 0.8)
         }
       })

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -42,10 +42,11 @@ describe('library/modules/instruments.ts', () => {
         length: Numbers.of(numeric('s', 1.5))
       })
 
-      assert.deepStrictEqual(InstrumentFacet.get(result), {
-        id: 1,
+      const { id, ...instrument } = InstrumentFacet.get(result)
+
+      assert.deepStrictEqual(instrument, {
         rootNote: 'C4',
-        gain: { id: 1, initial: numeric('db', -3) },
+        gain: { id: instrument.gain.id, initial: numeric('db', -3) },
         source: {
           type: 'sample',
           url: 'https://example.com/kick.wav',
@@ -54,23 +55,36 @@ describe('library/modules/instruments.ts', () => {
         envelope: declickEnvelope
       })
 
-      assert.deepStrictEqual([...context.instruments.values()], [InstrumentFacet.get(result)])
+      assert.deepStrictEqual([...context.instruments], [
+        [id, InstrumentFacet.get(result)]
+      ])
+
+      assert.deepStrictEqual([...context.automations.keys()], [instrument.gain.id])
     })
 
-    it('should create instrument with default values', () => {
+    it('should use default values', () => {
       const url = 'https://example.com/snare.wav'
 
       const context = createFunctionContext()
 
-      const result = sample.invoke(context, { url: StringFacet.type().of(url) })
-      assert.deepStrictEqual(InstrumentFacet.get(result), {
-        id: 1,
+      const result = sample.invoke(context, {
+        url: StringFacet.type().of(url)
+      })
+
+      const { id, ...instrument } = InstrumentFacet.get(result)
+
+      assert.deepStrictEqual(instrument, {
         rootNote: undefined,
-        gain: { id: 1, initial: numeric('db', 0) },
+        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
         source: { type: 'sample', url, length: undefined },
         envelope: declickEnvelope
       })
-      assert.deepStrictEqual([...context.instruments.values()], [InstrumentFacet.get(result)])
+
+      assert.deepStrictEqual([...context.instruments], [
+        [id, InstrumentFacet.get(result)]
+      ])
+
+      assert.deepStrictEqual([...context.automations.keys()], [instrument.gain.id])
     })
   })
 
@@ -81,13 +95,19 @@ describe('library/modules/instruments.ts', () => {
       const context = createFunctionContext()
 
       const result = sine.invoke(context, {})
-      assert.deepStrictEqual(InstrumentFacet.get(result), {
-        id: 1,
-        gain: { id: 1, initial: numeric('db', 0) },
+      const { id, ...instrument } = InstrumentFacet.get(result)
+
+      assert.deepStrictEqual(instrument, {
+        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
         source: { type: 'oscillator', shape: 'sine' },
         envelope: declickEnvelope
       })
-      assert.deepStrictEqual([...context.instruments.values()], [InstrumentFacet.get(result)])
+
+      assert.deepStrictEqual([...context.instruments], [
+        [id, InstrumentFacet.get(result)]
+      ])
+
+      assert.deepStrictEqual([...context.automations.keys()], [instrument.gain.id])
     })
   })
 
@@ -98,13 +118,19 @@ describe('library/modules/instruments.ts', () => {
       const context = createFunctionContext()
 
       const result = square.invoke(context, {})
-      assert.deepStrictEqual(InstrumentFacet.get(result), {
-        id: 1,
-        gain: { id: 1, initial: numeric('db', 0) },
+      const { id, ...instrument } = InstrumentFacet.get(result)
+
+      assert.deepStrictEqual(instrument, {
+        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
         source: { type: 'oscillator', shape: 'square' },
         envelope: declickEnvelope
       })
-      assert.deepStrictEqual([...context.instruments.values()], [InstrumentFacet.get(result)])
+
+      assert.deepStrictEqual([...context.instruments], [
+        [id, InstrumentFacet.get(result)]
+      ])
+
+      assert.deepStrictEqual([...context.automations.keys()], [instrument.gain.id])
     })
   })
 
@@ -115,13 +141,19 @@ describe('library/modules/instruments.ts', () => {
       const context = createFunctionContext()
 
       const result = saw.invoke(context, {})
-      assert.deepStrictEqual(InstrumentFacet.get(result), {
-        id: 1,
-        gain: { id: 1, initial: numeric('db', 0) },
+      const { id, ...instrument } = InstrumentFacet.get(result)
+
+      assert.deepStrictEqual(instrument, {
+        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
         source: { type: 'oscillator', shape: 'saw' },
         envelope: declickEnvelope
       })
-      assert.deepStrictEqual([...context.instruments.values()], [InstrumentFacet.get(result)])
+
+      assert.deepStrictEqual([...context.instruments], [
+        [id, InstrumentFacet.get(result)]
+      ])
+
+      assert.deepStrictEqual([...context.automations.keys()], [instrument.gain.id])
     })
   })
 
@@ -132,13 +164,19 @@ describe('library/modules/instruments.ts', () => {
       const context = createFunctionContext()
 
       const result = triangle.invoke(context, {})
-      assert.deepStrictEqual(InstrumentFacet.get(result), {
-        id: 1,
-        gain: { id: 1, initial: numeric('db', 0) },
+      const { id, ...instrument } = InstrumentFacet.get(result)
+
+      assert.deepStrictEqual(instrument, {
+        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
         source: { type: 'oscillator', shape: 'triangle' },
         envelope: declickEnvelope
       })
-      assert.deepStrictEqual([...context.instruments.values()], [InstrumentFacet.get(result)])
+
+      assert.deepStrictEqual([...context.instruments], [
+        [id, InstrumentFacet.get(result)]
+      ])
+
+      assert.deepStrictEqual([...context.automations.keys()], [instrument.gain.id])
     })
   })
 })


### PR DESCRIPTION
IDs for buses, instruments, and parameters are now all assigned starting at zero, based on the current size of the corresponding map. This avoids iterating over the map to find the next available ID which was defensive but also inefficient.

Instead of changing the IDs throughout the test suite, the tests have been updated to (mostly) not depend on specific ID values.