### PR TITLE
refactor: Simplify pattern by removing subdivision

### DIFF
--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -435,7 +435,7 @@ describe('lowering.ts', () => {
                   value: createSerialPattern([
                     { value: 'C4' },
                     { value: 'E4', velocity: numeric(undefined, 0.75) }
-                  ], 1)
+                  ])
                 },
                 destination: {
                   type: 'instrument',
@@ -454,7 +454,7 @@ describe('lowering.ts', () => {
                   value: createSerialPattern([
                     { value: 'G4' },
                     { value: 'B4' }
-                  ], 1)
+                  ])
                 },
                 destination: {
                   type: 'instrument',

--- a/packages/core/src/pattern.ts
+++ b/packages/core/src/pattern.ts
@@ -41,14 +41,14 @@ function getMaxLength (patterns: readonly Pattern[]): Pattern['length'] {
   return numeric('beats', max)
 }
 
-function pushStepEvent (events: NoteEvent[], step: Step, offset: number, baseLength = 1.0): void {
+function pushStepEvent (events: NoteEvent[], step: Step, offset: number): void {
   if (step.value === '-') {
     return
   }
 
   const time = numeric('beats', offset)
 
-  const stepGate = baseLength * (step.gate?.value ?? step.length?.value ?? 1)
+  const stepGate = step.gate?.value ?? step.length?.value ?? 1
   const gate = numeric('beats', stepGate)
   const velocity = step.velocity ?? defaultVelocity
 
@@ -60,27 +60,23 @@ function pushStepEvent (events: NoteEvent[], step: Step, offset: number, baseLen
 }
 
 /**
- * Create a pattern with equally spaced steps based on the provided subdivision.
- * For example, assuming a 4/4 time signature, a subdivision of 1 would create quarter notes,
- * while a subdivision of 4 would create sixteenth notes.
+ * Create a pattern with equally spaced steps, where each step is 1 beat long.
  */
-export function createSerialPattern (steps: readonly Step[], subdivision: number): Pattern {
-  if (steps.length === 0 || !isPositiveFiniteNumber(subdivision)) {
+export function createSerialPattern (steps: readonly Step[]): Pattern {
+  if (steps.length === 0) {
     return emptyPattern
   }
-
-  const defaultStepLength = 1 / subdivision
 
   const events: NoteEvent[] = []
   let offset = 0
 
   for (const step of steps) {
-    const stepLength = defaultStepLength * (step.length?.value ?? 1)
+    const stepLength = step.length?.value ?? 1
     if (!isPositiveFiniteNumber(stepLength)) {
       continue
     }
 
-    pushStepEvent(events, step, offset, defaultStepLength)
+    pushStepEvent(events, step, offset)
     offset += stepLength
   }
 

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -9,13 +9,12 @@ export interface Step {
   readonly value: StepValue
 
   /**
-   * The duration of the step relative to the pattern's subdivision. Defaults to 1.
+    * The duration of the step. Defaults to 1.
    */
   readonly length?: Numeric<undefined>
 
   /**
-   * The gate (duration) of the step relative to the pattern's subdivision.
-   * If undefined, the gate is equal to the step's length.
+    * The gate (duration) of the step. If undefined, the gate is equal to the step's length.
    */
   readonly gate?: Numeric<undefined>
 

--- a/packages/core/test/pattern.test.ts
+++ b/packages/core/test/pattern.test.ts
@@ -14,7 +14,7 @@ describe('pattern.ts', () => {
         { value: 'x' },
         { value: '-' },
         { value: 'x' }
-      ], 1)
+      ])
       assert.strictEqual(pattern.length?.value, 3)
       assert.deepStrictEqual([...pattern.evaluate()], [
         { time: beats(0), gate: beats(1), velocity: unitless(1) },
@@ -23,22 +23,9 @@ describe('pattern.ts', () => {
     })
 
     it('should create an empty pattern when given an empty array', () => {
-      const pattern = createSerialPattern([], 1)
+      const pattern = createSerialPattern([])
       assert.strictEqual(pattern.length?.value, 0)
       assert.deepStrictEqual([...pattern.evaluate()], [])
-    })
-
-    it('should adapt to subdivision', () => {
-      const pattern = createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'x' }
-      ], 2)
-      assert.strictEqual(pattern.length?.value, 1.5)
-      assert.deepStrictEqual([...pattern.evaluate()], [
-        { time: beats(0), gate: beats(0.5), velocity: unitless(1) },
-        { time: beats(1), gate: beats(0.5), velocity: unitless(1) }
-      ])
     })
 
     it('should handle steps with custom lengths', () => {
@@ -46,7 +33,7 @@ describe('pattern.ts', () => {
         { value: 'x', length: numeric(undefined, 2) },
         { value: '-' },
         { value: 'x', length: numeric(undefined, 0.5) }
-      ], 1)
+      ])
       assert.strictEqual(pattern.length?.value, 3.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
         { time: beats(0), gate: beats(2), velocity: unitless(1) },
@@ -59,7 +46,7 @@ describe('pattern.ts', () => {
         { value: 'C1', length: numeric(undefined, 0) },
         { value: 'C2', length: numeric(undefined, -1) },
         { value: 'C3' }
-      ], 1)
+      ])
       assert.strictEqual(pattern.length?.value, 1)
       assert.deepStrictEqual([...pattern.evaluate()], [
         { pitch: 'C3', time: beats(0), gate: beats(1), velocity: unitless(1) }
@@ -71,7 +58,7 @@ describe('pattern.ts', () => {
         { value: 'x', gate: numeric(undefined, 0.5) },
         { value: '-' },
         { value: 'x', gate: numeric(undefined, 0.25) }
-      ], 1)
+      ])
       assert.strictEqual(pattern.length?.value, 3)
       assert.deepStrictEqual([...pattern.evaluate()], [
         { time: beats(0), gate: beats(0.5), velocity: unitless(1) },
@@ -84,7 +71,7 @@ describe('pattern.ts', () => {
         { value: 'x', length: numeric(undefined, 2), gate: numeric(undefined, 1.5) },
         { value: '-' },
         { value: 'x', length: numeric(undefined, 0.5), gate: numeric(undefined, 0.1) }
-      ], 1)
+      ])
       assert.strictEqual(pattern.length?.value, 3.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
         { time: beats(0), gate: beats(1.5), velocity: unitless(1) },
@@ -107,7 +94,7 @@ describe('pattern.ts', () => {
           gate: numeric(undefined, 0.1),
           velocity: numeric(undefined, 0.5)
         }
-      ], 1)
+      ])
 
       assert.strictEqual(pattern.length?.value, 3.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
@@ -209,15 +196,19 @@ describe('pattern.ts', () => {
     })
 
     it('should return the same pattern when given a single pattern', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }], 1)
