### PR TITLE
feat: Add support for step velocity in patterns

### DIFF
--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -431,8 +431,7 @@ function createNoteEvents (track: Track, instruments: ReadonlyMap<InstrumentId, 
       const events: readonly NoteOptions[] = renderPatternEvents(routing.source.value, part.length).map((event) => ({
         time: (offsetBeats + event.time.value) * timePerBeat,
         pitch: event.pitch != null ? convertPitchToMidi(event.pitch) : undefined,
-        // TODO custom velocity
-        velocity: 1.0,
+        velocity: event.velocity.value,
         duration: event.gate != null ? event.gate.value * timePerBeat : undefined
       }))
 

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -366,7 +366,10 @@ describe('lowering.ts', () => {
               {
                 source: {
                   type: 'pattern',
-                  value: createSerialPattern([{ value: 'C4' }, { value: 'E4' }], 1)
+                  value: createSerialPattern([
+                    { value: 'C4' },
+                    { value: 'E4', velocity: numeric(undefined, 0.75) }
+                  ], 1)
                 },
                 destination: {
                   type: 'instrument',
@@ -376,13 +379,16 @@ describe('lowering.ts', () => {
             ]
           },
           {
-            name: 'Part 1',
+            name: 'Part 2',
             length: numeric('beats', 4),
             routings: [
               {
                 source: {
                   type: 'pattern',
-                  value: createSerialPattern([{ value: 'G4' }, { value: 'B4' }], 1)
+                  value: createSerialPattern([
+                    { value: 'G4' },
+                    { value: 'B4' }
+                  ], 1)
                 },
                 destination: {
                   type: 'instrument',
@@ -407,7 +413,7 @@ describe('lowering.ts', () => {
         2 as NodeId,
         [
           { time: 0, pitch: 60, velocity: 1.0, duration: 0.5 },
-          { time: 0.5, pitch: 64, velocity: 1.0, duration: 0.5 },
+          { time: 0.5, pitch: 64, velocity: 0.75, duration: 0.5 },
           { time: 2, pitch: 67, velocity: 1.0, duration: 0.5 },
           { time: 2.5, pitch: 71, velocity: 1.0, duration: 0.5 }
         ]

--- a/packages/core/src/pattern.ts
+++ b/packages/core/src/pattern.ts
@@ -3,6 +3,7 @@ import { numeric } from '@utility'
 import type { NoteEvent, Pattern, Step } from './program.js'
 
 const zeroBeats = numeric('beats', 0)
+const defaultVelocity = numeric(undefined, 1)
 
 const emptyPattern: Pattern = {
   length: zeroBeats,
@@ -49,8 +50,13 @@ function pushStepEvent (events: NoteEvent[], step: Step, offset: number, baseLen
 
   const stepGate = baseLength * (step.gate?.value ?? step.length?.value ?? 1)
   const gate = numeric('beats', stepGate)
+  const velocity = step.velocity ?? defaultVelocity
 
-  events.push(step.value === 'x' ? { time, gate } : { time, gate, pitch: step.value })
+  events.push(
+    step.value === 'x'
+      ? { time, gate, velocity }
+      : { time, gate, pitch: step.value, velocity }
+  )
 }
 
 /**

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -18,6 +18,11 @@ export interface Step {
    * If undefined, the gate is equal to the step's length.
    */
   readonly gate?: Numeric<undefined>
+
+  /**
+   * The velocity of the step, in the range [0, 1]. Defaults to 1.
+   */
+  readonly velocity?: Numeric<undefined>
 }
 
 export interface NoteEvent {
@@ -33,6 +38,11 @@ export interface NoteEvent {
    * The pitch associated with the event. If undefined, indicates that the instrument's default pitch should be used.
    */
   readonly pitch?: Pitch
+
+  /**
+   * The velocity of the note event, in the range [0, 1].
+   */
+  readonly velocity: Numeric<undefined>
 }
 
 export interface Pattern {

--- a/packages/core/test/pattern.test.ts
+++ b/packages/core/test/pattern.test.ts
@@ -6,6 +6,7 @@ import { concatPatterns, createParallelPattern, createSerialPattern, loopPattern
 describe('pattern.ts', () => {
   // helper to create Numeric<'beats'>
   const beats = (value: number) => numeric('beats', value)
+  const unitless = (value: number) => numeric(undefined, value)
 
   describe('createSerialPattern()', () => {
     it('should create a finite pattern with the correct length and events', () => {
@@ -16,8 +17,8 @@ describe('pattern.ts', () => {
       ], 1)
       assert.strictEqual(pattern.length?.value, 3)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(2), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(2), gate: beats(1), velocity: unitless(1) }
       ])
     })
 
@@ -35,8 +36,8 @@ describe('pattern.ts', () => {
       ], 2)
       assert.strictEqual(pattern.length?.value, 1.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(1), gate: beats(0.5) }
+        { time: beats(0), gate: beats(0.5), velocity: unitless(1) },
+        { time: beats(1), gate: beats(0.5), velocity: unitless(1) }
       ])
     })
 
@@ -48,8 +49,8 @@ describe('pattern.ts', () => {
       ], 1)
       assert.strictEqual(pattern.length?.value, 3.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(2) },
-        { time: beats(3), gate: beats(0.5) }
+        { time: beats(0), gate: beats(2), velocity: unitless(1) },
+        { time: beats(3), gate: beats(0.5), velocity: unitless(1) }
       ])
     })
 
@@ -61,7 +62,7 @@ describe('pattern.ts', () => {
       ], 1)
       assert.strictEqual(pattern.length?.value, 1)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { pitch: 'C3', time: beats(0), gate: beats(1) }
+        { pitch: 'C3', time: beats(0), gate: beats(1), velocity: unitless(1) }
       ])
     })
 
@@ -73,8 +74,8 @@ describe('pattern.ts', () => {
       ], 1)
       assert.strictEqual(pattern.length?.value, 3)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(2), gate: beats(0.25) }
+        { time: beats(0), gate: beats(0.5), velocity: unitless(1) },
+        { time: beats(2), gate: beats(0.25), velocity: unitless(1) }
       ])
     })
 
