### PR TITLE
feat!: Require assignment before usage in blocks

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -60,7 +60,7 @@ export function check (program: ast.Program): CheckResult {
   const errors: CompileError[] = []
 
   // Order matters, as assignments and mixers populate the scope
-  errors.push(...checkAssignments(scope, assignments))
+  errors.push(...assignments.flatMap((assignment) => checkAssignment(scope, assignment)))
   errors.push(...checkMixers(scope, mixers))
   errors.push(...checkTracks(scope, tracks))
 
@@ -151,10 +151,6 @@ function checkImports (imports: readonly ast.UseStatement[]): Checked<ReadonlyMa
   return { errors, result }
 }
 
-function checkAssignments (scope: MutableScope, assignments: readonly ast.Assignment[]): readonly CompileError[] {
-  return assignments.flatMap((assignment) => checkAssignment(scope, assignment))
-}
-
 function checkAssignment (scope: MutableScope, assignment: ast.Assignment): readonly CompileError[] {
   const errors: CompileError[] = []
 
@@ -193,28 +189,35 @@ function checkTrack (scope: MutableScope, track: ast.TrackStatement): readonly C
 
   errors.push(...checkArgumentList(trackScope, track.properties, trackSchema, track.range, 'property'))
 
-  const assignments = track.children.filter((c) => c.type === 'Assignment')
-  const parts = track.children.filter((c) => c.type === 'PartStatement')
-
-  errors.push(...checkAssignments(trackScope, assignments))
-
   const seenParts = new Set<string>()
 
-  for (const part of parts) {
-    if (part.name != null) {
-      if (seenParts.has(part.name.name)) {
-        errors.push(new CompileError(`Duplicate part named "${part.name.name}"`, part.range))
-      } else if (trackScope.resolutions.has(part.name.name)) {
-        errors.push(new CompileError(`Part name "${part.name.name}" conflicts with existing identifier`, part.name.range))
+  for (const child of track.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(trackScope, child))
+        break
+
+      case 'PartStatement': {
+        if (child.name != null) {
+          if (seenParts.has(child.name.name)) {
+            errors.push(new CompileError(`Duplicate part named "${child.name.name}"`, child.range))
+          } else if (trackScope.resolutions.has(child.name.name)) {
+            errors.push(new CompileError(`Part name "${child.name.name}" conflicts with existing identifier`, child.name.range))
+          }
+
+          seenParts.add(child.name.name)
+
+          // Reserve the name in the local scope
+          trackScope.resolutions.set(child.name.name, PartFacet.type())
+        }
+
+        errors.push(...checkPart(trackScope, child))
+        break
       }
 
-      seenParts.add(part.name.name)
-
-      // Reserve the name in the local scope
-      trackScope.resolutions.set(part.name.name, PartFacet.type())
+      default:
+        child satisfies never // exhaustiveness check
     }
-
-    errors.push(...checkPart(trackScope, part))
   }
 
   return errors
@@ -322,40 +325,45 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
 
   errors.push(...checkArgumentList(mixerScope, mixer.properties, mixerSchema, mixer.range, 'property'))
 
-  const assignments = mixer.children.filter((c) => c.type === 'Assignment')
-  const buses = mixer.children.filter((c) => c.type === 'BusStatement')
-
-  errors.push(...checkAssignments(mixerScope, assignments))
-
+  const buses: ast.BusStatement[] = []
   const seenBuses = new Map<string, FacetType>()
 
-  const declareBus = (name: string, type: FacetType): void => {
-    seenBuses.set(name, type)
-    mixerScope.resolutions.set(name, type)
-    mixerScope.top.buses.set(name, type)
-    busNamespace.resolutions.set(name, type)
-  }
+  for (const child of mixer.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(mixerScope, child))
+        break
 
-  // Build up the list of buses first
-  for (const bus of buses) {
-    if (seenBuses.has(bus.name.name)) {
-      errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
-    } else if (mixerScope.resolutions.has(bus.name.name)) {
-      errors.push(new CompileError(`Bus name "${bus.name.name}" conflicts with existing identifier`, bus.name.range))
+      case 'BusStatement': {
+        const bus = child
+        buses.push(bus)
+
+        if (seenBuses.has(bus.name.name)) {
+          errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
+        } else if (mixerScope.resolutions.has(bus.name.name)) {
+          errors.push(new CompileError(`Bus name "${bus.name.name}" conflicts with existing identifier`, bus.name.range))
+        }
+
+        const busCheck = checkBus(mixerScope, bus)
+        errors.push(...busCheck.errors)
+
+        const type = busCheck.result ?? BusFacet.type()
+        seenBuses.set(bus.name.name, type)
+        mixerScope.resolutions.set(bus.name.name, type)
+        mixerScope.top.buses.set(bus.name.name, type)
+        busNamespace.resolutions.set(bus.name.name, type)
+
+        break
+      }
+
+      default:
+        child satisfies never // exhaustiveness check
     }
-
-    // reserve a generic type first
-    declareBus(bus.name.name, BusFacet.type())
   }
 
   // Now that all buses are known, we can check the routings
   for (const bus of buses) {
-    const busCheck = checkBus(mixerScope, bus)
-    errors.push(...busCheck.errors)
-
-    if (busCheck.result != null) {
-      declareBus(bus.name.name, busCheck.result)
-    }
+    errors.push(...checkBusRoutings(mixerScope, bus))
   }
 
   errors.push(...checkCyclicRoutings(buses.map((bus) => ({
@@ -371,17 +379,6 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
   const errors: CompileError[] = []
 
   errors.push(...checkArgumentList(scope, bus.properties, busSchema, bus.range, 'property'))
-
-  // Sources
-  for (const source of bus.sources) {
-    const sourceCheck = checkExpression(scope, source)
-    errors.push(...sourceCheck.errors)
-
-    if (sourceCheck.result != null) {
-      const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
-      errors.push(...checkType(options, sourceCheck.result, source.range))
-    }
-  }
 
   // Effects
   const properties = {
@@ -429,6 +426,22 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
   const type = makeType(BusFacet, RecordFacet.with(record))
 
   return { errors, result: type }
+}
+
+function checkBusRoutings (scope: Scope, bus: ast.BusStatement): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  for (const source of bus.sources) {
+    const sourceCheck = checkExpression(scope, source)
+    errors.push(...sourceCheck.errors)
+
+    if (sourceCheck.result != null) {
+      const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
+      errors.push(...checkType(options, sourceCheck.result, source.range))
+    }
+  }
+
+  return errors
 }
 
 function checkExpression (scope: Scope, expression: ast.Expression): Checked<FacetType> {
@@ -632,13 +645,19 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
   const instrumentScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
-  const assignments = expression.children.filter((c) => c.type === 'Assignment')
-  const voices = expression.children.filter((c) => c.type === 'VoiceStatement')
+  for (const child of expression.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(instrumentScope, child))
+        break
 
-  errors.push(...checkAssignments(instrumentScope, assignments))
+      case 'VoiceStatement':
+        errors.push(...checkVoice(instrumentScope, child))
+        break
 
-  for (const voice of voices) {
-    errors.push(...checkVoice(instrumentScope, voice))
+      default:
+        child satisfies never // exhaustiveness check
+    }
   }
 
   return { errors, result: InstrumentFacet.type() }
@@ -654,7 +673,9 @@ function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileE
     voiceScope.resolutions.set(voice.bindings.note.name, noteType)
   }
 
-  errors.push(...checkAssignments(voiceScope, voice.children))
+  for (const child of voice.children) {
+    errors.push(...checkAssignment(voiceScope, child))
+  }
 
   return errors
 }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -51,7 +51,9 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
   assert(tracks.length <= 1)
   assert(mixers.length <= 1)
 
-  processAssignments(scope, assignments)
+  for (const assignment of assignments) {
+    processAssignment(scope, assignment)
+  }
 
   // Automations in the track may refer to mixer buses, so the mixer must be generated first.
   const mixer = generateMixer(scope, mixers.at(0))
@@ -114,11 +116,9 @@ function processImports (imports: readonly ast.UseStatement[]): ReadonlyMap<stri
   return result
 }
 
-function processAssignments (scope: MutableScope, assignments: readonly ast.Assignment[]): void {
-  for (const assignment of assignments) {
-    assert(!scope.resolutions.has(assignment.key.name))
-    scope.resolutions.set(assignment.key.name, resolve(scope, assignment.value))
-  }
+function processAssignment (scope: MutableScope, assignment: ast.Assignment): void {
+  assert(!scope.resolutions.has(assignment.key.name))
+  scope.resolutions.set(assignment.key.name, resolve(scope, assignment.value))
 }
 
 function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
@@ -131,21 +131,32 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
     : numeric('bpm', options.tempo.default)
 
   const trackScope = createLocalScope(scope)
-  processAssignments(trackScope, track.children.filter((c) => c.type === 'Assignment'))
-
   const parts: Part[] = []
 
   let currentTime = numeric('beats', 0)
-  for (const partStatement of track.children.filter((c) => c.type === 'PartStatement')) {
-    const part = generatePart(trackScope, partStatement, currentTime)
-    parts.push(part)
 
-    if (part.name != null) {
-      assert(!trackScope.resolutions.has(part.name))
-      trackScope.resolutions.set(part.name, PartFacet.type().of(part))
+  for (const child of track.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(trackScope, child)
+        break
+
+      case 'PartStatement': {
+        const part = generatePart(trackScope, child, currentTime)
+        parts.push(part)
+
+        if (part.name != null) {
+          assert(!trackScope.resolutions.has(part.name))
+          trackScope.resolutions.set(part.name, PartFacet.type().of(part))
+        }
+
+        currentTime = numeric('beats', currentTime.value + part.length.value)
+        break
+      }
+
+      default:
+        child satisfies never // exhaustiveness check
     }
-
-    currentTime = numeric('beats', currentTime.value + part.length.value)
   }
 
   return { tempo, parts }
@@ -205,13 +216,29 @@ function generateAutomation (scope: Scope, statement: ast.AutomateStatement, sta
 
 function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
   const mixerScope = createLocalScope(scope)
-  processAssignments(mixerScope, mixer?.children.filter((c) => c.type === 'Assignment') ?? [])
 
   const namespace = createNamespace()
   scope.top.namespaces.set(BUS_NAMESPACE, namespace)
 
-  const busStatements = mixer?.children.filter((c) => c.type === 'BusStatement') ?? []
-  const buses = busStatements.map((bus) => generateBus(mixerScope, bus, namespace))
+  const busStatements: ast.BusStatement[] = []
+  const buses: Bus[] = []
+
+  for (const child of mixer?.children ?? []) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(mixerScope, child)
+        break
+
+      case 'BusStatement':
+        busStatements.push(child)
+        buses.push(generateBus(mixerScope, child, namespace))
+        break
+
+      default:
+        child satisfies never // exhaustiveness check
+    }
+  }
+
   const routings = busStatements.flatMap((bus, index) => generateBusRoutings(mixerScope, bus, buses[index]))
 
   // Implicit output routings for unrouted buses and instruments
@@ -453,21 +480,21 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
 }
 
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
-  const assignments = expression.children.filter((c) => c.type === 'Assignment')
-  const voices = expression.children.filter((c) => c.type === 'VoiceStatement')
-
   const instrumentScope = createLocalScope(scope)
-  processAssignments(instrumentScope, assignments)
 
-  for (const voice of voices) {
-    const voiceScope = createLocalScope(instrumentScope)
+  for (const child of expression.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(instrumentScope, child)
+        break
 
-    if (voice.bindings.note != null) {
-      // TODO: Add note parameters
-      voiceScope.resolutions.set(voice.bindings.note.name, RecordFacet.type().of({}))
+      case 'VoiceStatement':
+        generateVoice(instrumentScope, child)
+        break
+
+      default:
+        child satisfies never // exhaustiveness check
     }
-
-    processAssignments(voiceScope, voice.children)
   }
 
   // TODO: Change -Infinity to 0 and expose gain on the record,
@@ -490,6 +517,19 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   })
 
   return InstrumentFacet.type().of(instrument)
+}
+
+function generateVoice (instrumentScope: Scope, voice: ast.VoiceStatement): void {
+  const voiceScope = createLocalScope(instrumentScope)
+
+  if (voice.bindings.note != null) {
+    // TODO: Add note parameters
+    voiceScope.resolutions.set(voice.bindings.note.name, RecordFacet.type().of({}))
+  }
+
+  for (const child of voice.children) {
+    processAssignment(voiceScope, child)
+  }
 }
 
 function resolveIdentifier (scope: Scope, identifier: ast.Identifier): Value {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -402,7 +402,7 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Part name "before" conflicts with existing identifier',
-        'Part name "after" conflicts with existing identifier'
+        'Identifier "after" is already defined'
       ])
     })
 