+      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }])
       const concatenated = concatPatterns([pattern])
       assert.strictEqual(concatenated, pattern)
     })
 
     it('should concatenate two finite patterns correctly', () => {
       const concatenated = concatPatterns([
-        createSerialPattern([{ value: 'x' }, { value: '-' }], 1),
-        createSerialPattern([{ value: '-' }, { value: 'x' }, { value: 'x', velocity: unitless(0.5) }], 2)
+        createSerialPattern([{ value: 'x' }, { value: '-' }]),
+        createSerialPattern([
+          { value: '-', length: numeric(undefined, 0.5) },
+          { value: 'x', length: numeric(undefined, 0.5) },
+          { value: 'x', length: numeric(undefined, 0.5), velocity: unitless(0.5) }
+        ])
       ])
       assert.strictEqual(concatenated.length?.value, 3.5)
       assert.deepStrictEqual([...concatenated.evaluate()], [
@@ -228,22 +219,22 @@ describe('pattern.ts', () => {
     })
 
     it('should return the second pattern if the first is empty', () => {
-      const first = createSerialPattern([], 1)
-      const second = createSerialPattern([{ value: 'x' }, { value: '-' }], 1)
+      const first = createSerialPattern([])
+      const second = createSerialPattern([{ value: 'x' }, { value: '-' }])
       const concatenated = concatPatterns([first, second])
       assert.strictEqual(concatenated, second)
     })
 
     it('should return the first pattern if the second is empty', () => {
-      const first = createSerialPattern([{ value: 'x' }, { value: '-' }], 1)
-      const second = createSerialPattern([], 1)
+      const first = createSerialPattern([{ value: 'x' }, { value: '-' }])
+      const second = createSerialPattern([])
       const concatenated = concatPatterns([first, second])
       assert.strictEqual(concatenated, first)
     })
 
     it('should return the first pattern if it is infinite', () => {
-      const first = loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }], 1))
-      const second = createSerialPattern([{ value: '-' }, { value: 'x' }], 1)
+      const first = loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }]))
+      const second = createSerialPattern([{ value: '-' }, { value: 'x' }])
       const concatenated = concatPatterns([first, second])
       assert.strictEqual(concatenated, first)
     })