@@ -86,8 +87,32 @@ describe('pattern.ts', () => {
       ], 1)
       assert.strictEqual(pattern.length?.value, 3.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(1.5) },
-        { time: beats(3), gate: beats(0.1) }
+        { time: beats(0), gate: beats(1.5), velocity: unitless(1) },
+        { time: beats(3), gate: beats(0.1), velocity: unitless(1) }
+      ])
+    })
+
+    it('should handle custom lengths, gates, and velocities', () => {
+      const pattern = createSerialPattern([
+        {
+          value: 'x',
+          length: numeric(undefined, 2),
+          gate: numeric(undefined, 1.5),
+          velocity: numeric(undefined, 0.8)
+        },
+        { value: '-' },
+        {
+          value: 'A#6',
+          length: numeric(undefined, 0.5),
+          gate: numeric(undefined, 0.1),
+          velocity: numeric(undefined, 0.5)
+        }
+      ], 1)
+
+      assert.strictEqual(pattern.length?.value, 3.5)
+      assert.deepStrictEqual([...pattern.evaluate()], [
+        { time: beats(0), gate: beats(1.5), velocity: unitless(0.8) },
+        { time: beats(3), gate: beats(0.1), pitch: 'A#6', velocity: unitless(0.5) }
       ])
     })
   })
@@ -107,8 +132,8 @@ describe('pattern.ts', () => {
       ])
       assert.strictEqual(pattern.length?.value, 1)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(0), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(0), gate: beats(1), velocity: unitless(1) }
       ])
     })
 
@@ -120,8 +145,8 @@ describe('pattern.ts', () => {
       ])
       assert.strictEqual(pattern.length?.value, 2)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(2) },
-        { time: beats(0), gate: beats(0.5) }
+        { time: beats(0), gate: beats(2), velocity: unitless(1) },
+        { time: beats(0), gate: beats(0.5), velocity: unitless(1) }
       ])
     })
 
@@ -133,8 +158,8 @@ describe('pattern.ts', () => {
       ])
       assert.strictEqual(pattern.length?.value, 1)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(0), gate: beats(0.25) }
