### PR TITLE
feat!: Begin implementing instrument expressions

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -95,7 +95,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Identifier | Number | String | Pattern | Curve
+export type Value = Identifier | Number | String | Pattern | Curve | Instrument
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -162,6 +162,11 @@ export interface AutomateStatement extends ASTNode {
   readonly curve: Expression
 }
 
+export interface Instrument extends ASTNode {
+  readonly type: 'Instrument'
+  readonly children: readonly Assignment[]
+}
+
 // Root Type
 
 export interface Program extends ASTNode {
@@ -215,6 +220,8 @@ export interface NodeByType {
   BusStatement: BusStatement
   EffectStatement: EffectStatement
   AutomateStatement: AutomateStatement
+
+  Instrument: Instrument
 
   Program: Program
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -111,7 +111,7 @@ argumentList {
 }
 
 primary {
-  "(" expression ")" | Number | String | Pattern | Curve | Call | VariableName | BusNamespace
+  "(" expression ")" | Number | String | Pattern | Curve | Instrument | Call | VariableName | BusNamespace
 }
 
 Call {
@@ -211,4 +211,11 @@ EffectStatement {
   kw<"effect">
   (VariableDefinition "=")?
   expression
+}
+
+Instrument {
+  kw<"instrument">
+  InstrumentBlock[group=Block] {
+    "{" (Assignment)* "}"
+  }
 }

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -87,7 +87,8 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       }
 
       case 'MixerBlock': {
-        nextScopeId = addScope({ kind: 'mixer', range, parentId: scopeId }).id
+        const scope = addScope({ kind: 'mixer', range, parentId: scopeId })
+        nextScopeId = scope.id
         break
       }
 
@@ -105,6 +106,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
           nextScopeId = pendingScope.id
           nextPendingScope = undefined
         }
+        break
+      }
+
+      case 'InstrumentBlock': {
+        const scope = addScope({ kind: 'instrument', range, parentId: scopeId })
+        nextScopeId = scope.id
         break
       }
 

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -32,7 +32,7 @@ export interface Scope {
   readonly range: SourceRange
 }
 
