### PR TITLE
feat: Forbid blocking calls in 'voice' scopes

### DIFF
--- a/packages/language-support/src/hover/extension.ts
+++ b/packages/language-support/src/hover/extension.ts
@@ -19,6 +19,16 @@ const theme = EditorView.baseTheme({
   '.cm-cadence-hoverSummary': {
     marginTop: '0.35rem',
     whiteSpace: 'pre-wrap'
+  },
+  '.cm-cadence-hoverAnnotation': {
+    display: 'inline-block',
+    marginTop: '0.35rem',
+    marginRight: '0.25rem',
+    fontSize: '0.8em',
+    padding: '2px 4px',
+    borderRadius: '2px',
+    backgroundColor: 'color-mix(in srgb, currentColor, transparent 80%)',
+    fontFamily: 'monospace'
   }
 })
 
@@ -43,6 +53,12 @@ const tooltip = hoverTooltip((view, position) => {
       const summary = dom.appendChild(document.createElement('div'))
       summary.className = 'cm-cadence-hoverSummary'
       summary.textContent = info.summary
+    }
+
+    for (const annotation of info.annotations ?? []) {
+      const annotationElement = dom.appendChild(document.createElement('div'))
+      annotationElement.className = 'cm-cadence-hoverAnnotation'
+      annotationElement.textContent = annotation
     }
 
     return { dom }

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -25,7 +25,8 @@ describe('hover/operation.ts', () => {
       {
         range: getRangeAt(source, source.indexOf('gain('), 'gain'.length),
         title: 'gain(gain: number(db)) -> effect + record(gain)',
-        summary: 'Applies a gain adjustment to the signal.'
+        summary: 'Applies a gain adjustment to the signal.',
+        annotations: ['may block']
       }
     )
   })
@@ -73,7 +74,8 @@ describe('hover/operation.ts', () => {
       {
         range: getRangeAt(source, source.indexOf('delay('), 'delay'.length),
         title: 'delay(mix: number, time: number(beats) | number(s), feedback: number, wet?: number(db)) -> effect + record(feedback)',
-        summary: 'Adds echoes with configurable mix, time, and feedback.'
+        summary: 'Adds echoes with configurable mix, time, and feedback.',
+        annotations: ['may block']
       }
     )
 
@@ -82,7 +84,8 @@ describe('hover/operation.ts', () => {
       {
         range: getRangeAt(source, source.indexOf('reverb('), 'reverb'.length),
         title: 'reverb(mix: number, decay: number(beats) | number(s), wet?: number(db)) -> effect',
-        summary: 'Adds reverberation with configurable mix and decay.'
+        summary: 'Adds reverberation with configurable mix and decay.',
+        annotations: ['may block']
       }
     )
   })