+        { time: beats(0), gate: beats(0.5), velocity: unitless(1) },
+        { time: beats(0), gate: beats(0.25), velocity: unitless(1) }
       ])
     })
 
@@ -146,8 +171,32 @@ describe('pattern.ts', () => {
       ])
       assert.strictEqual(pattern.length?.value, 2)
       assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(1.5) },
-        { time: beats(0), gate: beats(0.1) }
+        { time: beats(0), gate: beats(1.5), velocity: unitless(1) },
+        { time: beats(0), gate: beats(0.1), velocity: unitless(1) }
+      ])
+    })
+
+    it('should handle custom lengths, gates, and velocities', () => {
+      const pattern = createParallelPattern([
+        {
+          value: 'x',
+          length: numeric(undefined, 2),
+          gate: numeric(undefined, 1.5),
+          velocity: numeric(undefined, 0.8)
+        },
+        { value: '-' },
+        {
+          value: 'x',
+          length: numeric(undefined, 0.5),
+          gate: numeric(undefined, 0.1),
+          velocity: numeric(undefined, 0.5)
+        }
+      ])
+
+      assert.strictEqual(pattern.length?.value, 2)
+      assert.deepStrictEqual([...pattern.evaluate()], [
+        { time: beats(0), gate: beats(1.5), velocity: unitless(0.8) },
+        { time: beats(0), gate: beats(0.1), velocity: unitless(0.5) }
       ])
     })
   })
@@ -168,13 +217,13 @@ describe('pattern.ts', () => {
     it('should concatenate two finite patterns correctly', () => {
       const concatenated = concatPatterns([
         createSerialPattern([{ value: 'x' }, { value: '-' }], 1),
-        createSerialPattern([{ value: '-' }, { value: 'x' }, { value: 'x' }], 2)
+        createSerialPattern([{ value: '-' }, { value: 'x' }, { value: 'x', velocity: unitless(0.5) }], 2)
       ])
       assert.strictEqual(concatenated.length?.value, 3.5)
       assert.deepStrictEqual([...concatenated.evaluate()], [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(2.5), gate: beats(0.5) },
-        { time: beats(3), gate: beats(0.5) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(2.5), gate: beats(0.5), velocity: unitless(1) },
+        { time: beats(3), gate: beats(0.5), velocity: unitless(0.5) }
       ])
     })
 
@@ -216,12 +265,12 @@ describe('pattern.ts', () => {
     it('should combine multiple patterns correctly', () => {
       const parallel = mergePatterns([
         createSerialPattern([{ value: 'x' }, { value: '-' }], 1),
-        createSerialPattern([{ value: '-' }, { value: 'x' }], 1)
+        createSerialPattern([{ value: '-' }, { value: 'x', velocity: unitless(0.5) }], 1)
       ])
       assert.strictEqual(parallel.length?.value, 2)
       assert.deepStrictEqual([...parallel.evaluate()], [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(1), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(1), gate: beats(1), velocity: unitless(0.5) }
       ])
     })
 
@@ -232,9 +281,9 @@ describe('pattern.ts', () => {
       ])
       assert.strictEqual(parallel.length?.value, 3)
       assert.deepStrictEqual([...parallel.evaluate()], [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(1), gate: beats(1) },
-        { time: beats(2), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(1), gate: beats(1), velocity: unitless(1) },
+        { time: beats(2), gate: beats(1), velocity: unitless(1) }
       ])
     })
 
@@ -253,10 +302,10 @@ describe('pattern.ts', () => {
       }
 
       assert.deepStrictEqual(evaluated, [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(1), gate: beats(1) },
-        { time: beats(2), gate: beats(1) },
-        { time: beats(4), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(1), gate: beats(1), velocity: unitless(1) },
+        { time: beats(2), gate: beats(1), velocity: unitless(1) },
+        { time: beats(4), gate: beats(1), velocity: unitless(1) }
       ])
     })
 
