### PR TITLE
feat: Allow singular 'beat' and 'bar' units

### DIFF
--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -44,7 +44,9 @@ Unit[@dynamicPrecedence=1] {
   unit<"hz"> |
   unit<"s"> |
   unit<"ms"> |
+  unit<"bar"> |
   unit<"bars"> |
+  unit<"beat"> |
   unit<"beats">
 }
 

--- a/packages/language/src/compiler/units.ts
+++ b/packages/language/src/compiler/units.ts
@@ -6,7 +6,18 @@ interface Constants {
   readonly beatsPerBar: number
 }
 
-export const SyntaxUnits = ['bpm', 'bars', 'beats', 's', 'ms', 'hz', 'db'] as const
+export const SyntaxUnits = [
+  'bpm',
+  'db',
+  'hz',
+  's',
+  'ms',
+  'beat',
+  'beats',
+  'bar',
+  'bars'
+] as const
+
 export type SyntaxUnit = typeof SyntaxUnits[number]
 
 export function isSyntaxUnit (value: string): value is SyntaxUnit {
@@ -20,10 +31,13 @@ export function toNumberValue (constants: Constants, unit: SyntaxUnit | undefine
     case 'db':
     case 'hz':
     case 's':
-    case 'beats':
       return Numbers.of({ unit, value })
     case 'ms':
       return Numbers.of({ unit: 's', value: value / 1000 })
+    case 'beat':
+    case 'beats':
+      return Numbers.of({ unit: 'beats', value })
+    case 'bar':
     case 'bars':
       return Numbers.of({ unit: 'beats', value: value * constants.beatsPerBar })
   }
@@ -39,10 +53,13 @@ export function toBaseUnit (unit: SyntaxUnit | undefined): Unit {
     case 'db':
     case 'hz':
     case 's':
-    case 'beats':
       return unit
     case 'ms':
       return 's'
+    case 'beat':
+    case 'beats':
+      return 'beats'
+    case 'bar':
     case 'bars':
       return 'beats'
   }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -35,6 +35,20 @@ describe('compiler/checker/checker.ts', () => {
       assertValid('')
     })
 
+    it('should accept number literals with valid units', () => {
+      const source = [
+        'foo1 = 120.bpm',
+        'foo2 = -6.db',
+        'foo3 = 440.hz',
+        'foo4 = 2.s',
+        'foo5 = 3.beats',
+        'foo6 = 250.ms',
+        'foo7 = 2.bars'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept use statements without alias', () => {
       const source = [
         'use "instruments" as *',
@@ -265,6 +279,12 @@ describe('compiler/checker/checker.ts', () => {
   })
 
   describe('invalid', () => {
+    it('should reject number literals with invalid units', () => {
+      assertErrorMessages('foo = 120.unknownunit', [
+        'Unknown unit "unknownunit"'
+      ])
+    })
+
     it('should reject imports of unknown libraries', () => {
       assertErrorMessages('use "unknownlib" as *', [
         'Unknown module "unknownlib"'

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -158,6 +158,23 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.track.parts[2].length, numeric('beats', 200))
   })
 
+  it('should support units: beat, beats, bar, bars', () => {
+    const source = [
+      'track {',
+      '  part part0 (length: 1.beat) {}',
+      '  part part1 (length: 2.beats) {}',
+      '  part part2 (length: 1.bar) {}',
+      '  part part3 (length: 2.bars) {}',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 1))
+    assert.deepStrictEqual(result.track.parts[1].length, numeric('beats', 2))
+    assert.deepStrictEqual(result.track.parts[2].length, numeric('beats', 4))
+    assert.deepStrictEqual(result.track.parts[3].length, numeric('beats', 8))
+  })
+
   it('should resolve variables in mixer scope', () => {
     const source = [
       'root_scope = -42.db',

--- a/packages/language/test/compiler/units.test.ts
+++ b/packages/language/test/compiler/units.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { NumberFacet } from '../../src/type-system/base/number.js'
+import { SyntaxUnits, isSyntaxUnit, toBaseUnit, toNumberValue } from '../../src/compiler/units.js'
+
+describe('compiler/units.ts', () => {
+  describe('isSyntaxUnit()', () => {
+    it('should accept every declared syntax unit', () => {
+      for (const unit of SyntaxUnits) {
+        assert.strictEqual(isSyntaxUnit(unit), true)
+      }
+    })
+
+    it('should reject unknown units', () => {
+      assert.strictEqual(isSyntaxUnit('samples'), false)
+      assert.strictEqual(isSyntaxUnit(''), false)
+    })
+  })
+
+  describe('toNumberValue()', () => {
+    it('should preserve units that are already base units', () => {
+      const constants = { beatsPerBar: 4 }
+
+      const unitless = toNumberValue(constants, undefined, 8)
+      const bpm = toNumberValue(constants, 'bpm', 120)
+      const decibels = toNumberValue(constants, 'db', -6)
+      const hertz = toNumberValue(constants, 'hz', 440)
+      const seconds = toNumberValue(constants, 's', 2)
+      const beats = toNumberValue(constants, 'beats', 3)
+
+      assert.strictEqual(unitless.type, NumberFacet.with(undefined).type())
+      assert.deepStrictEqual(NumberFacet.get(unitless), { unit: undefined, value: 8 })
+      assert.deepStrictEqual(NumberFacet.with('bpm').get(bpm), { unit: 'bpm', value: 120 })
+      assert.deepStrictEqual(NumberFacet.with('db').get(decibels), { unit: 'db', value: -6 })
+      assert.deepStrictEqual(NumberFacet.with('hz').get(hertz), { unit: 'hz', value: 440 })
+      assert.deepStrictEqual(NumberFacet.with('s').get(seconds), { unit: 's', value: 2 })
+      assert.deepStrictEqual(NumberFacet.with('beats').get(beats), { unit: 'beats', value: 3 })
+    })
+
+    it('should normalize milliseconds and bars to base units', () => {
+      const constants = { beatsPerBar: 7 }
+
+      const milliseconds = toNumberValue(constants, 'ms', 250)
+      const bars = toNumberValue(constants, 'bars', 2)
+
+      assert.strictEqual(milliseconds.type, NumberFacet.with('s').type())
+      assert.deepStrictEqual(NumberFacet.with('s').get(milliseconds), { unit: 's', value: 0.25 })
+
+      assert.strictEqual(bars.type, NumberFacet.with('beats').type())
+      assert.deepStrictEqual(NumberFacet.with('beats').get(bars), { unit: 'beats', value: 14 })
+    })
+
+    it('should accept singular and plural forms of units', () => {
+      const constants = { beatsPerBar: 4 }
+
+      const beat = toNumberValue(constants, 'beat', 123)
+      const beats = toNumberValue(constants, 'beats', 123)
+      assert.deepStrictEqual(beat, beats)
+
+      const bar = toNumberValue(constants, 'bar', 456)
+      const bars = toNumberValue(constants, 'bars', 456)
+      assert.deepStrictEqual(bar, bars)
+    })
+  })
+
+  describe('toBaseUnit()', () => {
+    it('should preserve base units and convert derived syntax units', () => {
+      assert.strictEqual(toBaseUnit(undefined), undefined)
+      assert.strictEqual(toBaseUnit('bpm'), 'bpm')
+      assert.strictEqual(toBaseUnit('db'), 'db')
+      assert.strictEqual(toBaseUnit('hz'), 'hz')
+      assert.strictEqual(toBaseUnit('s'), 's')
+      assert.strictEqual(toBaseUnit('ms'), 's')
+      assert.strictEqual(toBaseUnit('beat'), 'beats')
+      assert.strictEqual(toBaseUnit('beats'), 'beats')
+      assert.strictEqual(toBaseUnit('bar'), 'beats')
+      assert.strictEqual(toBaseUnit('bars'), 'beats')
+    })
+  })
+})


### PR DESCRIPTION
It is natural to want to write, for example, both `1.bar` and `4.bars`, and having that be an error just for the sake of avoiding redundancy in the language is not worth it. Hence, this patch allows the singular and plural forms of the beat and bar units to be used interchangeably.