### PR TITLE
refactor: Introduce namespace concept in compiler

### DIFF
--- a/packages/language/src/compiler/checker.ts
+++ b/packages/language/src/compiler/checker.ts
@@ -19,7 +19,7 @@ import { PatternFacet } from '../type-system/domain/pattern.js'
 import { makeType, makeUnion } from '../type-system/factory.js'
 import type { Schema, SchemaItem } from '../type-system/schema.js'
 import type { FacetType, Type, Value } from '../type-system/types.js'
-import { busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from './common.js'
+import { BUS_NAMESPACE, busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from './common.js'
 import { getCurveSegmentType } from './curves.js'
 import { CompileError } from './error.js'
 import { checkCyclicRoutings } from './routings.js'
@@ -50,6 +50,7 @@ export function check (program: ast.Program): CheckResult {
 
   const globalScope = createGlobalScope({
     resolutions: importResult.result,
+    namespaces: new Map(),
     buses: new Map()
   })
 
@@ -66,14 +67,26 @@ export function check (program: ast.Program): CheckResult {
 }
 
 interface Context {
+  readonly top: GlobalContext
   readonly parent?: Context
   readonly resolutions: ReadonlyMap<string, FacetType>
-  readonly buses: ReadonlyMap<string, FacetType>
+}
+
+interface GlobalContext extends Context {
+  readonly buses: Map<string, FacetType>
+  readonly namespaces: Map<string, Namespace>
 }
 
 interface MutableContext extends Context {
   readonly resolutions: Map<string, FacetType>
-  readonly buses: Map<string, FacetType>
+}
+
+interface Namespace {
+  readonly resolutions: ReadonlyMap<string, FacetType>
+}
+
+interface MutableNamespace extends Namespace {
+  readonly resolutions: Map<string, FacetType>
 }
 
 interface Checked<TValue> {
@@ -92,15 +105,23 @@ function prependErrors<TValue> (errors: readonly CompileError[], check: Checked<
   }
 }
 
-function createGlobalScope (value: Omit<Context, 'parent'>): Context {
-  return value
+function createGlobalScope (value: Omit<GlobalContext, 'top' | 'parent'>): GlobalContext {
+  const scope = {
+    ...value,
+
+    get top (): GlobalContext {
+      return scope
+    }
+  }
+
+  return scope
 }
 
 function createLocalScope (parent: Context): MutableContext {
   return {
+    top: parent.top,
     parent,
-    resolutions: new Map(),
-    buses: new Map()
+    resolutions: new Map()
   }
 }
 
@@ -129,10 +150,6 @@ function recursiveLookup<T> (context: Context, lookup: (context: Context) => T |
 
 function resolve (context: Context, name: string): FacetType | undefined {
   return recursiveLookup(context, (ctx) => ctx.resolutions.get(name))
-}
-
-function resolveBus (context: Context, name: string): FacetType | undefined {
-  return recursiveLookup(context, (ctx) => ctx.buses.get(name))
 }
 
 function checkType (expected: Pick<Type, 'is' | 'format'>, actual: Type, range?: SourceRange): readonly CompileError[] {
@@ -333,7 +350,10 @@ function checkAutomation (context: Context, automation: ast.AutomateStatement): 
   return errors
 }
 
-function checkMixers (context: MutableContext, mixers: readonly ast.MixerStatement[]): readonly CompileError[] {
+function checkMixers (scope: MutableContext, mixers: readonly ast.MixerStatement[]): readonly CompileError[] {
+  const busNamespace: MutableNamespace = { resolutions: new Map() }
+  scope.top.namespaces.set(BUS_NAMESPACE, busNamespace)
+
   const errors: CompileError[] = []
 
   for (const mixer of mixers) {
@@ -341,11 +361,11 @@ function checkMixers (context: MutableContext, mixers: readonly ast.MixerStateme
       errors.push(new CompileError('Multiple mixer definitions', mixer.range))
     }
 
-    const mixerCheck = checkMixer(context, mixer)
+    const mixerCheck = checkMixer(scope, mixer, busNamespace)
     errors.push(...mixerCheck.errors)
 
     for (const [name, type] of mixerCheck.result?.buses.entries() ?? []) {
-      context.buses.set(name, type)
+      scope.top.buses.set(name, type)
     }
   }
 
@@ -356,8 +376,8 @@ interface MixerDetail {
   readonly buses: ReadonlyMap<string, FacetType>
 }
 
-function checkMixer (context: Context, mixer: ast.MixerStatement): Checked<MixerDetail> {
-  const mixerScope = createLocalScope(context)
+function checkMixer (scope: Context, mixer: ast.MixerStatement, busNamespace: MutableNamespace): Checked<MixerDetail> {
+  const mixerScope = createLocalScope(scope)
 
   const errors: CompileError[] = []
 
@@ -369,7 +389,8 @@ function checkMixer (context: Context, mixer: ast.MixerStatement): Checked<Mixer
   const declareBus = (name: string, type: FacetType): void => {
     seenBuses.set(name, type)
     mixerScope.resolutions.set(name, type)
-    mixerScope.buses.set(name, type)
+    mixerScope.top.buses.set(name, type)
+    busNamespace.resolutions.set(name, type)
   }
 
   // Build up the list of buses first
@@ -769,17 +790,17 @@ function checkDivide (left: FacetType, right: FacetType, range: SourceRange): Ch
 function checkPropertyAccess (context: Context, expression: ast.PropertyAccess): Checked<FacetType> {
   const errors: CompileError[] = []
 
-  // Special case: "bus" namespace
-  if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
-    const busName = expression.property.name
+  if (expression.object.type === 'Identifier') {
+    const namespace = context.top.namespaces.get(expression.object.name)
+    if (namespace != null) {
+      const propertyType = namespace.resolutions.get(expression.property.name)
+      if (propertyType == null) {
+        errors.push(new CompileError(`Namespace "${expression.object.name}" has no member named "${expression.property.name}"`, expression.property.range))
+        return { errors }
+      }
 
-    const busType = resolveBus(context, busName)
-    if (busType == null) {
-      errors.push(new CompileError(`Unknown bus "${busName}"`, expression.property.range))
-      return { errors }
+      return { errors, result: propertyType }
     }
-
-    return { errors, result: busType }
   }
 
   const objectCheck = checkExpression(context, expression.object)

--- a/packages/language/src/compiler/common.ts
+++ b/packages/language/src/compiler/common.ts
@@ -1,6 +1,8 @@
 import { NumberFacet } from '../type-system/base/number.js'
 import { makeSchema } from '../type-system/schema.js'
 
+export const BUS_NAMESPACE = 'bus'
+
 export const trackSchema = makeSchema([
   {
     name: 'tempo',

--- a/packages/language/src/compiler/generator.ts
+++ b/packages/language/src/compiler/generator.ts
@@ -22,13 +22,13 @@ import { Numbers, Parameters } from '../type-system/helpers.js'
 import type { InferSchema, Schema } from '../type-system/schema.js'
 import type { FacetType, Value } from '../type-system/types.js'
 import type { CheckedProgram } from './checker.js'
-import { busSchema, partSchema, stepSchema, trackSchema } from './common.js'
+import { BUS_NAMESPACE, busSchema, partSchema, stepSchema, trackSchema } from './common.js'
 import type { CurveSegment as GeneratedCurveSegment } from './curves.js'
 import { createCurve, createCurveSegment, getCurveSegmentType, renderCurvePoints } from './curves.js'
 import { CompileError } from './error.js'
 import type { GenerateOptions } from './options.js'
-import type { GlobalScope, MutableScope, Scope } from './scopes.js'
-import { createGlobalScope, createLocalScope, resolveInScope } from './scopes.js'
+import type { GlobalScope, MutableNamespace, MutableScope, Scope } from './scopes.js'
+import { createGlobalScope, createLocalScope, createNamespace, resolveInScope } from './scopes.js'
 import { isSyntaxUnit, toNumberValue } from './units.js'
 
 /**
@@ -196,8 +196,11 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
 function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
   const mixerScope = createLocalScope(scope)
 
-  const buses = mixer?.buses.map((bus) => generateBus(mixerScope, bus)) ?? []
-  const routings = mixer?.buses.flatMap((bus) => generateBusRoutings(mixerScope, bus)) ?? []
+  const namespace = createNamespace()
+  scope.top.namespaces.set(BUS_NAMESPACE, namespace)
+
+  const buses = mixer?.buses.map((bus) => generateBus(mixerScope, bus, namespace)) ?? []
+  const routings = mixer?.buses.flatMap((bus, index) => generateBusRoutings(mixerScope, bus, buses[index])) ?? []
 
   // Implicit output routings for unrouted buses and instruments
   const unroutedBuses = new Set<BusId>(buses.map((b) => b.id))
@@ -229,7 +232,7 @@ function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
   return { buses, routings }
 }
 
-function generateBus (scope: MutableScope, bus: ast.BusStatement): Bus {
+function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: MutableNamespace): Bus {
   const name = bus.name.name
   const properties = resolveArgumentList(scope, bus.properties, busSchema)
 
@@ -260,15 +263,13 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement): Bus {
   assert(!scope.resolutions.has(name))
   scope.resolutions.set(name, value)
 
-  assert(!scope.top.busValues.has(name))
-  scope.top.busValues.set(name, value)
+  assert(!namespace.resolutions.has(name))
+  namespace.resolutions.set(name, value)
 
   return data
 }
 
-function generateBusRoutings (mixerScope: Scope, bus: ast.BusStatement): readonly MixerRouting[] {
-  const destination = nonNull(mixerScope.top.buses.get(bus.name.name))
-
+function generateBusRoutings (mixerScope: Scope, bus: ast.BusStatement, destination: Bus): readonly MixerRouting[] {
   return bus.sources.map((identifier) => {
     const source = resolve(mixerScope, identifier)
 
@@ -542,9 +543,11 @@ function computeDivide (left: Value, right: Value): Value {
 }
 
 function resolvePropertyAccess (scope: Scope, expression: ast.PropertyAccess): Value {
-  // Special case: "bus" namespace
-  if (expression.object.type === 'Identifier' && expression.object.name === 'bus') {
-    return nonNull(scope.top.busValues.get(expression.property.name))
+  if (expression.object.type === 'Identifier') {
+    const namespace = scope.top.namespaces.get(expression.object.name)
+    if (namespace != null) {
+      return nonNull(namespace.resolutions.get(expression.property.name))
+    }
   }
 
   const object = resolve(scope, expression.object)

--- a/packages/language/src/compiler/scopes.ts
+++ b/packages/language/src/compiler/scopes.ts
@@ -31,15 +31,24 @@ export interface Scope {
 export interface GlobalScope extends Scope, Context {
   readonly options: GenerateOptions
 
-  // TODO generalize this to avoid the "bus" namespace special-case
-  readonly buses: Map<string, Bus>
-  readonly busValues: Map<string, Value>
+  readonly namespaces: Map<string, Namespace>
 
+  readonly buses: Map<BusId, Bus>
   readonly instruments: Map<InstrumentId, Instrument>
   readonly automations: Map<ParameterId, Automation>
 }
 
 export interface MutableScope extends Scope {
+  readonly resolutions: Map<string, Value>
+}
+
+// namespace
+
+export interface Namespace {
+  readonly resolutions: ReadonlyMap<string, Value>
+}
+
+export interface MutableNamespace extends Namespace {
   readonly resolutions: Map<string, Value>
 }
 
@@ -55,8 +64,8 @@ export function createGlobalScope (options: GenerateOptions, initialResolutions:
 
     // from GlobalScope
     options,
+    namespaces: new Map(),
     buses: new Map(),
-    busValues: new Map(),
     instruments: new Map(),
     automations: new Map(),
 
@@ -77,6 +86,12 @@ export function createLocalScope (parent: Scope): MutableScope {
   return {
     top: parent.top,
     parent,
+    resolutions: new Map()
+  }
+}
+
+export function createNamespace (): MutableNamespace {
+  return {
     resolutions: new Map()
   }
 }
@@ -103,7 +118,7 @@ function allocateBus (scope: GlobalScope, data: Omit<Bus, 'id'>): Bus {
   const id = scope.buses.size as BusId
 
   const bus = { ...data, id }
-  scope.buses.set(bus.name, bus)
+  scope.buses.set(id, bus)
 
   return bus
 }

--- a/packages/language/test/compiler/scopes.test.ts
+++ b/packages/language/test/compiler/scopes.test.ts
@@ -2,7 +2,7 @@ import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GenerateOptions } from '../../src/compiler/options.js'
-import { createGlobalScope, createLocalScope, resolveInScope } from '../../src/compiler/scopes.js'
+import { createGlobalScope, createLocalScope, createNamespace, resolveInScope } from '../../src/compiler/scopes.js'
 import { Numbers } from '../../src/type-system/helpers.js'
 
 const options: GenerateOptions = {
@@ -56,8 +56,8 @@ describe('compiler/scopes.ts', () => {
       assert.strictEqual(allocated2.id, 1)
 
       assert.deepStrictEqual([...scope.buses], [
-        ['bus0', { ...bus0, id: 0 }],
-        ['bus1', { ...bus1, id: 1 }]
+        [0, { ...bus0, id: 0 }],
+        [1, { ...bus1, id: 1 }]
       ])
     })
 
@@ -142,6 +142,14 @@ describe('compiler/scopes.ts', () => {
       assert.strictEqual(nestedLocalScope.parent, localScope)
       assert.strictEqual(nestedLocalScope.resolutions.get('foo'), undefined)
       assert.strictEqual(nestedLocalScope.resolutions.get('bar'), undefined)
+    })
+  })
+
+  describe('createNamespace()', () => {
+    it('should create a namespace with empty resolutions', () => {
+      const namespace = createNamespace()
+
+      assert.strictEqual(namespace.resolutions.size, 0)
     })
   })
 


### PR DESCRIPTION
This patch abstracts bus resolution via `bus.<name>` into a more general namespace concept such that property lookup does not need to be aware of buses specifically, and how to resolve them.