### PR TITLE
feat!: Add voice statement inside instruments

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -164,7 +164,15 @@ export interface AutomateStatement extends ASTNode {
 
 export interface Instrument extends ASTNode {
   readonly type: 'Instrument'
+  readonly children: ReadonlyArray<Assignment | VoiceStatement>
+}
+
+export interface VoiceStatement extends ASTNode {
+  readonly type: 'VoiceStatement'
   readonly children: readonly Assignment[]
+  readonly bindings: {
+    readonly note?: Identifier
+  }
 }
 
 // Root Type
@@ -222,6 +230,7 @@ export interface NodeByType {
   AutomateStatement: AutomateStatement
 
   Instrument: Instrument
+  VoiceStatement: VoiceStatement
 
   Program: Program
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -216,6 +216,14 @@ EffectStatement {
 Instrument {
   kw<"instrument">
   InstrumentBlock[group=Block] {
+    "{" (Assignment | VoiceStatement)* "}"
+  }
+}
+
+VoiceStatement {
+  kw<"voice">
+  VariableDefinition?
+  VoiceBlock[group=Block] {
     "{" (Assignment)* "}"
   }
 }

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -115,6 +115,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
+      case 'VoiceStatement': {
+        const scope = addScope({ kind: 'voice', range, parentId: scopeId })
+        nextScopeId = scope.id
+        break
+      }
+
       case 'Assignment': {
         nextAssignmentHasEquals = false
 
@@ -161,6 +167,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
           case 'EffectStatement': {
             addBinding({ kind: 'effect', scopeId, name, range })
+            addIdentifier({ kind: 'definition', scopeId, name, range })
+            break
+          }
+
+          case 'VoiceStatement': {
+            addBinding({ kind: 'regular', scopeId, name, range })
             addIdentifier({ kind: 'definition', scopeId, name, range })
             break
           }

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -32,7 +32,7 @@ export interface Scope {
   readonly range: SourceRange
 }
 
-export type ScopeKind = 'root' | 'track' | 'mixer' | 'bus' | 'instrument'
+export type ScopeKind = 'root' | 'track' | 'mixer' | 'bus' | 'instrument' | 'voice'
 
 // identifier
 

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -24,6 +24,10 @@ describe('model/analysis/base.ts', () => {
       'kick = sample("{base_path}/kick.wav")',
       'tempo = 120.bpm',
       '',
+      'synth = instrument {',
+      '  voice note {}',
+      '}',
+      '',
       'track (tempo: tempo) {',
       '  part intro (4.bars) {',
       '    kick << [x---].loop()',
@@ -55,6 +59,8 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'root', name: 'sample' },
         { kind: 'plain', scope: 'root', name: 'base_path' },
         { kind: 'definition', scope: 'root', name: 'tempo' },
+        { kind: 'definition', scope: 'root', name: 'synth' },
+        { kind: 'definition', scope: 'voice', name: 'note' },
         { kind: 'property-name', scope: 'root', name: 'tempo' },
         { kind: 'plain', scope: 'root', name: 'tempo' },
         { kind: 'definition', scope: 'track', name: 'intro' },
@@ -208,7 +214,10 @@ describe('model/analysis/base.ts', () => {
       'my_instrument = instrument {',
       '  foo = 42',
       '  bar = foo * 2',
-      '}',
+      '  voice note {',
+      '    baz = bar + 1',
+      '  } // end voice',
+      '} // end instrument',
       '',
       'track (120.bpm) {',
       '  part intro (4.bars) {',
@@ -233,9 +242,14 @@ describe('model/analysis/base.ts', () => {
     const rootScopeId = `root:${rootRange.offset}:${rootRange.length}`
 
     const instrumentBlockStart = source.indexOf('{', source.indexOf('my_instrument'))
-    const instrumentBlockEnd = source.indexOf('}', instrumentBlockStart) + 1
+    const instrumentBlockEnd = source.indexOf('} // end instrument') + '}'.length
     const instrumentRange = getRangeAt(source, instrumentBlockStart, instrumentBlockEnd - instrumentBlockStart)
     const instrumentScopeId = `instrument:${instrumentRange.offset}:${instrumentRange.length}`
+
+    const voiceBlockStart = source.indexOf('voice note')
+    const voiceBlockEnd = source.indexOf('} // end voice') + '}'.length
+    const voiceRange = getRangeAt(source, voiceBlockStart, voiceBlockEnd - voiceBlockStart)
+    const voiceScopeId = `voice:${voiceRange.offset}:${voiceRange.length}`
 
     const trackBlockStart = source.indexOf('{', source.indexOf('track'))
     const trackEnd = source.indexOf('} // end track') + '}'.length
@@ -262,6 +276,7 @@ describe('model/analysis/base.ts', () => {
       [
         { id: rootScopeId, kind: 'root', parentId: undefined },
         { id: instrumentScopeId, kind: 'instrument', parentId: rootScopeId },
+        { id: voiceScopeId, kind: 'voice', parentId: instrumentScopeId },
         { id: trackScopeId, kind: 'track', parentId: rootScopeId },
         { id: mixerScopeId, kind: 'mixer', parentId: rootScopeId },
         { id: drumsBusScopeId, kind: 'bus', parentId: mixerScopeId },
@@ -278,6 +293,8 @@ describe('model/analysis/base.ts', () => {
         { kind: 'regular', name: 'my_instrument', declaredScopeId: undefined },
         { kind: 'regular', name: 'foo', declaredScopeId: undefined },
         { kind: 'regular', name: 'bar', declaredScopeId: undefined },
+        { kind: 'regular', name: 'note', declaredScopeId: undefined },
+        { kind: 'regular', name: 'baz', declaredScopeId: undefined },
         { kind: 'part', name: 'intro', declaredScopeId: undefined },
         { kind: 'bus', name: 'drums', declaredScopeId: drumsBusScopeId },
         { kind: 'bus', name: 'delay', declaredScopeId: delayBusScopeId }
@@ -288,6 +305,14 @@ describe('model/analysis/base.ts', () => {
   it('includes bindings for definitions', () => {
     const source = [
       'kick = sample("/samples/kick.wav")',
+      '',
+      'synth = instrument {',
+      '  foo = 42',
+      '  voice note {',
+      '    bar = 440.hz',
+      '  }',
+      '}',
+      '',
       'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    kick << [x---]',
@@ -311,6 +336,26 @@ describe('model/analysis/base.ts', () => {
           kind: 'regular',
           name: 'kick',
           range: getRangeAt(source, source.indexOf('kick ='), 'kick'.length)
+        },
+        {
+          kind: 'regular',
+          name: 'synth',
+          range: getRangeAt(source, source.indexOf('synth ='), 'synth'.length)
+        },
+        {
+          kind: 'regular',
+          name: 'foo',
+          range: getRangeAt(source, source.indexOf('foo ='), 'foo'.length)
+        },
+        {
+          kind: 'regular',
+          name: 'note',
+          range: getRangeAt(source, source.indexOf('note'), 'note'.length)
+        },
+        {
+          kind: 'regular',
+          name: 'bar',
+          range: getRangeAt(source, source.indexOf('bar ='), 'bar'.length)
         },
         {
           kind: 'part',

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -342,4 +342,44 @@ describe('model/analysis/references.ts', () => {
     const resolution = model.resolutions.get(identifier.id)
     assert.strictEqual(resolution, undefined)
   })
+
+  it('resolves reference to voice note binding', () => {
+    const source = [
+      'my_instrument = instrument {',
+      '  voice my_note {',
+      '    foo = my_note',
+      '  }',
+      '  bar = my_note // invalid reference',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('voice my_note') + 'voice '.length
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
+    assert.strictEqual(binding.kind, 'regular')
+    assert.strictEqual(binding.name, 'my_note')
+    assert.deepStrictEqual(binding.range, getRangeAt(source, position, 'my_note'.length))
+
+    const assignmentPosition = source.indexOf('foo = my_note') + 'foo = '.length
+    const assignmentIdentifier = model.identifiers.find((identifier) => identifier.range.offset === assignmentPosition)
+    assert.ok(assignmentIdentifier != null)
+
+    const assignmentResolution = model.resolutions.get(assignmentIdentifier.id)
+    assert.deepStrictEqual(assignmentResolution, resolution)
+
+    const invalidReferencePosition = source.indexOf('bar = my_note') + 'bar = '.length
+    const invalidReferenceIdentifier = model.identifiers.find((identifier) => identifier.range.offset === invalidReferencePosition)
+    assert.ok(invalidReferenceIdentifier != null)
+
+    const invalidReferenceResolution = model.resolutions.get(invalidReferenceIdentifier.id)
+    assert.strictEqual(invalidReferenceResolution, undefined)
+  })
 })

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -625,11 +625,31 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
   const instrumentScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
-  for (const child of expression.children) {
-    errors.push(...checkAssignment(instrumentScope, child))
+  const assignments = expression.children.filter((c) => c.type === 'Assignment')
+  const voices = expression.children.filter((c) => c.type === 'VoiceStatement')
+
+  errors.push(...checkAssignments(instrumentScope, assignments))
+
+  for (const voice of voices) {
+    errors.push(...checkVoice(instrumentScope, voice))
   }
 
   return { errors, result: InstrumentFacet.type() }
+}
+
+function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileError[] {
+  const voiceScope = createLocalScope(scope)
+  const errors: CompileError[] = []
+
+  if (voice.bindings.note != null) {
+    // TODO: Add note parameters
+    const noteType = RecordFacet.type()
+    voiceScope.resolutions.set(voice.bindings.note.name, noteType)
+  }
+
+  errors.push(...checkAssignments(voiceScope, voice.children))
+
+  return errors
 }
 
 function checkIdentifier (scope: Scope, identifier: ast.Identifier): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -443,11 +443,21 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
 }
 
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
-  const instrumentScope = createLocalScope(scope)
+  const assignments = expression.children.filter((c) => c.type === 'Assignment')
+  const voices = expression.children.filter((c) => c.type === 'VoiceStatement')
 
-  for (const child of expression.children) {
-    assert(!instrumentScope.resolutions.has(child.key.name))
-    instrumentScope.resolutions.set(child.key.name, resolve(instrumentScope, child.value))
+  const instrumentScope = createLocalScope(scope)
+  processAssignments(instrumentScope, assignments)
+
+  for (const voice of voices) {
+    const voiceScope = createLocalScope(instrumentScope)
+
+    if (voice.bindings.note != null) {
+      // TODO: Add note parameters
+      voiceScope.resolutions.set(voice.bindings.note.name, RecordFacet.type().of({}))
+    }
+
+    processAssignments(voiceScope, voice.children)
   }
 
   // TODO: Change -Infinity to 0 and expose gain on the record,

--- a/packages/language/src/parser/constants.ts
+++ b/packages/language/src/parser/constants.ts
@@ -8,7 +8,8 @@ export const keywords = Object.freeze([
   'bus',
   'effect',
   'automate',
-  'instrument'
+  'instrument',
+  'voice'
 ] as const)
 
 export type Keyword = (typeof keywords)[number]

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -667,11 +667,31 @@ const mixerStatement_: p.Parser<Token, unknown, ast.MixerStatement> = p.abc(
   }
 )
 
+const voiceStatement_: p.Parser<Token, unknown, ast.VoiceStatement> = p.abc(
+  keyword('voice'),
+  p.option(identifier_, undefined),
+  combine3(
+    literal('{'),
+    p.many(assignment_),
+    expectLiteral('}')
+  ),
+  (_voice, note, [_lp, children, _rp]) => {
+    return ast.make('VoiceStatement', combineSourceRanges(_voice, _rp), {
+      children,
+      bindings: {
+        note
+      }
+    })
+  }
+)
+
 const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.ab(
   keyword('instrument'),
   combine3(
     expectLiteral('{'),
-    p.many(assignment_),
+    p.many(
+      p.eitherOr(assignment_, voiceStatement_)
+    ),
     expectLiteral('}')
   ),
   (_instrument, [_lp, children, _rp]) => {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -250,6 +250,13 @@ describe('compiler/checker/checker.ts', () => {
       const source = [
         'my_instrument = instrument {',
         '  foo = -6.db',
+        '  voice {',
+        '    bar = 440.hz',
+        '  }',
+        '  voice note {}',
+        '  voice note {',
+        '    baz = note',
+        '  }',
         '}'
       ].join('\n')
 
@@ -608,6 +615,50 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Identifier "foo" is already defined'
+      ])
+    })
+
+    it('should report errors in voice statements', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  voice {',
+        '    bar = 440.hz',
+        '    bar = 880.hz',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "bar" is already defined'
+      ])
+    })
+
+    it('should reject accessing note from another voice', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  voice note {}',
+        '  voice {',
+        '    baz = note',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "note"'
+      ])
+    })
+
+    it('should reject reassignment of the note binding', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  voice note {',
+        '    note = 440.hz',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "note" is already defined'
       ])
     })
   })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -495,6 +495,12 @@ describe('compiler/generator/generator.ts', () => {
     const source = [
       'my_instrument = instrument {',
       '  foo = -6.db',
+      '  voice {',
+      '    bar = 440.hz',
+      '  }',
+      '  voice note {',
+      '    baz = note',
+      '  }',
       '}'
     ].join('\n')
 

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -327,4 +327,35 @@ describe('lexer/lexer.ts', () => {
     const result = lex('~ [hold(0.db)]')
     assert.strictEqual(result.complete, false)
   })
+
+  it('should lex instrument definitions', () => {
+    const source = [
+      'my_synth = instrument {',
+      '  foo = -6.db',
+      '  voice note {}',
+      '}'
+    ].join('\n')
+
+    const result = lex(source)
+    assert.deepStrictEqual(stripTokenMeta(result), {
+      complete: true,
+      value: [
+        { name: 'word', text: 'my_synth' },
+        { name: '=', text: '=' },
+        { name: 'word', text: 'instrument' },
+        { name: '{', text: '{' },
+        { name: 'word', text: 'foo' },
+        { name: '=', text: '=' },
+        { name: '-', text: '-' },
+        { name: 'number', text: '6' },
+        { name: '.', text: '.' },
+        { name: 'word', text: 'db' },
+        { name: 'word', text: 'voice' },
+        { name: 'word', text: 'note' },
+        { name: '{', text: '{' },
+        { name: '}', text: '}' },
+        { name: '}', text: '}' }
+      ]
+    })
+  })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -717,6 +717,10 @@ describe('parser/parser.ts', () => {
     const source = [
       'my_synth = instrument {',
       '  foo = -6.db',
+      '  voice {',
+      '    bar = 440.hz',
+      '  }',
+      '  voice note {}',
       '}'
     ].join('\n')
 
@@ -742,6 +746,30 @@ describe('parser/parser.ts', () => {
                   property: { type: 'Identifier', name: 'db' }
                 }
               }
+            },
+            {
+              type: 'VoiceStatement',
+              bindings: {
+                note: undefined
+              },
+              children: [
+                {
+                  type: 'Assignment',
+                  key: { type: 'Identifier', name: 'bar' },
+                  value: {
+                    type: 'PropertyAccess',
+                    object: { type: 'Number', value: 440 },
+                    property: { type: 'Identifier', name: 'hz' }
+                  }
+                }
+              ]
+            },
+            {
+              type: 'VoiceStatement',
+              bindings: {
+                note: { type: 'Identifier', name: 'note' }
+              },
+              children: []
             }
           ]
         }


### PR DESCRIPTION
This patch continues the implementation of custom instrument definitions by adding a new `voice` statement, usable inside `instrument` blocks. This will be used to distinguish the per-note DSP chain from the global parameters, LFOs, etc. of the instrument. Note information will be bound to an identifier placed after the `voice` keyword (e.g., `voice note`), such that statements inside the voice block can refer to the note's pitch, velocity, and other properties.

BREAKING CHANGE: Keyword added (`voice`).