### PR TITLE
feat!: Require bus sources be defined before use

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -337,17 +337,14 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
         mixerScope.top.buses.set(bus.name.name, type)
         busNamespace.resolutions.set(bus.name.name, type)
 
+        errors.push(...checkBusRoutings(mixerScope, bus))
+
         break
       }
 
       default:
         child satisfies never // exhaustiveness check
     }
-  }
-
-  // Now that all buses are known, we can check the routings
-  for (const bus of buses) {
-    errors.push(...checkBusRoutings(mixerScope, bus))
   }
 
   errors.push(...checkCyclicRoutings(buses.map((bus) => ({

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -234,6 +234,7 @@ function generateMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: M
 
   const busStatements: ast.BusStatement[] = []
   const buses: Bus[] = []
+  const routings: MixerRouting[] = []
 
   for (const child of mixer.children) {
     switch (child.type) {
@@ -244,14 +245,13 @@ function generateMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: M
       case 'BusStatement':
         busStatements.push(child)
         buses.push(generateBus(mixerScope, child, busNamespace))
+        routings.push(...generateBusRoutings(mixerScope, child, nonNull(buses.at(-1))))
         break
 
       default:
         child satisfies never // exhaustiveness check
     }
   }
-
-  const routings = busStatements.flatMap((bus, index) => generateBusRoutings(mixerScope, bus, buses[index]))
 
   return { buses, routings }
 }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -189,8 +189,8 @@ describe('compiler/checker/checker.ts', () => {
     it('should allow buses as sources in mixer', () => {
       const source = [
         'mixer {',
-        '  bus bus1 { bus2 }',
-        '  bus bus2 {}',
+        '  bus bus0 {}',
+        '  bus bus1 { bus0 }',
         '}'
       ].join('\n')
 
@@ -562,30 +562,46 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
-    it('should reject cyclic mixer routings', () => {
+    it('should reject buses as sources in mixer before their declaration', () => {
       const source = [
         'mixer {',
-        '  bus bus1 { bus3 }',
-        '  bus bus2 { bus1 }',
-        '  bus bus3 { bus2 }',
+        '  bus bus0 { bus1 }',
+        '  bus bus1 {}',
         '}'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Cyclic routing: bus1 -> bus2 -> bus3 -> bus1'
+        'Unknown identifier "bus1"'
+      ])
+    })
+
+    it('should reject cyclic mixer routings', () => {
+      const source = [
+        'mixer {',
+        '  bus bus0 { bus2 }',
+        '  bus bus1 { bus0 }',
+        '  bus bus2 { bus1 }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "bus2"',
+        'Cyclic routing: bus0 -> bus1 -> bus2 -> bus0'
       ])
     })
 
     it('should only report buses that are part of a cycle', () => {
       const source = [
         'mixer {',
-        '  bus first { bus1 }',
+        '  bus bus0 { bus1 }',
         '  bus bus1 { bus2 }',
         '  bus bus2 { bus1 }',
         '}'
       ].join('\n')
 
       assertErrorMessages(source, [
+        'Unknown identifier "bus1"',
+        'Unknown identifier "bus2"',
         'Cyclic routing: bus1 -> bus2 -> bus1'
       ])
     })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -455,8 +455,8 @@ describe('compiler/generator/generator.ts', () => {
   it('should support buses as sources in mixer', () => {
     const source = [
       'mixer {',
-      '  bus bus0 { bus1 }',
-      '  bus bus1 {}',
+      '  bus bus0 {}',
+      '  bus bus1 { bus0 }',
       '}'
     ].join('\n')
 
@@ -471,13 +471,13 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.mixer.routings, [
       {
         implicit: false,
-        destination: { type: 'bus', id: bus0.id },
-        source: { type: 'bus', id: bus1.id }
+        destination: { type: 'bus', id: bus1.id },
+        source: { type: 'bus', id: bus0.id }
       },
       {
         implicit: true,
         destination: { type: 'output' },
-        source: { type: 'bus', id: bus0.id }
+        source: { type: 'bus', id: bus1.id }
       }
     ])
   })


### PR DESCRIPTION
This is a follow-up to PRs #566 and #568. When routing a bus (the source) into another bus (the destination), the source bus must be defined before the destination bus. This is to align with the rest of the language.

BREAKING CHANGE: Bus sources must be defined before use.