@@ -269,20 +318,24 @@ describe('pattern.ts', () => {
       ])
       assert.strictEqual(parallel.length?.value, 3)
       assert.deepStrictEqual([...parallel.evaluate()], [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(0), gate: beats(0.25) },
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(0.25), gate: beats(0.25) },
-        { time: beats(0.5), gate: beats(0.5) },
-        { time: beats(2), gate: beats(1) },
-        { time: beats(2), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(0), gate: beats(0.25), velocity: unitless(1) },
+        { time: beats(0), gate: beats(0.5), velocity: unitless(1) },
+        { time: beats(0.25), gate: beats(0.25), velocity: unitless(1) },
+        { time: beats(0.5), gate: beats(0.5), velocity: unitless(1) },
+        { time: beats(2), gate: beats(1), velocity: unitless(1) },
+        { time: beats(2), gate: beats(1), velocity: unitless(1) }
       ])
     })
   })
 
   describe('loopPattern()', () => {
     it('should create an infinite pattern when no duration is provided', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }, { value: '-' }], 2)
+      const pattern = createSerialPattern([
+        { value: 'x', velocity: unitless(0.75) },
+        { value: '-' },
+        { value: '-' }
+      ], 2)
       const looped = loopPattern(pattern)
 
       assert.strictEqual(looped.length, undefined)
@@ -295,10 +348,10 @@ describe('pattern.ts', () => {
       }
 
       assert.deepStrictEqual(evaluated, [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(1.5), gate: beats(0.5) },
-        { time: beats(3), gate: beats(0.5) },
-        { time: beats(4.5), gate: beats(0.5) }
+        { time: beats(0), gate: beats(0.5), velocity: unitless(0.75) },
+        { time: beats(1.5), gate: beats(0.5), velocity: unitless(0.75) },
+        { time: beats(3), gate: beats(0.5), velocity: unitless(0.75) },
+        { time: beats(4.5), gate: beats(0.5), velocity: unitless(0.75) }
       ])
     })
 
@@ -310,9 +363,9 @@ describe('pattern.ts', () => {
 
       const evaluated = [...looped.evaluate()]
       assert.deepStrictEqual(evaluated, [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(2), gate: beats(1) },
-        { time: beats(4), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(1) },
+        { time: beats(2), gate: beats(1), velocity: unitless(1) },
+        { time: beats(4), gate: beats(1), velocity: unitless(1) }
       ])
     })
 
@@ -325,10 +378,10 @@ describe('pattern.ts', () => {
 
       assert.strictEqual(looped.length?.value, 4)
       assert.deepStrictEqual([...looped.evaluate()], [
-        { time: beats(0), gate: beats(3), pitch: 'A4' },
-        { time: beats(1), gate: beats(3), pitch: 'B4' },
-        { time: beats(2), gate: beats(2), pitch: 'A4' },
-        { time: beats(3), gate: beats(1), pitch: 'B4' }
+        { time: beats(0), gate: beats(3), pitch: 'A4', velocity: unitless(1) },
+        { time: beats(1), gate: beats(3), pitch: 'B4', velocity: unitless(1) },
+        { time: beats(2), gate: beats(2), pitch: 'A4', velocity: unitless(1) },
+        { time: beats(3), gate: beats(1), pitch: 'B4', velocity: unitless(1) }
       ])
     })
 
@@ -368,34 +421,37 @@ describe('pattern.ts', () => {
 
     it('should keep pattern the same for factor of 1', () => {
       const pattern = createSerialPattern([
-        { value: 'x' },
+        { value: 'x', velocity: unitless(0.75) },
         { value: '-' },
         { value: 'x' }
       ], 1)
       const multiplied = multiplyPattern(pattern, 1)
       assert.strictEqual(multiplied.length?.value, 3)
       assert.deepStrictEqual([...multiplied.evaluate()], [
-        { time: beats(0), gate: beats(1) },
-        { time: beats(2), gate: beats(1) }
+        { time: beats(0), gate: beats(1), velocity: unitless(0.75) },
+        { time: beats(2), gate: beats(1), velocity: unitless(1) }
       ])
     })
 
     it('should multiply the length and timing of events by the given factor', () => {
       const pattern = createSerialPattern([
-        { value: 'x' },
+        { value: 'x', velocity: unitless(0.75) },
         { value: '-' },
         { value: 'x' }
       ], 1)
       const multiplied = multiplyPattern(pattern, 3)
       assert.strictEqual(multiplied.length?.value, 9)
       assert.deepStrictEqual([...multiplied.evaluate()], [
-        { time: beats(0), gate: beats(3) },
-        { time: beats(6), gate: beats(3) }
+        { time: beats(0), gate: beats(3), velocity: unitless(0.75) },
+        { time: beats(6), gate: beats(3), velocity: unitless(1) }
       ])
     })
 
     it('should keep infinite patterns infinite', () => {
-      const pattern = loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }], 1))
+      const pattern = loopPattern(createSerialPattern([
+        { value: 'x', velocity: unitless(0.75) },
+        { value: '-' }
+      ], 1))
       const multiplied = multiplyPattern(pattern, 4)
       assert.strictEqual(multiplied.length, undefined)
 
