### PR TITLE
feat: Allow assignments in part and bus scopes

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -132,7 +132,7 @@ export interface PartStatement extends ASTNode {
   readonly type: 'PartStatement'
   readonly name?: Identifier
   readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Routing | AutomateStatement>
+  readonly children: ReadonlyArray<Assignment | Routing | AutomateStatement>
 }
 
 export interface MixerStatement extends ASTNode {
@@ -145,7 +145,7 @@ export interface BusStatement extends ASTNode {
   readonly type: 'BusStatement'
   readonly name: Identifier
   readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Identifier | EffectStatement>
+  readonly children: ReadonlyArray<Assignment | Identifier | EffectStatement>
 }
 
 export interface EffectStatement extends ASTNode {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -188,7 +188,7 @@ PartStatement {
   VariableDefinition?
   ("(" argumentList? ")")?
   PartBlock[group=Block] {
-    "{" (Routing | Automation)* "}"
+    "{" (Assignment | Routing | Automation)* "}"
   }
 }
 
@@ -204,7 +204,7 @@ BusStatement {
   kw<"bus"> VariableDefinition
   ("(" argumentList? ")")?
   BusBlock[group=Block] {
-    "{" (VariableName | EffectStatement)* "}"
+    "{" (Assignment | VariableName | EffectStatement)* "}"
   }
 }
 

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -30,6 +30,9 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
   const addBinding = (input: Omit<Binding, 'id'>): Binding => {
     const binding = { ...input, id: bindingKey(input.kind, input.scopeId, input.range) }
     bindings.push(binding)
+
+    addIdentifier({ kind: 'definition', scopeId: input.scopeId, name: input.name, range: input.range })
+
     return binding
   }
 
@@ -71,7 +74,6 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
         const { alias, aliasRange, moduleName } = statement
         if (alias != null) {
-          addIdentifier({ kind: 'definition', scopeId, name: alias, range: aliasRange })
           addBinding({ kind: 'use-alias', scopeId, name: alias, range: aliasRange, moduleName })
         }
 
@@ -82,6 +84,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
       case 'TrackBlock': {
         const scope = addScope({ kind: 'track', range, parentId: scopeId })
+        nextScopeId = scope.id
+        break
+      }
+
+      case 'PartBlock': {
+        const scope = addScope({ kind: 'part', range, parentId: scopeId })
         nextScopeId = scope.id
         break
       }
@@ -136,44 +144,44 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       }
 
       case 'VariableDefinition': {
-        const name = document.sliceString(from, to)
+        // The parser can produce VariableDefinition nodes with trailing whitespace (possibly a bug).
+        // Example (emits "kick " with a trailing space):
+        //     track { part { kick } }
+        const rawName = document.sliceString(from, to)
+        const name = rawName.trimEnd()
+        const nameRange = toSourceRange(document, from, from + name.length)
 
         switch (parentType) {
           case 'Assignment': {
             if (assignmentHasEquals) {
-              addBinding({ kind: 'regular', scopeId, name, range })
-              addIdentifier({ kind: 'definition', scopeId, name, range })
+              addBinding({ kind: 'regular', scopeId, name, range: nameRange })
               break
             }
             // Invalid/incomplete syntax encountered.
             // We still add an identifier as a best-effort approach to provide some level of functionality.
-            accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range, previousSibling })
+            accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range: nameRange, previousSibling })
             break
           }
 
           case 'PartStatement': {
-            addBinding({ kind: 'part', scopeId, name, range })
-            addIdentifier({ kind: 'definition', scopeId, name, range })
+            addBinding({ kind: 'part', scopeId, name, range: nameRange })
             break
           }
 
           case 'BusStatement': {
             if (pendingScope?.kind === 'bus') {
-              addBinding({ kind: 'bus', scopeId, name, range, declaredScopeId: pendingScope.id })
-              addIdentifier({ kind: 'definition', scopeId, name, range })
+              addBinding({ kind: 'bus', scopeId, name, range: nameRange, declaredScopeId: pendingScope.id })
             }
             break
           }
 
           case 'EffectStatement': {
-            addBinding({ kind: 'effect', scopeId, name, range })
-            addIdentifier({ kind: 'definition', scopeId, name, range })
+            addBinding({ kind: 'effect', scopeId, name, range: nameRange })
             break
           }
 
           case 'VoiceStatement': {
-            addBinding({ kind: 'regular', scopeId, name, range })
-            addIdentifier({ kind: 'definition', scopeId, name, range })
+            addBinding({ kind: 'regular', scopeId, name, range: nameRange })
             break
           }
         }

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -32,7 +32,7 @@ export interface Scope {
   readonly range: SourceRange
 }
 
