### PR TITLE
feat!: Add voice 'output' and 'envelope' statements

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -167,10 +167,20 @@ export interface Instrument extends ASTNode {
 
 export interface VoiceStatement extends ASTNode {
   readonly type: 'VoiceStatement'
-  readonly children: readonly Assignment[]
+  readonly children: ReadonlyArray<Assignment | EnvelopeStatement | OutputStatement>
   readonly bindings: {
     readonly note?: Identifier
   }
+}
+
+export interface EnvelopeStatement extends ASTNode {
+  readonly type: 'EnvelopeStatement'
+  readonly expression: Expression
+}
+
+export interface OutputStatement extends ASTNode {
+  readonly type: 'OutputStatement'
+  readonly expression: Expression
 }
 
 // Root Type
@@ -229,6 +239,8 @@ export interface NodeByType {
 
   Instrument: Instrument
   VoiceStatement: VoiceStatement
+  EnvelopeStatement: EnvelopeStatement
+  OutputStatement: OutputStatement
 
   Program: Program
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -225,6 +225,16 @@ VoiceStatement {
   kw<"voice">
   VariableDefinition?
   VoiceBlock[group=Block] {
-    "{" (Assignment)* "}"
+    "{" (Assignment | EnvelopeStatement | OutputStatement)* "}"
   }
+}
+
+EnvelopeStatement {
+  kw<"envelope">
+  expression
+}
+
+OutputStatement {
+  kw<"output">
+  expression
 }

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -16,6 +16,7 @@ import { InstrumentFacet } from '../../type-system/domain/instrument.js'
 import { ParameterFacet } from '../../type-system/domain/parameter.js'
 import { PartFacet } from '../../type-system/domain/part.js'
 import { PatternFacet } from '../../type-system/domain/pattern.js'
+import { SourceFacet } from '../../type-system/domain/source.js'
 import { makeType, makeUnion } from '../../type-system/factory.js'
 import type { Schema, SchemaItem } from '../../type-system/schema.js'
 import type { FacetType, Type, Value } from '../../type-system/types.js'
@@ -679,8 +680,52 @@ function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileE
     voiceScope.resolutions.set(voice.bindings.note.name, noteType)
   }
 
+  let hasEnvelope = false
+  let hasOutput = false
+
   for (const child of voice.children) {
-    errors.push(...checkAssignment(voiceScope, child))
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(voiceScope, child))
+        break
+
+      case 'EnvelopeStatement': {
+        if (hasEnvelope) {
+          errors.push(new CompileError('Multiple envelope statements in a voice', child.range))
+        }
+
+        hasEnvelope = true
+
+        const expressionCheck = checkExpression(voiceScope, child.expression)
+        errors.push(...expressionCheck.errors)
+
+        if (expressionCheck.result != null) {
+          errors.push(...checkType(CurveFacet.with('db').type(), expressionCheck.result, child.expression.range))
+        }
+
+        break
+      }
+
+      case 'OutputStatement': {
+        if (hasOutput) {
+          errors.push(new CompileError('Multiple output statements in a voice', child.range))
+        }
+
+        hasOutput = true
+
+        const expressionCheck = checkExpression(voiceScope, child.expression)
+        errors.push(...expressionCheck.errors)
+
+        if (expressionCheck.result != null) {
+          errors.push(...checkType(SourceFacet.type(), expressionCheck.result, child.expression.range))
+        }
+
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
   }
 
   return errors

--- a/packages/language/src/library/modules.ts
+++ b/packages/language/src/library/modules.ts
@@ -3,8 +3,10 @@ import { ModuleFacet } from '../type-system/base/module.js'
 import type { Value } from '../type-system/types.js'
 import { effectsModule } from './modules/effects.js'
 import { instrumentsModule } from './modules/instruments.js'
+import { sourcesModule } from './modules/sources.js'
 
 const standardLibrary = Object.freeze(new Map([
+  ['sources', sourcesModule],
   ['instruments', instrumentsModule],
   ['effects', effectsModule]
 ]))

--- a/packages/language/src/library/modules/sources.ts
+++ b/packages/language/src/library/modules/sources.ts
@@ -1,0 +1,46 @@
+import type { Oscillator } from '@core'
+import { NumberFacet } from '../../type-system/base/number.js'
+import { SourceFacet } from '../../type-system/domain/source.js'
+import { Functions, Modules } from '../../type-system/helpers.js'
+import { makeSchema } from '../../type-system/schema.js'
+import type { Value } from '../../type-system/types.js'
+
+function createOscillatorFunction (shape: Oscillator['shape']): Value {
+  return Functions.of({
+    summary: `Creates a source that produces a ${shape} wave.`,
+
+    parameters: makeSchema([
+      { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
+    ]),
+    returnType: SourceFacet.type(),
+    effects: { blocking: false },
+
+    invoke: (context, { frequency }) => {
+      const frequencyValue = NumberFacet.get(frequency)
+
+      void frequencyValue // TODO: Use frequency value to create an oscillator source
+
+      return SourceFacet.type().of({
+        type: 'oscillator',
+        shape
+      })
+    }
+  })
+}
+
+const sine = createOscillatorFunction('sine')
+const square = createOscillatorFunction('square')
+const saw = createOscillatorFunction('saw')
+const triangle = createOscillatorFunction('triangle')
+
+export const sourcesModule = Modules.of({
+  name: 'sources',
+  summary: 'Functions for creating audio sources that can be used in instruments.',
+
+  exports: new Map<string, Value>([
+    ['sine', sine],
+    ['square', square],
+    ['saw', saw],
+    ['triangle', triangle]
+  ])
+})

--- a/packages/language/src/parser/constants.ts
+++ b/packages/language/src/parser/constants.ts
@@ -9,7 +9,9 @@ export const keywords = Object.freeze([
   'effect',
   'automate',
   'instrument',
-  'voice'
+  'voice',
+  'envelope',
+  'output'
 ] as const)
 
 export type Keyword = (typeof keywords)[number]

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -667,12 +667,30 @@ const mixerStatement_: p.Parser<Token, unknown, ast.MixerStatement> = p.abc(
   }
 )
 
+const outputStatement_: p.Parser<Token, unknown, ast.OutputStatement> = p.ab(
+  keyword('output'),
+  expression_,
+  (_output, expression) => {
+    return ast.make('OutputStatement', combineSourceRanges(_output, expression), { expression })
+  }
+)
+
+const envelopeStatement_: p.Parser<Token, unknown, ast.EnvelopeStatement> = p.ab(
+  keyword('envelope'),
+  expression_,
+  (_envelope, expression) => {
+    return ast.make('EnvelopeStatement', combineSourceRanges(_envelope, expression), { expression })
+  }
+)
+
 const voiceStatement_: p.Parser<Token, unknown, ast.VoiceStatement> = p.abc(
   keyword('voice'),
   p.option(identifier_, undefined),
   combine3(
     literal('{'),
-    p.many(assignment_),
+    p.many(
+      p.eitherOr(assignment_, p.eitherOr(outputStatement_, envelopeStatement_))
+    ),
     expectLiteral('}')
   ),
   (_voice, note, [_lp, children, _rp]) => {

--- a/packages/language/src/type-system/domain/source.ts
+++ b/packages/language/src/type-system/domain/source.ts
@@ -1,0 +1,6 @@
+import type { Source } from '@core'
+import { makeFacet } from '../factory.js'
+
+const FACET_NAME = 'source'
+
+export const SourceFacet = makeFacet<typeof FACET_NAME, Source>(FACET_NAME, {})

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -311,10 +311,14 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should allow valid instrument definitions', () => {
       const source = [
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
         '  foo = -6.db',
         '  voice {',
         '    bar = 440.hz',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    output src.sine(bar)',
         '  }',
         '  voice note {}',
         '  voice note {',
@@ -322,6 +326,9 @@ describe('compiler/checker/checker.ts', () => {
         '    note_frequency = note.frequency',
         '    note_gate = note.gate',
         '    note_velocity = note.velocity',
+        '',
+        '    envelope ~[lin(-60.db, 0.db):30.ms lin(-10.db):note_gate lin(-60.db):10.ms]',
+        '    output src.saw(note_frequency)',
         '  }',
         '}'
       ].join('\n')
@@ -775,16 +782,38 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should report errors in voice statements', () => {
       const source = [
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
         '  voice {',
         '    bar = 440.hz',
         '    bar = 880.hz',
+        '    output src.sine(440)',
         '  }',
         '}'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Identifier "bar" is already defined'
+        'Identifier "bar" is already defined',
+        'Expected type number(hz), got number'
+      ])
+    })
+
+    it('should report switched output and envelope values', () => {
+      const source = [
+        'use "sources" as src',
+        '',
+        'my_instrument = instrument {',
+        '  voice {',
+        '    output ~[lin(0.db, -60.db):100.ms]',
+        '    envelope src.sine(440.hz)',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Expected type source, got curve(db)',
+        'Expected type curve(db), got source'
       ])
     })
 
@@ -814,6 +843,38 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Identifier "note" is already defined'
+      ])
+    })
+
+    it('should reject multiple outputs in a voice', () => {
+      const source = [
+        'use "sources" as src',
+        '',
+        'my_instrument = instrument {',
+        '  voice {',
+        '    output src.sine(440.hz)',
+        '    output src.sine(880.hz)',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Multiple output statements in a voice'
+      ])
+    })
+
+    it('should reject multiple envelopes in a voice', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  voice {',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    envelope ~[lin(-60.db, 0.db):100.ms]',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Multiple envelope statements in a voice'
       ])
     })
 


### PR DESCRIPTION
This patch implements the parsing and type checking aspects of the two child statements for 'voice': 'output' and 'envelope'.

* 'output' defines the audio source for the voice. It takes a single argument of the newly-added 'source' facet type.
* 'envelope' defines the amplitude envelope for the voice. It uses the existing 'curve' facet type.

A new "sources" module is added to the standard library, which provides a selection of audio sources.

The generation of voices from these statements will be implemented in a future patch.

BREAKING CHANGE: Keywords added.