### PR TITLE
refactor: Separate assets from instruments

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -1,5 +1,5 @@
 import { createEntityKey } from '@audiograph'
-import type { Bus, Instrument } from '@core'
+import type { Bus, Instrument, Program } from '@core'
 import type { PanelProps } from '@editor'
 import { useNonNullValue, useService } from '@editor'
 import { Flowchart } from '@flowchart'
@@ -41,6 +41,8 @@ const FLOWCHART_OPTIONS: MixerFlowchartOptions = {
   }
 }
 
+const MISSING_ASSET_URL = '<missing asset>'
+
 function getNodeTypeLabel (type: MixerFlowNode['data']['type']): string {
   switch (type) {
     case 'output':
@@ -62,13 +64,25 @@ function getNodeLabel ({ data }: MixerFlowNode): string {
 
     case 'instrument': {
       switch (data.object.source.type) {
-        case 'sample':
-          return data.object.source.url.split('/').pop() ?? data.object.source.url
-        case 'oscillator':
+        case 'sample': {
+          const url = getSampleUrl(data.program, data.object)
+          return url?.split('/').pop() ?? url ?? MISSING_ASSET_URL
+        }
+
+        case 'oscillator': {
           return data.object.source.shape
+        }
       }
     }
   }
+}
+
+function getSampleUrl (program: Program, instrument: Instrument): string | undefined {
+  if (instrument.source.type !== 'sample') {
+    return undefined
+  }
+
+  return program.assets.get(instrument.source.assetId)?.url
 }
 
 export const MixerPanel: FunctionComponent<PanelProps> = () => {
@@ -220,7 +234,7 @@ const MixerNode: FunctionComponent<{
         <Popover anchor={container} onClose={closePopover}>
           {node.data.type === 'output' && (<OutputNodeInfo />)}
           {node.data.type === 'bus' && (<BusNodeInfo object={node.data.object} />)}
-          {node.data.type === 'instrument' && (<InstrumentNodeInfo object={node.data.object} />)}
+          {node.data.type === 'instrument' && (<InstrumentNodeInfo object={node.data.object} program={node.data.program} />)}
         </Popover>
       )}
     </>
@@ -250,13 +264,16 @@ const BusNodeInfo: FunctionComponent<{
 
 const InstrumentNodeInfo: FunctionComponent<{
   object: Instrument
-}> = ({ object }) => {
+  program: Program
+}> = ({ object, program }) => {
+  const sampleUrl = getSampleUrl(program, object) ?? MISSING_ASSET_URL
+
   return (
     <>
       <div className='font-bold'>(Instrument)</div>
       <div>type: {object.source.type}</div>
       {object.source.type === 'sample' && (
-        <div className='max-w-96'>url: {object.source.url}</div>
+        <div className='max-w-96'>url: {sampleUrl}</div>
       )}
       {object.source.type === 'oscillator' && (
         <div>shape: {object.source.shape}</div>

--- a/packages/app/src/modules/mixer/flowchart.ts
+++ b/packages/app/src/modules/mixer/flowchart.ts
@@ -9,12 +9,15 @@ type MixerObject = Bus | Instrument
 type MixerNodeData = {
   readonly type: 'output'
   readonly object?: undefined
+  readonly program: Program
 } | {
   readonly type: 'bus'
   readonly object: Bus
+  readonly program: Program
 } | {
   readonly type: 'instrument'
   readonly object: Instrument
+  readonly program: Program
 }
 
 interface MixerEdgeData {}
@@ -69,12 +72,12 @@ function createNodes (program: Program, options: MixerFlowchartOptions): Nodes {
     data
   })
 
-  const output = createNode({ type: 'output' })
+  const output = createNode({ type: 'output', program })
   all.push(output)
 
   for (const type of mixerObjectTypes) {
     for (const [objectId, object] of getObjectsOfType(program, type)) {
-      const node = createNode({ type, object } as any)
+      const node = createNode({ type, object, program } as any)
       all.push(node)
       byObject[type].set(objectId, node)
     }

--- a/packages/audiograph/src/builder.ts
+++ b/packages/audiograph/src/builder.ts
@@ -1,14 +1,15 @@
+import type { Asset, AssetId } from '@core'
 import type { Numeric } from '@utility'
-import type { AnyNode, AudioGraph, Edge, Meters, NodeId, NoteOptions } from './graph.js'
 import type { EntityKey } from './entities.js'
+import type { AnyNode, AudioGraph, Edge, Meters, NodeId, NoteOptions } from './graph.js'
 
 export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
   readonly addNode: <T extends TNode> (type: T['type'], node: Omit<T, 'id' | 'type'>) => T
-
   readonly addEdge: (from: NodeId, to: NodeId) => void
   readonly addEdges: (from: readonly NodeId[], to: readonly NodeId[]) => void
-
   readonly setOutput: (nodeId: NodeId) => void
+
+  readonly addAsset: (asset: Asset) => void
 
   readonly addNoteEvents: (nodeId: NodeId, events: readonly NoteOptions[]) => void
 
@@ -32,6 +33,7 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
   const nodes = new Map<NodeId, TNode>()
   const edges: Edge[] = []
   const outputIds: NodeId[] = []
+  const assets = new Map<AssetId, Asset>()
   const noteEvents = new Map<NodeId, readonly NoteOptions[]>()
   const meters = new Map<EntityKey, Meters>()
 
@@ -60,6 +62,10 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
     outputIds.push(nodeId)
   }
 
+  const addAsset: AudioGraphBuilder<TNode>['addAsset'] = (asset) => {
+    assets.set(asset.id, asset)
+  }
+
   const addNoteEvents: AudioGraphBuilder<TNode>['addNoteEvents'] = (nodeId, events) => {
     for (const event of events) {
       validateNoteEvent(event)
@@ -84,6 +90,7 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
     outputIds,
     tempo: meta.tempo,
     length: meta.length,
+    assets,
     noteEvents,
     meters
   })
@@ -94,6 +101,7 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
     addEdges,
     setOutput,
     addNoteEvents,
+    addAsset,
     addMeters,
     graph
   }

--- a/packages/audiograph/src/graph.ts
+++ b/packages/audiograph/src/graph.ts
@@ -1,4 +1,4 @@
-import type { MidiNote } from '@core'
+import type { Asset, AssetId, MidiNote } from '@core'
 import type { Brand, Numeric } from '@utility'
 import type { EntityKey } from './entities.js'
 
@@ -9,6 +9,8 @@ export interface AudioGraph<TNode = AnyNode> {
 
   readonly tempo: Numeric<'bpm'>
   readonly length: Numeric<'beats'>
+
+  readonly assets: ReadonlyMap<AssetId, Asset>
 
   readonly noteEvents: ReadonlyMap<NodeId, readonly NoteOptions[]>
 

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -35,6 +35,10 @@ export function createAudioGraph (program: Program, options?: AudioGraphOptions)
   const output = builder.addNode<IdentityNode>('identity', {})
   builder.setOutput(output.id)
 
+  for (const asset of program.assets.values()) {
+    builder.addAsset(asset)
+  }
+
   const busSubgraphs = new Map<BusId, SubGraph>()
   const instrumentSubgraphs = new Map<InstrumentId, SubGraph>()
   const instruments = new Map<InstrumentId, NodeId>()
@@ -188,7 +192,7 @@ function createSampleSource (sample: Sample, rootNote: MidiNote, envelope: Envel
   return builder.addNode<SampleNode>('sample', {
     rootNote,
     envelope: (note) => applyEnvelope(envelope, note),
-    url: sample.url,
+    assetId: sample.assetId,
     length
   })
 }

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -1,4 +1,4 @@
-import type { MidiNote } from '@core'
+import type { AssetId, MidiNote } from '@core'
 import type { Numeric } from '@utility'
 import type { TimeVariant } from './automation.js'
 import type { EntityKey } from './entities.js'
@@ -78,7 +78,7 @@ export interface SampleNode extends AnyNode {
   readonly type: 'sample'
   readonly rootNote: MidiNote
   readonly envelope: (note: Pick<NoteOptions, 'duration' | 'velocity'>) => TimeVariant<undefined>
-  readonly url: string
+  readonly assetId: AssetId
   readonly length?: Numeric<'s'>
 }
 

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, InstrumentRouting, MidiNote, MixerRouting, ParameterId, Pitch, Program, Track } from '@core'
+import type { Asset, AssetId, Bus, BusId, Effect, Envelope, Instrument, InstrumentId, InstrumentRouting, MidiNote, MixerRouting, ParameterId, Pitch, Program, Track } from '@core'
 import { beatsToSeconds, createSerialPattern } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
@@ -8,7 +8,7 @@ import { createEntityKey } from '../src/entities.js'
 import { applyEnvelope } from '../src/envelope.js'
 import type { NodeId } from '../src/graph.js'
 import { createAudioGraph } from '../src/lowering.js'
-import type { DelayNode, GainNode, IdentityNode, Node, ReverbNode, SampleNode, WaveShaperNode } from '../src/nodes.js'
+import type { DelayNode, GainNode, IdentityNode, Node, OscillatorNode, ReverbNode, SampleNode, WaveShaperNode } from '../src/nodes.js'
 
 const defaultEnvelope: Envelope = {
   attack: numeric('s', 0.01),
@@ -21,11 +21,17 @@ function compareIds (a: Node, b: Node): number {
   return a.id - b.id
 }
 
-function createProgramWithInstrument (instrument: Instrument): Program {
+function createProgramWithInstrument (instrument: Instrument, asset?: Asset): Program {
+  const assets = new Map<AssetId, Asset>()
+  if (asset != null) {
+    assets.set(asset.id, asset)
+  }
+
   return {
     beatsPerBar: 4,
     instruments: new Map([[instrument.id, instrument]]),
     automations: new Map(),
+    assets,
     track: {
       tempo: numeric('bpm', 120),
       parts: []
@@ -53,6 +59,7 @@ function createProgramWithEffect (effect: Effect): Program {
     beatsPerBar: 4,
     instruments: new Map(),
     automations: new Map(),
+    assets: new Map(),
     track: {
       tempo: numeric('bpm', 120),
       parts: []
@@ -95,6 +102,7 @@ describe('lowering.ts', () => {
       beatsPerBar: 4,
       instruments: new Map(),
       automations: new Map(),
+      assets: new Map(),
       track: {
         tempo: numeric('bpm', 120),
         parts: []
@@ -118,6 +126,45 @@ describe('lowering.ts', () => {
     assert.strictEqual(graph.noteEvents.size, 0)
   })
 
+  it('should include assets in the graph', () => {
+    const assetId = 100 as AssetId
+
+    const program: Program = {
+      beatsPerBar: 4,
+      instruments: new Map(),
+      automations: new Map(),
+      assets: new Map([
+        [
+          assetId,
+          {
+            id: assetId,
+            url: 'foo.wav'
+          }
+        ]
+      ]),
+      track: {
+        tempo: numeric('bpm', 120),
+        parts: []
+      },
+      mixer: {
+        buses: [],
+        routings: []
+      }
+    }
+
+    const graph = createAudioGraph(program)
+
+    assert.deepStrictEqual([...graph.assets.entries()], [
+      [
+        assetId,
+        {
+          id: assetId,
+          url: 'foo.wav'
+        }
+      ]
+    ])
+  })
+
   it('should lower a program with one instrument and one bus', () => {
     const instrumentId = 100 as InstrumentId
     const instrumentGainId = 200 as ParameterId
@@ -137,8 +184,8 @@ describe('lowering.ts', () => {
               initial: numeric('db', -6)
             },
             source: {
-              type: 'sample',
-              url: 'foo.wav'
+              type: 'oscillator',
+              shape: 'sine'
             },
             envelope: defaultEnvelope
           } satisfies Instrument
@@ -146,6 +193,7 @@ describe('lowering.ts', () => {
       ]),
 
       automations: new Map(),
+      assets: new Map(),
 
       track: {
         tempo: numeric('bpm', 120),
@@ -213,12 +261,11 @@ describe('lowering.ts', () => {
       } satisfies GainNode,
       {
         id: 3 as NodeId,
-        type: 'sample',
-        envelope: (graph.nodes.get(3 as NodeId) as SampleNode).envelope,
-        length: undefined,
-        url: 'foo.wav',
+        type: 'oscillator',
+        envelope: (graph.nodes.get(3 as NodeId) as OscillatorNode).envelope,
+        shape: 'sine',
         rootNote: 72 as MidiNote // C5
-      } satisfies SampleNode,
+      } satisfies OscillatorNode,
       {
         id: 4 as NodeId,
         type: 'gain',
@@ -256,8 +303,8 @@ describe('lowering.ts', () => {
               initial: numeric('db', -6)
             },
             source: {
-              type: 'sample',
-              url: 'foo.wav'
+              type: 'oscillator',
+              shape: 'sine'
             },
             envelope: defaultEnvelope
           } satisfies Instrument
@@ -285,6 +332,8 @@ describe('lowering.ts', () => {
           }
         ]
       ]),
+
+      assets: new Map(),
 
       track: {
         tempo: numeric('bpm', 120),
@@ -347,8 +396,8 @@ describe('lowering.ts', () => {
               initial: numeric('db', -6)
             },
             source: {
-              type: 'sample',
-              url: 'foo.wav'
+              type: 'oscillator',
+              shape: 'sine'
             },
             envelope: defaultEnvelope
           } satisfies Instrument
@@ -356,6 +405,7 @@ describe('lowering.ts', () => {
       ]),
 
       automations: new Map(),
+      assets: new Map(),
 
       track: {
         tempo: numeric('bpm', 120),
@@ -430,8 +480,8 @@ describe('lowering.ts', () => {
         initial: numeric('db', -Infinity)
       },
       source: {
-        type: 'sample',
-        url: 'foo.wav'
+        type: 'oscillator',
+        shape: 'sine'
       },
       envelope: defaultEnvelope
     })
@@ -448,8 +498,8 @@ describe('lowering.ts', () => {
           initial: numeric('db', gain)
         },
         source: {
-          type: 'sample',
-          url: 'foo.wav'
+          type: 'oscillator',
+          shape: 'sine'
         },
         envelope: defaultEnvelope
       })
@@ -468,8 +518,8 @@ describe('lowering.ts', () => {
           initial: numeric('db', -6)
         },
         source: {
-          type: 'sample',
-          url: 'foo.wav'
+          type: 'oscillator',
+          shape: 'sine'
         },
         envelope: defaultEnvelope
       })
@@ -487,10 +537,13 @@ describe('lowering.ts', () => {
       },
       source: {
         type: 'sample',
-        url: 'foo.wav',
+        assetId: 300 as AssetId,
         length: numeric('s', -1)
       },
       envelope: defaultEnvelope
+    }, {
+      id: 300 as AssetId,
+      url: 'foo.wav'
     })
 
     const graph = createAudioGraph(program)
@@ -498,7 +551,7 @@ describe('lowering.ts', () => {
       id: 2 as NodeId,
       type: 'sample',
       envelope: (graph.nodes.get(2 as NodeId) as SampleNode).envelope,
-      url: 'foo.wav',
+      assetId: 300 as AssetId,
       rootNote: 72 as MidiNote,
       length: numeric('s', 0)
     } satisfies SampleNode)
@@ -513,10 +566,13 @@ describe('lowering.ts', () => {
       },
       source: {
         type: 'sample',
-        url: 'foo.wav',
+        assetId: 300 as AssetId,
         length: numeric('s', Infinity)
       },
       envelope: defaultEnvelope
+    }, {
+      id: 300 as AssetId,
+      url: 'foo.wav'
     })
 
     const graph = createAudioGraph(program)
@@ -524,7 +580,7 @@ describe('lowering.ts', () => {
       id: 2 as NodeId,
       type: 'sample',
       envelope: (graph.nodes.get(2 as NodeId) as SampleNode).envelope,
-      url: 'foo.wav',
+      assetId: 300 as AssetId,
       rootNote: 72 as MidiNote,
       length: undefined
     } satisfies SampleNode)
@@ -539,10 +595,13 @@ describe('lowering.ts', () => {
       },
       source: {
         type: 'sample',
-        url: 'foo.wav',
+        assetId: 300 as AssetId,
         length: numeric('s', Number.NaN)
       },
       envelope: defaultEnvelope
+    }, {
+      id: 300 as AssetId,
+      url: 'foo.wav'
     })
 
     assert.throws(() => createAudioGraph(program), /Invalid length/)
@@ -612,8 +671,8 @@ describe('lowering.ts', () => {
           initial: numeric('db', -6)
         },
         source: {
-          type: 'sample',
-          url: 'foo.wav'
+          type: 'oscillator',
+          shape: 'sine'
         },
         envelope
       })
@@ -1436,8 +1495,8 @@ describe('lowering.ts', () => {
           initial: numeric('db', -6)
         },
         source: {
-          type: 'sample',
-          url: 'foo.wav'
+          type: 'oscillator',
+          shape: 'sine'
         },
         envelope: defaultEnvelope
       }))
@@ -1461,14 +1520,15 @@ describe('lowering.ts', () => {
                 initial: numeric('db', -6)
               },
               source: {
-                type: 'sample',
-                url: 'foo.wav'
+                type: 'oscillator',
+                shape: 'sine'
               },
               envelope: defaultEnvelope
             } satisfies Instrument
           ]
         ]),
         automations: new Map(),
+        assets: new Map(),
         track: {
           tempo: numeric('bpm', 120),
           parts: []
@@ -1558,8 +1618,8 @@ describe('lowering.ts', () => {
         initial: numeric('db', -6)
       },
       source: {
-        type: 'sample',
-        url: 'foo.wav'
+        type: 'oscillator',
+        shape: 'sine'
       },
       envelope: defaultEnvelope
     })

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -91,6 +91,13 @@ export interface AutomationPoint<U extends Unit = Unit> {
   readonly curve: 'linear' | 'step'
 }
 
+export type AssetId = Brand<number, 'core.AssetId'>
+
+export interface Asset {
+  readonly id: AssetId
+  readonly url: string
+}
+
 export type InstrumentId = Brand<number, 'core.InstrumentId'>
 
 export interface Instrument {
@@ -105,7 +112,7 @@ export type Source = Sample | Oscillator
 
 export interface Sample {
   readonly type: 'sample'
-  readonly url: string
+  readonly assetId: AssetId
   readonly length?: Numeric<'s'>
 }
 
@@ -240,6 +247,7 @@ export interface Program {
 
   readonly instruments: ReadonlyMap<InstrumentId, Instrument>
   readonly automations: ReadonlyMap<ParameterId, Automation>
+  readonly assets: ReadonlyMap<AssetId, Asset>
 
   readonly track: Track
   readonly mixer: Mixer

--- a/packages/flowchart/src/components/Flowchart.tsx
+++ b/packages/flowchart/src/components/Flowchart.tsx
@@ -1,8 +1,9 @@
-import { useLayoutEffect, useMemo, useState, type ReactElement } from 'react'
+import type { ReactElement } from 'react'
+import { useLayoutEffect, useMemo, useState } from 'react'
 import { computeLayout } from '../layout.js'
 import { getMarkerKey, getMarkerPath } from '../markers.js'
 import { getEdgeStyle } from '../style.js'
-import { FlowEdgeId, type FlowEdge, type FlowEdgeStyle, type FlowNode, type FlowNodeComponent, type FlowNodeId, type Marker } from '../types.js'
+import type { FlowEdge, FlowEdgeId, FlowEdgeStyle, FlowNode, FlowNodeComponent, FlowNodeId, Marker } from '../types.js'
 import { FlowchartEdge } from './FlowchartEdge.js'
 
 const LAYOUT_OPTIONS = Object.freeze({

--- a/packages/flowchart/src/layout.ts
+++ b/packages/flowchart/src/layout.ts
@@ -1,4 +1,5 @@
-import { createMultimap, type ReadonlyMultimap } from '@utility'
+import type { ReadonlyMultimap } from '@utility'
+import { createMultimap } from '@utility'
 import type { FlowEdge, FlowNode, FlowNodeId } from './types.js'
 
 export interface LayoutOptions {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -85,6 +85,7 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
 
     instruments: top.instruments,
     automations: top.automations,
+    assets: top.assets,
 
     track,
     mixer

--- a/packages/language/src/compiler/generator/scopes.ts
+++ b/packages/language/src/compiler/generator/scopes.ts
@@ -1,11 +1,11 @@
-import type { Automation, Bus, BusId, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
+import type { Asset, AssetId, Automation, Bus, BusId, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
 import type { Numeric, Unit } from '@utility'
 import type { Value } from '../../type-system/types.js'
 import type { GenerateOptions } from './options.js'
 
 // scope aspects
 
-type Context = BusContext & ParameterContext & InstrumentContext
+type Context = BusContext & ParameterContext & InstrumentContext & AssetContext
 
 export interface BusContext {
   readonly allocateBus: (data: Omit<Bus, 'id'>) => Bus
@@ -17,6 +17,10 @@ export interface ParameterContext {
 
 export interface InstrumentContext {
   readonly allocateInstrument: (data: Omit<Instrument, 'id'>) => Instrument
+}
+
+export interface AssetContext {
+  readonly allocateAsset: (data: Omit<Asset, 'id'>) => Asset
 }
 
 // scope types
@@ -36,6 +40,7 @@ export interface GlobalScope extends Scope, Context {
   readonly buses: Map<BusId, Bus>
   readonly instruments: Map<InstrumentId, Instrument>
   readonly automations: Map<ParameterId, Automation>
+  readonly assets: Map<AssetId, Asset>
 }
 
 export interface MutableScope extends Scope {
@@ -68,6 +73,7 @@ export function createGlobalScope (options: GenerateOptions, initialResolutions:
     buses: new Map(),
     instruments: new Map(),
     automations: new Map(),
+    assets: new Map(),
 
     // from BusContext
     allocateBus: (data) => allocateBus(scope, data),
@@ -76,7 +82,10 @@ export function createGlobalScope (options: GenerateOptions, initialResolutions:
     allocateParameter: (initial) => allocateParameter(scope, initial),
 
     // from InstrumentContext
-    allocateInstrument: (data) => allocateInstrument(scope, data)
+    allocateInstrument: (data) => allocateInstrument(scope, data),
+
+    // from AssetContext
+    allocateAsset: (data) => allocateAsset(scope, data)
   }
 
   return scope
@@ -125,4 +134,13 @@ function allocateInstrument (scope: GlobalScope, data: Omit<Instrument, 'id'>): 
   scope.instruments.set(instrument.id, instrument)
 
   return instrument
+}
+
+function allocateAsset (scope: GlobalScope, data: Omit<Asset, 'id'>): Asset {
+  const id = scope.assets.size as AssetId
+
+  const asset = { ...data, id }
+  scope.assets.set(asset.id, asset)
+
+  return asset
 }

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -1,7 +1,7 @@
 import type { Envelope, Oscillator } from '@core'
 import { isPitch } from '@core'
 import { numeric } from '@utility'
-import type { InstrumentContext, ParameterContext } from '../../compiler/generator/scopes.js'
+import type { AssetContext, InstrumentContext, ParameterContext } from '../../compiler/generator/scopes.js'
 import { NumberFacet } from '../../type-system/base/number.js'
 import { RecordFacet } from '../../type-system/base/record.js'
 import { StringFacet } from '../../type-system/base/string.js'
@@ -42,7 +42,7 @@ const sample = Functions.of({
   effects: { blocking: true },
 
   // eslint-disable-next-line camelcase
-  invoke: (context: ParameterContext & InstrumentContext, { url, gain, root_note, length }) => {
+  invoke: (context: ParameterContext & InstrumentContext & AssetContext, { url, gain, root_note, length }) => {
     const urlValue = StringFacet.get(url)
     const gainValue = gain != null ? NumberFacet.get(gain) : UNITY_GAIN
     // eslint-disable-next-line camelcase
@@ -51,12 +51,16 @@ const sample = Functions.of({
 
     const gainParameter = context.allocateParameter(gainValue)
 
+    const asset = context.allocateAsset({
+      url: urlValue
+    })
+
     const instrument = context.allocateInstrument({
       gain: gainParameter,
       rootNote: rootNoteValue != null && isPitch(rootNoteValue) ? rootNoteValue : undefined,
       source: {
         type: 'sample',
-        url: urlValue,
+        assetId: asset.id,
         length: lengthValue
       },
       envelope: ENVELOPE_DECLICK

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -35,6 +35,7 @@ describe('compiler/generator/generator.ts', () => {
       beatsPerBar: 4,
       instruments: new Map(),
       automations: new Map(),
+      assets: new Map(),
       track: {
         tempo: numeric('bpm', 120),
         parts: []
@@ -88,9 +89,12 @@ describe('compiler/generator/generator.ts', () => {
     const result = generateSource(source)
     assert.deepStrictEqual(result.instruments.size, 1)
 
+    const [asset] = result.assets.values()
+    assert.strictEqual(asset.url, 'kick.wav')
+
     const [instrument] = result.instruments.values()
     assert.strictEqual(instrument.source.type, 'sample')
-    assert.strictEqual(instrument.source.url, 'kick.wav')
+    assert.strictEqual(instrument.source.assetId, asset.id)
   })
 
   it('should support import aliases', () => {
@@ -102,9 +106,12 @@ describe('compiler/generator/generator.ts', () => {
     const result = generateSource(source)
     assert.deepStrictEqual(result.instruments.size, 1)
 
+    const [asset] = result.assets.values()
+    assert.strictEqual(asset.url, 'kick.wav')
+
     const [instrument] = result.instruments.values()
     assert.strictEqual(instrument.source.type, 'sample')
-    assert.strictEqual(instrument.source.url, 'kick.wav')
+    assert.strictEqual(instrument.source.assetId, asset.id)
   })
 
   it('should support shadowing of imported names', () => {

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -30,6 +30,7 @@ describe('compiler/generator/scopes.ts', () => {
       assert.strictEqual(result.buses.size, 0)
       assert.strictEqual(result.instruments.size, 0)
       assert.strictEqual(result.automations.size, 0)
+      assert.strictEqual(result.assets.size, 0)
     })
 
     it('should allocate buses with unique IDs', () => {
@@ -116,6 +117,29 @@ describe('compiler/generator/scopes.ts', () => {
       assert.deepStrictEqual([...scope.instruments], [
         [0, { ...instrument0, id: 0 }],
         [1, { ...instrument1, id: 1 }]
+      ])
+    })
+
+    it('should allocate assets with unique IDs', () => {
+      const scope = createGlobalScope(options, new Map())
+
+      const asset0 = {
+        url: 'foo.wav'
+      } as const
+
+      const asset1 = {
+        url: 'bar.wav'
+      } as const
+
+      const allocated0 = scope.allocateAsset(asset0)
+      const allocated1 = scope.allocateAsset(asset1)
+
+      assert.strictEqual(allocated0.id, 0)
+      assert.strictEqual(allocated1.id, 1)
+
+      assert.deepStrictEqual([...scope.assets], [
+        [0, { ...asset0, id: 0 }],
+        [1, { ...asset1, id: 1 }]
       ])
     })
   })

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -1,4 +1,4 @@
-import type { Envelope } from '@core'
+import type { Envelope, Instrument } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -42,21 +42,25 @@ describe('library/modules/instruments.ts', () => {
         length: Numbers.of(numeric('s', 1.5))
       })
 
-      const { id, ...instrument } = InstrumentFacet.get(result)
+      const [asset] = context.assets.values()
+      assert.strictEqual(asset.url, 'https://example.com/kick.wav')
+
+      const instrument = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
+        id: instrument.id,
         rootNote: 'C4',
         gain: { id: instrument.gain.id, initial: numeric('db', -3) },
         source: {
           type: 'sample',
-          url: 'https://example.com/kick.wav',
+          assetId: asset.id,
           length: numeric('s', 1.5)
         },
         envelope: declickEnvelope
-      })
+      } satisfies Instrument)
 
       assert.deepStrictEqual([...context.instruments], [
-        [id, InstrumentFacet.get(result)]
+        [instrument.id, InstrumentFacet.get(result)]
       ])
 
       assert.deepStrictEqual([...context.automations.keys()], [instrument.gain.id])
@@ -71,12 +75,19 @@ describe('library/modules/instruments.ts', () => {
         url: StringFacet.type().of(url)
       })
 
+      const [asset] = context.assets.values()
+      assert.strictEqual(asset.url, url)
+
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
         rootNote: undefined,
         gain: { id: instrument.gain.id, initial: numeric('db', 0) },
-        source: { type: 'sample', url, length: undefined },
+        source: {
+          type: 'sample',
+          assetId: asset.id,
+          length: undefined
+        },
         envelope: declickEnvelope
       })
 

--- a/packages/webaudio/src/graph/factory.ts
+++ b/packages/webaudio/src/graph/factory.ts
@@ -1,5 +1,4 @@
 import type { Node } from '@audiograph'
-import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
 import type { GainMeasurement } from '../worklets/metering/messages.js'
 import { createBiquadInstance, createDelayInstance, createGainInstance, createIdentityInstance, createPanInstance, createReverbInstance, createWaveShaperInstance, createWidthInstance } from './effect.js'
@@ -7,6 +6,7 @@ import type { Instance } from './instance.js'
 import { createOscillatorInstance } from './instruments/oscillator.js'
 import { createSampleInstance } from './instruments/sample.js'
 import { createGainMeterInstance } from './metering.js'
+import type { AssetId } from '@core'
 
 const factories = Object.freeze({
   identity: createIdentityInstance,
@@ -30,9 +30,13 @@ const factories = Object.freeze({
 
 type NodeFactoryArguments = readonly [
   transport: Transport,
-  fetcher: AudioFetcher,
+  assets: Assets,
   meterCallbacks?: MeterCallbacks
 ]
+
+export interface Assets {
+  readonly samples: ReadonlyMap<AssetId, AudioBuffer>
+}
 
 export interface MeterCallbacks {
   readonly onGain: (key: string, measurement: GainMeasurement) => void

--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -15,12 +15,43 @@ export async function createWebAudioGraph (
   fetcher: AudioFetcher,
   meterCallbacks?: MeterCallbacks
 ): Promise<WebAudioGraph> {
-  const instances = new Map<NodeId, Instance>()
   let disposed = false
 
-  const promises = new Map<NodeId, Promise<void>>()
+  const assets = {
+    samples: new Map()
+  }
+
+  const assetPromisesByUrl = new Map<string, Promise<AudioBuffer>>()
+
+  for (const asset of graph.assets.values()) {
+    const promise = assetPromisesByUrl.get(asset.url)
+
+    if (promise == null) {
+      assetPromisesByUrl.set(asset.url, fetcher.fetch(transport.ctx, asset.url).then((buffer) => {
+        assets.samples.set(asset.id, buffer)
+        return buffer
+      }))
+      continue
+    }
+
+    assetPromisesByUrl.set(asset.url, promise.then((buffer) => {
+      assets.samples.set(asset.id, buffer)
+      return buffer
+    }))
+  }
+
+  try {
+    await Promise.all(assetPromisesByUrl.values())
+  } catch (err: unknown) {
+    disposed = true
+    throw err
+  }
+
+  const instances = new Map<NodeId, Instance>()
+  const instancePromises = new Map<NodeId, Promise<void>>()
+
   for (const node of graph.nodes.values()) {
-    const promise = createNodeInstance(node, transport, fetcher, meterCallbacks).then((instance) => {
+    const promise = createNodeInstance(node, transport, assets, meterCallbacks).then((instance) => {
       if (disposed) {
         instance.dispose()
         return
@@ -29,11 +60,11 @@ export async function createWebAudioGraph (
       instances.set(node.id, instance)
     })
 
-    promises.set(node.id, promise)
+    instancePromises.set(node.id, promise)
   }
 
   try {
-    await Promise.all(promises.values())
+    await Promise.all(instancePromises.values())
   } catch (err: unknown) {
     disposed = true
     instances.forEach((instance) => instance.dispose())

--- a/packages/webaudio/src/graph/instruments/sample.ts
+++ b/packages/webaudio/src/graph/instruments/sample.ts
@@ -1,14 +1,17 @@
 import type { SampleNode } from '@audiograph'
-import type { AudioFetcher } from '../../assets/fetcher.js'
 import type { Transport } from '../../transport/transport.js'
+import type { Assets } from '../factory.js'
 import type { Instance } from '../instance.js'
 import type { CreateSource } from './common.js'
 import { createInstrumentInstance } from './common.js'
 
-export async function createSampleInstance (node: SampleNode, transport: Transport, fetcher: AudioFetcher): Promise<Instance> {
+export async function createSampleInstance (node: SampleNode, transport: Transport, assets: Assets): Promise<Instance> {
   const { ctx } = transport
 
-  const sampleBuffer = await fetcher.fetch(ctx, node.url)
+  const sampleBuffer = assets.samples.get(node.assetId)
+  if (!sampleBuffer) {
+    throw new Error(`Asset not found: ${node.assetId}`)
+  }
 
   const createSource: CreateSource = (note) => {
     const sourceNode = ctx.createBufferSource()

--- a/packages/webaudio/src/graph/metering.ts
+++ b/packages/webaudio/src/graph/metering.ts
@@ -1,15 +1,14 @@
 import type { GainMeterNode } from '@audiograph'
 import type { UnsubscribeFn } from '@utility'
-import type { AudioFetcher } from '../assets/fetcher.js'
 import type { Transport } from '../transport/transport.js'
 import { createGainMeter } from '../worklets/metering/factory.js'
-import type { MeterCallbacks } from './factory.js'
+import type { Assets, MeterCallbacks } from './factory.js'
 import type { Instance } from './instance.js'
 
 export async function createGainMeterInstance (
   node: GainMeterNode,
   transport: Transport,
-  fetcher: AudioFetcher,
+  assets: Assets,
   meterCallbacks?: MeterCallbacks
 ): Promise<Instance> {
   const instance = await createGainMeter(transport.ctx, {


### PR DESCRIPTION
The assets used throughout the program are now stored in a separate collection and referenced by ID. This allows them to be loaded up-front and reused for any number of instrument sources. Therefore, no assets need to be loaded during realtime playback, which would be impossible.