### PR TITLE
feat: Support named effects

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -152,6 +152,7 @@ export interface BusStatement extends ASTNode {
 
 export interface EffectStatement extends ASTNode {
   readonly type: 'EffectStatement'
+  readonly name?: Identifier
   readonly expression: Expression
 }
 

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -209,5 +209,6 @@ BusStatement {
 
 EffectStatement {
   kw<"effect">
+  (VariableDefinition "=")?
   expression
 }

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -96,6 +96,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
+      case 'BusStatement': {
+        const scope = addScope({ kind: 'bus', range, parentId: scopeId })
+        nextScopeId = scope.id
+        break
+      }
+
       case 'Assignment': {
         nextAssignmentHasEquals = false
 
@@ -261,6 +267,9 @@ function getDefinitionBinding (context: DefinitionBindingContext): Omit<Binding,
       return context.mixerScopeId != null
         ? { kind: 'bus', scopeId: context.mixerScopeId }
         : undefined
+
+    case 'EffectStatement':
+      return { kind: 'effect', scopeId: context.scopeId }
   }
 
   return undefined

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -55,6 +55,7 @@ interface BindingLookup {
   readonly namedImports: ReadonlyMap<string, Binding>
   readonly defaultImports: ReadonlyMap<string, Import>
   readonly buses: ReadonlyMap<string, Binding>
+  readonly effectsByBusName: ReadonlyMap<string, ReadonlyMap<string, Binding>>
   readonly byScopeAndName: ReadonlyMap<string, ReadonlyMap<string, Binding>>
   readonly parentScopes: ReadonlyMap<string, string>
 }
@@ -63,7 +64,29 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
   const namedImports = new Map<string, Binding>()
   const defaultImports = new Map<string, Import>()
   const buses = new Map<string, Binding>()
+  const effectsByBusName = new Map<string, Map<string, Binding>>()
   const byScopeAndName = new Map<string, Map<string, Binding>>()
+
+  const busNameByScopeId = new Map<string, string>()
+
+  const busScopes = model.scopes.filter((scope) => scope.kind === 'bus')
+  const getBusScopeIdAt = (offset: number): string | undefined => {
+    let bestScopeId: string | undefined
+    let bestLength = Number.POSITIVE_INFINITY
+
+    for (const scope of busScopes) {
+      const start = scope.range.offset
+      const end = start + scope.range.length
+      if (offset < start || offset > end || scope.range.length >= bestLength) {
+        continue
+      }
+
+      bestScopeId = scope.id
+      bestLength = scope.range.length
+    }
+
+    return bestScopeId
+  }
 
   for (const binding of model.bindings) {
     switch (binding.kind) {
@@ -76,8 +99,29 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
       case 'bus':
         if (!buses.has(binding.name)) {
           buses.set(binding.name, binding)
+
+          const busScopeId = getBusScopeIdAt(binding.range.offset)
+          if (busScopeId != null) {
+            busNameByScopeId.set(busScopeId, binding.name)
+          }
         }
         break
+
+      case 'effect': {
+        const busName = busNameByScopeId.get(binding.scopeId)
+        if (busName != null) {
+          let busEffects = effectsByBusName.get(busName)
+          if (busEffects == null) {
+            busEffects = new Map<string, Binding>()
+            effectsByBusName.set(busName, busEffects)
+          }
+
+          if (!busEffects.has(binding.name)) {
+            busEffects.set(binding.name, binding)
+          }
+        }
+        break
+      }
 
       default:
         break
@@ -89,7 +133,9 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
       byScopeAndName.set(binding.scopeId, scopeMap)
     }
 
-    scopeMap.set(binding.name, binding)
+    if (binding.kind !== 'effect') {
+      scopeMap.set(binding.name, binding)
+    }
   }
 
   for (const imp of model.imports) {
@@ -105,7 +151,7 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
     }
   }
 
-  return { namedImports, defaultImports, buses, byScopeAndName, parentScopes }
+  return { namedImports, defaultImports, buses, effectsByBusName, byScopeAndName, parentScopes }
 }
 
 function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, lookup: BindingLookup): Binding | undefined {
@@ -125,6 +171,15 @@ function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, loo
 }
 
 function findRegularBinding (occurrence: Identifier, lookup: BindingLookup): Binding | undefined {
+  if (isExplicitBusMemberReference(occurrence)) {
+    const busIdentifier = occurrence.previousSibling
+    if (busIdentifier == null) {
+      return undefined
+    }
+
+    return lookup.effectsByBusName.get(busIdentifier.name)?.get(occurrence.name)
+  }
+
   if (isExplicitBusReference(occurrence)) {
     return lookup.buses.get(occurrence.name)
   }
@@ -157,6 +212,14 @@ function isExplicitBusReference (identifier: Identifier): boolean {
   return identifier.previousSibling != null &&
     identifier.previousSibling.name === 'bus' &&
     identifier.previousSibling.previousSibling == null
+}
+
+function isExplicitBusMemberReference (identifier: Identifier): boolean {
+  const objectIdentifier = identifier.previousSibling
+  const namespaceIdentifier = objectIdentifier?.previousSibling
+
+  return namespaceIdentifier?.name === 'bus' &&
+    namespaceIdentifier.previousSibling == null
 }
 
 const importCache = new WeakMap<BindingLookup, Map<string, Import | undefined>>()

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -32,7 +32,7 @@ export interface Scope {
   readonly range: SourceRange
 }
 
-export type ScopeKind = 'root' | 'track' | 'mixer'
+export type ScopeKind = 'root' | 'track' | 'mixer' | 'bus'
 
 // identifier
 
@@ -71,7 +71,7 @@ export interface Binding {
   readonly moduleName?: string
 }
 
-export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus'
+export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus' | 'effect'
 
 // import
 

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -92,6 +92,31 @@ describe('go-to-definition/operation.ts', () => {
     assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'foo'.length))
   })
 
