### PR TITLE
feat!: Require durations for curve segments

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -61,7 +61,7 @@ track (120.bpm) {
     snare << snare_pattern
     synth << arp_intro
 
-    automate synth.gain as ~[hold(-60.db):3 lin(0.db):1]
+    automate synth.gain as ~[hold(-60.db):2.bars lin(0.db):2.bars]
   }
 
   part main (8.bars) {

--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -42,7 +42,7 @@ export interface CurveSegment extends ASTNode {
   readonly type: 'CurveSegment'
   readonly curveType: string
   readonly parameters: readonly Expression[]
-  readonly length?: Expression
+  readonly length: Expression
 }
 
 export interface Curve extends ASTNode {

--- a/packages/audiograph/src/automation.ts
+++ b/packages/audiograph/src/automation.ts
@@ -1,5 +1,4 @@
 import type { AutomationPoint, Parameter, Program } from '@core'
-import { beatsToSeconds } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
 import { dbToGain } from './constants.js'
@@ -41,7 +40,7 @@ export function toTimeVariant<FromUnit extends Unit, ToUnit extends Unit = FromU
   return {
     initial: transform.transformValue(initial),
     points: points.map((point) => ({
-      time: beatsToSeconds(point.time, program.track.tempo),
+      time: point.time,
       value: transform.transformValue(point.value),
       curve: transform.transformCurve(point.curve)
     }))

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -334,12 +334,12 @@ describe('lowering.ts', () => {
             type: 'gain',
             points: [
               {
-                time: numeric('beats', 1),
+                time: numeric('s', 0.5),
                 value: numeric('db', -3),
                 curve: 'linear'
               },
               {
-                time: numeric('beats', 2),
+                time: numeric('s', 1),
                 value: numeric('db', -12),
                 curve: 'step'
               }

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -5,6 +5,8 @@ export type Octave = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
 export type Pitch = `${Note}${Octave}`
 export type StepValue = '-' | 'x' | Pitch
 
+// Patterns
+
 export interface Step {
   readonly value: StepValue
 
@@ -81,7 +83,7 @@ export interface Automation<U extends Unit = Unit> {
 }
 
 export interface AutomationPoint<U extends Unit = Unit> {
-  readonly time: Numeric<'beats'>
+  readonly time: Numeric<'s'>
   readonly value: Numeric<U>
 
   /**

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -94,7 +94,7 @@ parallelPattern {
 }
 
 step {
-  (word | "-") ("(" argumentList? ")")? (":" primary)?
+  (word | "-") ("(" argumentList? ")")? (":" AccessOrCall)?
 }
 
 Curve {
@@ -104,7 +104,7 @@ Curve {
 }
 
 curveSegment {
-  CurveType { word } ("(" argumentList? ")")? (":" primary)?
+  CurveType { word } ("(" argumentList? ")")? (":" AccessOrCall)?
 }
 
 argumentList {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -576,16 +576,19 @@ function checkCurve (scope: Scope, curve: ast.Curve): Checked<FacetType> {
   return { errors, result: CurveFacet.with(firstUnit).type() }
 }
 
+const curveSegmentLengthType = makeUnion(
+  NumberFacet.with('beats').type(),
+  NumberFacet.with('s').type()
+)
+
 function checkCurveSegment (scope: Scope, segment: ast.CurveSegment, hasPrevious: boolean, previousUnit: Unit | undefined): Checked<Unit> {
   const errors: CompileError[] = []
 
-  if (segment.length != null) {
-    const lengthCheck = checkExpression(scope, segment.length)
-    errors.push(...lengthCheck.errors)
+  const lengthCheck = checkExpression(scope, segment.length)
+  errors.push(...lengthCheck.errors)
 
-    if (lengthCheck.result != null) {
-      errors.push(...checkType(NumberFacet.with(undefined).type(), lengthCheck.result, segment.length.range))
-    }
+  if (lengthCheck.result != null) {
+    errors.push(...checkType(curveSegmentLengthType, lengthCheck.result, segment.length.range))
   }
 
   const expectedParameters = getCurveSegmentType(segment.curveType)?.parameterCount

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -1,37 +1,21 @@
 import type { AutomationPoint } from '@core'
+import { timeToSeconds } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
+import type { Curve, CurveDuration, CurveSegment, HoldCurveSegment, LinearCurveSegment } from '../type-system/domain/curve.js'
 import { assert, nonNull } from './assert.js'
 
 const SEGMENT_TYPE_HOLD = 'hold'
 const SEGMENT_TYPE_LINEAR = 'lin'
 
-export interface Curve<U extends Unit> {
-  readonly unit: U
-  readonly segments: ReadonlyArray<CurveSegment<U>>
-}
+const ZERO_SECONDS = numeric('s', 0)
 
-export type CurveSegment<U extends Unit> = HoldCurveSegment<U> | LinearCurveSegment<U>
-
-export interface HoldCurveSegment<U extends Unit> {
-  readonly type: typeof SEGMENT_TYPE_HOLD
-  readonly length: Numeric<undefined>
-  readonly unit: U
-  readonly value: Numeric<U>
-}
-
-export interface LinearCurveSegment<U extends Unit> {
-  readonly type: typeof SEGMENT_TYPE_LINEAR
-  readonly length: Numeric<undefined>
-  readonly unit: U
-  readonly start: Numeric<U>
-  readonly end: Numeric<U>
-}
+const TIME_EPSILON = 1e-6 // 1 microsecond, which is less than 1 sample at 96 kHz
 
 export interface CurveSegmentType {
   readonly type: CurveSegment<any>['type']
   readonly parameterCount: number
-  readonly create: <U extends Unit>(parameters: ReadonlyArray<Numeric<U>>, length: Numeric<undefined>) => CurveSegment<U>
+  readonly create: <U extends Unit>(parameters: ReadonlyArray<Numeric<U>>, length: CurveDuration) => CurveSegment<U>
   readonly start: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
   readonly end: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
   readonly endCurve: AutomationPoint<any>['curve']
@@ -75,7 +59,7 @@ export function createCurve<U extends Unit> (segments: ReadonlyArray<CurveSegmen
 export function createCurveSegment<U extends Unit> (
   type: string,
   parameters: ReadonlyArray<Numeric<U>>,
-  length = numeric(undefined, 1)
+  length: CurveDuration
 ): CurveSegment<U> {
   const definition = nonNull(curveSegmentTypes.get(type), `Unknown curve segment type: ${type}`)
   assert(definition.parameterCount === parameters.length, 'Invalid curve parameters')
@@ -83,59 +67,200 @@ export function createCurveSegment<U extends Unit> (
   return definition.create(parameters, length)
 }
 
-export function renderCurvePoints<U extends Unit> (curve: Curve<U>, timeStart: Numeric<'beats'>, timeEnd: Numeric<'beats'>): ReadonlyArray<AutomationPoint<U>> {
+export interface RenderCurveOptions {
+  readonly offset: CurveDuration
+  readonly limit?: CurveDuration
+  readonly tempo: Numeric<'bpm'>
+}
+
+export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: RenderCurveOptions): ReadonlyArray<AutomationPoint<U>> {
   const segments = curve.segments
-  if (segments.length === 0) {
+  if (segments.length === 0 || (options.limit != null && options.limit.value <= 0)) {
     return []
   }
 
-  const totalDuration = timeEnd.value - timeStart.value
-  const segmentWeights = segments.map((segment) => Math.max(segment.length.value, 0))
-  const totalWeight = segmentWeights.reduce((sum, weight) => sum + weight, 0)
-
-  const getTimeAtWeight = (weight: number) => {
-    if (totalWeight === 0) {
-      return timeStart
-    }
-    return numeric('beats', timeStart.value + totalDuration * (weight / totalWeight))
-  }
-
   const points: Array<AutomationPoint<U>> = []
-  let currentWeight = 0
 
-  for (let i = 0; i < segments.length; ++i) {
-    const segment = segments[i]
-    const segmentWeight = segmentWeights[i]
+  const offsetSeconds = timeToSeconds(options.offset, options.tempo)
+  let currentTime: Numeric<'s'> = offsetSeconds
+
+  for (const segment of segments) {
+    const segmentLength = segment.length.value > 0
+      ? timeToSeconds(segment.length, options.tempo)
+      : ZERO_SECONDS
 
     const definition = nonNull(getCurveSegmentType(segment.type), `Unknown curve segment type: ${segment.type}`)
 
+    const startTime = currentTime
+    const endTime = numeric('s', currentTime.value + segmentLength.value)
+
     points.push({
-      time: getTimeAtWeight(currentWeight),
+      time: startTime,
       value: definition.start(segment),
       curve: 'step'
     }, {
-      time: getTimeAtWeight(i === segments.length - 1 ? totalWeight : currentWeight + segmentWeight),
+      time: endTime,
       value: definition.end(segment),
-      curve: segmentWeight <= 0 ? 'step' : definition.endCurve
+      curve: segmentLength.value <= 0 ? 'step' : definition.endCurve
     })
 
-    currentWeight += segmentWeight
+    currentTime = endTime
   }
 
-  return simplifyCurvePoints(points)
+  const simplifiedPoints = simplifyCurvePoints(points)
+
+  const endTime = options.limit != null
+    ? numeric('s', offsetSeconds.value + timeToSeconds(options.limit, options.tempo).value)
+    : undefined
+
+  if (endTime != null && currentTime.value > endTime.value) {
+    return takePointsBefore(simplifiedPoints, endTime)
+  }
+
+  return simplifiedPoints
+}
+
+function interpolatePoint<U extends Unit> (start: AutomationPoint<U>, end: AutomationPoint<U>, time: Numeric<'s'>): AutomationPoint<U> {
+  assert(time.value >= start.time.value && time.value <= end.time.value)
+
+  const deltaTime = end.time.value - start.time.value
+  if (deltaTime < TIME_EPSILON) {
+    return { time, value: start.value, curve: 'step' }
+  }
+
+  const t = (time.value - start.time.value) / deltaTime
+
+  switch (end.curve) {
+    case 'step':
+      return { time, value: start.value, curve: 'step' }
+
+    case 'linear': {
+      const value = {
+        unit: start.value.unit,
+        value: start.value.value + t * (end.value.value - start.value.value)
+      }
+      return { time, value, curve: 'linear' }
+    }
+  }
+}
+
+export function mergeCurvePoints<U extends Unit> (
+  first: ReadonlyArray<AutomationPoint<U>>,
+  second: ReadonlyArray<AutomationPoint<U>>
+): ReadonlyArray<AutomationPoint<U>> {
+  if (first.length === 0) {
+    return second
+  }
+
+  if (second.length === 0) {
+    return first
+  }
+
+  const start = second[0].time
+  const end = second.at(-1)?.time
+
+  assert(end != null)
+
+  return simplifyCurvePoints([
+    ...takePointsBefore(first, start),
+    ...second,
+    ...takePointsAfter(first, end)
+  ])
+}
+
+function takePointsBefore<U extends Unit> (
+  points: ReadonlyArray<AutomationPoint<U>>,
+  time: Numeric<'s'>
+): ReadonlyArray<AutomationPoint<U>> {
+  const result: Array<AutomationPoint<U>> = []
+
+  for (let i = 0; i < points.length; ++i) {
+    const point = points[i]
+
+    const pointComparison = compareTimes(point.time, time)
+    if (pointComparison < 0) {
+      result.push(point)
+      continue
+    }
+
+    const previous = i > 0 ? points[i - 1] : undefined
+
+    if (pointComparison === 0) {
+      if (previous != null && compareTimes(previous.time, time) < 0) {
+        result.push(point)
+      }
+      break
+    }
+
+    if (previous != null && compareTimes(previous.time, time) < 0) {
+      result.push(interpolatePoint(previous, point, time))
+    }
+
+    break
+  }
+
+  return result
+}
+
+function takePointsAfter<U extends Unit> (
+  points: ReadonlyArray<AutomationPoint<U>>,
+  time: Numeric<'s'>
+): ReadonlyArray<AutomationPoint<U>> {
+  for (let i = 0; i < points.length; ++i) {
+    const point = points[i]
+
+    const pointComparison = compareTimes(point.time, time)
+    if (pointComparison < 0) {
+      continue
+    }
+
+    if (pointComparison === 0) {
+      return i < points.length - 1 ? points.slice(i) : []
+    }
+
+    const previous = i > 0 ? points[i - 1] : undefined
+    if (previous != null && compareTimes(previous.time, time) < 0) {
+      return [interpolatePoint(previous, point, time), ...points.slice(i)]
+    }
+
+    return points.slice(i)
+  }
+
+  return []
+}
+
+function compareTimes (left: Numeric<'s'>, right: Numeric<'s'>): number {
+  const difference = left.value - right.value
+  if (Math.abs(difference) <= TIME_EPSILON) {
+    return 0
+  }
+
+  return difference < 0 ? -1 : 1
 }
 
 function simplifyCurvePoints<U extends Unit> (points: ReadonlyArray<AutomationPoint<U>>): ReadonlyArray<AutomationPoint<U>> {
-  // Note: This assumes exact floating point equality, which works since the start/end times are calculated
-  // using the same formula.
-
   const simplified: Array<AutomationPoint<U>> = []
 
   for (const point of points) {
     const previous = simplified.at(-1)
-    if (previous == null || point.time.value !== previous.time.value || point.value.value !== previous.value.value) {
+
+    if (previous == null || compareTimes(point.time, previous.time) !== 0) {
       simplified.push(point)
+      continue
     }
+
+    if (point.value.value === previous.value.value) {
+      continue
+    }
+
+    // not first, same time, different values: the point should be emitted as a step
+
+    // repetitive step points should be avoided
+    if (previous.curve === 'step') {
+      simplified.pop()
+    }
+
+    simplified.push({ ...point, curve: 'step' })
   }
 
   return simplified

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -11,6 +11,7 @@ import { NumberFacet } from '../../type-system/base/number.js'
 import { RecordFacet } from '../../type-system/base/record.js'
 import { StringFacet } from '../../type-system/base/string.js'
 import { BusFacet } from '../../type-system/domain/bus.js'
+import type { CurveSegment } from '../../type-system/domain/curve.js'
 import { CurveFacet } from '../../type-system/domain/curve.js'
 import { EffectFacet } from '../../type-system/domain/effect.js'
 import { InstrumentFacet } from '../../type-system/domain/instrument.js'
@@ -25,8 +26,8 @@ import { assert, assertNever, fail, nonNull } from '../assert.js'
 import { patternBuiltins } from '../builtins/patterns.js'
 import type { CheckedProgram } from '../checker/checker.js'
 import { BUS_NAMESPACE, busSchema, partSchema, stepSchema, trackSchema } from '../common.js'
-import type { CurveSegment as GeneratedCurveSegment } from '../curves.js'
-import { createCurve, createCurveSegment, getCurveSegmentType, renderCurvePoints } from '../curves.js'
+import type { RenderCurveOptions } from '../curves.js'
+import { createCurve, createCurveSegment, getCurveSegmentType, mergeCurvePoints, renderCurvePoints } from '../curves.js'
 import { binaryOperations } from '../operators/binary.js'
 import { unaryOperations } from '../operators/unary.js'
 import { resolveInScope } from '../resolution.js'
@@ -158,7 +159,7 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
         break
 
       case 'PartStatement': {
-        const part = generatePart(trackScope, child, currentTime)
+        const part = generatePart(trackScope, child, currentTime, tempo)
         parts.push(part)
 
         if (part.name != null) {
@@ -178,14 +179,12 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
   return { tempo, parts }
 }
 
-function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric<'beats'>): Part {
+function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric<'beats'>, tempo: Numeric<'bpm'>): Part {
   const partScope = createLocalScope(scope)
 
   const name = part.name?.name
   const properties = resolveArgumentList(scope, part.properties, partSchema)
-
   const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)
-  const endTime = numeric('beats', startTime.value + length.value)
 
   const routings: InstrumentRouting[] = []
 
@@ -210,7 +209,7 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
         break
 
       case 'AutomateStatement':
-        generateAutomation(partScope, child, startTime, endTime)
+        generateAutomation(partScope, child, { offset: startTime, limit: length, tempo })
         break
 
       default:
@@ -221,14 +220,14 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
   return { name, length, routings }
 }
 
-function generateAutomation (scope: Scope, statement: ast.AutomateStatement, startTime: Numeric<'beats'>, endTime: Numeric<'beats'>): void {
+function generateAutomation (scope: Scope, statement: ast.AutomateStatement, options: RenderCurveOptions): void {
   const target = ParameterFacet.get(resolve(scope, statement.target))
   const curve = CurveFacet.get(resolve(scope, statement.curve))
 
-  const rendered = renderCurvePoints(curve, startTime, endTime)
+  const rendered = renderCurvePoints(curve, options)
   const existing = nonNull(scope.top.automations.get(target.id), 'Parameter allocated incorrectly')
 
-  const points = [...existing.points, ...rendered].sort((a, b) => a.time.value - b.time.value)
+  const points = mergeCurvePoints(existing.points, rendered)
 
   scope.top.automations.set(target.id, {
     parameterId: target.id,
@@ -498,7 +497,7 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
   assert(segments.length > 0)
   assert(otherChildren.length === 0)
 
-  const generatedSegments: Array<GeneratedCurveSegment<Unit>> = []
+  const generatedSegments: Array<CurveSegment<Unit>> = []
 
   const getPreviousSegmentEnd = (): Numeric<Unit> => {
     const previous = nonNull(generatedSegments.at(-1))
@@ -511,9 +510,11 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
       return NumberFacet.get(resolve(scope, point))
     })
 
-    const length = segment.length != null
-      ? NumberFacet.with(undefined).get(resolve(scope, segment.length))
-      : undefined
+    const length = (() => {
+      const value = NumberFacet.get(resolve(scope, segment.length))
+      assert(value.unit === 'beats' || value.unit === 's')
+      return value as Numeric<'beats'> | Numeric<'s'>
+    })()
 
     const { parameterCount } = nonNull(getCurveSegmentType(segment.curveType))
     const resolvedParameters = parameters.length < parameterCount

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -193,7 +193,7 @@ const steps_: p.Parser<Token, unknown, readonly ast.Step[]> = p.abc(
     combine2(
       literal(':'),
       // Require parantheses around complex length expressions
-      p.recursive(() => primary_)
+      p.recursive(() => accessOrCall_)
     ),
     undefined
   ),
@@ -308,27 +308,21 @@ const curveSegment_: p.Parser<Token, unknown, ast.CurveSegment> = p.ab(
     p.option(
       combine2(
         literal(':'),
-        p.recursive(() => primary_)
+        p.recursive(() => accessOrCall_)
       ),
       undefined
     )
   ),
   (curveTypeToken, [callTail, curveLength]) => {
+    if (curveLength == null) {
+      throw new ParseError(`Curve segment "${curveTypeToken.text}" is missing a length`, getSourceRange(curveTypeToken))
+    }
+
     const curveType = curveTypeToken.text
     const parameters = callTail == null ? [] : callTail[1]
-    const length = curveLength?.[1]
+    const length = curveLength[1]
 
-    const range = length != null
-      ? combineSourceRanges(curveTypeToken, length)
-      : callTail == null
-        ? getSourceRange(curveTypeToken)
-        : combineSourceRanges(curveTypeToken, callTail[2])
-
-    return ast.make('CurveSegment', range, {
-      curveType,
-      parameters,
-      ...(length == null ? {} : { length })
-    })
+    return ast.make('CurveSegment', combineSourceRanges(curveTypeToken, length), { curveType, parameters, length })
   }
 )
 

--- a/packages/language/src/type-system/domain/curve.ts
+++ b/packages/language/src/type-system/domain/curve.ts
@@ -2,6 +2,8 @@ import type { Numeric, Unit } from '@utility'
 import { makeFacet } from '../factory.js'
 import type { Facet, FacetType } from '../types.js'
 
+export type CurveDuration = Numeric<'beats'> | Numeric<'s'>
+
 export interface Curve<U extends Unit> {
   readonly unit: U
   readonly segments: ReadonlyArray<CurveSegment<U>>
@@ -11,14 +13,14 @@ export type CurveSegment<U extends Unit> = HoldCurveSegment<U> | LinearCurveSegm
 
 export interface HoldCurveSegment<U extends Unit> {
   readonly type: 'hold'
-  readonly length: Numeric<undefined>
+  readonly length: CurveDuration
   readonly unit: U
   readonly value: Numeric<U>
 }
 
 export interface LinearCurveSegment<U extends Unit> {
   readonly type: 'lin'
-  readonly length: Numeric<undefined>
+  readonly length: CurveDuration
   readonly unit: U
   readonly start: Numeric<U>
   readonly end: Numeric<U>

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -234,7 +234,7 @@ describe('compiler/checker/checker.ts', () => {
         'foo_gain = bus.foo.gain',
         'track {',
         '  part intro (4.bars) {',
-        '    automate bus.bar.pan as ~[lin(-1, 1)]',
+        '    automate bus.bar.pan as ~[lin(-1, 1):1.bar]',
         '  }',
         '}'
       ].join('\n')
@@ -242,20 +242,24 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
-    it('should accept lin curves', () => {
-      assertValid('my_curve = ~[lin((-60).db, 0.db)]')
+    it('should accept curves with beat and bar length units', () => {
+      assertValid('my_curve = ~[lin((-60).db, 0.db):4.bars lin(0.db, -60.db):16.beats]')
     })
 
-    it('should accept curves with weighted segments', () => {
-      assertValid('my_curve = ~[hold((-60).db):3 lin((-60).db, 0.db):1]')
+    it('should accept curves with second length units', () => {
+      assertValid('my_curve = ~[hold((-60).db):3.s lin((-60).db, 0.db):1.0.s]')
+    })
+
+    it('should accept curves with mixed length units', () => {
+      assertValid('my_curve = ~[hold((-60).db):1.bar lin(0.db, -60.db):1.s]')
     })
 
     it('should accept lin curves that omit the start after the first segment', () => {
-      assertValid('my_curve = ~[hold((-60).db):3 lin(0.db):1]')
+      assertValid('my_curve = ~[hold((-60).db):1.bar lin(0.db):1.bar]')
     })
 
     it('should accept hold curves that omit the value after the first segment', () => {
-      assertValid('my_curve = ~[lin((-60).db, (-30).db):3 hold:1]')
+      assertValid('my_curve = ~[lin((-60).db, (-30).db):1.bar hold:1.bar]')
     })
 
     it('should accept bus gain automation via explicit namespace', () => {
@@ -265,7 +269,7 @@ describe('compiler/checker/checker.ts', () => {
         '}',
         'track {',
         '  part intro (4.bars) {',
-        '    automate bus.main.gain as ~[lin((-20).db, 0.db)]',
+        '    automate bus.main.gain as ~[lin((-20).db, 0.db):4.bars]',
         '  }',
         '}'
       ].join('\n')
@@ -283,7 +287,7 @@ describe('compiler/checker/checker.ts', () => {
         '}',
         'track {',
         '  part intro (4.bars) {',
-        '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
+        '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz):4.bars]',
         '  }',
         '}'
       ].join('\n')
@@ -517,25 +521,31 @@ describe('compiler/checker/checker.ts', () => {
     })
 
     it('should reject curves with non-numeric parameters', () => {
-      assertErrorMessages('my_curve = ~[hold("not a number")]', [
+      assertErrorMessages('my_curve = ~[hold("not a number"):1.bar]', [
         'Expected type number, got string'
       ])
     })
 
     it('should reject lin curves that omit the start for the first segment', () => {
-      assertErrorMessages('my_curve = ~[lin(0.db)]', [
+      assertErrorMessages('my_curve = ~[lin(0.db):1.bar]', [
         'First curve segment cannot omit its first parameter'
       ])
     })
 
     it('should reject hold curves that omit the value for the first segment', () => {
-      assertErrorMessages('my_curve = ~[hold]', [
+      assertErrorMessages('my_curve = ~[hold:1.bar]', [
         'First curve segment cannot omit its first parameter'
       ])
     })
 
+    it('should reject curves when the units differ between segments', () => {
+      assertErrorMessages('my_curve = ~[hold(0.db):1.bar hold(100.hz):1.bar]', [
+        'Curve segments must have the same unit'
+      ])
+    })
+
     it('should reject omitted lin starts when the inherited and explicit units differ', () => {
-      assertErrorMessages('my_curve = ~[hold((-60).db) lin(120.bpm)]', [
+      assertErrorMessages('my_curve = ~[hold((-60).db):1.bar lin(120.bpm):1.bar]', [
         'Expected type number(db), got number(bpm)'
       ])
     })
@@ -544,8 +554,14 @@ describe('compiler/checker/checker.ts', () => {
       // If the first segment is entirely discarded by the compiler, then
       // the second would emit a second error: 'Expected type number, got number(hz)',
       // which is obviously not correct.
-      assertErrorMessages('my_curve = ~[lin(10.hz, 20.hz):unknown lin(30.hz)]', [
+      assertErrorMessages('my_curve = ~[lin(10.hz, 20.hz):unknown lin(30.hz):1.bar]', [
         'Unknown identifier "unknown"'
+      ])
+    })
+
+    it('should reject curves with invalid length units', () => {
+      assertErrorMessages('my_curve = ~[hold((-60).db):42]', [
+        'Expected type number(beats) | number(s), got number'
       ])
     })
 
@@ -554,7 +570,7 @@ describe('compiler/checker/checker.ts', () => {
         'some_value = ""',
         'track {',
         '  part intro (4.bars) {',
-        '    automate some_value as ~[hold(-60)]',
+        '    automate some_value as ~[hold(-60):1.bar]',
         '  }',
         '}'
       ].join('\n')
@@ -846,7 +862,7 @@ describe('compiler/checker/checker.ts', () => {
         'foo_gain = bus.foo.gain',
         'track {',
         '  part intro (4.bars) {',
-        '    automate bus.bar.pan as ~[lin(-1, 1)]',
+        '    automate bus.bar.pan as ~[lin(-1, 1):1.bar]',
         '  }',
         '}',
         'mixer {',

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -304,9 +304,9 @@ describe('compiler/generator/generator.ts', () => {
     const source = [
       'use "instruments" as *',
       'synth = sample("synth.wav")',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as ~[lin((-60).db, 0.db)]',
+      '    automate synth.gain as ~[lin((-60).db, 0.db):2.bars]',
       '  }',
       '}'
     ].join('\n')
@@ -317,18 +317,18 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 4), value: numeric('db', 0), curve: 'linear' }
     ])
   })
 
-  it('should allocate equal time to multiple curve segments', () => {
+  it('should handle multiple curve segments', () => {
     const source = [
       'use "instruments" as *',
       'synth = sample("synth.wav")',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as ~[lin((-60).db, (-30).db) lin((-30).db, 0.db)]',
+      '    automate synth.gain as ~[lin(-60.db, -30.db):2.bars lin(-30.db, 0.db):1.bar]',
       '  }',
       '}'
     ].join('\n')
@@ -339,19 +339,19 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 8), value: numeric('db', -30), curve: 'linear' },
-      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 4), value: numeric('db', -30), curve: 'linear' },
+      { time: numeric('s', 6), value: numeric('db', 0), curve: 'linear' }
     ])
   })
 
-  it('should allocate curve time by segment length weights', () => {
+  it('should clip curve lengths to the part length', () => {
     const source = [
       'use "instruments" as *',
       'synth = sample("synth.wav")',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (8.bars) {',
-      '    automate synth.gain as ~[hold((-60).db):3 lin((-60).db, 0.db):1]',
+      '    automate synth.gain as ~[hold(-60.db):5.bars lin(-60.db, 0.db):6.bars hold:2.bars]',
       '  }',
       '}'
     ].join('\n')
@@ -362,9 +362,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 24), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 32), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 10), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 16), value: numeric('db', -30), curve: 'linear' }
     ])
   })
 
@@ -372,9 +372,9 @@ describe('compiler/generator/generator.ts', () => {
     const source = [
       'use "instruments" as *',
       'synth = sample("synth.wav")',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (8.bars) {',
-      '    automate synth.gain as ~[hold((-60).db):3 lin(0.db):1]',
+      '    automate synth.gain as ~[hold((-60).db):6.bars lin(0.db):2.bars]',
       '  }',
       '}'
     ].join('\n')
@@ -385,9 +385,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 24), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 32), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 12), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 16), value: numeric('db', 0), curve: 'linear' }
     ])
   })
 
@@ -395,9 +395,9 @@ describe('compiler/generator/generator.ts', () => {
     const source = [
       'use "instruments" as *',
       'synth = sample("synth.wav")',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (8.bars) {',
-      '    automate synth.gain as ~[lin((-60).db, (-30).db):3 hold:1]',
+      '    automate synth.gain as ~[lin((-60).db, (-30).db):6.bars hold:2.bars]',
       '  }',
       '}'
     ].join('\n')
@@ -408,19 +408,19 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 24), value: numeric('db', -30), curve: 'linear' },
-      { time: numeric('beats', 32), value: numeric('db', -30), curve: 'step' }
+      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 12), value: numeric('db', -30), curve: 'linear' },
+      { time: numeric('s', 16), value: numeric('db', -30), curve: 'step' }
     ])
   })
 
-  it('should clamp non-positive curve segment lengths and step zero-length segments', () => {
+  it('should clamp non-positive curve segment lengths and skip zero-length segments', () => {
     const source = [
       'use "instruments" as *',
       'synth = sample("synth.wav")',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate synth.gain as ~[hold((-60).db):(-2) lin((-60).db, (-30).db):0 lin((-30).db, 0.db):1]',
+      '    automate synth.gain as ~[hold((-60).db):(-2.beats) lin((-60).db, (-30).db):0.s lin((-30).db, 0.db):4.bars]',
       '  }',
       '}'
     ].join('\n')
@@ -431,9 +431,82 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('beats', 0), value: numeric('db', -30), curve: 'step' },
-      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -30), curve: 'step' },
+      { time: numeric('s', 8), value: numeric('db', 0), curve: 'linear' }
+    ])
+  })
+
+  it('should combine automations from multiple parts', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      'track (120.bpm) {',
+      '  part intro (8.beats) {',
+      '    automate synth.gain as ~[lin(-60.db, 0.db):8.beats]',
+      '  }',
+      '  part outro (8.beats) {',
+      '    automate synth.gain as ~[lin(-15.db, -30.db):8.beats]',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    assert.strictEqual(result.automations.size, 1)
+    const [automation] = result.automations.values()
+
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
+      { time: numeric('s', 4), value: numeric('db', 0), curve: 'linear' },
+      { time: numeric('s', 4), value: numeric('db', -15), curve: 'step' },
+      { time: numeric('s', 8), value: numeric('db', -30), curve: 'linear' }
+    ])
+  })
+
+  it('should let later automations override earlier ones in the same part', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      'track (120.bpm) {',
+      '  part intro (8.beats) {',
+      '    automate synth.gain as ~[lin(-60.db, 0.db):8.beats]',
+      '    automate synth.gain as ~[hold(-15.db):8.beats]',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    assert.strictEqual(result.automations.size, 1)
+    const [automation] = result.automations.values()
+
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('s', 0), value: numeric('db', -15), curve: 'step' },
+      { time: numeric('s', 4), value: numeric('db', -15), curve: 'step' }
+    ])
+  })
+
+  it('should resume earlier automations after a later overlap ends', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      'track (120.bpm) {',
+      '  part intro (8.beats) {',
+      '    automate synth.gain as ~[lin(-60.db, 0.db):8.beats]',
+      '    automate synth.gain as ~[hold(-15.db):4.beats]',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    assert.strictEqual(result.automations.size, 1)
+    const [automation] = result.automations.values()
+
+    assert.deepStrictEqual(automation.points, [
+      { time: numeric('s', 0), value: numeric('db', -15), curve: 'step' },
+      { time: numeric('s', 2), value: numeric('db', -30), curve: 'step' },
+      { time: numeric('s', 4), value: numeric('db', 0), curve: 'linear' }
     ])
   })
 
@@ -442,9 +515,9 @@ describe('compiler/generator/generator.ts', () => {
       'mixer {',
       '  bus main {}',
       '}',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate bus.main.gain as ~[lin((-20).db, 0.db)]',
+      '    automate bus.main.gain as ~[lin((-20).db, 0.db):4.bars]',
       '  }',
       '}'
     ].join('\n')
@@ -454,8 +527,8 @@ describe('compiler/generator/generator.ts', () => {
     const automation = result.automations.get(result.mixer.buses[0].gain.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('db', -20), curve: 'step' },
-      { time: numeric('beats', 16), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -20), curve: 'step' },
+      { time: numeric('s', 8), value: numeric('db', 0), curve: 'linear' }
     ])
   })
 
@@ -467,9 +540,9 @@ describe('compiler/generator/generator.ts', () => {
       '    effect lp = fx.lowpass(123.hz)',
       '  }',
       '}',
-      'track {',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
+      '    automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz):4.bars]',
       '  }',
       '}'
     ].join('\n')
@@ -483,18 +556,18 @@ describe('compiler/generator/generator.ts', () => {
     const automation = result.automations.get(effect.frequency.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('hz', 100), curve: 'step' },
-      { time: numeric('beats', 16), value: numeric('hz', 4000), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('hz', 100), curve: 'step' },
+      { time: numeric('s', 8), value: numeric('hz', 4000), curve: 'linear' }
     ])
   })
 
   it('should automate effect parameters', () => {
     const source = [
       'use "effects" as fx',
-      'lp = fx.lowpass(123.hz)',
-      'track {',
+      'lp = fx.lowpass(200.hz)',
+      'track (120.bpm) {',
       '  part intro (4.bars) {',
-      '    automate lp.frequency as ~[lin(500.hz, 1000.hz)]',
+      '    automate lp.frequency as ~[lin(500.hz, 1000.hz):4.bars]',
       '  }',
       '}',
       'mixer {',
@@ -508,13 +581,13 @@ describe('compiler/generator/generator.ts', () => {
 
     const effect = result.mixer.buses[0].effects[0]
     assert.strictEqual(effect.type, 'lowpass')
-    assert.deepStrictEqual(effect.frequency.initial, numeric('hz', 123))
+    assert.deepStrictEqual(effect.frequency.initial, numeric('hz', 200))
 
     const automation = result.automations.get(effect.frequency.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('beats', 0), value: numeric('hz', 500), curve: 'step' },
-      { time: numeric('beats', 16), value: numeric('hz', 1000), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('hz', 500), curve: 'step' },
+      { time: numeric('s', 8), value: numeric('hz', 1000), curve: 'linear' }
     ])
   })
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -471,39 +471,7 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse curve expressions', () => {
-    const result = parse(lexSource('foo = ~[hold(0) lin(0, 1)]'))
-    assertResultComplete(result)
-
-    assert.deepStrictEqual(stripRanges(result.value.children), [
-      {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'foo' },
-        value: {
-          type: 'Curve',
-          children: [
-            {
-              type: 'CurveSegment',
-              curveType: 'hold',
-              parameters: [
-                { type: 'Number', value: 0 }
-              ]
-            },
-            {
-              type: 'CurveSegment',
-              curveType: 'lin',
-              parameters: [
-                { type: 'Number', value: 0 },
-                { type: 'Number', value: 1 }
-              ]
-            }
-          ]
-        }
-      }
-    ])
-  })
-
-  it('should parse curve segment lengths', () => {
-    const result = parse(lexSource('foo = ~[hold(0):3 lin(0, 1):1]'))
+    const result = parse(lexSource('foo = ~[hold(0):1.bar lin(0, 1):2.beats]'))
     assertResultComplete(result)
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -519,7 +487,11 @@ describe('parser/parser.ts', () => {
               parameters: [
                 { type: 'Number', value: 0 }
               ],
-              length: { type: 'Number', value: 3 }
+              length: {
+                type: 'PropertyAccess',
+                object: { type: 'Number', value: 1 },
+                property: { type: 'Identifier', name: 'bar' }
+              }
             },
             {
               type: 'CurveSegment',
@@ -528,7 +500,11 @@ describe('parser/parser.ts', () => {
                 { type: 'Number', value: 0 },
                 { type: 'Number', value: 1 }
               ],
-              length: { type: 'Number', value: 1 }
+              length: {
+                type: 'PropertyAccess',
+                object: { type: 'Number', value: 2 },
+                property: { type: 'Identifier', name: 'beats' }
+              }
             }
           ]
         }
@@ -537,7 +513,7 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse curve segments without parameters', () => {
-    const result = parse(lexSource('foo = ~[hold hold:2]'))
+    const result = parse(lexSource('foo = ~[hold:1.bar hold:2.bars]'))
     assertResultComplete(result)
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -550,18 +526,33 @@ describe('parser/parser.ts', () => {
             {
               type: 'CurveSegment',
               curveType: 'hold',
-              parameters: []
+              parameters: [],
+              length: {
+                type: 'PropertyAccess',
+                object: { type: 'Number', value: 1 },
+                property: { type: 'Identifier', name: 'bar' }
+              }
             },
             {
               type: 'CurveSegment',
               curveType: 'hold',
               parameters: [],
-              length: { type: 'Number', value: 2 }
+              length: {
+                type: 'PropertyAccess',
+                object: { type: 'Number', value: 2 },
+                property: { type: 'Identifier', name: 'bars' }
+              }
             }
           ]
         }
       }
     ])
+  })
+
+  it('should reject curve segments that omit the length', () => {
+    const result = parse(lexSource('foo = ~[hold(0) lin(1, 2):1.bar]'))
+    assert.strictEqual(result.complete, false)
+    assert.strictEqual(result.error.message, 'Curve segment "hold" is missing a length')
   })
 
   it('should parse property access with function calls', () => {

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -102,13 +102,13 @@ describe('type-system/domain', () => {
         segments: [
           {
             type: 'hold',
-            length: numeric(undefined, 1),
+            length: numeric('beats', 1),
             unit: 'db',
             value: numeric('db', -6)
           },
           {
             type: 'lin',
-            length: numeric(undefined, 2),
+            length: numeric('beats', 2),
             unit: 'db',
             start: numeric('db', -6),
             end: numeric('db', 0)


### PR DESCRIPTION
Before this patch, curves would use the duration from the surrounding 'part' statement. Segments used weights to indicate their relative share of that duration. While convenient for the case of an automation that is supposed to span the entire part, it breaks down in two situations:

* Automations that should span less than the entire part.
* Curves used in other contexts, such as voice envelopes, where there is no surrounding part and the time span should be specified directly to match the note timing, ADSR parameters, etc.

Therefore, this patch now requires an explicit duration in seconds or beats/bars for each segment. For example:

```
automate synth.gain as ~[
  lin(-10.db, 0.db):4.bars
  hold(-6.db):4.bars
]
```

BREAKING CHANGE: Curve syntax has changed.