-export type ScopeKind = 'root' | 'track' | 'mixer' | 'bus' | 'instrument' | 'voice'
+export type ScopeKind = 'root' | 'track' | 'part' | 'mixer' | 'bus' | 'instrument' | 'voice'
 
 // identifier
 

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -66,11 +66,11 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'root', name: 'tempo' },
         { kind: 'definition', scope: 'track', name: 'intro' },
         { kind: 'plain', scope: 'track', name: 'bars' },
-        { kind: 'plain', scope: 'track', name: 'kick' },
-        { kind: 'plain', scope: 'track', name: 'loop' },
-        { kind: 'plain', scope: 'track', name: 'kick' },
-        { kind: 'plain', scope: 'track', name: 'gain' },
-        { kind: 'plain', scope: 'track', name: 'db' },
+        { kind: 'plain', scope: 'part', name: 'kick' },
+        { kind: 'plain', scope: 'part', name: 'loop' },
+        { kind: 'plain', scope: 'part', name: 'kick' },
+        { kind: 'plain', scope: 'part', name: 'gain' },
+        { kind: 'plain', scope: 'part', name: 'db' },
         { kind: 'definition', scope: 'mixer', name: 'drums' },
         { kind: 'definition', scope: 'bus', name: 'crush' },
         { kind: 'plain', scope: 'bus', name: 'fx' },
