### PR TITLE
refactor: Preserve order of PartStatement children

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -132,8 +132,7 @@ export interface PartStatement extends ASTNode {
   readonly type: 'PartStatement'
   readonly name?: Identifier
   readonly properties: ArgumentList
-  readonly routings: readonly Routing[]
-  readonly automations: readonly AutomateStatement[]
+  readonly children: ReadonlyArray<Routing | AutomateStatement>
 }
 
 export interface MixerStatement extends ASTNode {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -225,12 +225,19 @@ function checkPart (scope: Scope, part: ast.PartStatement): readonly CompileErro
 
   errors.push(...checkArgumentList(scope, part.properties, partSchema, part.range, 'property'))
 
-  for (const routing of part.routings) {
-    errors.push(...checkInstrumentRouting(scope, routing))
-  }
+  for (const child of part.children) {
+    switch (child.type) {
+      case 'Routing':
+        errors.push(...checkInstrumentRouting(scope, child))
+        break
 
-  for (const automation of part.automations) {
-    errors.push(...checkAutomation(scope, automation))
+      case 'AutomateStatement':
+        errors.push(...checkAutomation(scope, child))
+        break
+
+      default:
+        child satisfies never // exhaustiveness check
+    }
   }
 
   return errors

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -158,39 +158,49 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
   const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)
   const endTime = numeric('beats', startTime.value + length.value)
 
-  const routings = part.routings.map((routing): InstrumentRouting => {
-    const source = PatternFacet.get(resolve(scope, routing.source))
-    const instrument = InstrumentFacet.get(resolve(scope, routing.destination))
+  const routings: InstrumentRouting[] = []
 
-    return {
-      source: {
-        type: 'pattern',
-        value: source
-      },
+  for (const child of part.children) {
+    switch (child.type) {
+      case 'Routing':
+        routings.push({
+          source: {
+            type: 'pattern',
+            value: PatternFacet.get(resolve(scope, child.source))
+          },
 
-      destination: {
-        type: 'instrument',
-        id: instrument.id
-      }
+          destination: {
+            type: 'instrument',
+            id: InstrumentFacet.get(resolve(scope, child.destination)).id
+          }
+        })
+        break
+
+      case 'AutomateStatement':
+        generateAutomation(scope, child, startTime, endTime)
+        break
+
+      default:
+        child satisfies never // exhaustiveness check
     }
-  })
-
-  for (const automation of part.automations) {
-    const target = ParameterFacet.get(resolve(scope, automation.target))
-    const curve = CurveFacet.get(resolve(scope, automation.curve))
-
-    const rendered = renderCurvePoints(curve, startTime, endTime)
-    const existing = nonNull(scope.top.automations.get(target.id), 'Parameter allocated incorrectly')
-
-    const points = [...existing.points, ...rendered].sort((a, b) => a.time.value - b.time.value)
-
-    scope.top.automations.set(target.id, {
-      parameterId: target.id,
-      points
-    })
   }
 
   return { name, length, routings }
+}
+
+function generateAutomation (scope: Scope, statement: ast.AutomateStatement, startTime: Numeric<'beats'>, endTime: Numeric<'beats'>): void {
+  const target = ParameterFacet.get(resolve(scope, statement.target))
+  const curve = CurveFacet.get(resolve(scope, statement.curve))
+
+  const rendered = renderCurvePoints(curve, startTime, endTime)
+  const existing = nonNull(scope.top.automations.get(target.id), 'Parameter allocated incorrectly')
+
+  const points = [...existing.points, ...rendered].sort((a, b) => a.time.value - b.time.value)
+
+  scope.top.automations.set(target.id, {
+    parameterId: target.id,
+    points
+  })
 }
 
 function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -557,8 +557,7 @@ const partStatement_: p.Parser<Token, unknown, ast.PartStatement> = p.abc(
     return ast.make('PartStatement', combineSourceRanges(_part, _rp), {
       name,
       properties: args,
-      routings: children.filter((c) => c.type === 'Routing'),
-      automations: children.filter((c) => c.type === 'AutomateStatement')
+      children
     })
   }
 )

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -642,9 +642,17 @@ describe('parser/parser.ts', () => {
     ])
   })
 
-  it('should allow unnamed parts', () => {
-    const result = parse(lexSource('track { part (4.bars) {} }'))
-    assert.strictEqual(result.complete, true)
+  it('should allow named and unnamed parts', () => {
+    const source = [
+      'track {',
+      '  part (4.bars) {}',
+      '  part my_part (2.bars) {}',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
         type: 'TrackStatement',
@@ -660,8 +668,19 @@ describe('parser/parser.ts', () => {
                 property: { type: 'Identifier', name: 'bars' }
               }
             ],
-            routings: [],
-            automations: []
+            children: []
+          },
+          {
+            type: 'PartStatement',
+            name: { type: 'Identifier', name: 'my_part' },
+            properties: [
+              {
+                type: 'PropertyAccess',
+                object: { type: 'Number', value: 2 },
+                property: { type: 'Identifier', name: 'bars' }
+              }
+            ],
+            children: []
           }
         ]
       }


### PR DESCRIPTION
This patch refactors the AST and parser such that `PartStatement` nodes have a single `children` array, instead of already separating out the routings and automations in that layer. This brings the node closer to other AST nodes, and moves the decision of whether order matters to the semantic layer, which is more appropriate.