@@ -257,15 +248,15 @@ describe('pattern.ts', () => {
     })
 
     it('should return the same pattern when given a single pattern', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }], 1)
+      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }])
       const parallel = mergePatterns([pattern])
       assert.strictEqual(parallel, pattern)
     })
 
     it('should combine multiple patterns correctly', () => {
       const parallel = mergePatterns([
-        createSerialPattern([{ value: 'x' }, { value: '-' }], 1),
-        createSerialPattern([{ value: '-' }, { value: 'x', velocity: unitless(0.5) }], 1)
+        createSerialPattern([{ value: 'x' }, { value: '-' }]),
+        createSerialPattern([{ value: '-' }, { value: 'x', velocity: unitless(0.5) }])
       ])
       assert.strictEqual(parallel.length?.value, 2)
       assert.deepStrictEqual([...parallel.evaluate()], [
@@ -276,8 +267,8 @@ describe('pattern.ts', () => {
 
     it('should handle patterns of different lengths', () => {
       const parallel = mergePatterns([
-        createSerialPattern([{ value: 'x' }, { value: '-' }, { value: 'x' }], 1),
-        createSerialPattern([{ value: '-' }, { value: 'x' }], 1)
+        createSerialPattern([{ value: 'x' }, { value: '-' }, { value: 'x' }]),
+        createSerialPattern([{ value: '-' }, { value: 'x' }])
       ])
       assert.strictEqual(parallel.length?.value, 3)
       assert.deepStrictEqual([...parallel.evaluate()], [
@@ -289,8 +280,8 @@ describe('pattern.ts', () => {
 
     it('should handle infinite patterns', () => {
       const parallel = mergePatterns([
-        loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }], 1)),
-        createSerialPattern([{ value: '-' }, { value: 'x' }], 1)
+        loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }])),
+        createSerialPattern([{ value: '-' }, { value: 'x' }])
       ])
       assert.strictEqual(parallel.length, undefined)
 
@@ -311,10 +302,16 @@ describe('pattern.ts', () => {
 
     it('should produce steps in the correct order', () => {
       const parallel = mergePatterns([
-        createSerialPattern([{ value: 'x' }, { value: '-' }, { value: 'x' }], 1),
-        createSerialPattern([{ value: '-' }, { value: '-' }, { value: 'x' }], 1),
-        createSerialPattern([{ value: 'x' }, { value: 'x' }], 4),
-        createSerialPattern([{ value: 'x' }, { value: 'x' }], 2)
+        createSerialPattern([{ value: 'x' }, { value: '-' }, { value: 'x' }]),
+        createSerialPattern([{ value: '-' }, { value: '-' }, { value: 'x' }]),
+        createSerialPattern([
+          { value: 'x', length: numeric(undefined, 0.25) },
+          { value: 'x', length: numeric(undefined, 0.25) }
+        ]),
+        createSerialPattern([
+          { value: 'x', length: numeric(undefined, 0.5) },
+          { value: 'x', length: numeric(undefined, 0.5) }
+        ])
       ])
       assert.strictEqual(parallel.length?.value, 3)
       assert.deepStrictEqual([...parallel.evaluate()], [
@@ -332,10 +329,10 @@ describe('pattern.ts', () => {
   describe('loopPattern()', () => {
     it('should create an infinite pattern when no duration is provided', () => {
       const pattern = createSerialPattern([
-        { value: 'x', velocity: unitless(0.75) },
-        { value: '-' },
-        { value: '-' }
-      ], 2)
+        { value: 'x', velocity: unitless(0.75), length: numeric(undefined, 0.5) },
+        { value: '-', length: numeric(undefined, 0.5) },
+        { value: '-', length: numeric(undefined, 0.5) }
+      ])
       const looped = loopPattern(pattern)
 
       assert.strictEqual(looped.length, undefined)
@@ -356,7 +353,7 @@ describe('pattern.ts', () => {
     })
 
     it('should loop a finite pattern to a specific length', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }], 1)
+      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }])
       const looped = loopPattern(pattern, beats(5))
 
       assert.strictEqual(looped.length?.value, 5)
@@ -373,7 +370,7 @@ describe('pattern.ts', () => {
       const pattern = createSerialPattern([
         { value: 'A4', gate: numeric(undefined, 3) },
         { value: 'B4', gate: numeric(undefined, 5) }
-      ], 1)
+      ])
       const looped = loopPattern(pattern, beats(4))
 
       assert.strictEqual(looped.length?.value, 4)
@@ -386,19 +383,19 @@ describe('pattern.ts', () => {
     })
 
     it('should return the same pattern if it is infinite and no duration is provided', () => {
-      const pattern = loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }], 1))
+      const pattern = loopPattern(createSerialPattern([{ value: 'x' }, { value: '-' }]))
       const looped = loopPattern(pattern)
       assert.strictEqual(looped, pattern)
     })
 
     it('should return empty pattern when looping an empty pattern', () => {
-      const pattern = loopPattern(createSerialPattern([], 1), beats(10))
+      const pattern = loopPattern(createSerialPattern([]), beats(10))
       assert.strictEqual(pattern.length?.value, 0)
       assert.deepStrictEqual([...pattern.evaluate()], [])
     })
 
     it('should return empty pattern when looping an empty pattern infinitely', () => {
-      const pattern = loopPattern(createSerialPattern([], 1))
+      const pattern = loopPattern(createSerialPattern([]))
       assert.strictEqual(pattern.length?.value, 0)
       assert.deepStrictEqual([...pattern.evaluate()], [])
     })
@@ -406,14 +403,14 @@ describe('pattern.ts', () => {
 
   describe('multiplyPattern()', () => {
     it('should return an empty pattern when multiplied by 0', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }], 1)
+      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }])
       const multiplied = multiplyPattern(pattern, 0)
       assert.strictEqual(multiplied.length?.value, 0)
       assert.deepStrictEqual([...multiplied.evaluate()], [])
     })
 
     it('should return an empty pattern when multiplied by a negative number', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }], 1)
+      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }])
       const multiplied = multiplyPattern(pattern, -1)
       assert.strictEqual(multiplied.length?.value, 0)
       assert.deepStrictEqual([...multiplied.evaluate()], [])