-export type ScopeKind = 'root' | 'track' | 'mixer' | 'bus'
+export type ScopeKind = 'root' | 'track' | 'mixer' | 'bus' | 'instrument'
 
 // identifier
 

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -71,7 +71,7 @@ describe('language-support.ts', () => {
       'tempo = 128.bpm',
       'mix = 0.5 + 0.25',
       'pattern = [D4:2 - x]',
-      'instrument = sample("kick-{tempo}")',
+      'inst = sample("kick-{tempo}")',
       'track (tempo: 140.bpm) {',
       '  part drums {',
       '    automate lib.gain as ~[hold(-60.db) lin(-60.db, 0.db)]',
@@ -79,7 +79,7 @@ describe('language-support.ts', () => {
       '}',
       'mixer {',
       '  bus main {',
-      '    instrument',
+      '    inst',
       '    effect fx.pan(-1)',
       '  }',
       '}',
@@ -88,8 +88,8 @@ describe('language-support.ts', () => {
 
     const spans = getHighlightSpans(source)
 
-    const definitionInstrumentStart = source.indexOf('instrument =')
-    const useInstrumentStart = source.indexOf('    instrument') + '    '.length
+    const definitionInstrumentStart = source.indexOf('inst =')
+    const useInstrumentStart = source.indexOf('    inst') + '    '.length
 
     assertHighlightAt(spans, source, '// comment', source.indexOf('// comment'), 'comment')
     assertHighlightAt(spans, source, 'use', source.indexOf('use'), 'keyword')
@@ -99,7 +99,7 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, ' x', source.indexOf(' x]'), 'pattern')
     assertHighlightAt(spans, source, 'tempo', source.indexOf('tempo ='), 'definition-variable')
     assertHighlightAt(spans, source, 'mix', source.indexOf('mix ='), 'definition-variable')
-    assertHighlightAt(spans, source, 'instrument', definitionInstrumentStart, 'definition-variable')
+    assertHighlightAt(spans, source, 'inst', definitionInstrumentStart, 'definition-variable')
     assertHighlightAt(spans, source, 'lib', source.indexOf('lib', source.indexOf('as lib')), 'definition-variable')
     assertHighlightAt(spans, source, 'tempo', source.indexOf('(tempo:') + 1, 'definition-property')
     assertHighlightAt(spans, source, 'gain', source.indexOf('.gain') + 1, 'property')
@@ -115,7 +115,7 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, '{', source.indexOf('{'), 'brace')
     assertHighlightAt(spans, source, '(', source.indexOf('('), 'paren')
     assertHighlightAt(spans, source, ':', source.indexOf(':2'), 'separator')
-    assertHighlightAt(spans, source, 'instrument', useInstrumentStart, 'variable')
+    assertHighlightAt(spans, source, 'inst', useInstrumentStart, 'variable')
     assertHighlightAt(spans, source, 'fx', source.indexOf('fx.pan'), 'variable')
   })
 

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -205,6 +205,11 @@ describe('model/analysis/base.ts', () => {
       'kick = sample("/samples/kick.wav")',
       'snare = sample("/samples/snare.wav", gain: -3.db)',
       '',
+      'my_instrument = instrument {',
+      '  foo = 42',
+      '  bar = foo * 2',
+      '}',
+      '',
       'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    kick << [x---]',
@@ -226,6 +231,11 @@ describe('model/analysis/base.ts', () => {
 
     const rootRange = getRangeAt(source, 0, source.length)
     const rootScopeId = `root:${rootRange.offset}:${rootRange.length}`
+
+    const instrumentBlockStart = source.indexOf('{', source.indexOf('my_instrument'))
+    const instrumentBlockEnd = source.indexOf('}', instrumentBlockStart) + 1
+    const instrumentRange = getRangeAt(source, instrumentBlockStart, instrumentBlockEnd - instrumentBlockStart)
+    const instrumentScopeId = `instrument:${instrumentRange.offset}:${instrumentRange.length}`
 
     const trackBlockStart = source.indexOf('{', source.indexOf('track'))
     const trackEnd = source.indexOf('} // end track') + '}'.length
@@ -251,6 +261,7 @@ describe('model/analysis/base.ts', () => {
       model.scopes.map(({ id, kind, parentId }) => ({ id, kind, parentId })),
       [
         { id: rootScopeId, kind: 'root', parentId: undefined },
+        { id: instrumentScopeId, kind: 'instrument', parentId: rootScopeId },
         { id: trackScopeId, kind: 'track', parentId: rootScopeId },
         { id: mixerScopeId, kind: 'mixer', parentId: rootScopeId },
         { id: drumsBusScopeId, kind: 'bus', parentId: mixerScopeId },
@@ -264,6 +275,9 @@ describe('model/analysis/base.ts', () => {
         { kind: 'use-alias', name: 'fx', declaredScopeId: undefined },
         { kind: 'regular', name: 'kick', declaredScopeId: undefined },
         { kind: 'regular', name: 'snare', declaredScopeId: undefined },
+        { kind: 'regular', name: 'my_instrument', declaredScopeId: undefined },
+        { kind: 'regular', name: 'foo', declaredScopeId: undefined },
+        { kind: 'regular', name: 'bar', declaredScopeId: undefined },
         { kind: 'part', name: 'intro', declaredScopeId: undefined },
         { kind: 'bus', name: 'drums', declaredScopeId: drumsBusScopeId },
         { kind: 'bus', name: 'delay', declaredScopeId: delayBusScopeId }

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -152,20 +152,22 @@ function checkImports (imports: readonly ast.UseStatement[]): Checked<ReadonlyMa
 }
 
 function checkAssignments (scope: MutableScope, assignments: readonly ast.Assignment[]): readonly CompileError[] {
+  return assignments.flatMap((assignment) => checkAssignment(scope, assignment))
+}
+
+function checkAssignment (scope: MutableScope, assignment: ast.Assignment): readonly CompileError[] {
   const errors: CompileError[] = []
 
-  for (const assignment of assignments) {
-    const duplicate = scope.resolutions.has(assignment.key.name)
-    if (duplicate) {
-      errors.push(new CompileError(`Identifier "${assignment.key.name}" is already defined`, assignment.key.range))
-    }
+  const duplicate = scope.resolutions.has(assignment.key.name)
+  if (duplicate) {
+    errors.push(new CompileError(`Identifier "${assignment.key.name}" is already defined`, assignment.key.range))
+  }
 
-    const expressionCheck = checkExpression(scope, assignment.value)
-    errors.push(...expressionCheck.errors)
+  const expressionCheck = checkExpression(scope, assignment.value)
+  errors.push(...expressionCheck.errors)
 
-    if (!duplicate && expressionCheck.result != null) {
-      scope.resolutions.set(assignment.key.name, expressionCheck.result)
-    }
+  if (!duplicate && expressionCheck.result != null) {
+    scope.resolutions.set(assignment.key.name, expressionCheck.result)
   }
 
   return errors
@@ -436,6 +438,9 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
     case 'Curve':
       return checkCurve(scope, expression)
 
+    case 'Instrument':
+      return checkInstrument(scope, expression)
+
     case 'Identifier':
       return checkIdentifier(scope, expression)
 
@@ -614,6 +619,17 @@ function checkCurveSegment (scope: Scope, segment: ast.CurveSegment, hasPrevious
   }
 
   return { errors, result: firstUnit }
+}
+
+function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<FacetType> {
+  const instrumentScope = createLocalScope(scope)
+  const errors: CompileError[] = []
+
+  for (const child of expression.children) {
+    errors.push(...checkAssignment(instrumentScope, child))
+  }
+
+  return { errors, result: InstrumentFacet.type() }
 }
 
 function checkIdentifier (scope: Scope, identifier: ast.Identifier): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -321,6 +321,9 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
     case 'Curve':
       return generateCurve(scope, expression)
 
+    case 'Instrument':
+      return generateInstrument(scope, expression)
+
     case 'Identifier':
       return resolveIdentifier(scope, expression)
 
@@ -437,6 +440,36 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
   }
 
   return CurveFacet.type().of(createCurve(generatedSegments))
+}
+
+function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
+  const instrumentScope = createLocalScope(scope)
+
+  for (const child of expression.children) {
+    assert(!instrumentScope.resolutions.has(child.key.name))
+    instrumentScope.resolutions.set(child.key.name, resolve(instrumentScope, child.value))
+  }
+
+  // TODO: Change -Infinity to 0 and expose gain on the record,
+  //       once instrument definitions are fully supported.
+  const gainValue = numeric('db', -Infinity)
+  const gainParameter = scope.top.allocateParameter(gainValue)
+
+  const instrument = scope.top.allocateInstrument({
+    gain: gainParameter,
+    source: {
+      type: 'oscillator',
+      shape: 'sine'
+    },
+    envelope: {
+      attack: numeric('s', 0),
+      decay: numeric('s', 0),
+      sustain: numeric(undefined, 1),
+      release: numeric('s', 0)
+    }
+  })
+
+  return InstrumentFacet.type().of(instrument)
 }
 
 function resolveIdentifier (scope: Scope, identifier: ast.Identifier): Value {

--- a/packages/language/src/parser/constants.ts
+++ b/packages/language/src/parser/constants.ts
@@ -7,7 +7,8 @@ export const keywords = Object.freeze([
   'mixer',
   'bus',
   'effect',
-  'automate'
+  'automate',
+  'instrument'
 ] as const)
 
 export type Keyword = (typeof keywords)[number]

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -343,18 +343,13 @@ const curve_: p.Parser<Token, unknown, ast.Curve> = p.abc(
   }
 )
 
-const value_: p.Parser<Token, unknown, ast.Value> = p.eitherOr(
+const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast.Value>(
   identifier_,
-  p.eitherOr(
-    number_,
-    p.eitherOr(
-      string_,
-      p.eitherOr(
-        serialPattern_,
-        curve_
-      )
-    )
-  )
+  number_,
+  string_,
+  serialPattern_,
+  curve_,
+  p.recursive(() => instrument_)
 )
 
 const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
@@ -667,6 +662,20 @@ const mixerStatement_: p.Parser<Token, unknown, ast.MixerStatement> = p.abc(
 
     return ast.make('MixerStatement', combineSourceRanges(_mixer, _rp), {
       properties: args,
+      children
+    })
+  }
+)
+
+const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.ab(
+  keyword('instrument'),
+  combine3(
+    expectLiteral('{'),
+    p.many(assignment_),
+    expectLiteral('}')
+  ),
+  (_instrument, [_lp, children, _rp]) => {
+    return ast.make('Instrument', combineSourceRanges(_instrument, _rp), {
       children
     })
   }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -245,6 +245,16 @@ describe('compiler/checker/checker.ts', () => {
 
       assertValid(source)
     })
+
+    it('should allow valid instrument definitions', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  foo = -6.db',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
   })
 
   describe('invalid', () => {
@@ -585,6 +595,19 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Missing required argument "duration"'
+      ])
+    })
+
+    it('should report errors in instrument definitions', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  foo = 42',
+        '  foo = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "foo" is already defined'
       ])
     })
   })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -490,4 +490,20 @@ describe('compiler/generator/generator.ts', () => {
       wet: numeric('db', 0)
     })
   })