@@ -407,10 +463,10 @@ describe('pattern.ts', () => {
       }
 
       assert.deepStrictEqual(evaluated, [
-        { time: beats(0), gate: beats(4) },
-        { time: beats(8), gate: beats(4) },
-        { time: beats(16), gate: beats(4) },
-        { time: beats(24), gate: beats(4) }
+        { time: beats(0), gate: beats(4), velocity: unitless(0.75) },
+        { time: beats(8), gate: beats(4), velocity: unitless(0.75) },
+        { time: beats(16), gate: beats(4), velocity: unitless(0.75) },
+        { time: beats(24), gate: beats(4), velocity: unitless(0.75) }
       ])
     })
 
@@ -440,15 +496,20 @@ describe('pattern.ts', () => {
       const multiplied = multiplyPattern(pattern, 1 / 3)
       assert.strictEqual(multiplied.length?.value, 4 / 3)
       assert.deepStrictEqual([...multiplied.evaluate()], [
-        { time: beats(0), gate: beats(1 / 3) },
-        { time: beats(1), gate: beats(1 / 3) }
+        { time: beats(0), gate: beats(1 / 3), velocity: unitless(1) },
+        { time: beats(1), gate: beats(1 / 3), velocity: unitless(1) }
       ])
     })
   })
 
   describe('renderPatternEvents()', () => {
     it('should render the correct number of events from a finite pattern', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }, { value: 'x' }, { value: 'x' }], 1)
+      const pattern = createSerialPattern([
+        { value: 'x' },
+        { value: '-' },
+        { value: 'x', velocity: unitless(0.5) },
+        { value: 'x' }
+      ], 1)
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(0)),
         []
@@ -456,22 +517,22 @@ describe('pattern.ts', () => {
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(1)),
         [
-          { time: beats(0), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(1) }
         ]
       )
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(3)),
         [
-          { time: beats(0), gate: beats(1) },
-          { time: beats(2), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(1) },
+          { time: beats(2), gate: beats(1), velocity: unitless(0.5) }
         ]
       )
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(4)),
         [
-          { time: beats(0), gate: beats(1) },
-          { time: beats(2), gate: beats(1) },
-          { time: beats(3), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(1) },
+          { time: beats(2), gate: beats(1), velocity: unitless(0.5) },
+          { time: beats(3), gate: beats(1), velocity: unitless(1) }
         ]
       )
     })
@@ -484,7 +545,7 @@ describe('pattern.ts', () => {
       assert.deepStrictEqual(
         renderPatternEvents(createSerialPattern([{ value: 'x' }, { value: '-' }], 1), beats(8)),
         [
-          { time: beats(0), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(1) }
         ]
       )
     })
@@ -493,7 +554,7 @@ describe('pattern.ts', () => {
       const pattern = createSerialPattern([
         { value: 'x' },
         { value: '-' },
-        { value: 'x' },
+        { value: 'x', velocity: unitless(0.5) },
         { value: 'x' },
         { value: '-' },
         { value: 'x' }
@@ -501,14 +562,14 @@ describe('pattern.ts', () => {
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(3)),
         [
-          { time: beats(0), gate: beats(1) },
-          { time: beats(2), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(1) },
+          { time: beats(2), gate: beats(1), velocity: unitless(0.5) }
         ]
       )
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(2)),
         [
-          { time: beats(0), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(1) }
         ]
       )
     })
