### PR TITLE
feat: Add properties to note binding in voice

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -657,13 +657,17 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
   return { errors, result: InstrumentFacet.type() }
 }
 
+const noteType = RecordFacet.with({
+  frequency: NumberFacet.with('hz').type(),
+  gate: NumberFacet.with('beats').type(),
+  velocity: NumberFacet.with(undefined).type()
+}).type()
+
 function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileError[] {
   const voiceScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
   if (voice.bindings.note != null) {
-    // TODO: Add note parameters
-    const noteType = RecordFacet.type()
     voiceScope.resolutions.set(voice.bindings.note.name, noteType)
   }
 

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -534,7 +534,7 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
         break
 
       case 'VoiceStatement':
-        generateVoice(instrumentScope, child)
+        // TODO: voice instantiation needs to happen at runtime, not compile time
         break
 
       default:
@@ -562,19 +562,6 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   })
 
   return InstrumentFacet.type().of(instrument)
-}
-
-function generateVoice (instrumentScope: Scope, voice: ast.VoiceStatement): void {
-  const voiceScope = createLocalScope(instrumentScope)
-
-  if (voice.bindings.note != null) {
-    // TODO: Add note parameters
-    voiceScope.resolutions.set(voice.bindings.note.name, RecordFacet.type().of({}))
-  }
-
-  for (const child of voice.children) {
-    processAssignment(voiceScope, child)
-  }
 }
 
 function resolveIdentifier (scope: Scope, identifier: ast.Identifier): Value {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -307,6 +307,9 @@ describe('compiler/checker/checker.ts', () => {
         '  voice note {}',
         '  voice note {',
         '    baz = note',
+        '    note_frequency = note.frequency',
+        '    note_gate = note.gate',
+        '    note_velocity = note.velocity',
         '  }',
         '}'
       ].join('\n')

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -594,6 +594,9 @@ describe('compiler/generator/generator.ts', () => {
       '  }',
       '  voice note {',
       '    baz = note',
+      '    note_frequency = note.frequency',
+      '    note_gate = note.gate',
+      '    note_velocity = note.velocity',
       '  }',
       '}'
     ].join('\n')


### PR DESCRIPTION
Another step towards custom instruments. The note binding in a voice now has the following properties:

- frequency: `number(hz)`
- gate: `number(beats)`
- velocity: `number` (0 to 1)

The actual instantiation of the voice is not yet implemented.