--- a/packages/language/src/compiler/builtins/patterns.ts
+++ b/packages/language/src/compiler/builtins/patterns.ts
@@ -19,8 +19,8 @@ const loopDeclaration = {
   parameters: makeSchema([
     { name: 'times', type: NumberFacet.with(undefined).type(), required: false }
   ]),
-
-  returnType: PatternFacet.type()
+  returnType: PatternFacet.type(),
+  effects: { blocking: false }
 } as const
 
 const loop: PatternBuiltin = {
@@ -57,8 +57,8 @@ const fillDeclaration = {
   parameters: makeSchema([
     { name: 'duration', type: NumberFacet.with('beats').type(), required: true }
   ]),
-
-  returnType: PatternFacet.type()
+  returnType: PatternFacet.type(),
+  effects: { blocking: false }
 } as const
 
 const fill: PatternBuiltin = {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -636,8 +636,13 @@ function checkCurveSegment (scope: Scope, segment: ast.CurveSegment, hasPrevious
 }
 
 function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<FacetType> {
-  const instrumentScope = createLocalScope(scope)
   const errors: CompileError[] = []
+
+  if (!scope.allowedEffects.blocking) {
+    errors.push(new CompileError('Cannot construct an instrument in a realtime context', expression.range))
+  }
+
+  const instrumentScope = createLocalScope(scope)
 
   for (const child of expression.children) {
     switch (child.type) {
@@ -664,7 +669,7 @@ const noteType = RecordFacet.with({
 }).type()
 
 function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileError[] {
-  const voiceScope = createLocalScope(scope)
+  const voiceScope = createLocalScope(scope, { blocking: false })
   const errors: CompileError[] = []
 
   if (voice.bindings.note != null) {
@@ -811,9 +816,17 @@ function checkCall (scope: Scope, expression: ast.Call): Checked<FacetType> {
     return { errors }
   }
 
-  const { parameters, returnType } = FunctionFacet.detail(callee)
+  const { parameters, returnType, effects } = FunctionFacet.detail(callee)
 
   errors.push(...checkArgumentList(scope, expression.arguments, parameters, expression.range))
+
+  if (!scope.allowedEffects.blocking && effects.blocking) {
+    const functionName = tryGetFunctionName(expression.callee)
+    const message = functionName != null
+      ? `Function "${functionName}" may block and cannot be called from a realtime context`
+      : `Function may block and cannot be called from a realtime context`
+    errors.push(new CompileError(message, expression.range))
+  }
 
   return { errors, result: returnType }
 }
@@ -880,4 +893,16 @@ function checkArgumentList (
   }
 
   return errors
+}
+
+function tryGetFunctionName (callee: ast.Expression): string | undefined {
+  if (callee.type === 'Identifier') {
+    return callee.name
+  }
+
+  if (callee.type === 'PropertyAccess') {
+    return callee.property.name
+  }
+
+  return undefined
 }

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -1,3 +1,4 @@
+import type { Effects } from '../../type-system/base/function.js'
 import type { FacetType } from '../../type-system/types.js'
 
 // scope types
@@ -6,6 +7,7 @@ export interface Scope {
   readonly top: GlobalScope
   readonly parent?: Scope
   readonly resolutions: ReadonlyMap<string, FacetType>
+  readonly allowedEffects: Effects
 }
 
 export interface GlobalScope extends Scope {
@@ -35,7 +37,12 @@ export function createGlobalScope (initialResolutions: ReadonlyMap<string, Facet
     get top (): GlobalScope {
       return scope
     },
+
     resolutions: new Map(initialResolutions),
+
+    allowedEffects: {
+      blocking: true
+    },
 
     // from GlobalScope
     namespaces: new Map(),
@@ -45,11 +52,12 @@ export function createGlobalScope (initialResolutions: ReadonlyMap<string, Facet
   return scope
 }
 
-export function createLocalScope (parent: Scope): MutableScope {
+export function createLocalScope (parent: Scope, overrideEffects?: Effects): MutableScope {
   return {
     top: parent.top,
     parent,
-    resolutions: new Map()
+    resolutions: new Map(),
+    allowedEffects: overrideEffects ?? parent.allowedEffects
   }
 }
 

--- a/packages/language/src/library/documentation.ts
+++ b/packages/language/src/library/documentation.ts
@@ -8,6 +8,7 @@ import { getStandardModule } from './modules.js'
 export interface Documentation {
   readonly title: string
   readonly summary?: string
+  readonly annotations?: string[]
 }
 
 export function getDocumentation (moduleName: string, exportName?: string): Documentation | undefined {
@@ -39,9 +40,15 @@ function describeValue (name: string, value: Value): Documentation {
   if (FunctionFacet.has(value)) {
     const functionValue = FunctionFacet.get(value)
 
+    const annotations = []
+    if (functionValue.effects.blocking) {
+      annotations.push('may block')
+    }
+
     return {
       title: formatFunctionSignature(name, functionValue),
-      summary: functionValue.summary
+      summary: functionValue.summary,
+      annotations
     }
   }
 

--- a/packages/language/src/library/modules/effects.ts
+++ b/packages/language/src/library/modules/effects.ts
@@ -50,8 +50,8 @@ const gain = Functions.of({
   parameters: makeSchema([
     { name: 'gain', type: NumberFacet.with('db').type(), required: true }
   ]),
-
   returnType: GainEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
@@ -71,8 +71,8 @@ const pan = Functions.of({
   parameters: makeSchema([
     { name: 'pan', type: NumberFacet.with(undefined).type(), required: true }
   ]),
-
   returnType: PanEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
@@ -92,8 +92,8 @@ const lowpass = Functions.of({
   parameters: makeSchema([
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
   ]),
-
   returnType: LowpassEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
@@ -113,8 +113,8 @@ const highpass = Functions.of({
   parameters: makeSchema([
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
   ]),
-
   returnType: HighpassEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
@@ -134,8 +134,8 @@ const width = Functions.of({
   parameters: makeSchema([
     { name: 'width', type: NumberFacet.with(undefined).type(), required: true }
   ]),
-
   returnType: WidthEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
@@ -156,8 +156,8 @@ const delay = Functions.of({
     { name: 'feedback', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
-
   returnType: DelayEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
@@ -182,8 +182,8 @@ const reverb = Functions.of({
     { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
-
   returnType: ReverbEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
@@ -203,8 +203,8 @@ const clip = Functions.of({
   parameters: makeSchema([
     { name: 'threshold', type: NumberFacet.with('db').type(), required: true }
   ]),
-
   returnType: ClipEffectType,
+  effects: { blocking: true },
 
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -38,8 +38,8 @@ const sample = Functions.of({
     { name: 'root_note', type: StringFacet.type(), required: false },
     { name: 'length', type: NumberFacet.with('s').type(), required: false }
   ]),
-
   returnType: SampleInstrumentType,
+  effects: { blocking: true },
 
   // eslint-disable-next-line camelcase
   invoke: (context: ParameterContext & InstrumentContext, { url, gain, root_note, length }) => {
@@ -75,8 +75,8 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
     parameters: makeSchema([
       { name: 'gain', type: NumberFacet.with('db').type(), required: false }
     ]),
-
     returnType: OscillatorInstrumentType,
+    effects: { blocking: true },
 
     invoke: (context: ParameterContext & InstrumentContext, { gain }) => {
       const gainValue = gain != null ? NumberFacet.get(gain) : UNITY_GAIN

--- a/packages/language/src/type-system/base/function.ts
+++ b/packages/language/src/type-system/base/function.ts
@@ -2,9 +2,14 @@ import { makeFacet } from '../factory.js'
 import type { InferSchema, Schema } from '../schema.js'
 import type { CustomComparable, FacetType, ValueForType } from '../types.js'
 
+export interface Effects {
+  readonly blocking: boolean
+}
+
 export interface Function<S extends Schema = Schema, R extends FacetType = FacetType, Context = never> {
   readonly parameters: S
   readonly returnType: R
+  readonly effects: Effects
   readonly invoke: (context: Context, args: InferSchema<S>) => ValueForType<R>
 
   // documentation
@@ -14,6 +19,7 @@ export interface Function<S extends Schema = Schema, R extends FacetType = Facet
 interface FunctionSpec<S extends Schema = Schema, R extends FacetType = FacetType> {
   readonly parameters: S
   readonly returnType: R
+  readonly effects: Effects
 }
 
 interface FunctionSpecGeneric extends CustomComparable {

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -15,7 +15,8 @@ export const Functions = {
   of: <const S extends Schema, const R extends FacetType, const Context> (value: Function<S, R, Context>): Value => {
     const type = FunctionFacet.with({
       parameters: value.parameters,
-      returnType: value.returnType
+      returnType: value.returnType,
+      effects: value.effects
     }).type()
 
     return type.of(value)

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -792,6 +792,35 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
+    it('should reject blocking effects in non-blocking contexts', () => {
+      const source = [
+        'use "instruments" as *',
+        'my_instrument = instrument {',
+        '  voice {',
+        '    foo = sample("piano.wav")',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Function "sample" may block and cannot be called from a realtime context'
+      ])
+    })
+
+    it('should reject instrument expressions in non-blocking contexts', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  voice {',
+        '    foo = instrument {}',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Cannot construct an instrument in a realtime context'
+      ])
+    })
+
     it('should enforce ordering in the global scope', () => {
       const source = [
         'track (my_tempo) {}',

--- a/packages/language/test/compiler/checker/scopes.test.ts
+++ b/packages/language/test/compiler/checker/scopes.test.ts
@@ -12,8 +12,8 @@ describe('compiler/checker/scopes.ts', () => {
 
       assert.strictEqual(result.top, result)
       assert.strictEqual(result.parent, undefined)
-
       assert.strictEqual(result.resolutions.get('foo'), foo)
+      assert.deepStrictEqual(result.allowedEffects, { blocking: true })
 
       assert.strictEqual(result.buses.size, 0)
       assert.strictEqual(result.namespaces.size, 0)
@@ -31,6 +31,7 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(localScope.top, globalScope)
       assert.strictEqual(localScope.parent, globalScope)
       assert.strictEqual(localScope.resolutions.get('foo'), undefined)
+      assert.deepStrictEqual(localScope.allowedEffects, globalScope.allowedEffects)
 
       const bar = NumberFacet.with(undefined).type()
       localScope.resolutions.set('bar', bar)
@@ -42,6 +43,18 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(nestedLocalScope.parent, localScope)
       assert.strictEqual(nestedLocalScope.resolutions.get('foo'), undefined)
       assert.strictEqual(nestedLocalScope.resolutions.get('bar'), undefined)
+    })
+
+    it('can override allowedEffects', () => {
+      const globalScope = createGlobalScope(new Map([
+        ['foo', NumberFacet.with('db').type()]
+      ]))
+
+      const localScopeWithoutOverride = createLocalScope(globalScope)
+      assert.deepStrictEqual(localScopeWithoutOverride.allowedEffects, { blocking: true })
+
+      const localScopeWithOverride = createLocalScope(globalScope, { blocking: false })
+      assert.deepStrictEqual(localScopeWithOverride.allowedEffects, { blocking: false })
     })
   })
 

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -49,17 +49,19 @@ describe('type-system/base', () => {
     it('should preserve function specs through with() and detail()', () => {
       const amountType = NumberFacet.with('db').type()
       const returnType = StringFacet.type()
+      const effects = { blocking: true }
       const schema = makeSchema([
         { name: 'amount', type: amountType, required: true },
         { name: 'label', type: returnType, required: false }
       ])
-      const spec = { parameters: schema, returnType }
+      const spec = { parameters: schema, returnType, effects }
       const typedFacet = FunctionFacet.with(spec)
       const typedType = typedFacet.type()
 
       const func: Function<typeof schema, typeof returnType> = {
         parameters: schema,
         returnType,
+        effects,
         invoke: (_context, args) => args.label ?? returnType.of('fallback'),
         summary: 'demo function'
       }
@@ -76,7 +78,7 @@ describe('type-system/base', () => {
       assert.strictEqual(typedFacet.format(), 'function')
       assert.strictEqual(typedFacet.is(FunctionFacet.with(spec)), true)
 
-      const identicalShapeSpec = { parameters: schema, returnType }
+      const identicalShapeSpec = { parameters: schema, returnType, effects }
       assert.strictEqual(typedFacet.is(FunctionFacet.with(identicalShapeSpec)), false)
 
       assert.strictEqual(FunctionFacet.detail(typedType), spec)


### PR DESCRIPTION
Some functions from the standard library, as well as language constructs like `instrument`, must register global state and/or prepare resources before playback even starts. These are now annotated as "blocking". Scopes such as `voice` can disallow blocking calls. The user is then required to move the call to a parent scope that can be evaluated early.

As a specific example, consider sample loading. This takes an arbitrary amount of time. Therefore, it cannot work in a `voice` scope, which only has a few milliseconds to evaluate for each incoming note. Furthermore, it would be highly undesirable to load a sample for every note played. Instead, we must provide and enforce mechanisms to do this work upfront.