### PR TITLE
fix: Only highlight units when used as members

### DIFF
--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -36,16 +36,16 @@
 @detectDelim
 
 kw<term> { @specialize[@name=keyword]<word, term> }
-unit<term> { @specialize[@name=unit]<word, term> }
+unit<term> { @extend[@name=unit]<word, term> }
 
-Unit {
+Unit[@dynamicPrecedence=1] {
   unit<"bpm"> |
-  unit<"bars"> |
-  unit<"beats"> |
+  unit<"db"> |
+  unit<"hz"> |
   unit<"s"> |
   unit<"ms"> |
-  unit<"hz"> |
-  unit<"db">
+  unit<"bars"> |
+  unit<"beats">
 }
 
 @precedence {
@@ -122,9 +122,8 @@ Call {
 AccessOrCall {
   primary
   (
-    "." Unit |
     "." Call |
-    "." MemberAccess { word }
+    "." Member { Unit | word }
   )*
 }
 

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -188,7 +188,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
       case 'VariableName':
       case 'Callee':
-      case 'MemberAccess':
+      case 'Member':
       case 'BusNamespace': {
         const name = document.sliceString(from, to)
         accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range, previousSibling })
@@ -261,7 +261,7 @@ function shouldKeepPreviousSibling (node: SyntaxNode): boolean {
   return type === 'AccessOrCall' ||
     type === 'Callee' ||
     type === 'Call' ||
-    type === 'MemberAccess' ||
+    type === 'Member' ||
     type === 'VariableName' ||
     type === 'BusNamespace'
 }

--- a/packages/language-support/src/parser-metadata.ts
+++ b/packages/language-support/src/parser-metadata.ts
@@ -32,7 +32,7 @@ export const cadenceParserConfig: ParserConfig = {
       VariableName: t.variableName,
 
       PropertyName: t.definition(t.propertyName),
-      MemberAccess: t.propertyName,
+      Member: t.propertyName,
 
       Callee: t.function(t.name)
     }),

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -138,4 +138,29 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, '<<', source.indexOf('<<'), 'operator')
     assertHighlightAt(spans, source, 'my_pattern', source.indexOf('my_pattern'), 'variable')
   })
+
+  it('higlights units only when used as members', () => {
+    const source = [
+      'bpm = 120',
+      'bars = 4',
+      'part_length = 4.bars',
+      'tempo = 120.bpm',
+      'gain = 0.5.db',
+      'delay = 250.ms'
+    ].join('\n')
+
+    const spans = getHighlightSpans(source)
+
+    assertHighlightAt(spans, source, 'bpm', source.indexOf('bpm ='), 'definition-variable')
+    assertHighlightAt(spans, source, 'bars', source.indexOf('bars ='), 'definition-variable')
+    assertHighlightAt(spans, source, 'part_length', source.indexOf('part_length ='), 'definition-variable')
+    assertHighlightAt(spans, source, 'tempo', source.indexOf('tempo ='), 'definition-variable')
+    assertHighlightAt(spans, source, 'gain', source.indexOf('gain ='), 'definition-variable')
+    assertHighlightAt(spans, source, 'delay', source.indexOf('delay ='), 'definition-variable')
+
+    assertHighlightAt(spans, source, 'bars', source.indexOf('4.bars') + '4.'.length, 'number')
+    assertHighlightAt(spans, source, 'bpm', source.indexOf('120.bpm') + '120.'.length, 'number')
+    assertHighlightAt(spans, source, 'db', source.indexOf('0.5.db') + '0.5.'.length, 'number')
+    assertHighlightAt(spans, source, 'ms', source.indexOf('250.ms') + '250.'.length, 'number')
+  })
 })

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -59,19 +59,23 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'root', name: 'sample' },
         { kind: 'plain', scope: 'root', name: 'base_path' },
         { kind: 'definition', scope: 'root', name: 'tempo' },
+        { kind: 'plain', scope: 'root', name: 'bpm' },
         { kind: 'definition', scope: 'root', name: 'synth' },
         { kind: 'definition', scope: 'voice', name: 'note' },
         { kind: 'property-name', scope: 'root', name: 'tempo' },
         { kind: 'plain', scope: 'root', name: 'tempo' },
         { kind: 'definition', scope: 'track', name: 'intro' },
+        { kind: 'plain', scope: 'track', name: 'bars' },
         { kind: 'plain', scope: 'track', name: 'kick' },
         { kind: 'plain', scope: 'track', name: 'loop' },
         { kind: 'plain', scope: 'track', name: 'kick' },
         { kind: 'plain', scope: 'track', name: 'gain' },
+        { kind: 'plain', scope: 'track', name: 'db' },
         { kind: 'definition', scope: 'mixer', name: 'drums' },
         { kind: 'definition', scope: 'bus', name: 'crush' },
         { kind: 'plain', scope: 'bus', name: 'fx' },
         { kind: 'plain', scope: 'bus', name: 'clip' },
+        { kind: 'plain', scope: 'bus', name: 'db' },
         { kind: 'plain', scope: 'bus', name: 'kick' },
         { kind: 'plain', scope: 'bus', name: 'snare' }
       ]
@@ -129,7 +133,8 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
       [
-        { kind: 'plain', name: 'delay' }
+        { kind: 'plain', name: 'delay' },
+        { kind: 'plain', name: 'beats' }
       ]
     )
   })


### PR DESCRIPTION
Fixes highlighting of statements such as `bars = 4`, which should not highlight `bars` as a unit; units should only be highlighted when used in a member expression, such as `foo = 4.bars`.