@@ -522,14 +583,17 @@ describe('pattern.ts', () => {
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(2)),
         [
-          { time: beats(0), gate: beats(2), pitch: 'A4' },
-          { time: beats(1), gate: beats(1), pitch: 'B4' }
+          { time: beats(0), gate: beats(2), pitch: 'A4', velocity: unitless(1) },
+          { time: beats(1), gate: beats(1), pitch: 'B4', velocity: unitless(1) }
         ]
       )
     })
 
     it('should render events from an infinite pattern', () => {
-      const pattern = loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }], 1))
+      const pattern = loopPattern(createSerialPattern([
+        { value: 'x', velocity: unitless(0.5) },
+        { value: '-' }
+      ], 1))
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(0)),
         []
@@ -537,14 +601,14 @@ describe('pattern.ts', () => {
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(1)),
         [
-          { time: beats(0), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(0.5) }
         ]
       )
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(3)),
         [
-          { time: beats(0), gate: beats(1) },
-          { time: beats(2), gate: beats(1) }
+          { time: beats(0), gate: beats(1), velocity: unitless(0.5) },
+          { time: beats(2), gate: beats(1), velocity: unitless(0.5) }
         ]
       )
     })

--- a/packages/language/src/compiler/common.ts
+++ b/packages/language/src/compiler/common.ts
@@ -41,5 +41,10 @@ export const stepSchema = makeSchema([
     name: 'gate',
     type: NumberFacet.with(undefined).type(),
     required: false
+  },
+  {
+    name: 'vel',
+    type: NumberFacet.with(undefined).type(),
+    required: false
   }
 ])

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -482,12 +482,15 @@ function generateStep (scope: Scope, expression: ast.Step): Step {
 
   const parameters = resolveArgumentList(scope, expression.parameters, stepSchema)
   const gate = parameters.gate != null ? NumberFacet.get(parameters.gate) : undefined
+  const velocity = parameters.vel != null
+    ? clamped(NumberFacet.get(parameters.vel), 0, 1)
+    : undefined
 
   if (length == null) {
-    return { value, gate }
+    return { value, gate, velocity }
   }
 
-  return { value, length, gate }
+  return { value, length, gate, velocity }
 }
 
 function generateCurve (scope: Scope, curve: ast.Curve): Value {

--- a/packages/language/test/compiler/builtins/patterns.test.ts
+++ b/packages/language/test/compiler/builtins/patterns.test.ts
@@ -46,7 +46,7 @@ describe('library/modules/patterns.ts', () => {
 
     it('should loop finite patterns infinitely', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
+        { value: 'x', velocity: numeric(undefined, 0.5) },
         { value: '-' },
         { value: '-' },
         { value: 'G5' }
@@ -59,10 +59,10 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(2.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.25) },
-        { time: beats(0.75), gate: beats(0.25), pitch: 'G5' },
-        { time: beats(1), gate: beats(0.25) },
-        { time: beats(1.75), gate: beats(0.25), pitch: 'G5' }
+        { time: beats(0), gate: beats(0.25), velocity: numeric(undefined, 0.5) },
+        { time: beats(0.75), gate: beats(0.25), pitch: 'G5', velocity: numeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.25), velocity: numeric(undefined, 0.5) },
+        { time: beats(1.75), gate: beats(0.25), pitch: 'G5', velocity: numeric(undefined, 1) }
       ])
     })
 
@@ -80,9 +80,9 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(2.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4' },
-        { time: beats(1.5), gate: beats(0.5) }
+        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
+        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) }
       ])
     })
 
@@ -113,12 +113,12 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(5.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4' },
-        { time: beats(1.5), gate: beats(0.5) },
-        { time: beats(2.5), gate: beats(0.5), pitch: 'C4' },
-        { time: beats(3.0), gate: beats(0.5) },
-        { time: beats(4.0), gate: beats(0.5), pitch: 'C4' }
+        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
+        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) },
+        { time: beats(2.5), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
+        { time: beats(3.0), gate: beats(0.5), velocity: numeric(undefined, 1) },
+        { time: beats(4.0), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) }
       ])
     })
 