+  it('resolves explicit bus namespace effect access to the effect definition', () => {
+    const source = [
+      'use "effects" as fx',
+      'track (120.bpm) {',
+      '  part foo {',
+      '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus main {',
+      '    effect lp = fx.lowpass(1000.hz)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const defPos = source.indexOf('effect lp') + 'effect '.length
+    const refPos = source.indexOf('bus.main.lp.frequency') + 'bus.main.'.length
+
+    const result = applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos)
+
+    assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'lp'.length))
+    assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'lp'.length))
+  })
+
   it('does not resolve named argument keys', () => {
     const source = [
       'tempo = 128.bpm',

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -33,6 +33,7 @@ describe('model/analysis/base.ts', () => {
       '',
       'mixer {',
       '  bus drums {',
+      '    effect crush = fx.clip(-6.db)',
       '    kick snare',
       '  }',
       '}',
@@ -62,9 +63,12 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'track', name: 'loop' },
         { kind: 'plain', scope: 'track', name: 'kick' },
         { kind: 'plain', scope: 'track', name: 'gain' },
-        { kind: 'definition', scope: 'mixer', name: 'drums' },
-        { kind: 'plain', scope: 'mixer', name: 'kick' },
-        { kind: 'plain', scope: 'mixer', name: 'snare' }
+        { kind: 'definition', scope: 'bus', name: 'drums' },
+        { kind: 'definition', scope: 'bus', name: 'crush' },
+        { kind: 'plain', scope: 'bus', name: 'fx' },
+        { kind: 'plain', scope: 'bus', name: 'clip' },
+        { kind: 'plain', scope: 'bus', name: 'kick' },
+        { kind: 'plain', scope: 'bus', name: 'snare' }
       ]
     )
   })
