### PR TITLE
refactor: Preserve order of BusStatement children

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -145,8 +145,7 @@ export interface BusStatement extends ASTNode {
   readonly type: 'BusStatement'
   readonly name: Identifier
   readonly properties: ArgumentList
-  readonly sources: readonly Identifier[]
-  readonly effects: readonly EffectStatement[]
+  readonly children: ReadonlyArray<Identifier | EffectStatement>
 }
 
 export interface EffectStatement extends ASTNode {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -349,7 +349,7 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
 
   errors.push(...checkCyclicRoutings(buses.map((bus) => ({
     name: bus.name.name,
-    sources: bus.sources.map((s) => s.name),
+    sources: bus.children.filter((child) => child.type === 'Identifier').map((source) => source.name),
     range: bus.name.range
   }))))
 
@@ -370,7 +370,11 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
   const record: Record<string, FacetType> = Object.create(null)
   Object.assign(record, properties)
 
-  for (const effect of bus.effects) {
+  for (const effect of bus.children) {
+    if (effect.type !== 'EffectStatement') {
+      continue
+    }
+
     const effectCheck = checkExpression(scope, effect.expression)
     errors.push(...effectCheck.errors)
 
@@ -412,7 +416,11 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
 function checkBusRoutings (scope: Scope, bus: ast.BusStatement): readonly CompileError[] {
   const errors: CompileError[] = []
 
-  for (const source of bus.sources) {
+  for (const source of bus.children) {
+    if (source.type !== 'Identifier') {
+      continue
+    }
+
     const sourceCheck = checkExpression(scope, source)
     errors.push(...sourceCheck.errors)
 

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -292,14 +292,15 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
   const name = bus.name.name
   const properties = resolveArgumentList(scope, bus.properties, busSchema)
 
-  const effectValues = bus.effects.map((effect) => resolve(scope, effect.expression))
+  const effectStatements = bus.children.filter((child) => child.type === 'EffectStatement')
+  const effectValues = effectStatements.map((effect) => resolve(scope, effect.expression))
   const effects = effectValues.map((value) => EffectFacet.get(value))
 
   const valueRecord: Record<string, Value> = Object.create(null)
   const typeRecord: Record<string, FacetType> = Object.create(null)
 
-  for (let i = 0; i < bus.effects.length; ++i) {
-    const effectName = bus.effects[i].name?.name
+  for (let i = 0; i < effectStatements.length; ++i) {
+    const effectName = effectStatements[i].name?.name
     if (effectName == null) {
       continue
     }
@@ -334,7 +335,9 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
 }
 
 function generateBusRoutings (mixerScope: Scope, bus: ast.BusStatement, destination: Bus): readonly MixerRouting[] {
-  return bus.sources.map((identifier) => {
+  const sources = bus.children.filter((child) => child.type === 'Identifier')
+
+  return sources.map((identifier) => {
     const source = resolve(mixerScope, identifier)
 
     const toRouting = (src: { type: 'instrument' | 'bus', id: InstrumentId | BusId }): MixerRouting => ({

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -633,8 +633,7 @@ const busStatement_: p.Parser<Token, unknown, ast.BusStatement> = p.abc(
     return ast.make('BusStatement', combineSourceRanges(_bus, _rp), {
       name,
       properties: args,
-      sources: children.filter((c) => c.type === 'Identifier'),
-      effects: children.filter((c) => c.type === 'EffectStatement')
+      children
     })
   }
 )

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -595,12 +595,10 @@ describe('parser/parser.ts', () => {
                 }
               }
             ],
-            sources: [
+            children: [
               { type: 'Identifier', name: 'kick' },
               { type: 'Identifier', name: 'snare' },
-              { type: 'Identifier', name: 'hihat' }
-            ],
-            effects: [
+              { type: 'Identifier', name: 'hihat' },
               {
                 type: 'EffectStatement',
                 name: undefined,


### PR DESCRIPTION
See PR #565. This patch applies the same change to the bus statement. The idea is to move decisions about how to interpret ordering from the parser to the semantic layer.