### PR TITLE
fix: Improve error for bad curve segment lengths

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -556,7 +556,7 @@ function checkCurve (scope: Scope, curve: ast.Curve): Checked<FacetType> {
     segmentChecks.push(segmentCheck)
     errors.push(...segmentCheck.errors)
 
-    if (segmentCheck.errors.length === 0) {
+    if (segmentCheck.result != null) {
       previousUnit = segmentCheck.result
     }
   }
@@ -621,7 +621,7 @@ function checkCurveSegment (scope: Scope, segment: ast.CurveSegment, hasPrevious
     }
   }
 
-  if (errors.length > 0) {
+  if (!omittedFirstParameter && units.length === 0) {
     return { errors }
   }
 

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -540,6 +540,15 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
+    it('should use segment unit if only the segment length is invalid', () => {
+      // If the first segment is entirely discarded by the compiler, then
+      // the second would emit a second error: 'Expected type number, got number(hz)',
+      // which is obviously not correct.
+      assertErrorMessages('my_curve = ~[lin(10.hz, 20.hz):unknown lin(30.hz)]', [
+        'Unknown identifier "unknown"'
+      ])
+    })
+
     it('should reject automations that target non-parameters', () => {
       const source = [
         'some_value = ""',


### PR DESCRIPTION
This patch ensures that we use the first segment's unit even if that segment has an invalid length (but valid unit information). The next segments can then be properly compared against that unit instead of assuming the default unit `undefined` and generating misleading errors.