### PR TITLE
feat: Allow assignments in track and mixer scopes

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -125,7 +125,7 @@ export type ArgumentList = ReadonlyArray<Expression | Property>
 export interface TrackStatement extends ASTNode {
   readonly type: 'TrackStatement'
   readonly properties: ArgumentList
-  readonly parts: readonly PartStatement[]
+  readonly children: ReadonlyArray<Assignment | PartStatement>
 }
 
 export interface PartStatement extends ASTNode {
@@ -139,7 +139,7 @@ export interface PartStatement extends ASTNode {
 export interface MixerStatement extends ASTNode {
   readonly type: 'MixerStatement'
   readonly properties: ArgumentList
-  readonly buses: readonly BusStatement[]
+  readonly children: ReadonlyArray<Assignment | BusStatement>
 }
 
 export interface BusStatement extends ASTNode {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -178,7 +178,7 @@ TrackStatement {
   kw<"track">
   ("(" argumentList? ")")?
   TrackBlock[group=Block] {
-    "{" (PartStatement)* "}"
+    "{" (Assignment | PartStatement)* "}"
   }
 }
 
@@ -195,7 +195,7 @@ MixerStatement {
   kw<"mixer">
   ("(" argumentList? ")")?
   MixerBlock[group=Block] {
-    "{" (BusStatement)* "}"
+    "{" (Assignment | BusStatement)* "}"
   }
 }
 

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -45,8 +45,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     cursor: TreeCursor,
     parentType: string | undefined,
     scopeId: string,
-    trackScopeId: string | undefined,
-    mixerScopeId: string | undefined,
+    pendingScope: Scope | undefined,
     assignmentHasEquals: boolean,
     previousSibling?: Identifier
   ): Identifier | undefined => {
@@ -59,8 +58,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     const nextParentType = typeName
 
     let nextScopeId = scopeId
-    let nextTrackScopeId = trackScopeId
-    let nextMixerScopeId = mixerScopeId
+    let nextPendingScope = pendingScope
     let nextAssignmentHasEquals = assignmentHasEquals
     let accessChainTail: Identifier | undefined
 
@@ -82,23 +80,31 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
-      case 'TrackStatement': {
+      case 'TrackBlock': {
         const scope = addScope({ kind: 'track', range, parentId: scopeId })
         nextScopeId = scope.id
-        nextTrackScopeId = scope.id
         break
       }
 
-      case 'MixerStatement': {
-        const scope = addScope({ kind: 'mixer', range, parentId: scopeId })
-        nextScopeId = scope.id
-        nextMixerScopeId = scope.id
+      case 'MixerBlock': {
+        nextScopeId = addScope({ kind: 'mixer', range, parentId: scopeId }).id
         break
       }
 
       case 'BusStatement': {
-        const scope = addScope({ kind: 'bus', range, parentId: scopeId })
-        nextScopeId = scope.id
+        const block = cursor.node.getChild('BusBlock')
+        if (block != null) {
+          const blockRange = toSourceRange(document, block.from, block.to)
+          nextPendingScope = addScope({ kind: 'bus', range: blockRange, parentId: scopeId })
+        }
+        break
+      }
+
+      case 'BusBlock': {
+        if (pendingScope?.kind === 'bus') {
+          nextScopeId = pendingScope.id
+          nextPendingScope = undefined
+        }
         break
       }
 
@@ -119,24 +125,39 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       case 'VariableDefinition': {
         const name = document.sliceString(from, to)
 
-        const binding = getDefinitionBinding({
-          parentType,
-          scopeId,
-          trackScopeId: nextTrackScopeId,
-          mixerScopeId: nextMixerScopeId,
-          assignmentHasEquals: nextAssignmentHasEquals
-        })
+        switch (parentType) {
+          case 'Assignment': {
+            if (assignmentHasEquals) {
+              addBinding({ kind: 'regular', scopeId, name, range })
+              addIdentifier({ kind: 'definition', scopeId, name, range })
+              break
+            }
+            // Invalid/incomplete syntax encountered.
+            // We still add an identifier as a best-effort approach to provide some level of functionality.
+            accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range, previousSibling })
+            break
+          }
 
-        if (binding == null) {
-          // Invalid/incomplete syntax encountered.
-          // We still add an identifier as a best-effort approach to provide some level of functionality.
-          accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range, previousSibling })
-          break
+          case 'PartStatement': {
+            addBinding({ kind: 'part', scopeId, name, range })
+            addIdentifier({ kind: 'definition', scopeId, name, range })
+            break
+          }
+
+          case 'BusStatement': {
+            if (pendingScope?.kind === 'bus') {
+              addBinding({ kind: 'bus', scopeId, name, range, declaredScopeId: pendingScope.id })
+              addIdentifier({ kind: 'definition', scopeId, name, range })
+            }
+            break
+          }
+
+          case 'EffectStatement': {
+            addBinding({ kind: 'effect', scopeId, name, range })
+            addIdentifier({ kind: 'definition', scopeId, name, range })
+            break
+          }
         }
-
-        addIdentifier({ kind: 'definition', scopeId, name, range })
-        addBinding({ ...binding, name, range })
-
         break
       }
 
@@ -180,8 +201,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
           cursor,
           nextParentType,
           nextScopeId,
-          nextTrackScopeId,
-          nextMixerScopeId,
+          nextPendingScope,
           nextAssignmentHasEquals,
           childPreviousSibling
         )
@@ -202,7 +222,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     return accessChainTail
   }
 