@@ -510,7 +510,7 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Bus name "before" conflicts with existing identifier',
-        'Bus name "after" conflicts with existing identifier'
+        'Identifier "after" is already defined'
       ])
     })
 
@@ -679,6 +679,34 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Identifier "note" is already defined'
+      ])
+    })
+
+    it('should enforce ordering within mixer', () => {
+      const source = [
+        'mixer {',
+        '  bus bus0 (gain: level) {}',
+        '  level = -6.db',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "level"'
+      ])
+    })
+
+    it('should enforce ordering within instrument definitions', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  voice {',
+        '    bar = foo',
+        '  }',
+        '  foo = -6.db',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "foo"'
       ])
     })
   })


### PR DESCRIPTION
The language started out with the idea that variable assignments are always processed first, and any nested blocks, which may refer to those variables, are processed after. In practice, this has turned out to be a source of confusion. Hence, we now apply a simple rule: For an identifier reference to be allowed at a given point, it must have been declared before that point in the source file.

Example:

```
// invalid (was valid before)
track {
  part intro (intro_length) {
    // ...
  }
  intro_length = 16.bars
}

// always valid
track {
  intro_length = 16.bars
  part intro (intro_length) {
    // ...
  }
}
```

This patch explicitly does NOT yet enforce ordering for:

- global scope (still processed as: assignments -> mixer -> track)
- bus sources (a bus can still be used as a source before declaration)

These will be addressed in a future patch.

BREAKING CHANGE: Some programs may need to be reordered to satisfy the new rule.