@@ -172,7 +172,7 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(2.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5) }
+        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) }
       ])
     })
   })
@@ -184,7 +184,7 @@ describe('library/modules/patterns.ts', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
         { value: 'x' },
         { value: '-' },
-        { value: 'C4' }
+        { value: 'C4', velocity: numeric(undefined, 0.5) }
       ], 2))
 
       const result = invoke(fill, pattern, {
@@ -196,9 +196,9 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(5.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4' },
-        { time: beats(1.5), gate: beats(0.5) }
+        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 0.5) },
+        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) }
       ])
     })
 
@@ -218,9 +218,9 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(5.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4' },
-        { time: beats(1.5), gate: beats(0.5) }
+        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
+        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) }
       ])
     })
 
@@ -291,7 +291,7 @@ describe('library/modules/patterns.ts', () => {
     it('should trim notes with gate that extends beyond the duration', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
         { value: 'A4', gate: numeric(undefined, 3) },
-        { value: 'B4', gate: numeric(undefined, 5) }
+        { value: 'B4', gate: numeric(undefined, 5), velocity: numeric(undefined, 0.5) }
       ], 1))
 
       const result = invoke(fill, pattern, {
@@ -303,10 +303,10 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(4.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(3.0), pitch: 'A4' },
-        { time: beats(1), gate: beats(3.0), pitch: 'B4' },
-        { time: beats(2), gate: beats(2.0), pitch: 'A4' },
-        { time: beats(3), gate: beats(1.0), pitch: 'B4' }
+        { time: beats(0), gate: beats(3.0), pitch: 'A4', velocity: numeric(undefined, 1) },
+        { time: beats(1), gate: beats(3.0), pitch: 'B4', velocity: numeric(undefined, 0.5) },
+        { time: beats(2), gate: beats(2.0), pitch: 'A4', velocity: numeric(undefined, 1) },
+        { time: beats(3), gate: beats(1.0), pitch: 'B4', velocity: numeric(undefined, 0.5) }
       ])
     })
   })

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -171,6 +171,14 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept patterns with step arguments', () => {
+      const source = [
+        'my_pattern = [x C4(1.5):2 G4(vel: 0.75) A#4(0.5, 0.75) G4(gate: 0.5, vel: 0.75) -:3]'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept a pattern with interpolation', () => {
       const source = [
         'some_chord = [<D4 G4>]',
@@ -483,6 +491,28 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Unknown identifier "bar"'
+      ])
+    })
+
+    it('should reject patterns with step arguments of the wrong type', () => {
+      assertErrorMessages('my_pattern = [C4:"foo"]', [
+        'Expected type number, got string'
+      ])
+
+      assertErrorMessages('my_pattern = [C4("foo")]', [
+        'Expected type number, got string'
+      ])
+
+      assertErrorMessages('my_pattern = [C4(gate: "foo")]', [
+        'Expected type number, got string'
+      ])
+
+      assertErrorMessages('my_pattern = [C4(vel: "foo")]', [
+        'Expected type number, got string'
+      ])
+
+      assertErrorMessages('my_pattern = [C4(0.5, "foo")]', [
+        'Expected type number, got string'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -229,8 +229,8 @@ describe('compiler/generator/generator.ts', () => {
     const routing = result.track.parts[0].routings[0]
     assert.strictEqual(routing.source.type, 'pattern')
     assert.deepStrictEqual([...routing.source.value.evaluate()], [
-      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 1) },
-      { time: numeric('beats', 1), pitch: 'D4', gate: numeric('beats', 1) }
+      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 1), velocity: numeric(undefined, 1) },
+      { time: numeric('beats', 1), pitch: 'D4', gate: numeric('beats', 1), velocity: numeric(undefined, 1) }
     ])
   })
 