@@ -424,7 +421,7 @@ describe('pattern.ts', () => {
         { value: 'x', velocity: unitless(0.75) },
         { value: '-' },
         { value: 'x' }
-      ], 1)
+      ])
       const multiplied = multiplyPattern(pattern, 1)
       assert.strictEqual(multiplied.length?.value, 3)
       assert.deepStrictEqual([...multiplied.evaluate()], [
@@ -438,7 +435,7 @@ describe('pattern.ts', () => {
         { value: 'x', velocity: unitless(0.75) },
         { value: '-' },
         { value: 'x' }
-      ], 1)
+      ])
       const multiplied = multiplyPattern(pattern, 3)
       assert.strictEqual(multiplied.length?.value, 9)
       assert.deepStrictEqual([...multiplied.evaluate()], [
@@ -451,7 +448,7 @@ describe('pattern.ts', () => {
       const pattern = loopPattern(createSerialPattern([
         { value: 'x', velocity: unitless(0.75) },
         { value: '-' }
-      ], 1))
+      ]))
       const multiplied = multiplyPattern(pattern, 4)
       assert.strictEqual(multiplied.length, undefined)
 
@@ -471,28 +468,28 @@ describe('pattern.ts', () => {
     })
 
     it('should return an empty pattern when multiplying an empty pattern', () => {
-      const pattern = createSerialPattern([], 1)
+      const pattern = createSerialPattern([])
       const multiplied = multiplyPattern(pattern, 5)
       assert.strictEqual(multiplied.length?.value, 0)
       assert.deepStrictEqual([...multiplied.evaluate()], [])
     })
 
     it('should handle non-empty patterns with no events', () => {
-      const pattern = createSerialPattern([{ value: '-' }, { value: '-' }, { value: '-' }], 1)
+      const pattern = createSerialPattern([{ value: '-' }, { value: '-' }, { value: '-' }])
       const multiplied = multiplyPattern(pattern, 2)
       assert.strictEqual(multiplied.length?.value, 6)
       assert.deepStrictEqual([...multiplied.evaluate()], [])
     })
 
     it('should handle infinite patterns with no events', () => {
-      const pattern = loopPattern(createSerialPattern([{ value: '-' }, { value: '-' }, { value: '-' }], 1))
+      const pattern = loopPattern(createSerialPattern([{ value: '-' }, { value: '-' }, { value: '-' }]))
       const multiplied = multiplyPattern(pattern, 2)
       assert.strictEqual(multiplied.length, undefined)
       assert.deepStrictEqual([...multiplied.evaluate()], [])
     })
 
     it('should handle fractional factors', () => {
-      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }, { value: '-' }, { value: 'x' }], 1)
+      const pattern = createSerialPattern([{ value: 'x' }, { value: '-' }, { value: '-' }, { value: 'x' }])
       const multiplied = multiplyPattern(pattern, 1 / 3)
       assert.strictEqual(multiplied.length?.value, 4 / 3)
       assert.deepStrictEqual([...multiplied.evaluate()], [
@@ -509,7 +506,7 @@ describe('pattern.ts', () => {
         { value: '-' },
         { value: 'x', velocity: unitless(0.5) },
         { value: 'x' }
-      ], 1)
+      ])
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(0)),
         []