+
+  it('should generate silent instruments', () => {
+    const source = [
+      'my_instrument = instrument {',
+      '  foo = -6.db',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.instruments.size, 1)
+
+    const [instrument] = result.instruments.values()
+    assert.strictEqual(instrument.source.type, 'oscillator')
+    assert.strictEqual(instrument.source.shape, 'sine')
+    assert.deepStrictEqual(instrument.gain.initial, numeric('db', -Infinity))
+  })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -712,4 +712,40 @@ describe('parser/parser.ts', () => {
       }
     ])
   })
+
+  it('should parse instrument expressions', () => {
+    const source = [
+      'my_synth = instrument {',
+      '  foo = -6.db',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'my_synth' },
+        value: {
+          type: 'Instrument',
+          children: [
+            {
+              type: 'Assignment',
+              key: { type: 'Identifier', name: 'foo' },
+              value: {
+                type: 'UnaryExpression',
+                operator: '-',
+                argument: {
+                  type: 'PropertyAccess',
+                  object: { type: 'Number', value: 6 },
+                  property: { type: 'Identifier', name: 'db' }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ])
+  })
 })


### PR DESCRIPTION
This patch lays the groundwork for custom instrument definitions via `instrument { ... }` expressions. In the future, it will be possible to define sources, envelopes, LFOs, effects, and more within such a block. For now, simply add the keyword and scope handling, and validate any assignments within the block.

BREAKING CHANGE: Keyword added.