-  walk(cursor, undefined, rootScopeId, undefined, undefined, false)
+  walk(cursor, undefined, rootScopeId, undefined, false)
 
   sortByOffset(scopes)
   sortByOffset(identifiers)
@@ -241,38 +261,6 @@ function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): Bi
 
 function importKey (moduleName: string, range: SourceRange): ImportId {
   return `${moduleName}:${range.offset}:${range.length}` as ImportId
-}
-
-interface DefinitionBindingContext {
-  readonly parentType: string | undefined
-  readonly scopeId: string
-  readonly trackScopeId: string | undefined
-  readonly mixerScopeId: string | undefined
-  readonly assignmentHasEquals: boolean
-}
-
-function getDefinitionBinding (context: DefinitionBindingContext): Omit<Binding, 'id' | 'name' | 'range'> | undefined {
-  switch (context.parentType) {
-    case 'Assignment':
-      return context.assignmentHasEquals
-        ? { kind: 'regular', scopeId: context.scopeId }
-        : undefined
-
-    case 'PartStatement':
-      return context.trackScopeId != null
-        ? { kind: 'part', scopeId: context.trackScopeId }
-        : undefined
-
-    case 'BusStatement':
-      return context.mixerScopeId != null
-        ? { kind: 'bus', scopeId: context.mixerScopeId }
-        : undefined
-
-    case 'EffectStatement':
-      return { kind: 'effect', scopeId: context.scopeId }
-  }
-
-  return undefined
 }
 
 function parseUseStatement (document: TextLike, node: SyntaxNode): Omit<Import, 'id'> | undefined {

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -69,25 +69,6 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
 
   const busNameByScopeId = new Map<string, string>()
 
-  const busScopes = model.scopes.filter((scope) => scope.kind === 'bus')
-  const getBusScopeIdAt = (offset: number): string | undefined => {
-    let bestScopeId: string | undefined
-    let bestLength = Number.POSITIVE_INFINITY
-
-    for (const scope of busScopes) {
-      const start = scope.range.offset
-      const end = start + scope.range.length
-      if (offset < start || offset > end || scope.range.length >= bestLength) {
-        continue
-      }
-
-      bestScopeId = scope.id
-      bestLength = scope.range.length
-    }
-
-    return bestScopeId
-  }
-
   for (const binding of model.bindings) {
     switch (binding.kind) {
       case 'use-alias':
@@ -100,9 +81,8 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
         if (!buses.has(binding.name)) {
           buses.set(binding.name, binding)
 
-          const busScopeId = getBusScopeIdAt(binding.range.offset)
-          if (busScopeId != null) {
-            busNameByScopeId.set(busScopeId, binding.name)
+          if (binding.declaredScopeId != null) {
+            busNameByScopeId.set(binding.declaredScopeId, binding.name)
           }
         }
         break

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -61,7 +61,12 @@ export type BindingId = Brand<string, 'language-support.BindingId'>
 export interface Binding {
   readonly id: BindingId
   readonly kind: BindingKind
+
+  /**
+   * The scope that contains this binding.
+   */
   readonly scopeId: string
+
   readonly name: string
   readonly range: SourceRange
 
@@ -69,6 +74,11 @@ export interface Binding {
    * For use-aliases, this is the module that is being imported.
    */
   readonly moduleName?: string
+
+  /**
+   * The scope declared by this binding, if applicable (e.g. for bus bindings).
+   */
+  readonly declaredScopeId?: string
 }
 
 export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus' | 'effect'

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -55,15 +55,15 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'root', name: 'sample' },
         { kind: 'plain', scope: 'root', name: 'base_path' },
         { kind: 'definition', scope: 'root', name: 'tempo' },
-        { kind: 'property-name', scope: 'track', name: 'tempo' },
-        { kind: 'plain', scope: 'track', name: 'tempo' },
+        { kind: 'property-name', scope: 'root', name: 'tempo' },
+        { kind: 'plain', scope: 'root', name: 'tempo' },
         { kind: 'definition', scope: 'track', name: 'intro' },
         { kind: 'plain', scope: 'track', name: 'kick' },
         { kind: 'plain', scope: 'track', name: 'p' },
         { kind: 'plain', scope: 'track', name: 'loop' },
         { kind: 'plain', scope: 'track', name: 'kick' },
         { kind: 'plain', scope: 'track', name: 'gain' },
-        { kind: 'definition', scope: 'bus', name: 'drums' },
+        { kind: 'definition', scope: 'mixer', name: 'drums' },
         { kind: 'definition', scope: 'bus', name: 'crush' },
         { kind: 'plain', scope: 'bus', name: 'fx' },
         { kind: 'plain', scope: 'bus', name: 'clip' },
@@ -228,24 +228,24 @@ describe('model/analysis/base.ts', () => {
     const rootRange = getRangeAt(source, 0, source.length)
     const rootScopeId = `root:${rootRange.offset}:${rootRange.length}`
 
-    const trackStart = source.indexOf('track')
+    const trackBlockStart = source.indexOf('{', source.indexOf('track'))
     const trackEnd = source.indexOf('} // end track') + '}'.length
-    const trackRange = getRangeAt(source, trackStart, trackEnd - trackStart)
+    const trackRange = getRangeAt(source, trackBlockStart, trackEnd - trackBlockStart)
     const trackScopeId = `track:${trackRange.offset}:${trackRange.length}`
 
-    const mixerStart = source.indexOf('mixer')
+    const mixerBlockStart = source.indexOf('{', source.indexOf('mixer'))
     const mixerEnd = source.indexOf('} // end mixer') + '}'.length
-    const mixerRange = getRangeAt(source, mixerStart, mixerEnd - mixerStart)
+    const mixerRange = getRangeAt(source, mixerBlockStart, mixerEnd - mixerBlockStart)
     const mixerScopeId = `mixer:${mixerRange.offset}:${mixerRange.length}`
 
-    const drumsBusStart = source.indexOf('bus drums')
-    const drumsBusEnd = source.indexOf('  }', drumsBusStart) + '  }'.length
-    const drumsBusRange = getRangeAt(source, drumsBusStart, drumsBusEnd - drumsBusStart)
+    const drumsBusBlockStart = source.indexOf('{', source.indexOf('bus drums'))
+    const drumsBusEnd = source.indexOf('  }', source.indexOf('bus drums')) + '  }'.length
+    const drumsBusRange = getRangeAt(source, drumsBusBlockStart, drumsBusEnd - drumsBusBlockStart)
     const drumsBusScopeId = `bus:${drumsBusRange.offset}:${drumsBusRange.length}`
 
-    const delayBusStart = source.indexOf('bus delay')
-    const delayBusEnd = source.indexOf('  }', delayBusStart) + '  }'.length
-    const delayBusRange = getRangeAt(source, delayBusStart, delayBusEnd - delayBusStart)
+    const delayBusBlockStart = source.indexOf('{', source.indexOf('bus delay'))
+    const delayBusEnd = source.indexOf('  }', source.indexOf('bus delay')) + '  }'.length
+    const delayBusRange = getRangeAt(source, delayBusBlockStart, delayBusEnd - delayBusBlockStart)
     const delayBusScopeId = `bus:${delayBusRange.offset}:${delayBusRange.length}`
 
     assert.deepStrictEqual(
@@ -260,14 +260,14 @@ describe('model/analysis/base.ts', () => {
     )
 
     assert.deepStrictEqual(
-      model.bindings.map(({ kind, name }) => ({ kind, name })),
+      model.bindings.map(({ kind, name, declaredScopeId }) => ({ kind, name, declaredScopeId })),
       [
-        { kind: 'use-alias', name: 'fx' },
-        { kind: 'regular', name: 'kick' },
-        { kind: 'regular', name: 'snare' },
-        { kind: 'part', name: 'intro' },
-        { kind: 'bus', name: 'drums' },
-        { kind: 'bus', name: 'delay' }
+        { kind: 'use-alias', name: 'fx', declaredScopeId: undefined },
+        { kind: 'regular', name: 'kick', declaredScopeId: undefined },
+        { kind: 'regular', name: 'snare', declaredScopeId: undefined },
+        { kind: 'part', name: 'intro', declaredScopeId: undefined },
+        { kind: 'bus', name: 'drums', declaredScopeId: drumsBusScopeId },
+        { kind: 'bus', name: 'delay', declaredScopeId: delayBusScopeId }
       ]
     )
   })

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -121,6 +121,45 @@ describe('model/analysis/references.ts', () => {
     assert.strictEqual(binding, undefined)
   })
 
+  it('resolves track parameters declared in the root scope', () => {
+    const source = [
+      'my_tempo = 128.bpm',
+      'track (my_tempo) {}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.lastIndexOf('my_tempo')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
+    assert.strictEqual(binding.kind, 'regular')
+    assert.strictEqual(binding.name, 'my_tempo')
+  })
+
+  it('does not resolve track parameters to declarations inside the track scope', () => {
+    const source = [
+      'track (my_tempo) {',
+      '  my_tempo = 140.bpm',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('my_tempo')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const binding = model.resolutions.get(identifier.id)
+    assert.strictEqual(binding, undefined)
+  })
+
   it('does not resolve member access', () => {
     const source = [
       'use "effects" as fx',

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -186,12 +186,18 @@ function checkTracks (scope: MutableScope, tracks: readonly ast.TrackStatement[]
 
 function checkTrack (scope: MutableScope, track: ast.TrackStatement): readonly CompileError[] {
   const trackScope = createLocalScope(scope)
-
   const errors: CompileError[] = []
+
+  errors.push(...checkArgumentList(trackScope, track.properties, trackSchema, track.range, 'property'))
+
+  const assignments = track.children.filter((c) => c.type === 'Assignment')
+  const parts = track.children.filter((c) => c.type === 'PartStatement')
+
+  errors.push(...checkAssignments(trackScope, assignments))
 
   const seenParts = new Set<string>()
 
-  for (const part of track.parts) {
+  for (const part of parts) {
     if (part.name != null) {
       if (seenParts.has(part.name.name)) {
         errors.push(new CompileError(`Duplicate part named "${part.name.name}"`, part.range))
@@ -207,8 +213,6 @@ function checkTrack (scope: MutableScope, track: ast.TrackStatement): readonly C
 
     errors.push(...checkPart(trackScope, part))
   }
-
-  errors.push(...checkArgumentList(trackScope, track.properties, trackSchema, track.range, 'property'))
 
   return errors
 }
@@ -304,10 +308,14 @@ interface MixerDetail {
 
 function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: MutableNamespace): Checked<MixerDetail> {
   const mixerScope = createLocalScope(scope)
-
   const errors: CompileError[] = []
 
   errors.push(...checkArgumentList(mixerScope, mixer.properties, mixerSchema, mixer.range, 'property'))
+
+  const assignments = mixer.children.filter((c) => c.type === 'Assignment')
+  const buses = mixer.children.filter((c) => c.type === 'BusStatement')
+
+  errors.push(...checkAssignments(mixerScope, assignments))
 
   const seenBuses = new Map<string, FacetType>()
 
@@ -319,7 +327,7 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
   }
 
   // Build up the list of buses first
-  for (const bus of mixer.buses) {
+  for (const bus of buses) {
     if (seenBuses.has(bus.name.name)) {
       errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
     } else if (mixerScope.resolutions.has(bus.name.name)) {
@@ -331,7 +339,7 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
   }
 
   // Now that all buses are known, we can check the routings
-  for (const bus of mixer.buses) {
+  for (const bus of buses) {
     const busCheck = checkBus(mixerScope, bus)
     errors.push(...busCheck.errors)
 
@@ -340,7 +348,7 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
     }
   }
 
-  errors.push(...checkCyclicRoutings(mixer.buses.map((bus) => ({
+  errors.push(...checkCyclicRoutings(buses.map((bus) => ({
     name: bus.name.name,
     sources: bus.sources.map((s) => s.name),
     range: bus.name.range

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -123,12 +123,19 @@ function processAssignments (scope: MutableScope, assignments: readonly ast.Assi
 function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
   const { options } = scope.top
 
+  const properties = resolveArgumentList(scope, track.properties, trackSchema)
+
+  const tempo = properties.tempo != null
+    ? clamped(NumberFacet.get(properties.tempo), options.tempo.minimum, options.tempo.maximum)
+    : numeric('bpm', options.tempo.default)
+
   const trackScope = createLocalScope(scope)
+  processAssignments(trackScope, track.children.filter((c) => c.type === 'Assignment'))
 
   const parts: Part[] = []
 
   let currentTime = numeric('beats', 0)
-  for (const partStatement of track.parts) {
+  for (const partStatement of track.children.filter((c) => c.type === 'PartStatement')) {
     const part = generatePart(trackScope, partStatement, currentTime)
     parts.push(part)
 
@@ -139,12 +146,6 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
 
     currentTime = numeric('beats', currentTime.value + part.length.value)
   }
-
-  const properties = resolveArgumentList(trackScope, track.properties, trackSchema)
-
-  const tempo = properties.tempo != null
-    ? clamped(NumberFacet.get(properties.tempo), options.tempo.minimum, options.tempo.maximum)
-    : numeric('bpm', options.tempo.default)
 
   return { tempo, parts }
 }
@@ -193,12 +194,14 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
 
 function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
   const mixerScope = createLocalScope(scope)
+  processAssignments(mixerScope, mixer?.children.filter((c) => c.type === 'Assignment') ?? [])
 
   const namespace = createNamespace()
   scope.top.namespaces.set(BUS_NAMESPACE, namespace)
 
-  const buses = mixer?.buses.map((bus) => generateBus(mixerScope, bus, namespace)) ?? []
-  const routings = mixer?.buses.flatMap((bus, index) => generateBusRoutings(mixerScope, bus, buses[index])) ?? []
+  const busStatements = mixer?.children.filter((c) => c.type === 'BusStatement') ?? []
+  const buses = busStatements.map((bus) => generateBus(mixerScope, bus, namespace))
+  const routings = busStatements.flatMap((bus, index) => generateBusRoutings(mixerScope, bus, buses[index]))
 
   // Implicit output routings for unrouted buses and instruments
   const unroutedBuses = new Set<BusId>(buses.map((b) => b.id))

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -580,7 +580,9 @@ const trackStatement_: p.Parser<Token, unknown, ast.TrackStatement> = p.abc(
   ),
   combine3(
     expectLiteral('{'),
-    p.many(partStatement_),
+    p.many(
+      p.eitherOr(assignment_, partStatement_)
+    ),
     expectLiteral('}')
   ),
   (_track, callChain, [_lp, children, _rp]) => {
@@ -588,7 +590,7 @@ const trackStatement_: p.Parser<Token, unknown, ast.TrackStatement> = p.abc(
 
     return ast.make('TrackStatement', combineSourceRanges(_track, _rp), {
       properties: args,
-      parts: children
+      children
     })
   }
 )
@@ -655,7 +657,9 @@ const mixerStatement_: p.Parser<Token, unknown, ast.MixerStatement> = p.abc(
   ),
   combine3(
     expectLiteral('{'),
-    p.many(busStatement_),
+    p.many(
+      p.eitherOr(assignment_, busStatement_)
+    ),
     expectLiteral('}')
   ),
   (_mixer, callChain, [_lp, children, _rp]) => {
@@ -663,7 +667,7 @@ const mixerStatement_: p.Parser<Token, unknown, ast.MixerStatement> = p.abc(
 
     return ast.make('MixerStatement', combineSourceRanges(_mixer, _rp), {
       properties: args,
-      buses: children
+      children
     })
   }
 )

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -132,6 +132,28 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should allow assignments in track scope to shadow top-level variables', () => {
+      const source = [
+        'foo = 42',
+        'track {',
+        '  foo = 100',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow assignments in mixer scope to shadow top-level variables', () => {
+      const source = [
+        'foo = 42',
+        'mixer {',
+        '  foo = 100',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept a pattern with interpolation', () => {
       const source = [
         'some_chord = [<D4 G4>]',
@@ -273,6 +295,24 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
+    it('should reject variable reassignment in nested scopes', () => {
+      const source = [
+        'mixer {',
+        '  bar = 42',
+        '  bar = 100',
+        '}',
+        'track {',
+        '  foo = 42',
+        '  foo = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "bar" is already defined',
+        'Identifier "foo" is already defined'
+      ])
+    })
+
     it('should reject duplicate track blocks', () => {
       const source = [
         'track {}',
@@ -301,6 +341,50 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Duplicate part named "intro"'
+      ])
+    })
+
+    it('should reject conflicting part name and local variable name', () => {
+      const source = [
+        'track {',
+        '  before = 42',
+        '  part before (4.bars) {}',
+        '  part after (4.bars) {}',
+        '  after = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Part name "before" conflicts with existing identifier',
+        'Part name "after" conflicts with existing identifier'
+      ])
+    })
+
+    it('should reject variable usage from within the track scope', () => {
+      const source = [
+        'foo = bar',
+        'track (my_tempo) {',
+        '  my_tempo = 123.bpm',
+        '  bar = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "bar"',
+        'Unknown identifier "my_tempo"'
+      ])
+    })
+
+    it('should reject variable usage from within the mixer scope', () => {
+      const source = [
+        'foo = bar',
+        'mixer {',
+        '  bar = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "bar"'
       ])
     })
 
@@ -365,6 +449,22 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Duplicate bus named "foo"'
+      ])
+    })
+
+    it('should reject conflicting bus name and local variable name', () => {
+      const source = [
+        'mixer {',
+        '  before = 42',
+        '  bus before {}',
+        '  bus after {}',
+        '  after = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Bus name "before" conflicts with existing identifier',
+        'Bus name "after" conflicts with existing identifier'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -67,6 +67,18 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.track.tempo, numeric('bpm', 180))
   })
 
+  it('should use tempo variable from outer scope', () => {
+    const source = [
+      'my_tempo = 90.bpm',
+      'track (tempo: my_tempo) {',
+      '  my_tempo = 150.bpm',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.track.tempo, numeric('bpm', 90))
+  })
+
   it('should support imported names', () => {
     const source = [
       'use "instruments" as *',
@@ -125,6 +137,44 @@ describe('compiler/generator/generator.ts', () => {
   it('should clamp negative part lengths to 0', () => {
     const result = generateSource('track { part intro (-4.bars) {} }')
     assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 0))
+  })
+
+  it('should support part lengths from variables', () => {
+    const source = [
+      'root_scope = 42.beats',
+      'shadowed = 100.beats',
+      'track {',
+      '  track_scope = root_scope + 1.beats',
+      '  shadowed = 200.beats',
+      '  part part0 (length: root_scope) {}',
+      '  part part1 (length: track_scope) {}',
+      '  part part2 (length: shadowed) {}',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 42))
+    assert.deepStrictEqual(result.track.parts[1].length, numeric('beats', 43))
+    assert.deepStrictEqual(result.track.parts[2].length, numeric('beats', 200))
+  })
+
+  it('should resolve variables in mixer scope', () => {
+    const source = [
+      'root_scope = -42.db',
+      'shadowed = -100.db',
+      'mixer {',
+      '  mixer_scope = root_scope + 1.db',
+      '  shadowed = -200.db',
+      '  bus bus0 (gain: root_scope) {}',
+      '  bus bus1 (gain: mixer_scope) {}',
+      '  bus bus2 (gain: shadowed) {}',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.mixer.buses[0].gain.initial, numeric('db', -42))
+    assert.deepStrictEqual(result.mixer.buses[1].gain.initial, numeric('db', -41))
+    assert.deepStrictEqual(result.mixer.buses[2].gain.initial, numeric('db', -200))
   })
 
   it('should generate automation points for a lin curve', () => {

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -580,7 +580,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'MixerStatement',
         properties: [],
-        buses: [
+        children: [
           {
             type: 'BusStatement',
             name: { type: 'Identifier', name: 'mybus' },
@@ -649,7 +649,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'TrackStatement',
         properties: [],
-        parts: [
+        children: [
           {
             type: 'PartStatement',
             name: undefined,
@@ -672,5 +672,44 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource('mixer { bus {} }'))
     assert.strictEqual(result.complete, false)
     assert.strictEqual(result.error.message, 'Unexpected "{"; expected bus name')
+  })
+
+  it('should allow assignments in track and mixer bodies', () => {
+    const source = [
+      'track {',
+      '  foo = 42',
+      '}',
+      'mixer {',
+      '  bar = 43',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'TrackStatement',
+        properties: [],
+        children: [
+          {
+            type: 'Assignment',
+            key: { type: 'Identifier', name: 'foo' },
+            value: { type: 'Number', value: 42 }
+          }
+        ]
+      },
+      {
+        type: 'MixerStatement',
+        properties: [],
+        children: [
+          {
+            type: 'Assignment',
+            key: { type: 'Identifier', name: 'bar' },
+            value: { type: 'Number', value: 43 }
+          }
+        ]
+      }
+    ])
   })
 })


### PR DESCRIPTION
As titled: It is now possible to perform variable assignments at the top of track and mixer blocks, and use them within the block, such as for part lengths, effect parameters, and so on.