@@ -227,7 +227,7 @@ describe('model/analysis/base.ts', () => {
       'track (120.bpm) {',
       '  part intro (4.bars) {',
       '    kick << [x---]',
-      '  }',
+      '  } // end part',
       '} // end track',
       '',
       'mixer {',
@@ -261,6 +261,11 @@ describe('model/analysis/base.ts', () => {
     const trackRange = getRangeAt(source, trackBlockStart, trackEnd - trackBlockStart)
     const trackScopeId = `track:${trackRange.offset}:${trackRange.length}`
 
+    const partBlockStart = source.indexOf('{', source.indexOf('part intro'))
+    const partEnd = source.indexOf('} // end part') + '}'.length
+    const partRange = getRangeAt(source, partBlockStart, partEnd - partBlockStart)
+    const partScopeId = `part:${partRange.offset}:${partRange.length}`
+
     const mixerBlockStart = source.indexOf('{', source.indexOf('mixer'))
     const mixerEnd = source.indexOf('} // end mixer') + '}'.length
     const mixerRange = getRangeAt(source, mixerBlockStart, mixerEnd - mixerBlockStart)
@@ -283,6 +288,7 @@ describe('model/analysis/base.ts', () => {
         { id: instrumentScopeId, kind: 'instrument', parentId: rootScopeId },
         { id: voiceScopeId, kind: 'voice', parentId: instrumentScopeId },
         { id: trackScopeId, kind: 'track', parentId: rootScopeId },
+        { id: partScopeId, kind: 'part', parentId: trackScopeId },
         { id: mixerScopeId, kind: 'mixer', parentId: rootScopeId },
         { id: drumsBusScopeId, kind: 'bus', parentId: mixerScopeId },
         { id: delayBusScopeId, kind: 'bus', parentId: mixerScopeId }

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -234,18 +234,23 @@ function checkTrack (scope: MutableScope, track: ast.TrackStatement): readonly C
 }
 
 function checkPart (scope: Scope, part: ast.PartStatement): readonly CompileError[] {
+  const partScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
   errors.push(...checkArgumentList(scope, part.properties, partSchema, part.range, 'property'))
 
   for (const child of part.children) {
     switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(partScope, child))
+        break
+
       case 'Routing':
-        errors.push(...checkInstrumentRouting(scope, child))
+        errors.push(...checkInstrumentRouting(partScope, child))
         break
 
       case 'AutomateStatement':
-        errors.push(...checkAutomation(scope, child))
+        errors.push(...checkAutomation(partScope, child))
         break
 
       default:
@@ -337,8 +342,6 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
         mixerScope.top.buses.set(bus.name.name, type)
         busNamespace.resolutions.set(bus.name.name, type)
 
-        errors.push(...checkBusRoutings(mixerScope, bus))
-
         break
       }
 
@@ -357,11 +360,11 @@ function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: Muta
 }
 
 function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
+  const busScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
   errors.push(...checkArgumentList(scope, bus.properties, busSchema, bus.range, 'property'))
 
-  // Effects
   const properties = {
     gain: ParameterFacet.with('db').type(),
     pan: ParameterFacet.with(undefined).type()
@@ -370,67 +373,68 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
   const record: Record<string, FacetType> = Object.create(null)
   Object.assign(record, properties)
 
-  for (const effect of bus.children) {
-    if (effect.type !== 'EffectStatement') {
-      continue
-    }
+  for (const child of bus.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(busScope, child))
+        break
 
-    const effectCheck = checkExpression(scope, effect.expression)
-    errors.push(...effectCheck.errors)
+      case 'Identifier': {
+        const sourceCheck = checkExpression(busScope, child)
+        errors.push(...sourceCheck.errors)
 
-    let effectType: FacetType | undefined
+        if (sourceCheck.result != null) {
+          const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
+          errors.push(...checkType(options, sourceCheck.result, child.range))
+        }
 
-    if (effectCheck.result != null) {
-      const typeErrors = checkType(EffectFacet.type(), effectCheck.result, effect.expression.range)
-      errors.push(...typeErrors)
-
-      if (typeErrors.length === 0) {
-        effectType = effectCheck.result
+        break
       }
-    }
 
-    if (effect.name == null) {
-      continue
-    }
+      case 'EffectStatement': {
+        const effectCheck = checkExpression(busScope, child.expression)
+        errors.push(...effectCheck.errors)
 
-    if (Object.hasOwn(properties, effect.name.name)) {
-      errors.push(new CompileError(`Effect name "${effect.name.name}" conflicts with bus property of the same name`, effect.name.range))
-      continue
-    }
+        let effectType: FacetType | undefined
 
-    if (Object.hasOwn(record, effect.name.name)) {
-      errors.push(new CompileError(`Duplicate effect name "${effect.name.name}"`, effect.name.range))
-      continue
-    }
+        if (effectCheck.result != null) {
+          const typeErrors = checkType(EffectFacet.type(), effectCheck.result, child.expression.range)
+          errors.push(...typeErrors)
 
-    if (effectType != null) {
-      record[effect.name.name] = effectType
+          if (typeErrors.length === 0) {
+            effectType = effectCheck.result
+          }
+        }
+
+        if (child.name == null) {
+          continue
+        }
+
+        if (Object.hasOwn(properties, child.name.name)) {
+          errors.push(new CompileError(`Effect name "${child.name.name}" conflicts with bus property of the same name`, child.name.range))
+          continue
+        }
+
+        if (Object.hasOwn(record, child.name.name)) {
+          errors.push(new CompileError(`Duplicate effect name "${child.name.name}"`, child.name.range))
+          continue
+        }
+
+        if (effectType != null) {
+          record[child.name.name] = effectType
+        }
+
+        break
+      }
+
+      default:
+        child satisfies never // exhaustiveness check
     }
   }
 
   const type = makeType(BusFacet, RecordFacet.with(record))
 
   return { errors, result: type }
-}
-
-function checkBusRoutings (scope: Scope, bus: ast.BusStatement): readonly CompileError[] {
-  const errors: CompileError[] = []
-
-  for (const source of bus.children) {
-    if (source.type !== 'Identifier') {
-      continue
-    }
-
-    const sourceCheck = checkExpression(scope, source)
-    errors.push(...sourceCheck.errors)
-
-    if (sourceCheck.result != null) {
-      const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
-      errors.push(...checkType(options, sourceCheck.result, source.range))
-    }
-  }
-
-  return errors
 }
 
 function checkExpression (scope: Scope, expression: ast.Expression): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -1,5 +1,5 @@
 import { ast } from '@ast'
-import type { Bus, BusId, InstrumentId, InstrumentRouting, Mixer, MixerRouting, Part, Pattern, Program, Step, Track } from '@core'
+import type { Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, Part, Pattern, Program, Step, Track } from '@core'
 import { concatPatterns, createParallelPattern, createSerialPattern, mergePatterns } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
@@ -178,6 +178,8 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
 }
 
 function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric<'beats'>): Part {
+  const partScope = createLocalScope(scope)
+
   const name = part.name?.name
   const properties = resolveArgumentList(scope, part.properties, partSchema)
 
@@ -188,22 +190,26 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
 
   for (const child of part.children) {
     switch (child.type) {
+      case 'Assignment':
+        processAssignment(partScope, child)
+        break
+
       case 'Routing':
         routings.push({
           source: {
             type: 'pattern',
-            value: PatternFacet.get(resolve(scope, child.source))
+            value: PatternFacet.get(resolve(partScope, child.source))
           },
 
           destination: {
             type: 'instrument',
-            id: InstrumentFacet.get(resolve(scope, child.destination)).id
+            id: InstrumentFacet.get(resolve(partScope, child.destination)).id
           }
         })
         break
 
       case 'AutomateStatement':
-        generateAutomation(scope, child, startTime, endTime)
+        generateAutomation(partScope, child, startTime, endTime)
         break
 
       default:
@@ -242,11 +248,13 @@ function generateMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: M
         processAssignment(mixerScope, child)
         break
 
-      case 'BusStatement':
+      case 'BusStatement': {
         busStatements.push(child)
-        buses.push(generateBus(mixerScope, child, busNamespace))
-        routings.push(...generateBusRoutings(mixerScope, child, nonNull(buses.at(-1))))
+        const generated = generateBus(mixerScope, child, busNamespace)
+        buses.push(generated.bus)
+        routings.push(...generated.routings)
         break
+      }
 
       default:
         child satisfies never // exhaustiveness check
@@ -288,25 +296,59 @@ function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRo
   return routings
 }
 
-function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: MutableNamespace): Bus {
+interface BusGenerationResult {
+  readonly bus: Bus
+  readonly routings: readonly MixerRouting[]
+}
+
+function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: MutableNamespace): BusGenerationResult {
+  const busScope = createLocalScope(scope)
+
   const name = bus.name.name
   const properties = resolveArgumentList(scope, bus.properties, busSchema)
-
-  const effectStatements = bus.children.filter((child) => child.type === 'EffectStatement')
-  const effectValues = effectStatements.map((effect) => resolve(scope, effect.expression))
-  const effects = effectValues.map((value) => EffectFacet.get(value))
 
   const valueRecord: Record<string, Value> = Object.create(null)
   const typeRecord: Record<string, FacetType> = Object.create(null)
 
-  for (let i = 0; i < effectStatements.length; ++i) {
-    const effectName = effectStatements[i].name?.name
-    if (effectName == null) {
-      continue
-    }
+  const sources: Array<MixerRouting['source']> = []
+  const effects: Effect[] = []
 
-    valueRecord[effectName] = effectValues[i]
-    typeRecord[effectName] = effectValues[i].type
+  for (const child of bus.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(busScope, child)
+        break
+
+      case 'Identifier': {
+        const source = resolve(busScope, child)
+
+        if (InstrumentFacet.has(source)) {
+          sources.push({ type: 'instrument', id: InstrumentFacet.get(source).id })
+        } else if (BusFacet.has(source)) {
+          sources.push({ type: 'bus', id: BusFacet.get(source).id })
+        } else {
+          fail()
+        }
+
+        break
+      }
+
+      case 'EffectStatement': {
+        const effectValue = resolve(busScope, child.expression)
+        effects.push(EffectFacet.get(effectValue))
+
+        const effectName = child.name?.name
+        if (effectName != null) {
+          valueRecord[effectName] = effectValue
+          typeRecord[effectName] = effectValue.type
+        }
+
+        break
+      }
+
+      default:
+        child satisfies never // exhaustiveness check
+    }
   }
 
   // These must always be allocated even if not explicitly set,
@@ -331,33 +373,14 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
   assert(!namespace.resolutions.has(name))
   namespace.resolutions.set(name, value)
 
-  return data
-}
+  const destination = { type: 'bus', id: data.id } as const
+  const routings = sources.map((source) => ({
+    implicit: false,
+    source,
+    destination
+  }))
 
-function generateBusRoutings (mixerScope: Scope, bus: ast.BusStatement, destination: Bus): readonly MixerRouting[] {
-  const sources = bus.children.filter((child) => child.type === 'Identifier')
-
-  return sources.map((identifier) => {
-    const source = resolve(mixerScope, identifier)
-
-    const toRouting = (src: { type: 'instrument' | 'bus', id: InstrumentId | BusId }): MixerRouting => ({
-      implicit: false,
-      source: src.type === 'instrument'
-        ? { type: 'instrument', id: src.id as InstrumentId }
-        : { type: 'bus', id: src.id as BusId },
-      destination: { type: 'bus', id: destination.id }
-    })
-
-    if (InstrumentFacet.has(source)) {
-      return toRouting({ type: 'instrument', id: InstrumentFacet.get(source).id })
-    }
-
-    if (BusFacet.has(source)) {
-      return toRouting({ type: 'bus', id: BusFacet.get(source).id })
-    }
-
-    fail()
-  })
+  return { bus: data, routings }
 }
 
 /**

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -547,7 +547,10 @@ const partStatement_: p.Parser<Token, unknown, ast.PartStatement> = p.abc(
   combine3(
     literal('{'),
     p.many(
-      p.eitherOr(routing_, automateStatement_)
+      p.eitherOr(
+        assignment_,
+        p.eitherOr(routing_, automateStatement_)
+      )
     ),
     expectLiteral('}')
   ),
@@ -624,7 +627,12 @@ const busStatement_: p.Parser<Token, unknown, ast.BusStatement> = p.abc(
   ),
   combine3(
     expectLiteral('{'),
-    p.many(p.eitherOr(identifier_, effectStatement_)),
+    p.many(
+      p.eitherOr(
+        assignment_,
+        p.eitherOr(identifier_, effectStatement_)
+      )
+    ),
     expectLiteral('}')
   ),
   ([_bus, name], callChain, [_lp, children, _rp]) => {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -146,22 +146,25 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
-    it('should allow assignments in track scope to shadow top-level variables', () => {
+    it('should allow scoped assignments to shadow top-level variables', () => {
       const source = [
-        'foo = 42',
+        'shadowed_by_track = 100',
+        'shadowed_by_mixer = 200',
+        'shadowed_by_part = 300',
+        'shadowed_by_bus = 400',
+        '',
         'track {',
-        '  foo = 100',
-        '}'
-      ].join('\n')
-
-      assertValid(source)
-    })
-
-    it('should allow assignments in mixer scope to shadow top-level variables', () => {
-      const source = [
-        'foo = 42',
+        '  shadowed_by_track = 101',
+        '  part (4.bars) {',
+        '    shadowed_by_part = 301',
+        '  }',
+        '}',
+        '',
         'mixer {',
-        '  foo = 100',
+        '  shadowed_by_mixer = 201',
+        '  bus foo {',
+        '    shadowed_by_bus = 401',
+        '  }',
         '}'
       ].join('\n')
 
@@ -181,6 +184,23 @@ describe('compiler/checker/checker.ts', () => {
       const source = [
         'my_pattern = [C4 E4 G4].loop()',
         'my_filled_pattern = my_pattern.fill(2.bars)'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow instruments as sources in mixer', () => {
+      const source = [
+        'use "instruments" as *',
+        'kick = sample("kick.wav")',
+        'synth = sample("synth.wav")',
+        'mixer {',
+        '  bus main {',
+        '    kick',
+        '    renamed_synth = synth',
+        '    renamed_synth',
+        '  }',
+        '}'
       ].join('\n')
 
       assertValid(source)
@@ -361,18 +381,31 @@ describe('compiler/checker/checker.ts', () => {
     it('should reject variable reassignment in nested scopes', () => {
       const source = [
         'mixer {',
-        '  bar = 42',
-        '  bar = 100',
+        '  in_mixer = 1',
+        '  in_mixer = 2',
+        '',
+        '  bus main {',
+        '    in_bus = 1',
+        '    in_bus = 2',
+        '  }',
         '}',
+        '',
         'track {',
-        '  foo = 42',
-        '  foo = 100',
+        '  in_track = 1',
+        '  in_track = 2',
+        '',
+        '  part (4.bars) {',
+        '    in_part = 1',
+        '    in_part = 2',
+        '  }',
         '}'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Identifier "bar" is already defined',
-        'Identifier "foo" is already defined'
+        'Identifier "in_mixer" is already defined',
+        'Identifier "in_bus" is already defined',
+        'Identifier "in_track" is already defined',
+        'Identifier "in_part" is already defined'
       ])
     })
 
@@ -572,6 +605,19 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Unknown identifier "bus1"'
+      ])
+    })
+
+    it('should reject bus referring to itself as a source', () => {
+      const source = [
+        'mixer {',
+        '  bus bus0 { bus0 }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown identifier "bus0"',
+        'Cyclic routing: bus0 -> bus0'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -175,6 +175,25 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.track.parts[3].length, numeric('beats', 8))
   })
 
+  it('should resolve variables in track scope', () => {
+    const source = [
+      'root_scope = 8.beats',
+      'shadowed = 100.beats',
+      'track {',
+      '  track_scope = root_scope + 1.beats',
+      '  shadowed = 200.beats',
+      '  part part0 (length: root_scope) {}',
+      '  part part1 (length: track_scope) {}',
+      '  part part2 (length: shadowed) {}',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 8))
+    assert.deepStrictEqual(result.track.parts[1].length, numeric('beats', 9))
+    assert.deepStrictEqual(result.track.parts[2].length, numeric('beats', 200))
+  })
+
   it('should resolve variables in mixer scope', () => {
     const source = [
       'root_scope = -42.db',
@@ -192,6 +211,44 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.mixer.buses[0].gain.initial, numeric('db', -42))
     assert.deepStrictEqual(result.mixer.buses[1].gain.initial, numeric('db', -41))
     assert.deepStrictEqual(result.mixer.buses[2].gain.initial, numeric('db', -200))
+  })
+
+  it('should resolve variables in part scope', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      'track {',
+      '  part intro (4.bars) {',
+      '    my_pattern = [C4 D4]',
+      '    synth << my_pattern',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    const routing = result.track.parts[0].routings[0]
+    assert.strictEqual(routing.source.type, 'pattern')
+    assert.deepStrictEqual([...routing.source.value.evaluate()], [
+      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 1) },
+      { time: numeric('beats', 1), pitch: 'D4', gate: numeric('beats', 1) }
+    ])
+  })
+
+  it('should resolve variables in bus scope', () => {
+    const source = [
+      'use "effects" as *',
+      'mixer {',
+      '  bus main {',
+      '    my_gain = -20.db',
+      '    effect gain(my_gain)',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    const effect = result.mixer.buses[0].effects[0]
+    assert.strictEqual(effect.type, 'gain')
+    assert.deepStrictEqual(effect.gain.initial, numeric('db', -20))
   })
 
   it('should generate automation points for a lin curve', () => {


### PR DESCRIPTION
As titled: It is now possible to perform variable assignments within part and bus blocks and use them locally within the block.

After this change, variable assignments are valid in all block scopes instead of only some.