### PR TITLE
feat!: Require declaration before use in top scope

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -29,6 +29,29 @@ arp_main    = ([D3:3 D4:3 G4 G4] + [D3:3 D4:2 G5 G4 F4]) / 4
 // Steps can have custom lengths. The hit below is 8 times the default step length.
 clap_pattern = [x:8]
 
+mixer {
+  // Mixer buses are used to modify groups of instruments.
+  // Buses can receive signals from instruments, but also other buses.
+
+  bus drums (gain: -1.5.db) {
+    kick snare hat tom
+  }
+
+  bus synths (gain: -10.db) {
+    synth
+  }
+
+  // A bus can have zero or more effects, which are applied in order.
+  // input -> effects... -> pan -> gain -> output
+
+  bus clap_delay (gain: 3.db, pan: -0.25) {
+    clap
+
+    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)
+    effect fx.reverb(mix: 0.3, decay: 1.s)
+  }
+}
+
 track (120.bpm) {
   // Parts play in sequence. Patterns will trigger notes for their
   // defined length or the length of the part, whichever is shorter.
@@ -55,29 +78,6 @@ track (120.bpm) {
     tom   << ([---- -x-- ---- ---x] / 4).loop()
     synth << arp_main.loop()
     clap  << clap_pattern
-  }
-}
-
-mixer {
-  // Mixer buses are used to modify groups of instruments.
-  // Buses can receive signals from instruments, but also other buses.
-
-  bus drums (gain: -1.5.db) {
-    kick snare hat tom
-  }
-
-  bus synths (gain: -10.db) {
-    synth
-  }
-
-  // A bus can have zero or more effects, which are applied in order.
-  // input -> effects... -> pan -> gain -> output
-
-  bus clap_delay (gain: 3.db, pan: -0.25) {
-    clap
-
-    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)
-    effect fx.reverb(mix: 0.3, decay: 1.s)
   }
 }
 `.trimStart()

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -29,7 +29,7 @@ import { resolveInScope } from '../resolution.js'
 import { isSyntaxUnit, toBaseUnit } from '../units.js'
 import { checkCyclicRoutings } from './routings.js'
 import type { MutableNamespace, MutableScope, Scope } from './scopes.js'
-import { createGlobalScope, createLocalScope } from './scopes.js'
+import { createGlobalScope, createLocalScope, createNamespace } from './scopes.js'
 
 export type CheckedProgram = Brand<ast.Program, 'language.CheckedProgram'>
 export type CheckResult = Result<CheckedProgram, CompoundError<CompileError>>
@@ -50,19 +50,43 @@ export function check (program: ast.Program): CheckResult {
     return failure(importResult.errors)
   }
 
-  const assignments = program.children.filter((c) => c.type === 'Assignment')
-  const tracks = program.children.filter((c) => c.type === 'TrackStatement')
-  const mixers = program.children.filter((c) => c.type === 'MixerStatement')
-
   const globalScope = createGlobalScope(importResult.result)
   const scope = createLocalScope(globalScope)
 
   const errors: CompileError[] = []
 
-  // Order matters, as assignments and mixers populate the scope
-  errors.push(...assignments.flatMap((assignment) => checkAssignment(scope, assignment)))
-  errors.push(...checkMixers(scope, mixers))
-  errors.push(...checkTracks(scope, tracks))
+  const busNamespace = createNamespace()
+  scope.top.namespaces.set(BUS_NAMESPACE, busNamespace)
+
+  let hasTrack = false
+  let hasMixer = false
+
+  for (const child of program.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(scope, child))
+        break
+
+      case 'TrackStatement':
+        if (hasTrack) {
+          errors.push(new CompileError('Multiple track definitions', child.range))
+        }
+        hasTrack = true
+        errors.push(...checkTrack(scope, child))
+        break
+
+      case 'MixerStatement':
+        if (hasMixer) {
+          errors.push(new CompileError('Multiple mixer definitions', child.range))
+        }
+        hasMixer = true
+        errors.push(...checkMixer(scope, child, busNamespace))
+        break
+
+      default:
+        child satisfies never // exhaustiveness check
+    }
+  }
 
   return errors.length === 0 ? success(program as CheckedProgram) : failure(errors)
 }
@@ -164,20 +188,6 @@ function checkAssignment (scope: MutableScope, assignment: ast.Assignment): read
 
   if (!duplicate && expressionCheck.result != null) {
     scope.resolutions.set(assignment.key.name, expressionCheck.result)
-  }
-
-  return errors
-}
-
-function checkTracks (scope: MutableScope, tracks: readonly ast.TrackStatement[]): readonly CompileError[] {
-  const errors: CompileError[] = []
-
-  for (const track of tracks) {
-    if (tracks.length > 1) {
-      errors.push(new CompileError('Multiple track definitions', track.range))
-    }
-
-    errors.push(...checkTrack(scope, track))
   }
 
   return errors
@@ -293,33 +303,7 @@ function checkAutomation (scope: Scope, automation: ast.AutomateStatement): read
   return errors
 }
 
-function checkMixers (scope: MutableScope, mixers: readonly ast.MixerStatement[]): readonly CompileError[] {
-  const busNamespace: MutableNamespace = { resolutions: new Map() }
-  scope.top.namespaces.set(BUS_NAMESPACE, busNamespace)
-
-  const errors: CompileError[] = []
-
-  for (const mixer of mixers) {
-    if (mixers.length > 1) {
-      errors.push(new CompileError('Multiple mixer definitions', mixer.range))
-    }
-
-    const mixerCheck = checkMixer(scope, mixer, busNamespace)
-    errors.push(...mixerCheck.errors)
-
-    for (const [name, type] of mixerCheck.result?.buses.entries() ?? []) {
-      scope.top.buses.set(name, type)
-    }
-  }
-
-  return errors
-}
-
-interface MixerDetail {
-  readonly buses: ReadonlyMap<string, FacetType>
-}
-
-function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: MutableNamespace): Checked<MixerDetail> {
+function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: MutableNamespace): readonly CompileError[] {
   const mixerScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
@@ -372,7 +356,7 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
     range: bus.name.range
   }))))
 
-  return { errors, result: { buses: seenBuses } }
+  return errors
 }
 
 function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -44,26 +44,41 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
 
   const scope = createLocalScope(top)
 
-  const assignments = program.children.filter((c) => c.type === 'Assignment')
-  const tracks = program.children.filter((c) => c.type === 'TrackStatement')
-  const mixers = program.children.filter((c) => c.type === 'MixerStatement')
+  const busNamespace = createNamespace()
+  scope.top.namespaces.set(BUS_NAMESPACE, busNamespace)
 
-  assert(tracks.length <= 1)
-  assert(mixers.length <= 1)
+  let mixer: Mixer | undefined
+  let track: Track | undefined
 
-  for (const assignment of assignments) {
-    processAssignment(scope, assignment)
+  for (const child of program.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(scope, child)
+        break
+
+      case 'MixerStatement':
+        assert(mixer == null)
+        mixer = generateMixer(scope, child, busNamespace)
+        break
+
+      case 'TrackStatement':
+        assert(track == null)
+        track = generateTrack(scope, child)
+        break
+
+      default:
+        child satisfies never // exhaustiveness check
+    }
   }
 
-  // Automations in the track may refer to mixer buses, so the mixer must be generated first.
-  const mixer = generateMixer(scope, mixers.at(0))
+  mixer ??= { buses: [], routings: [] }
+  track ??= { tempo: numeric('bpm', options.tempo.default), parts: [] }
 
-  const track = tracks.length > 0
-    ? generateTrack(scope, tracks[0])
-    : {
-        tempo: numeric('bpm', options.tempo.default),
-        parts: []
-      }
+  // Implicit output routings for unrouted buses and instruments
+  mixer = {
+    ...mixer,
+    routings: [...mixer.routings, ...generateImplicitRoutings(scope, mixer)]
+  }
 
   return {
     beatsPerBar: options.beatsPerBar,
@@ -214,16 +229,13 @@ function generateAutomation (scope: Scope, statement: ast.AutomateStatement, sta
   })
 }
 
-function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
+function generateMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: MutableNamespace): Mixer {
   const mixerScope = createLocalScope(scope)
-
-  const namespace = createNamespace()
-  scope.top.namespaces.set(BUS_NAMESPACE, namespace)
 
   const busStatements: ast.BusStatement[] = []
   const buses: Bus[] = []
 
-  for (const child of mixer?.children ?? []) {
+  for (const child of mixer.children) {
     switch (child.type) {
       case 'Assignment':
         processAssignment(mixerScope, child)
@@ -231,7 +243,7 @@ function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
 
       case 'BusStatement':
         busStatements.push(child)
-        buses.push(generateBus(mixerScope, child, namespace))
+        buses.push(generateBus(mixerScope, child, busNamespace))
         break
 
       default:
@@ -241,11 +253,16 @@ function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
 
   const routings = busStatements.flatMap((bus, index) => generateBusRoutings(mixerScope, bus, buses[index]))
 
-  // Implicit output routings for unrouted buses and instruments
-  const unroutedBuses = new Set<BusId>(buses.map((b) => b.id))
+  return { buses, routings }
+}
+
+function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRouting[] {
+  const routings: MixerRouting[] = []
+
+  const unroutedBuses = new Set<BusId>(mixer.buses.map((b) => b.id))
   const unroutedInstruments = new Set<InstrumentId>(scope.top.instruments.keys())
 
-  for (const routing of routings) {
+  for (const routing of mixer.routings) {
     switch (routing.source.type) {
       case 'bus':
         unroutedBuses.delete(routing.source.id)
@@ -268,7 +285,7 @@ function generateMixer (scope: Scope, mixer?: ast.MixerStatement): Mixer {
     createImplicitRouting({ type: 'instrument', id: instrumentId })
   }
 
-  return { buses, routings }
+  return routings
 }
 
 function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: MutableNamespace): Bus {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -135,11 +135,11 @@ describe('compiler/checker/checker.ts', () => {
     it('should allow parts and buses to shadow top-level variables', () => {
       const source = [
         'foo = 42',
-        'track {',
-        '  part foo (4.bars) {}',
-        '}',
         'mixer {',
         '  bus foo {}',
+        '}',
+        'track {',
+        '  part foo (4.bars) {}',
         '}'
       ].join('\n')
 
@@ -197,6 +197,23 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept bus references after the mixer declaration', () => {
+      const source = [
+        'mixer {',
+        '  bus foo {}',
+        '  bus bar {}',
+        '}',
+        'foo_gain = bus.foo.gain',
+        'track {',
+        '  part intro (4.bars) {',
+        '    automate bus.bar.pan as ~[lin(-1, 1)]',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept lin curves', () => {
       assertValid('my_curve = ~[lin((-60).db, 0.db)]')
     })
@@ -215,13 +232,13 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should accept bus gain automation via explicit namespace', () => {
       const source = [
+        'mixer {',
+        '  bus main {}',
+        '}',
         'track {',
         '  part intro (4.bars) {',
         '    automate bus.main.gain as ~[lin((-20).db, 0.db)]',
         '  }',
-        '}',
-        'mixer {',
-        '  bus main {}',
         '}'
       ].join('\n')
 
@@ -231,14 +248,14 @@ describe('compiler/checker/checker.ts', () => {
     it('should accept bus effect automation via explicit namespace', () => {
       const source = [
         'use "effects" as fx',
-        'track {',
-        '  part intro (4.bars) {',
-        '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
-        '  }',
-        '}',
         'mixer {',
         '  bus main {',
         '    effect lp = fx.lowpass(1000.hz)',
+        '  }',
+        '}',
+        'track {',
+        '  part intro (4.bars) {',
+        '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
         '  }',
         '}'
       ].join('\n')
@@ -366,7 +383,6 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Multiple track definitions',
         'Multiple track definitions'
       ])
     })
@@ -480,7 +496,6 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Multiple mixer definitions',
         'Multiple mixer definitions'
       ])
     })
@@ -679,6 +694,37 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Identifier "note" is already defined'
+      ])
+    })
+
+    it('should enforce ordering in the global scope', () => {
+      const source = [
+        'track (my_tempo) {}',
+        'my_tempo = 120.bpm'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "my_tempo"'
+      ])
+    })
+
+    it('should reject bus references before the mixer declaration', () => {
+      const source = [
+        'foo_gain = bus.foo.gain',
+        'track {',
+        '  part intro (4.bars) {',
+        '    automate bus.bar.pan as ~[lin(-1, 1)]',
+        '  }',
+        '}',
+        'mixer {',
+        '  bus foo {}',
+        '  bus bar {}',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Namespace "bus" has no member named "foo"',
+        'Namespace "bus" has no member named "bar"'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -333,13 +333,13 @@ describe('compiler/generator/generator.ts', () => {
 
   it('should automate bus gain via explicit namespace', () => {
     const source = [
+      'mixer {',
+      '  bus main {}',
+      '}',
       'track {',
       '  part intro (4.bars) {',
       '    automate bus.main.gain as ~[lin((-20).db, 0.db)]',
       '  }',
-      '}',
-      'mixer {',
-      '  bus main {}',
       '}'
     ].join('\n')
 
@@ -356,14 +356,14 @@ describe('compiler/generator/generator.ts', () => {
   it('should automate bus effect parameters via explicit namespace', () => {
     const source = [
       'use "effects" as fx',
-      'track {',
-      '  part intro (4.bars) {',
-      '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
-      '  }',
-      '}',
       'mixer {',
       '  bus main {',
       '    effect lp = fx.lowpass(123.hz)',
+      '  }',
+      '}',
+      'track {',
+      '  part intro (4.bars) {',
+      '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
       '  }',
       '}'
     ].join('\n')
@@ -417,6 +417,26 @@ describe('compiler/generator/generator.ts', () => {
       'use "instruments" as *',
       'synth = sample("synth.wav")',
       ''
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    const [instrument] = result.instruments.values()
+
+    assert.deepStrictEqual(result.mixer.routings, [
+      {
+        implicit: true,
+        destination: { type: 'output' },
+        source: { type: 'instrument', id: instrument.id }
+      }
+    ])
+  })
+
+  it('should route instruments into the output when they are declared after the mixer', () => {
+    const source = [
+      'use "instruments" as *',
+      'mixer {}',
+      'synth = sample("synth.wav")'
     ].join('\n')
 
     const result = generateSource(source)


### PR DESCRIPTION
This is a follow-up to PR #566, enforcing ordering of top-level declarations as well. Previously, the semantic layer would process the global scope always in the order: assignments, then mixer, then tracks. Now, it is processed in source order, such that variables must be assigned before they are used, and the track can only refer to the mixer (and its buses) if the mixer is declared first.

In modern programming languages, this would usually be considered a bad design, but I am confident that it is the right choice for Cadence as a domain-specific music composition language, as it will reduce the cognitive load and eliminate special-cases that the user has to learn. Instead, it is sufficient to teach: "declare before use".

BREAKING CHANGE: The order of top-level declarations is now enforced.