### PR TITLE
refactor: Extract unary and binary operator logic

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -22,6 +22,8 @@ import type { FacetType, Type, Value } from '../../type-system/types.js'
 import { BUS_NAMESPACE, busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from '../common.js'
 import { getCurveSegmentType } from '../curves.js'
 import { CompileError } from '../error.js'
+import { binaryOperations } from '../operators/binary.js'
+import { unaryOperations } from '../operators/unary.js'
 import { resolveInScope } from '../resolution.js'
 import { isSyntaxUnit, toBaseUnit } from '../units.js'
 import { checkCyclicRoutings } from './routings.js'
@@ -67,17 +69,6 @@ export function check (program: ast.Program): CheckResult {
 interface Checked<TValue> {
   readonly errors: readonly CompileError[]
   readonly result?: TValue
-}
-
-function prependErrors<TValue> (errors: readonly CompileError[], check: Checked<TValue>): Checked<TValue> {
-  if (errors.length === 0) {
-    return check
-  }
-
-  return {
-    errors: [...errors, ...check.errors],
-    result: check.result
-  }
 }
 
 function ensureStandardModule (moduleName: string): Value<typeof ModuleFacet> {
@@ -601,28 +592,21 @@ function checkIdentifier (scope: Scope, identifier: ast.Identifier): Checked<Fac
 }
 
 function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Checked<FacetType> {
-  const argumentCheck = checkExpression(scope, expression.argument)
+  const operandCheck = checkExpression(scope, expression.argument)
+  const errors = [...operandCheck.errors]
 
-  const errors = [...argumentCheck.errors]
-
-  if (argumentCheck.result == null) {
+  const operand = operandCheck.result
+  if (operand == null) {
     return { errors }
   }
 
-  const { range, operator } = expression
-  const argument = argumentCheck.result
-
-  if (!NumberFacet.is(argument)) {
-    errors.push(new CompileError(`Incompatible operand for "${operator}": ${argument.format()}`, range))
+  const result = unaryOperations[expression.operator].check(operand)
+  if (result == null) {
+    errors.push(new CompileError(`Incompatible operand for "${expression.operator}": ${operand.format()}`, expression.range))
     return { errors }
   }
 
-  // TypeScript will error if an operator is not handled
-  switch (operator) {
-    case '+':
-    case '-':
-      return { errors, result: argument }
-  }
+  return { errors, result }
 }
 
 function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression): Checked<FacetType> {
@@ -631,97 +615,20 @@ function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression):
 
   const errors = [...leftCheck.errors, ...rightCheck.errors]
 
-  if (leftCheck.result == null || rightCheck.result == null) {
-    return { errors }
-  }
-
-  const { range, operator } = expression
   const left = leftCheck.result
   const right = rightCheck.result
 
-  switch (operator) {
-    case '+':
-      return prependErrors(errors, checkPlus(left, right, range))
-    case '-':
-      return prependErrors(errors, checkMinus(left, right, range))
-    case '*':
-      return prependErrors(errors, checkMultiply(left, right, range))
-    case '/':
-      return prependErrors(errors, checkDivide(left, right, range))
-  }
-}
-
-function checkPlus (left: FacetType, right: FacetType, range: SourceRange): Checked<FacetType> {
-  if (StringFacet.is(left) && StringFacet.is(right)) {
-    return { errors: [], result: left }
+  if (left == null || right == null) {
+    return { errors }
   }
 
-  if (PatternFacet.is(left) && PatternFacet.is(right)) {
-    return { errors: [], result: left }
+  const result = binaryOperations[expression.operator].check(left, right)
+  if (result == null) {
+    errors.push(new CompileError(`Incompatible operands for "${expression.operator}": ${left.format()} and ${right.format()}`, expression.range))
+    return { errors }
   }
 
-  if (NumberFacet.is(left) && NumberFacet.is(right)) {
-    const leftUnit = NumberFacet.detail(left)
-    const rightUnit = NumberFacet.detail(right)
-    if (leftUnit === rightUnit) {
-      return { errors: [], result: left }
-    }
-  }
-
-  return { errors: [new CompileError(`Incompatible operands for "+": ${left.format()} and ${right.format()}`, range)] }
-}
-
-function checkMinus (left: FacetType, right: FacetType, range: SourceRange): Checked<FacetType> {
-  if (NumberFacet.is(left) && NumberFacet.is(right)) {
-    const leftUnit = NumberFacet.detail(left)
-    const rightUnit = NumberFacet.detail(right)
-    if (leftUnit === rightUnit) {
-      return { errors: [], result: left }
-    }
-  }
-
-  return { errors: [new CompileError(`Incompatible operands for "-": ${left.format()} and ${right.format()}`, range)] }
-}
-
-function checkMultiply (left: FacetType, right: FacetType, range: SourceRange): Checked<FacetType> {
-  if (NumberFacet.is(left) && NumberFacet.is(right)) {
-    const leftUnit = NumberFacet.detail(left)
-    const rightUnit = NumberFacet.detail(right)
-    if (leftUnit == null || rightUnit == null) {
-      return { errors: [], result: NumberFacet.with(leftUnit ?? rightUnit).type() }
-    }
-  }
-
-  if (
-    (PatternFacet.is(left) && NumberFacet.with(undefined).is(right)) ||
-    (NumberFacet.with(undefined).is(left) && PatternFacet.is(right))
-  ) {
-    return { errors: [], result: PatternFacet.type() }
-  }
-
-  return { errors: [new CompileError(`Incompatible operands for "*": ${left.format()} and ${right.format()}`, range)] }
-}
-
-function checkDivide (left: FacetType, right: FacetType, range: SourceRange): Checked<FacetType> {
-  if (NumberFacet.is(left) && NumberFacet.is(right)) {
-    const leftUnit = NumberFacet.detail(left)
-    const rightUnit = NumberFacet.detail(right)
-
-    // equal units cancel out
-    if (leftUnit === rightUnit) {
-      return { errors: [], result: NumberFacet.with(undefined).type() }
-    }
-
-    if (rightUnit == null) {
-      return { errors: [], result: left }
-    }
-  }
-
-  if (PatternFacet.is(left) && NumberFacet.with(undefined).is(right)) {
-    return { errors: [], result: left }
-  }
-
-  return { errors: [new CompileError(`Incompatible operands for "/": ${left.format()} and ${right.format()}`, range)] }
+  return { errors, result }
 }
 
 function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -1,6 +1,6 @@
 import { ast } from '@ast'
 import type { Bus, BusId, InstrumentId, InstrumentRouting, Mixer, MixerRouting, Part, Pattern, Program, Step, Track } from '@core'
-import { concatPatterns, createParallelPattern, createSerialPattern, mergePatterns, multiplyPattern } from '@core'
+import { concatPatterns, createParallelPattern, createSerialPattern, mergePatterns } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
 import { getStandardModuleValue } from '../../library/modules.js'
@@ -18,7 +18,7 @@ import { ParameterFacet } from '../../type-system/domain/parameter.js'
 import { PartFacet } from '../../type-system/domain/part.js'
 import { PatternFacet } from '../../type-system/domain/pattern.js'
 import { makeType } from '../../type-system/factory.js'
-import { Numbers, Parameters } from '../../type-system/helpers.js'
+import { Parameters } from '../../type-system/helpers.js'
 import type { InferSchema, Schema } from '../../type-system/schema.js'
 import type { FacetType, Value } from '../../type-system/types.js'
 import type { CheckedProgram } from '../checker/checker.js'
@@ -26,6 +26,8 @@ import { BUS_NAMESPACE, busSchema, partSchema, stepSchema, trackSchema } from '.
 import type { CurveSegment as GeneratedCurveSegment } from '../curves.js'
 import { createCurve, createCurveSegment, getCurveSegmentType, renderCurvePoints } from '../curves.js'
 import { CompileError } from '../error.js'
+import { binaryOperations } from '../operators/binary.js'
+import { unaryOperations } from '../operators/unary.js'
 import { resolveInScope } from '../resolution.js'
 import { isSyntaxUnit, toNumberValue } from '../units.js'
 import type { GenerateOptions } from './options.js'
@@ -435,112 +437,16 @@ function resolveIdentifier (scope: Scope, identifier: ast.Identifier): Value {
 }
 
 function computeUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Value {
-  const argument = resolve(scope, expression.argument)
-
-  switch (expression.operator) {
-    case '+':
-      if (NumberFacet.has(argument)) {
-        return argument
-      }
-      break
-
-    case '-':
-      if (NumberFacet.has(argument)) {
-        const numberData = NumberFacet.get(argument)
-        return Numbers.of({ unit: numberData.unit, value: -numberData.value })
-      }
-      break
-  }
-
-  assert(false)
+  return unaryOperations[expression.operator].compute(
+    resolve(scope, expression.argument)
+  )
 }
 
 function computeBinaryExpression (scope: Scope, expression: ast.BinaryExpression): Value {
-  const left = resolve(scope, expression.left)
-  const right = resolve(scope, expression.right)
-
-  switch (expression.operator) {
-    case '+':
-      return computePlus(left, right)
-    case '-':
-      return computeMinus(left, right)
-    case '*':
-      return computeMultiply(left, right)
-    case '/':
-      return computeDivide(left, right)
-  }
-}
-
-function computePlus (left: Value, right: Value): Value {
-  if (StringFacet.has(left) && StringFacet.has(right)) {
-    const leftData = StringFacet.get(left)
-    const rightData = StringFacet.get(right)
-    return StringFacet.type().of(leftData + rightData)
-  }
-
-  if (PatternFacet.has(left) && PatternFacet.has(right)) {
-    const leftData = PatternFacet.get(left)
-    const rightData = PatternFacet.get(right)
-    return PatternFacet.type().of(concatPatterns([leftData, rightData]))
-  }
-
-  if (NumberFacet.has(left) && NumberFacet.has(right)) {
-    const leftData = NumberFacet.get(left)
-    const rightData = NumberFacet.get(right)
-    return Numbers.of({ unit: leftData.unit, value: leftData.value + rightData.value })
-  }
-
-  assert(false)
-}
-
-function computeMinus (left: Value, right: Value): Value {
-  if (NumberFacet.has(left) && NumberFacet.has(right)) {
-    const leftData = NumberFacet.get(left)
-    const rightData = NumberFacet.get(right)
-    return Numbers.of({ unit: leftData.unit, value: leftData.value - rightData.value })
-  }
-
-  assert(false)
-}
-
-function computeMultiply (left: Value, right: Value): Value {
-  if (NumberFacet.has(left) && NumberFacet.has(right)) {
-    const leftData = NumberFacet.get(left)
-    const rightData = NumberFacet.get(right)
-    return Numbers.of({ unit: leftData.unit ?? rightData.unit, value: leftData.value * rightData.value })
-  }
-
-  if (PatternFacet.has(left) && NumberFacet.has(right)) {
-    const leftData = PatternFacet.get(left)
-    const rightData = NumberFacet.get(right)
-    return PatternFacet.type().of(multiplyPattern(leftData, rightData.value))
-  }
-
-  if (NumberFacet.has(left) && PatternFacet.has(right)) {
-    const leftData = NumberFacet.get(left)
-    const rightData = PatternFacet.get(right)
-    return PatternFacet.type().of(multiplyPattern(rightData, leftData.value))
-  }
-
-  assert(false)
-}
-
-function computeDivide (left: Value, right: Value): Value {
-  if (NumberFacet.has(left) && NumberFacet.has(right)) {
-    const leftData = NumberFacet.get(left)
-    const rightData = NumberFacet.get(right)
-    // Equal units cancel out
-    const unit = leftData.unit === rightData.unit ? undefined : leftData.unit
-    return Numbers.of({ unit, value: leftData.value / rightData.value })
-  }
-
-  if (PatternFacet.has(left) && NumberFacet.has(right)) {
-    const leftData = PatternFacet.get(left)
-    const rightData = NumberFacet.get(right)
-    return PatternFacet.type().of(multiplyPattern(leftData, 1.0 / rightData.value))
-  }
-
-  assert(false)
+  return binaryOperations[expression.operator].compute(
+    resolve(scope, expression.left),
+    resolve(scope, expression.right)
+  )
 }
 
 function resolvePropertyAccess (scope: Scope, expression: ast.PropertyAccess): Value {

--- a/packages/language/src/compiler/operators/binary.ts
+++ b/packages/language/src/compiler/operators/binary.ts
@@ -1,0 +1,186 @@
+import type { ast } from '@ast'
+import { concatPatterns, multiplyPattern } from '@core'
+import { NumberFacet } from '../../type-system/base/number.js'
+import { StringFacet } from '../../type-system/base/string.js'
+import { PatternFacet } from '../../type-system/domain/pattern.js'
+import { Numbers } from '../../type-system/helpers.js'
+import type { FacetType, Value } from '../../type-system/types.js'
+import { CompileError } from '../error.js'
+
+export interface BinaryOperation {
+  readonly operator: ast.BinaryOperator
+  readonly check: (left: FacetType, right: FacetType) => FacetType | undefined
+  readonly compute: (left: Value, right: Value) => Value
+}
+
+function fail (): never {
+  throw new CompileError('Internal error in binary operation: incompatible operand types')
+}
+
+const add: BinaryOperation = {
+  operator: '+',
+
+  check: (left, right) => {
+    if (StringFacet.is(left) && StringFacet.is(right)) {
+      return left
+    }
+
+    if (PatternFacet.is(left) && PatternFacet.is(right)) {
+      return left
+    }
+
+    if (NumberFacet.is(left) && NumberFacet.is(right)) {
+      const leftUnit = NumberFacet.detail(left)
+      const rightUnit = NumberFacet.detail(right)
+      if (leftUnit === rightUnit) {
+        return left
+      }
+    }
+
+    return undefined
+  },
+
+  compute: (left, right) => {
+    if (StringFacet.has(left) && StringFacet.has(right)) {
+      const leftData = StringFacet.get(left)
+      const rightData = StringFacet.get(right)
+      return StringFacet.type().of(leftData + rightData)
+    }
+
+    if (PatternFacet.has(left) && PatternFacet.has(right)) {
+      const leftData = PatternFacet.get(left)
+      const rightData = PatternFacet.get(right)
+      return PatternFacet.type().of(concatPatterns([leftData, rightData]))
+    }
+
+    if (NumberFacet.has(left) && NumberFacet.has(right)) {
+      const leftData = NumberFacet.get(left)
+      const rightData = NumberFacet.get(right)
+      return Numbers.of({ unit: leftData.unit, value: leftData.value + rightData.value })
+    }
+
+    fail()
+  }
+}
+
+const subtract: BinaryOperation = {
+  operator: '-',
+
+  check: (left, right) => {
+    if (NumberFacet.is(left) && NumberFacet.is(right)) {
+      const leftUnit = NumberFacet.detail(left)
+      const rightUnit = NumberFacet.detail(right)
+      if (leftUnit === rightUnit) {
+        return left
+      }
+    }
+
+    return undefined
+  },
+
+  compute: (left, right) => {
+    if (NumberFacet.has(left) && NumberFacet.has(right)) {
+      const leftData = NumberFacet.get(left)
+      const rightData = NumberFacet.get(right)
+      return Numbers.of({ unit: leftData.unit, value: leftData.value - rightData.value })
+    }
+
+    fail()
+  }
+}
+
+const multiply: BinaryOperation = {
+  operator: '*',
+
+  check: (left, right) => {
+    if (NumberFacet.is(left) && NumberFacet.is(right)) {
+      const leftUnit = NumberFacet.detail(left)
+      const rightUnit = NumberFacet.detail(right)
+      if (leftUnit == null || rightUnit == null) {
+        return NumberFacet.with(leftUnit ?? rightUnit).type()
+      }
+    }
+
+    if (
+      (PatternFacet.is(left) && NumberFacet.with(undefined).is(right)) ||
+      (NumberFacet.with(undefined).is(left) && PatternFacet.is(right))
+    ) {
+      return PatternFacet.type()
+    }
+
+    return undefined
+  },
+
+  compute: (left, right) => {
+    if (NumberFacet.has(left) && NumberFacet.has(right)) {
+      const leftData = NumberFacet.get(left)
+      const rightData = NumberFacet.get(right)
+      return Numbers.of({ unit: leftData.unit ?? rightData.unit, value: leftData.value * rightData.value })
+    }
+
+    if (PatternFacet.has(left) && NumberFacet.has(right)) {
+      const leftData = PatternFacet.get(left)
+      const rightData = NumberFacet.get(right)
+      return PatternFacet.type().of(multiplyPattern(leftData, rightData.value))
+    }
+
+    if (NumberFacet.has(left) && PatternFacet.has(right)) {
+      const leftData = NumberFacet.get(left)
+      const rightData = PatternFacet.get(right)
+      return PatternFacet.type().of(multiplyPattern(rightData, leftData.value))
+    }
+
+    fail()
+  }
+}
+
+const divide: BinaryOperation = {
+  operator: '/',
+
+  check: (left, right) => {
+    if (NumberFacet.is(left) && NumberFacet.is(right)) {
+      const leftUnit = NumberFacet.detail(left)
+      const rightUnit = NumberFacet.detail(right)
+
+      // equal units cancel out
+      if (leftUnit === rightUnit) {
+        return NumberFacet.with(undefined).type()
+      }
+
+      if (rightUnit == null) {
+        return left
+      }
+    }
+
+    if (PatternFacet.is(left) && NumberFacet.with(undefined).is(right)) {
+      return left
+    }
+
+    return undefined
+  },
+
+  compute: (left, right) => {
+    if (NumberFacet.has(left) && NumberFacet.has(right)) {
+      const leftData = NumberFacet.get(left)
+      const rightData = NumberFacet.get(right)
+      // Equal units cancel out
+      const unit = leftData.unit === rightData.unit ? undefined : leftData.unit
+      return Numbers.of({ unit, value: leftData.value / rightData.value })
+    }
+
+    if (PatternFacet.has(left) && NumberFacet.has(right)) {
+      const leftData = PatternFacet.get(left)
+      const rightData = NumberFacet.get(right)
+      return PatternFacet.type().of(multiplyPattern(leftData, 1.0 / rightData.value))
+    }
+
+    fail()
+  }
+}
+
+export const binaryOperations: Readonly<Record<ast.BinaryOperator, BinaryOperation>> = {
+  '+': add,
+  '-': subtract,
+  '*': multiply,
+  '/': divide
+}

--- a/packages/language/src/compiler/operators/unary.ts
+++ b/packages/language/src/compiler/operators/unary.ts
@@ -1,0 +1,27 @@
+import type { ast } from '@ast'
+import type { FacetType, Value } from '../../type-system/types.js'
+import { NumberFacet } from '../../type-system/base/number.js'
+import { Numbers } from '../../type-system/helpers.js'
+
+export interface UnaryOperation {
+  readonly operator: ast.UnaryOperator
+  readonly check: (operand: FacetType) => FacetType | undefined
+  readonly compute: (operand: Value) => Value
+}
+
+export const unaryOperations: Readonly<Record<ast.UnaryOperator, UnaryOperation>> = {
+  '+': {
+    operator: '+',
+    check: (operand) => NumberFacet.is(operand) ? operand : undefined,
+    compute: (operand) => operand
+  },
+
+  '-': {
+    operator: '-',
+    check: (operand) => NumberFacet.is(operand) ? operand : undefined,
+    compute: (operand) => {
+      const { unit, value } = NumberFacet.get(operand)
+      return Numbers.of({ unit, value: -value })
+    }
+  }
+}


### PR DESCRIPTION
The checker and generator previously implemented the unary and binary operators directly, as completely separate code paths. This patch now moves all operator-specific logic into separate modules, such that both stages of operator compilation are adjacent, making them less likely to subtly diverge. As an added benefit, the core checker/generator sources shrink significantly.