@@ -539,11 +536,11 @@ describe('pattern.ts', () => {
 
     it('should not produce additional events', () => {
       assert.deepStrictEqual(
-        renderPatternEvents(createSerialPattern([], 1), beats(2)),
+        renderPatternEvents(createSerialPattern([]), beats(2)),
         []
       )
       assert.deepStrictEqual(
-        renderPatternEvents(createSerialPattern([{ value: 'x' }, { value: '-' }], 1), beats(8)),
+        renderPatternEvents(createSerialPattern([{ value: 'x' }, { value: '-' }]), beats(8)),
         [
           { time: beats(0), gate: beats(1), velocity: unitless(1) }
         ]
@@ -558,7 +555,7 @@ describe('pattern.ts', () => {
         { value: 'x' },
         { value: '-' },
         { value: 'x' }
-      ], 1)
+      ])
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(3)),
         [
@@ -578,7 +575,7 @@ describe('pattern.ts', () => {
       const pattern = createSerialPattern([
         { value: 'A4', gate: numeric(undefined, 3) },
         { value: 'B4', gate: numeric(undefined, 5) }
-      ], 1)
+      ])
 
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(2)),
@@ -593,7 +590,7 @@ describe('pattern.ts', () => {
       const pattern = loopPattern(createSerialPattern([
         { value: 'x', velocity: unitless(0.5) },
         { value: '-' }
-      ], 1))
+      ]))
       assert.deepStrictEqual(
         renderPatternEvents(pattern, beats(0)),
         []

--- a/packages/language/src/compiler/builtins/patterns.ts
+++ b/packages/language/src/compiler/builtins/patterns.ts
@@ -38,7 +38,7 @@ const loop: PatternBuiltin = {
 
       const { value: factor } = NumberFacet.get(times)
       if (factor <= 0 || !Number.isFinite(factor)) {
-        return PatternFacet.type().of(createSerialPattern([], 1))
+        return PatternFacet.type().of(createSerialPattern([]))
       }
 
       if (pattern.length == null) {
@@ -73,7 +73,7 @@ const fill: PatternBuiltin = {
       const durationValue = NumberFacet.get(duration)
 
       if (durationValue.value <= 0 || !Number.isFinite(durationValue.value)) {
-        return PatternFacet.type().of(createSerialPattern([], 1))
+        return PatternFacet.type().of(createSerialPattern([]))
       }
 
       return PatternFacet.type().of(loopPattern(pattern, durationValue))

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -437,10 +437,8 @@ function generateString (scope: Scope, parts: ReadonlyArray<string | ast.Express
 }
 
 function generatePattern (scope: Scope, expression: ast.Pattern): Value {
-  const subdivision = 1
-
   const create = expression.mode === 'serial'
-    ? (steps: readonly Step[]) => createSerialPattern(steps, subdivision)
+    ? (steps: readonly Step[]) => createSerialPattern(steps)
     : (steps: readonly Step[]) => createParallelPattern(steps)
 
   const combine = expression.mode === 'serial'

--- a/packages/language/test/compiler/builtins/patterns.test.ts
+++ b/packages/language/test/compiler/builtins/patterns.test.ts
@@ -40,17 +40,19 @@ function invoke (builtin: PatternBuiltin, self: Value<Facet<'pattern', Pattern>>
 describe('library/modules/patterns.ts', () => {
   // helper to create Numeric<'beats'>
   const beats = (value: number) => numeric('beats', value)
+  const half = numeric(undefined, 0.5)
+  const quarter = numeric(undefined, 0.25)
 
   describe('loop', () => {
     const loop = getPatternBuiltin('loop')
 
     it('should loop finite patterns infinitely', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x', velocity: numeric(undefined, 0.5) },
-        { value: '-' },
-        { value: '-' },
-        { value: 'G5' }
-      ], 4))
+        { value: 'x', velocity: numeric(undefined, 0.5), length: quarter },
+        { value: '-', length: quarter },
+        { value: '-', length: quarter },
+        { value: 'G5', length: quarter }
+      ]))
 
       const result = invoke(loop, pattern, {})
       const resultPattern = PatternFacet.get(result)
@@ -68,10 +70,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should keep infinite patterns infinite', () => {
       const pattern = PatternFacet.type().of(loopPattern(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2)))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ])))
 
       const result = invoke(loop, pattern, {})
       const resultPattern = PatternFacet.get(result)
@@ -87,7 +89,7 @@ describe('library/modules/patterns.ts', () => {
     })
 
     it('should return empty pattern when looping empty pattern', () => {
-      const pattern = PatternFacet.type().of(createSerialPattern([], 4))
+      const pattern = PatternFacet.type().of(createSerialPattern([]))
 
       const result = invoke(loop, pattern, {})
       const resultPattern = PatternFacet.get(result)
@@ -99,10 +101,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should support times parameter', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ]))
 
       const result = invoke(loop, pattern, {
         times: Numbers.of(numeric(undefined, 3))
@@ -124,10 +126,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should support times parameter of zero', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ]))
 
       const result = invoke(loop, pattern, {
         times: Numbers.of(numeric(undefined, 0))
@@ -141,10 +143,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should treat negative times parameter as zero', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ]))
 
       const result = invoke(loop, pattern, {
         times: Numbers.of(numeric(undefined, -2))
@@ -158,10 +160,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should support fractional times parameter', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ]))
 
       const result = invoke(loop, pattern, {
         times: Numbers.of(numeric(undefined, 0.5))
@@ -182,10 +184,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should loop finite patterns until the duration is filled', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4', velocity: numeric(undefined, 0.5) }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', velocity: numeric(undefined, 0.5), length: half }
+      ]))
 
       const result = invoke(fill, pattern, {
         duration: Numbers.of(beats(2.0))
@@ -204,10 +206,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should truncate infinite patterns to the requested duration', () => {
       const pattern = PatternFacet.type().of(loopPattern(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2)))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ])))
 
       const result = invoke(fill, pattern, {
         duration: Numbers.of(beats(2.0))
@@ -225,7 +227,7 @@ describe('library/modules/patterns.ts', () => {
     })
 
     it('should return empty pattern when filling an empty pattern', () => {
-      const pattern = PatternFacet.type().of(createSerialPattern([], 4))
+      const pattern = PatternFacet.type().of(createSerialPattern([]))
 
       const result = invoke(fill, pattern, {
         duration: Numbers.of(beats(2.0))
@@ -239,10 +241,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should return empty pattern when duration is zero', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ]))
 
       const result = invoke(fill, pattern, {
         duration: Numbers.of(beats(0))
@@ -256,10 +258,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should treat negative duration as empty', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ]))
 
       const result = invoke(fill, pattern, {
         duration: Numbers.of(beats(-2.0))
@@ -273,10 +275,10 @@ describe('library/modules/patterns.ts', () => {
 
     it('should treat non-finite duration as empty', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x' },
-        { value: '-' },
-        { value: 'C4' }
-      ], 2))
+        { value: 'x', length: half },
+        { value: '-', length: half },
+        { value: 'C4', length: half }
+      ]))
 
       const result = invoke(fill, pattern, {
         duration: Numbers.of(beats(Number.POSITIVE_INFINITY))
@@ -292,7 +294,7 @@ describe('library/modules/patterns.ts', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
         { value: 'A4', gate: numeric(undefined, 3) },
         { value: 'B4', gate: numeric(undefined, 5), velocity: numeric(undefined, 0.5) }
-      ], 1))
+      ]))
 
       const result = invoke(fill, pattern, {
         duration: Numbers.of(beats(4.0))

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -27,7 +27,7 @@ const pattern: Pattern = createSerialPattern([
   { value: 'C4' },
   { value: '-', length: numeric(undefined, 1) },
   { value: 'E4', gate: numeric(undefined, 0.5) }
-], 4)
+])
 
 const effect: Effect = {
   type: 'gain',


### PR DESCRIPTION
The subdivision was always 1 in practice, so we can save an unnecessary multiplication by removing it.