@@ -234,12 +238,24 @@ describe('model/analysis/base.ts', () => {
     const mixerRange = getRangeAt(source, mixerStart, mixerEnd - mixerStart)
     const mixerScopeId = `mixer:${mixerRange.offset}:${mixerRange.length}`
 
+    const drumsBusStart = source.indexOf('bus drums')
+    const drumsBusEnd = source.indexOf('  }', drumsBusStart) + '  }'.length
+    const drumsBusRange = getRangeAt(source, drumsBusStart, drumsBusEnd - drumsBusStart)
+    const drumsBusScopeId = `bus:${drumsBusRange.offset}:${drumsBusRange.length}`
+
+    const delayBusStart = source.indexOf('bus delay')
+    const delayBusEnd = source.indexOf('  }', delayBusStart) + '  }'.length
+    const delayBusRange = getRangeAt(source, delayBusStart, delayBusEnd - delayBusStart)
+    const delayBusScopeId = `bus:${delayBusRange.offset}:${delayBusRange.length}`
+
     assert.deepStrictEqual(
       model.scopes.map(({ id, kind, parentId }) => ({ id, kind, parentId })),
       [
         { id: rootScopeId, kind: 'root', parentId: undefined },
         { id: trackScopeId, kind: 'track', parentId: rootScopeId },
-        { id: mixerScopeId, kind: 'mixer', parentId: rootScopeId }
+        { id: mixerScopeId, kind: 'mixer', parentId: rootScopeId },
+        { id: drumsBusScopeId, kind: 'bus', parentId: mixerScopeId },
+        { id: delayBusScopeId, kind: 'bus', parentId: mixerScopeId }
       ]
     )
 

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -167,6 +167,41 @@ describe('model/analysis/references.ts', () => {
     assert.strictEqual(binding, undefined)
   })
 
+  it('resolves named effect access of an explicit bus access', () => {
+    const source = [
+      'use "effects" as fx',
+      'track (120.bpm) {',
+      '  part main (4.bars) {',
+      '    automate bus.main.lp.frequency as ~[hold(1000.hz)]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus main {',
+      '    effect lp = fx.lowpass(1000.hz)',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('bus.main.lp.frequency') + 'bus.main.'.length
+
+    const identifier = model.identifiers.find((item) => item.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
+    assert.strictEqual(binding.kind, 'effect')
+    assert.strictEqual(binding.name, 'lp')
+    assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('effect lp') + 'effect '.length, 'lp'.length))
+
+    const references = model.bindingReferences.get(binding.id)
+    assert.ok(references != null)
+    assert.ok(references.includes(identifier))
+  })
+
   it('prefers import aliases over assignments with the same name', () => {
     const source = [
       'fx = sample("/samples/fx.wav")',

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -366,19 +366,49 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
   }
 
   // Effects
+  const properties = {
+    gain: ParameterFacet.with('db').type(),
+    pan: ParameterFacet.with(undefined).type()
+  }
+
+  const record: Record<string, FacetType> = Object.create(null)
+  Object.assign(record, properties)
+
   for (const effect of bus.effects) {
     const effectCheck = checkExpression(scope, effect.expression)
     errors.push(...effectCheck.errors)
 
+    let effectType: FacetType | undefined
+
     if (effectCheck.result != null) {
-      errors.push(...checkType(EffectFacet.type(), effectCheck.result, effect.expression.range))
+      const typeErrors = checkType(EffectFacet.type(), effectCheck.result, effect.expression.range)
+      errors.push(...typeErrors)
+
+      if (typeErrors.length === 0) {
+        effectType = effectCheck.result
+      }
+    }
+
+    if (effect.name == null) {
+      continue
+    }
+
+    if (Object.hasOwn(properties, effect.name.name)) {
+      errors.push(new CompileError(`Effect name "${effect.name.name}" conflicts with bus property of the same name`, effect.name.range))
+      continue
+    }
+
+    if (Object.hasOwn(record, effect.name.name)) {
+      errors.push(new CompileError(`Duplicate effect name "${effect.name.name}"`, effect.name.range))
+      continue
+    }
+
+    if (effectType != null) {
+      record[effect.name.name] = effectType
     }
   }
 
-  const type = makeType(BusFacet, RecordFacet.with({
-    gain: ParameterFacet.with('db').type(),
-    pan: ParameterFacet.with(undefined).type()
-  }))
+  const type = makeType(BusFacet, RecordFacet.with(record))
 
   return { errors, result: type }
 }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -234,9 +234,21 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
   const name = bus.name.name
   const properties = resolveArgumentList(scope, bus.properties, busSchema)
 
-  const effects = bus.effects.map((effect) => {
-    return EffectFacet.get(resolve(scope, effect.expression))
-  })
+  const effectValues = bus.effects.map((effect) => resolve(scope, effect.expression))
+  const effects = effectValues.map((value) => EffectFacet.get(value))
+
+  const valueRecord: Record<string, Value> = Object.create(null)
+  const typeRecord: Record<string, FacetType> = Object.create(null)
+
+  for (let i = 0; i < bus.effects.length; ++i) {
+    const effectName = bus.effects[i].name?.name
+    if (effectName == null) {
+      continue
+    }
+
+    valueRecord[effectName] = effectValues[i]
+    typeRecord[effectName] = effectValues[i].type
+  }
 
   // These must always be allocated even if not explicitly set,
   // as they could still be automated.
@@ -244,19 +256,15 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
   const panData = properties.pan != null ? NumberFacet.get(properties.pan) : numeric(undefined, 0)
 
   const gain = scope.top.allocateParameter(gainData)
+  valueRecord.gain = Parameters.of(gain)
+  typeRecord.gain = valueRecord.gain.type
+
   const pan = scope.top.allocateParameter(panData)
+  valueRecord.pan = Parameters.of(pan)
+  typeRecord.pan = valueRecord.pan.type
 
   const data = scope.top.allocateBus({ name, gain, pan, effects })
-
-  const type = makeType(BusFacet, RecordFacet.with({
-    gain: ParameterFacet.with('db').type(),
-    pan: ParameterFacet.with(undefined).type()
-  }))
-
-  const value = type.of(data, {
-    gain: Parameters.of(gain),
-    pan: Parameters.of(pan)
-  })
+  const value = makeType(BusFacet, RecordFacet.with(typeRecord)).of(data, valueRecord)
 
   assert(!scope.resolutions.has(name))
   scope.resolutions.set(name, value)

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -593,11 +593,21 @@ const trackStatement_: p.Parser<Token, unknown, ast.TrackStatement> = p.abc(
   }
 )
 
-const effectStatement_: p.Parser<Token, unknown, ast.EffectStatement> = p.ab(
+const effectStatement_: p.Parser<Token, unknown, ast.EffectStatement> = p.abc(
   keyword('effect'),
+  p.option(
+    combine2(
+      identifier_,
+      literal('=')
+    ),
+    undefined
+  ),
   expression_,
-  (_effect, expression) => {
+  (_effect, nameAndEq, expression) => {
+    const name = nameAndEq == null ? undefined : nameAndEq[0]
+
     return ast.make('EffectStatement', combineSourceRanges(_effect, expression), {
+      name,
       expression
     })
   }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -182,6 +182,38 @@ describe('compiler/checker/checker.ts', () => {
 
       assertValid(source)
     })
+
+    it('should accept bus effect automation via explicit namespace', () => {
+      const source = [
+        'use "effects" as fx',
+        'track {',
+        '  part intro (4.bars) {',
+        '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
+        '  }',
+        '}',
+        'mixer {',
+        '  bus main {',
+        '    effect lp = fx.lowpass(1000.hz)',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow named effects to shadow other identifiers', () => {
+      const source = [
+        'use "effects" as fx',
+        'lp = 42',
+        'mixer {',
+        '  bus main {',
+        '    effect lp = fx.lowpass(1000.hz)',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
   })
 
   describe('invalid', () => {
@@ -333,6 +365,39 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Duplicate bus named "foo"'
+      ])
+    })
+
+    it('should reject duplicate named effects within the same bus', () => {
+      const source = [
+        'use "effects" as fx',
+        'mixer {',
+        '  bus main {',
+        '    effect lp = fx.lowpass(1000.hz)',
+        '    effect lp = fx.highpass(200.hz)',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Duplicate effect name "lp"'
+      ])
+    })
+
+    it('should reject named effects that collide with built-in bus fields', () => {
+      const source = [
+        'use "effects" as fx',
+        'mixer {',
+        '  bus main {',
+        '    effect gain = fx.lowpass(1000.hz)',
+        '    effect pan = fx.highpass(200.hz)',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Effect name "gain" conflicts with bus property of the same name',
+        'Effect name "pan" conflicts with bus property of the same name'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -286,6 +286,35 @@ describe('compiler/generator/generator.ts', () => {
     ])
   })
 
+  it('should automate bus effect parameters via explicit namespace', () => {
+    const source = [
+      'use "effects" as fx',
+      'track {',
+      '  part intro (4.bars) {',
+      '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
+      '  }',
+      '}',
+      'mixer {',
+      '  bus main {',
+      '    effect lp = fx.lowpass(123.hz)',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    const effect = result.mixer.buses[0].effects[0]
+    assert.strictEqual(effect.type, 'lowpass')
+    assert.deepStrictEqual(effect.frequency.initial, numeric('hz', 123))
+
+    const automation = result.automations.get(effect.frequency.id)
+    assert.ok(automation != null)
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('beats', 0), value: numeric('hz', 100), curve: 'step' },
+      { time: numeric('beats', 16), value: numeric('hz', 4000), curve: 'linear' }
+    ])
+  })
+
   it('should automate effect parameters', () => {
     const source = [
       'use "effects" as fx',

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -568,6 +568,7 @@ describe('parser/parser.ts', () => {
       '  bus mybus(gain: (-3).db) {',
       '    kick snare hihat',
       '    effect fx.pan(0.5)',
+      '    effect lp = fx.lowpass(400.hz)',
       '  }',
       '}'
     ].join('\n')
@@ -602,6 +603,7 @@ describe('parser/parser.ts', () => {
             effects: [
               {
                 type: 'EffectStatement',
+                name: undefined,
                 expression: {
                   type: 'Call',
                   callee: {
@@ -611,6 +613,25 @@ describe('parser/parser.ts', () => {
                   },
                   arguments: [
                     { type: 'Number', value: 0.5 }
+                  ]
+                }
+              },
+              {
+                type: 'EffectStatement',
+                name: { type: 'Identifier', name: 'lp' },
+                expression: {
+                  type: 'Call',
+                  callee: {
+                    type: 'PropertyAccess',
+                    object: { type: 'Identifier', name: 'fx' },
+                    property: { type: 'Identifier', name: 'lowpass' }
+                  },
+                  arguments: [
+                    {
+                      type: 'PropertyAccess',
+                      object: { type: 'Number', value: 400 },
+                      property: { type: 'Identifier', name: 'hz' }
+                    }
                   ]
                 }
               }


### PR DESCRIPTION
This patch adds support for providing a name to a bus effect, by which it can be referred to in the rest of the project. For instance:

```
use "effects" as fx

mixer {
  bus synth_bus {
    effect lp = fx.lowpass(200.hz)
  }
}

track {
  part (16.bars) {
    automate bus.synth_bus.lp as ~[lin(200.hz, 4000.hz)]
  }
}
```

The implementation includes changes to the AST, parser, type checker, generator, and editor features (language-support).