### PR TITLE
fix: Cache number facets by unit for performance

### DIFF
--- a/packages/language/src/type-system/base/number.ts
+++ b/packages/language/src/type-system/base/number.ts
@@ -1,16 +1,25 @@
 import type { Numeric, Unit } from '@utility'
 import { makeFacet } from '../factory.js'
-import type { FacetType } from '../types.js'
+import type { Facet, FacetType } from '../types.js'
 
 const FACET_NAME = 'number'
+
+const cache = new Map<Unit, Facet<typeof FACET_NAME, Numeric<Unit>>>()
 
 export const NumberFacet = {
   ...makeFacet<typeof FACET_NAME, Numeric<Unit>>(FACET_NAME, {}),
 
   with: <const U extends Unit> (unit: U) => {
-    return makeFacet<typeof FACET_NAME, Numeric<U>>(FACET_NAME, { unit }, {
-      format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
-    })
+    let cached = cache.get(unit) as Facet<typeof FACET_NAME, Numeric<U>> | undefined
+
+    if (cached == null) {
+      cached = makeFacet<typeof FACET_NAME, Numeric<U>>(FACET_NAME, { unit }, {
+        format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
+      })
+      cache.set(unit, cached)
+    }
+
+    return cached
   },
 
   detail: (type: FacetType): Unit => {

--- a/packages/language/src/type-system/domain/curve.ts
+++ b/packages/language/src/type-system/domain/curve.ts
@@ -1,6 +1,6 @@
 import type { Numeric, Unit } from '@utility'
 import { makeFacet } from '../factory.js'
-import type { FacetType } from '../types.js'
+import type { Facet, FacetType } from '../types.js'
 
 export interface Curve<U extends Unit> {
   readonly unit: U
@@ -26,13 +26,22 @@ export interface LinearCurveSegment<U extends Unit> {
 
 const FACET_NAME = 'curve'
 
+const cache = new Map<Unit, Facet<typeof FACET_NAME, Curve<Unit>>>()
+
 export const CurveFacet = {
   ...makeFacet<typeof FACET_NAME, Curve<Unit>>(FACET_NAME, {}),
 
   with: <const U extends Unit> (unit: U) => {
-    return makeFacet<typeof FACET_NAME, Curve<U>>(FACET_NAME, { unit }, {
-      format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
-    })
+    let cached = cache.get(unit) as Facet<typeof FACET_NAME, Curve<U>> | undefined
+
+    if (cached == null) {
+      cached = makeFacet<typeof FACET_NAME, Curve<U>>(FACET_NAME, { unit }, {
+        format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
+      })
+      cache.set(unit, cached)
+    }
+
+    return cached
   },
 
   detail: (type: FacetType): Unit => {

--- a/packages/language/src/type-system/domain/parameter.ts
+++ b/packages/language/src/type-system/domain/parameter.ts
@@ -1,17 +1,26 @@
 import type { Parameter } from '@core'
 import type { Unit } from '@utility'
 import { makeFacet } from '../factory.js'
-import type { FacetType } from '../types.js'
+import type { Facet, FacetType } from '../types.js'
 
 const FACET_NAME = 'parameter'
+
+const cache = new Map<Unit, Facet<typeof FACET_NAME, Parameter<Unit>>>()
 
 export const ParameterFacet = {
   ...makeFacet<typeof FACET_NAME, Parameter<Unit>>(FACET_NAME, {}),
 
   with: <const U extends Unit> (unit: U) => {
-    return makeFacet<typeof FACET_NAME, Parameter<U>>(FACET_NAME, { unit }, {
-      format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
-    })
+    let cached = cache.get(unit) as Facet<typeof FACET_NAME, Parameter<U>> | undefined
+
+    if (cached == null) {
+      cached = makeFacet<typeof FACET_NAME, Parameter<U>>(FACET_NAME, { unit }, {
+        format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
+      })
+      cache.set(unit, cached)
+    }
+
+    return cached
   },
 
   detail: (type: FacetType): Unit => {

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -13,10 +13,10 @@ import type { Facet, FacetType, Value } from './types.js'
 
 export const Functions = {
   of: <const S extends Schema, const R extends FacetType, const Context> (value: Function<S, R, Context>): Value => {
-    const type = makeType(FunctionFacet.with({
+    const type = FunctionFacet.with({
       parameters: value.parameters,
       returnType: value.returnType
-    }))
+    }).type()
 
     return type.of(value)
   }


### PR DESCRIPTION
This patch improves the performance of the checker and generator stages by caching in the type system, particularly for number-related facets, i.e., 'number', 'parameter', and 'curve', based on their unit.

A benchmark of 10,000 iterations of the demo code shows the following improvements:

- checker: 3.60s -> 1.05s (3.4x faster)
- generator: 4.45s -> 1.65s (2.7x faster)