### PR TITLE
fix: Optimize schema by including an item map

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -720,7 +720,7 @@ function checkArgumentList (
   scope: Scope,
   args: ast.ArgumentList,
   schema: Schema,
-  parentRange: SourceRange,
+  range: SourceRange,
   kind = 'argument'
 ): Checked<ReadonlyMap<string, Type>> {
   const errors: CompileError[] = []
@@ -731,8 +731,6 @@ function checkArgumentList (
   // in addition to reporting the expression's error, we would also report the argument as missing,
   // which is not correct.
   const errorArguments = new Set<string>()
-
-  const schemaAsMap = new Map<string, SchemaItem>(schema.map((spec) => [spec.name, spec]))
 
   const checkArgumentValue = (spec: SchemaItem, value: ast.Expression): void => {
     const expressionCheck = checkExpression(scope, value)
@@ -756,7 +754,7 @@ function checkArgumentList (
       break
     }
 
-    const spec = schema.at(index)
+    const spec = schema.items.at(index)
     if (spec == null) {
       errors.push(new CompileError(`Unknown positional ${kind}`, arg.range))
       continue
@@ -773,7 +771,7 @@ function checkArgumentList (
       continue
     }
 
-    const spec = schemaAsMap.get(arg.key.name)
+    const spec = schema.byName.get(arg.key.name)
     if (spec == null) {
       errors.push(new CompileError(`Unknown ${kind} "${arg.key.name}"`, arg.key.range))
       continue
@@ -787,9 +785,9 @@ function checkArgumentList (
     checkArgumentValue(spec, arg.value)
   }
 
-  for (const spec of schema) {
+  for (const spec of schema.items) {
     if (spec.required && !result.has(spec.name) && !errorArguments.has(spec.name)) {
-      errors.push(new CompileError(`Missing required ${kind} "${spec.name}"`, parentRange))
+      errors.push(new CompileError(`Missing required ${kind} "${spec.name}"`, range))
     }
   }
 

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -487,17 +487,15 @@ function resolveArgumentList<S extends Schema> (scope: Scope, args: ast.Argument
       break
     }
 
-    const param = nonNull(schema.at(i))
-    entries.push([param.name, resolve(scope, arg)])
+    const { name } = nonNull(schema.items.at(i))
+    entries.push([name, resolve(scope, arg)])
   }
 
   // named
   for (let i = entries.length; i < args.length; ++i) {
     const arg = args[i]
-    assert(arg.type === 'Property')
-
-    const param = nonNull(schema.find((s) => s.name === arg.key.name))
-    entries.push([param.name, resolve(scope, arg.value)])
+    assert(arg.type === 'Property' && schema.byName.has(arg.key.name))
+    entries.push([arg.key.name, resolve(scope, arg.value)])
   }
 
   return Object.fromEntries(entries) as InferSchema<S>

--- a/packages/language/src/library/documentation.ts
+++ b/packages/language/src/library/documentation.ts
@@ -52,7 +52,7 @@ function describeValue (name: string, value: Value): Documentation {
 }
 
 function formatFunctionSignature (name: string, functionValue: Function): string {
-  const parametersText = functionValue.parameters
+  const parametersText = functionValue.parameters.items
     .map((parameter) => `${parameter.name}${parameter.required ? '' : '?'}: ${parameter.type.format()}`)
     .join(', ')
 

--- a/packages/language/src/library/modules/effects.ts
+++ b/packages/language/src/library/modules/effects.ts
@@ -7,6 +7,7 @@ import { EffectFacet } from '../../type-system/domain/effect.js'
 import { ParameterFacet } from '../../type-system/domain/parameter.js'
 import { makeType, makeUnion } from '../../type-system/factory.js'
 import { Functions, Modules, Parameters } from '../../type-system/helpers.js'
+import { makeSchema } from '../../type-system/schema.js'
 import type { Value } from '../../type-system/types.js'
 
 const UNITY_GAIN = numeric('db', 0)
@@ -46,9 +47,9 @@ const ClipEffectType = makeType(EffectFacet, RecordFacet.with({
 const gain = Functions.of({
   summary: 'Applies a gain adjustment to the signal.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'gain', type: NumberFacet.with('db').type(), required: true }
-  ],
+  ]),
 
   returnType: GainEffectType,
 
@@ -67,9 +68,9 @@ const gain = Functions.of({
 const pan = Functions.of({
   summary: 'Places the signal in the stereo field.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'pan', type: NumberFacet.with(undefined).type(), required: true }
-  ],
+  ]),
 
   returnType: PanEffectType,
 
@@ -88,9 +89,9 @@ const pan = Functions.of({
 const lowpass = Functions.of({
   summary: 'Filters out frequencies above the cutoff.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
-  ],
+  ]),
 
   returnType: LowpassEffectType,
 
@@ -109,9 +110,9 @@ const lowpass = Functions.of({
 const highpass = Functions.of({
   summary: 'Filters out frequencies below the cutoff.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
-  ],
+  ]),
 
   returnType: HighpassEffectType,
 
@@ -130,9 +131,9 @@ const highpass = Functions.of({
 const width = Functions.of({
   summary: 'Adjusts the stereo width of the signal.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'width', type: NumberFacet.with(undefined).type(), required: true }
-  ],
+  ]),
 
   returnType: WidthEffectType,
 
@@ -149,12 +150,12 @@ const width = Functions.of({
 const delay = Functions.of({
   summary: 'Adds echoes with configurable mix, time, and feedback.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'time', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
     { name: 'feedback', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
-  ],
+  ]),
 
   returnType: DelayEffectType,
 
@@ -176,11 +177,11 @@ const delay = Functions.of({
 const reverb = Functions.of({
   summary: 'Adds reverberation with configurable mix and decay.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
-  ],
+  ]),
 
   returnType: ReverbEffectType,
 
@@ -199,9 +200,9 @@ const reverb = Functions.of({
 const clip = Functions.of({
   summary: 'Applies hard clipping to the signal at the specified threshold.',
 
-  parameters: [
+  parameters: makeSchema([
     { name: 'threshold', type: NumberFacet.with('db').type(), required: true }
-  ],
+  ]),
 
   returnType: ClipEffectType,
 

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -9,6 +9,7 @@ import { InstrumentFacet } from '../../type-system/domain/instrument.js'
 import { ParameterFacet } from '../../type-system/domain/parameter.js'
 import { makeType } from '../../type-system/factory.js'
 import { Functions, Modules, Parameters } from '../../type-system/helpers.js'
+import { makeSchema } from '../../type-system/schema.js'
 import type { Value } from '../../type-system/types.js'
 
 const UNITY_GAIN = numeric('db', 0)
@@ -30,12 +31,13 @@ const OscillatorInstrumentType = makeType(InstrumentFacet, RecordFacet.with({
 
 const sample = Functions.of({
   summary: 'Creates a sample-backed instrument from a URL.',
-  parameters: [
+
+  parameters: makeSchema([
     { name: 'url', type: StringFacet.type(), required: true },
     { name: 'gain', type: NumberFacet.with('db').type(), required: false },
     { name: 'root_note', type: StringFacet.type(), required: false },
     { name: 'length', type: NumberFacet.with('s').type(), required: false }
-  ],
+  ]),
 
   returnType: SampleInstrumentType,
 
@@ -69,9 +71,10 @@ const sample = Functions.of({
 function createOscillatorFunction (shape: Oscillator['shape']): Value {
   return Functions.of({
     summary: `Creates an instrument that produces a ${shape} wave.`,
-    parameters: [
+
+    parameters: makeSchema([
       { name: 'gain', type: NumberFacet.with('db').type(), required: false }
-    ],
+    ]),
 
     returnType: OscillatorInstrumentType,
 

--- a/packages/language/src/library/modules/patterns.ts
+++ b/packages/language/src/library/modules/patterns.ts
@@ -4,13 +4,15 @@ import { NumberFacet } from '../../type-system/base/number.js'
 import { PatternFacet } from '../../type-system/domain/pattern.js'
 import { Functions, Modules } from '../../type-system/helpers.js'
 import type { Value } from '../../type-system/types.js'
+import { makeSchema } from '../../type-system/schema.js'
 
 const loop = Functions.of({
   summary: 'Repeats a pattern for a fixed number of cycles, or indefinitely when times is omitted.',
-  parameters: [
+
+  parameters: makeSchema([
     { name: 'pattern', type: PatternFacet.type(), required: true },
     { name: 'times', type: NumberFacet.with(undefined).type(), required: false }
-  ],
+  ]),
 
   returnType: PatternFacet.type(),
 
@@ -39,10 +41,11 @@ const loop = Functions.of({
 
 const fill = Functions.of({
   summary: 'Repeats a pattern until it fills the specified duration. Longer patterns are truncated.',
-  parameters: [
+
+  parameters: makeSchema([
     { name: 'pattern', type: PatternFacet.type(), required: true },
     { name: 'duration', type: NumberFacet.with('beats').type(), required: true }
-  ],
+  ]),
 
   returnType: PatternFacet.type(),
 

--- a/packages/language/src/type-system/schema.ts
+++ b/packages/language/src/type-system/schema.ts
@@ -1,6 +1,9 @@
 import type { Type, ValueForType } from './types.js'
 
-export type Schema = readonly SchemaItem[]
+export interface Schema<Items extends readonly SchemaItem[] = readonly SchemaItem[]> {
+  readonly items: Items
+  readonly byName: ReadonlyMap<string, SchemaItem>
+}
 
 export interface SchemaItem<T extends Type = Type> {
   readonly name: string
@@ -9,11 +12,19 @@ export interface SchemaItem<T extends Type = Type> {
 }
 
 export type InferSchema<S extends Schema> = {
-  [P in S[number] as P['required'] extends true ? P['name'] : never]: ValueForType<P['type']>
+  [P in S['items'][number] as P['required'] extends true ? P['name'] : never]: ValueForType<P['type']>
 } & {
-  [P in S[number] as P['required'] extends false ? P['name'] : never]?: ValueForType<P['type']>
+  [P in S['items'][number] as P['required'] extends false ? P['name'] : never]?: ValueForType<P['type']>
 }
 
-export function makeSchema<const S extends Schema> (schema: S): S {
-  return schema
+export function makeSchema<const Items extends readonly SchemaItem[]> (items: Items): Schema<Items> {
+  const byName = new Map<string, SchemaItem>(
+    items.map((item) => [item.name, item])
+  )
+
+  if (byName.size !== items.length) {
+    throw new Error('Duplicate item names in schema')
+  }
+
+  return { items, byName }
 }

--- a/packages/language/test/type-system/schema.test.ts
+++ b/packages/language/test/type-system/schema.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { NumberFacet } from '../../src/type-system/base/number.js'
+import { StringFacet } from '../../src/type-system/base/string.js'
+import { makeSchema } from '../../src/type-system/schema.js'
+
+describe('type-system/schema.ts', () => {
+  describe('makeSchema()', () => {
+    it('creates a schema with items and byName map', () => {
+      const foo = { name: 'foo', type: NumberFacet.with('hz').type(), required: true }
+      const bar = { name: 'bar', type: StringFacet.type(), required: false }
+
+      const schema = makeSchema([foo, bar])
+
+      assert.strictEqual(schema.items.length, 2)
+      assert.strictEqual(schema.items[0], foo)
+      assert.strictEqual(schema.items[1], bar)
+
+      assert.strictEqual(schema.byName.size, 2)
+      assert.strictEqual(schema.byName.get('foo'), foo)
+      assert.strictEqual(schema.byName.get('bar'), bar)
+    })
+
+    it('should throw when given duplicate item names', () => {
+      const item1 = { name: 'duplicate', type: NumberFacet.with('hz').type(), required: true }
+      const item2 = { name: 'duplicate', type: StringFacet.type(), required: false }
+
+      assert.throws(() => makeSchema([item1, item2]), /Duplicate item names in schema/)
+    })
+
+    it('allows empty schema', () => {
+      const schema = makeSchema([])
+
+      assert.strictEqual(schema.items.length, 0)
+      assert.strictEqual(schema.byName.size, 0)
+    })
+  })
+})


### PR DESCRIPTION
This patch avoids O(n) schema item lookups by directly including a map in the schema upon construction.