@@ -249,6 +249,48 @@ describe('compiler/generator/generator.ts', () => {
     const effect = result.mixer.buses[0].effects[0]
     assert.strictEqual(effect.type, 'gain')
     assert.deepStrictEqual(effect.gain.initial, numeric('db', -20))
+  })
+
+  it('should generate instrument routings for patterns', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      'track {',
+      '  part (4.bars) {',
+      '    synth << [C4(0.5):2 D4(1, vel: 0.75) -]',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    const routing = result.track.parts[0].routings[0]
+    assert.strictEqual(routing.source.type, 'pattern')
+    assert.deepStrictEqual([...routing.source.value.evaluate()], [
+      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 0.5), velocity: numeric(undefined, 1) },
+      { time: numeric('beats', 2), pitch: 'D4', gate: numeric('beats', 1), velocity: numeric(undefined, 0.75) }
+    ])
+  })
+
+  it('should clamp step velocity to [0, 1]', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      'track {',
+      '  part (4.bars) {',
+      '    synth << [C4(vel: 1.5):2 D4(vel: -0.5)]',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    const routing = result.track.parts[0].routings[0]
+    assert.strictEqual(routing.source.type, 'pattern')
+    assert.deepStrictEqual([...routing.source.value.evaluate()], [
+      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 2), velocity: numeric(undefined, 1) },
+      { time: numeric('beats', 2), pitch: 'D4', gate: numeric('beats', 1), velocity: numeric(undefined, 0) }
+    ])
   })
 
   it('should generate automation points for a lin curve', () => {

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -269,7 +269,31 @@ describe('parser/parser.ts', () => {
     ])
   })
 
-  it('should parse a pattern with named arguments', () => {
+  it('should parse a pattern with gate and velocity', () => {
+    const result = parse(lexSource('pattern = [C4(2.0, 0.75):1.5-]'))
+    assertResultComplete(result)
+
+    const gate = { type: 'Number', value: 2.0 }
+    const velocity = { type: 'Number', value: 0.75 }
+    const length = { type: 'Number', value: 1.5 }
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'pattern' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            { type: 'Step', value: 'C4', length, parameters: [gate, velocity] },
+            { type: 'Step', value: '-', parameters: [] }
+          ]
+        }
+      }
+    ])
+  })
+
+  it('should parse a pattern with a single named parameter', () => {
     const result = parse(lexSource('pattern = [C4(gate: 2.0):1.5-]'))
     assertResultComplete(result)
 
@@ -286,6 +310,42 @@ describe('parser/parser.ts', () => {
               value: 'C4',
               length: { type: 'Number', value: 1.5 },
               parameters: [
+                {
+                  type: 'Property',
+                  key: { type: 'Identifier', name: 'gate' },
+                  value: { type: 'Number', value: 2.0 }
+                }
+              ]
+            },
+            { type: 'Step', value: '-', parameters: [] }
+          ]
+        }
+      }
+    ])
+  })
+
+  it('should parse a pattern with multiple named parameters', () => {
+    const result = parse(lexSource('pattern = [C4(vel: 0.75, gate: 2.0):1.5-]'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Assignment',
+        key: { type: 'Identifier', name: 'pattern' },
+        value: {
+          type: 'Pattern',
+          mode: 'serial',
+          children: [
+            {
+              type: 'Step',
+              value: 'C4',
+              length: { type: 'Number', value: 1.5 },
+              parameters: [
+                {
+                  type: 'Property',
+                  key: { type: 'Identifier', name: 'vel' },
+                  value: { type: 'Number', value: 0.75 }
+                },
                 {
                   type: 'Property',
                   key: { type: 'Identifier', name: 'gate' },


### PR DESCRIPTION
It was already possible to specify the "gate" of a step via function call syntax, e.g., `my_pattern = [D4(0.5)]` would create a pattern with a single step of length 1 beat, but gate 0.5 beats. Alternatively, a named parameter could be used, e.g., `my_pattern = [D4(gate: 0.5)]`. Now, the velocity ("vel") of a step can be specified in the same way:

```
// first step: pitch D4, length 1, gate 1, velocity 0.5
// second step: pitch G5, length 3, gate 2, velocity 0.75
my_pattern = [D4(1, 0.5) G5(gate: 2, vel: 0.75):3]
```

The default velocity of is 1.0, and it is clamped to the range [0, 1].