### PR TITLE
feat: Create instrument voices dynamically

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -41,8 +41,6 @@ const FLOWCHART_OPTIONS: MixerFlowchartOptions = {
   }
 }
 
-const MISSING_ASSET_URL = '<missing asset>'
-
 function getNodeTypeLabel (type: MixerFlowNode['data']['type']): string {
   switch (type) {
     case 'output':
@@ -54,7 +52,7 @@ function getNodeTypeLabel (type: MixerFlowNode['data']['type']): string {
   }
 }
 
-function getNodeLabel ({ data }: MixerFlowNode): string {
+function getNodeLabel ({ data }: MixerFlowNode): string | undefined {
   switch (data.type) {
     case 'output':
       return 'Main Output'
@@ -62,27 +60,9 @@ function getNodeLabel ({ data }: MixerFlowNode): string {
     case 'bus':
       return data.object.name
 
-    case 'instrument': {
-      switch (data.object.source.type) {
-        case 'sample': {
-          const url = getSampleUrl(data.program, data.object)
-          return url?.split('/').pop() ?? url ?? MISSING_ASSET_URL
-        }
-
-        case 'oscillator': {
-          return data.object.source.shape
-        }
-      }
-    }
+    case 'instrument':
+      return undefined // TODO: Find a way to describe the instrument
   }
-}
-
-function getSampleUrl (program: Program, instrument: Instrument): string | undefined {
-  if (instrument.source.type !== 'sample') {
-    return undefined
-  }
-
-  return program.assets.get(instrument.source.assetId)?.url
 }
 
 export const MixerPanel: FunctionComponent<PanelProps> = () => {
@@ -265,21 +245,10 @@ const BusNodeInfo: FunctionComponent<{
 const InstrumentNodeInfo: FunctionComponent<{
   object: Instrument
   program: Program
-}> = ({ object, program }) => {
-  const sampleUrl = getSampleUrl(program, object) ?? MISSING_ASSET_URL
-
+}> = () => {
   return (
     <>
       <div className='font-bold'>(Instrument)</div>
-      <div>type: {object.source.type}</div>
-      {object.source.type === 'sample' && (
-        <div className='max-w-96'>url: {sampleUrl}</div>
-      )}
-      {object.source.type === 'oscillator' && (
-        <div>shape: {object.source.shape}</div>
-      )}
-      <div>root_note: {object.rootNote ?? 'undefined'}</div>
-      <div>gain: {object.gain.initial.value.toFixed(2)} {object.gain.initial.unit}</div>
     </>
   )
 }

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MidiNote, MixerRouting, Oscillator, Program, Sample, Track } from '@core'
+import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MidiNote, MixerRouting, Oscillator, Program, Sample, Track, Voice } from '@core'
 import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, getMidiFrequency, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
@@ -10,7 +10,7 @@ import type { EntityKey } from './entities.js'
 import { createEntityKey } from './entities.js'
 import { applyEnvelope } from './envelope.js'
 import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
-import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, InstrumentNode, Node, PanNode, ReverbNode, WaveShaperNode, WidthNode } from './nodes.js'
+import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, InstrumentNode, Node, PanNode, ReverbNode, SourceNode, WaveShaperNode, WidthNode } from './nodes.js'
 
 type Builder = AudioGraphBuilder<Node>
 
@@ -126,11 +126,31 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
     ? convertPitchToMidi(instrument.rootNote)
     : DEFAULT_ROOT_NOTE
 
+  const instrumentNode = builder.addNode<InstrumentNode>('instrument', {
+    trigger: (note) => {
+      return instrument.trigger().map((voice) => createSourceNode(voice, rootNote, note))
+    }
+  })
+
+  const gain = builder.addNode<GainNode>('gain', {
+    gain: toTimeVariant(instrument.gain, program, gainTransform)
+  })
+
+  builder.addEdge(instrumentNode.id, gain.id)
+
+  return {
+    inputs: [instrumentNode.id],
+    outputs: [gain.id],
+    instrument: instrumentNode.id
+  }
+}
+
+function createSourceNode (voice: Voice, rootNote: MidiNote, note: Omit<NoteOptions, 'time'>): SourceNode {
   const envelope = (() => {
-    const a = instrument.envelope.attack.value
-    const d = instrument.envelope.decay.value
-    const s = instrument.envelope.sustain.value
-    const r = instrument.envelope.release.value
+    const a = voice.envelope.attack.value
+    const d = voice.envelope.decay.value
+    const s = voice.envelope.sustain.value
+    const r = voice.envelope.release.value
 
     const clampDuration = (value: number): Numeric<'s'> => {
       return Number.isFinite(value) && value >= 0
@@ -152,35 +172,16 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
     }
   })()
 
-  const instrumentNode = (() => {
-    switch (instrument.source.type) {
-      case 'sample':
-        return createSampleInstrumentNode(instrument.source, envelope, rootNote, builder)
+  switch (voice.source.type) {
+    case 'sample':
+      return createSampleSourceNode(voice.source, envelope, rootNote, note)
 
-      case 'oscillator':
-        return createOscillatorInstrumentNode(instrument.source, envelope, rootNote, builder)
-    }
-  })()
-
-  const gain = builder.addNode<GainNode>('gain', {
-    gain: toTimeVariant(instrument.gain, program, gainTransform)
-  })
-
-  builder.addEdge(instrumentNode.id, gain.id)
-
-  return {
-    inputs: [instrumentNode.id],
-    outputs: [gain.id],
-    instrument: instrumentNode.id
+    case 'oscillator':
+      return createOscillatorSourceNode(voice.source, envelope, rootNote, note)
   }
 }
 
-function createSampleInstrumentNode (
-  sample: Sample,
-  envelope: Envelope,
-  rootNote: MidiNote,
-  builder: Builder
-): InstrumentNode {
+function createSampleSourceNode (sample: Sample, envelope: Envelope, rootNote: MidiNote, note: Omit<NoteOptions, 'time'>): SourceNode {
   const { assetId } = sample
 
   const length = (() => {
@@ -196,65 +197,48 @@ function createSampleInstrumentNode (
     return value < 0 ? numeric('s', 0) : !Number.isFinite(value) ? undefined : numeric('s', value)
   })()
 
-  return builder.addNode<InstrumentNode>('instrument', {
-    trigger: (note) => {
-      const holdDuration = (() => {
-        if (note.duration == null || length == null) {
-          return note.duration ?? length?.value
-        }
-        return Math.min(note.duration, length.value)
-      })()
-
-      const gainCurve = applyEnvelope(envelope, { ...note, duration: holdDuration })
-      const duration = holdDuration != null
-        ? gainCurve.points.at(-1)?.time
-        : undefined
-
-      const playbackRate = Math.pow(2, ((note.pitch ?? rootNote) - rootNote) / 12)
-
-      return [
-        {
-          id: -1 as NodeId, // TODO: avoid invalid id
-          type: 'sample',
-          gainCurve,
-          duration,
-          assetId,
-          playbackRate
-        }
-      ]
+  const holdDuration = (() => {
+    if (note.duration == null || length == null) {
+      return note.duration ?? length?.value
     }
-  })
+    return Math.min(note.duration, length.value)
+  })()
+
+  const gainCurve = applyEnvelope(envelope, { ...note, duration: holdDuration })
+  const duration = holdDuration != null
+    ? gainCurve.points.at(-1)?.time
+    : undefined
+
+  const playbackRate = Math.pow(2, ((note.pitch ?? rootNote) - rootNote) / 12)
+
+  return {
+    id: -1 as NodeId, // TODO: avoid invalid id
+    type: 'sample',
+    gainCurve,
+    duration,
+    assetId,
+    playbackRate
+  }
 }
 
-function createOscillatorInstrumentNode (
-  oscillator: Oscillator,
-  envelope: Envelope,
-  rootNote: MidiNote,
-  builder: Builder
-): InstrumentNode {
+function createOscillatorSourceNode (oscillator: Oscillator, envelope: Envelope, rootNote: MidiNote, note: Omit<NoteOptions, 'time'>): SourceNode {
   const { shape } = oscillator
 
-  return builder.addNode<InstrumentNode>('instrument', {
-    trigger: (note) => {
-      const gainCurve = applyEnvelope(envelope, note)
-      const duration = note.duration != null
-        ? gainCurve.points.at(-1)?.time
-        : undefined
+  const gainCurve = applyEnvelope(envelope, note)
+  const duration = note.duration != null
+    ? gainCurve.points.at(-1)?.time
+    : undefined
 
-      const frequency = numeric('hz', getMidiFrequency(note.pitch ?? rootNote))
+  const frequency = numeric('hz', getMidiFrequency(note.pitch ?? rootNote))
 
-      return [
-        {
-          id: -1 as NodeId, // TODO: avoid invalid id
-          type: 'oscillator',
-          gainCurve,
-          duration,
-          shape,
-          frequency
-        }
-      ]
-    }
-  })
+  return {
+    id: -1 as NodeId, // TODO: avoid invalid id
+    type: 'oscillator',
+    gainCurve,
+    duration,
+    shape,
+    frequency
+  }
 }
 
 function createEffect (program: Program, effect: Effect, builder: Builder): SubGraph {

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -184,11 +184,15 @@ describe('lowering.ts', () => {
               id: instrumentGainId,
               initial: numeric('db', -6)
             },
-            source: {
-              type: 'oscillator',
-              shape: 'sine'
-            },
-            envelope: defaultEnvelope
+            trigger: () => [
+              {
+                envelope: defaultEnvelope,
+                source: {
+                  type: 'oscillator',
+                  shape: 'sine'
+                }
+              }
+            ]
           } satisfies Instrument
         ]
       ]),
@@ -320,11 +324,15 @@ describe('lowering.ts', () => {
               id: instrumentGainId,
               initial: numeric('db', -6)
             },
-            source: {
-              type: 'oscillator',
-              shape: 'sine'
-            },
-            envelope: defaultEnvelope
+            trigger: () => [
+              {
+                envelope: defaultEnvelope,
+                source: {
+                  type: 'oscillator',
+                  shape: 'sine'
+                }
+              }
+            ]
           } satisfies Instrument
         ]
       ]),
@@ -413,11 +421,15 @@ describe('lowering.ts', () => {
               id: 200 as ParameterId,
               initial: numeric('db', -6)
             },
-            source: {
-              type: 'oscillator',
-              shape: 'sine'
-            },
-            envelope: defaultEnvelope
+            trigger: () => [
+              {
+                envelope: defaultEnvelope,
+                source: {
+                  type: 'oscillator',
+                  shape: 'sine'
+                }
+              }
+            ]
           } satisfies Instrument
         ]
       ]),
@@ -497,11 +509,15 @@ describe('lowering.ts', () => {
         id: 200 as ParameterId,
         initial: numeric('db', -Infinity)
       },
-      source: {
-        type: 'oscillator',
-        shape: 'sine'
-      },
-      envelope: defaultEnvelope
+      trigger: () => [
+        {
+          envelope: defaultEnvelope,
+          source: {
+            type: 'oscillator',
+            shape: 'sine'
+          }
+        }
+      ]
     })
 
     assert.doesNotThrow(() => createAudioGraph(program))
@@ -515,11 +531,15 @@ describe('lowering.ts', () => {
           id: 200 as ParameterId,
           initial: numeric('db', gain)
         },
-        source: {
-          type: 'oscillator',
-          shape: 'sine'
-        },
-        envelope: defaultEnvelope
+        trigger: () => [
+          {
+            envelope: defaultEnvelope,
+            source: {
+              type: 'oscillator',
+              shape: 'sine'
+            }
+          }
+        ]
       })
 
       assert.throws(() => createAudioGraph(program), /Invalid gain/, `should throw for gain: ${gain}`)
@@ -535,11 +555,15 @@ describe('lowering.ts', () => {
           id: 200 as ParameterId,
           initial: numeric('db', -6)
         },
-        source: {
-          type: 'oscillator',
-          shape: 'sine'
-        },
-        envelope: defaultEnvelope
+        trigger: () => [
+          {
+            envelope: defaultEnvelope,
+            source: {
+              type: 'oscillator',
+              shape: 'sine'
+            }
+          }
+        ]
       })
 
       assert.throws(() => createAudioGraph(program), /Invalid pitch/, `should throw for root note: ${rootNote}`)
@@ -553,12 +577,16 @@ describe('lowering.ts', () => {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      source: {
-        type: 'sample',
-        assetId: 300 as AssetId,
-        length: numeric('s', -1)
-      },
-      envelope: defaultEnvelope
+      trigger: () => [
+        {
+          envelope: defaultEnvelope,
+          source: {
+            type: 'sample',
+            assetId: 300 as AssetId,
+            length: numeric('s', -1)
+          }
+        }
+      ]
     }, {
       id: 300 as AssetId,
       url: 'foo.wav'
@@ -593,12 +621,16 @@ describe('lowering.ts', () => {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      source: {
-        type: 'sample',
-        assetId: 300 as AssetId,
-        length: numeric('s', Infinity)
-      },
-      envelope: defaultEnvelope
+      trigger: () => [
+        {
+          envelope: defaultEnvelope,
+          source: {
+            type: 'sample',
+            assetId: 300 as AssetId,
+            length: numeric('s', Infinity)
+          }
+        }
+      ]
     }, {
       id: 300 as AssetId,
       url: 'foo.wav'
@@ -619,18 +651,31 @@ describe('lowering.ts', () => {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      source: {
-        type: 'sample',
-        assetId: 300 as AssetId,
-        length: numeric('s', Number.NaN)
-      },
-      envelope: defaultEnvelope
+      trigger: () => [
+        {
+          envelope: defaultEnvelope,
+          source: {
+            type: 'sample',
+            assetId: 300 as AssetId,
+            length: numeric('s', Number.NaN)
+          }
+        }
+      ]
     }, {
       id: 300 as AssetId,
       url: 'foo.wav'
     })
 
-    assert.throws(() => createAudioGraph(program), /Invalid length/)
+    const graph = createAudioGraph(program)
+
+    assert.throws(() => {
+      const instrumentNode = graph.nodes.get(2 as NodeId) as InstrumentNode
+      instrumentNode.trigger({
+        pitch: 60 as MidiNote,
+        velocity: 1.0,
+        duration: 0.5
+      })
+    }, /Invalid length/)
   })
 
   it('should clamp envelope parameters to valid ranges', () => {
@@ -696,11 +741,15 @@ describe('lowering.ts', () => {
           id: 200 as ParameterId,
           initial: numeric('db', -6)
         },
-        source: {
-          type: 'oscillator',
-          shape: 'sine'
-        },
-        envelope
+        trigger: () => [
+          {
+            envelope,
+            source: {
+              type: 'oscillator',
+              shape: 'sine'
+            }
+          }
+        ]
       })
 
       const graph = createAudioGraph(program)
@@ -1521,11 +1570,15 @@ describe('lowering.ts', () => {
           id: 200 as ParameterId,
           initial: numeric('db', -6)
         },
-        source: {
-          type: 'oscillator',
-          shape: 'sine'
-        },
-        envelope: defaultEnvelope
+        trigger: () => [
+          {
+            envelope: defaultEnvelope,
+            source: {
+              type: 'oscillator',
+              shape: 'sine'
+            }
+          }
+        ]
       }))
 
       assert.strictEqual(graph.meters.size, 0)
@@ -1546,11 +1599,15 @@ describe('lowering.ts', () => {
                 id: 200 as ParameterId,
                 initial: numeric('db', -6)
               },
-              source: {
-                type: 'oscillator',
-                shape: 'sine'
-              },
-              envelope: defaultEnvelope
+              trigger: () => [
+                {
+                  envelope: defaultEnvelope,
+                  source: {
+                    type: 'oscillator',
+                    shape: 'sine'
+                  }
+                }
+              ]
             } satisfies Instrument
           ]
         ]),
@@ -1644,11 +1701,15 @@ describe('lowering.ts', () => {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      source: {
-        type: 'oscillator',
-        shape: 'sine'
-      },
-      envelope: defaultEnvelope
+      trigger: () => [
+        {
+          envelope: defaultEnvelope,
+          source: {
+            type: 'oscillator',
+            shape: 'sine'
+          }
+        }
+      ]
     })
 
     for (const interval of [Infinity, -Infinity, Number.NaN, 0, -1]) {

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -105,6 +105,10 @@ export interface Instrument {
   readonly id: InstrumentId
   readonly rootNote?: Pitch
   readonly gain: Parameter<'db'>
+  readonly trigger: () => readonly Voice[]
+}
+
+export interface Voice {
   readonly source: Source
   readonly envelope: Envelope
 }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -552,16 +552,20 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
 
   const instrument = scope.top.allocateInstrument({
     gain: gainParameter,
-    source: {
-      type: 'oscillator',
-      shape: 'sine'
-    },
-    envelope: {
-      attack: numeric('s', 0),
-      decay: numeric('s', 0),
-      sustain: numeric(undefined, 1),
-      release: numeric('s', 0)
-    }
+    trigger: () => [
+      {
+        envelope: {
+          attack: numeric('s', 0),
+          decay: numeric('s', 0),
+          sustain: numeric(undefined, 1),
+          release: numeric('s', 0)
+        },
+        source: {
+          type: 'oscillator',
+          shape: 'sine'
+        }
+      }
+    ]
   })
 
   return InstrumentFacet.type().of(instrument)

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -58,12 +58,16 @@ const sample = Functions.of({
     const instrument = context.allocateInstrument({
       gain: gainParameter,
       rootNote: rootNoteValue != null && isPitch(rootNoteValue) ? rootNoteValue : undefined,
-      source: {
-        type: 'sample',
-        assetId: asset.id,
-        length: lengthValue
-      },
-      envelope: ENVELOPE_DECLICK
+      trigger: () => [
+        {
+          envelope: ENVELOPE_DECLICK,
+          source: {
+            type: 'sample',
+            assetId: asset.id,
+            length: lengthValue
+          }
+        }
+      ]
     })
 
     return SampleInstrumentType.of(instrument, {
@@ -88,11 +92,15 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
 
       const instrument = context.allocateInstrument({
         gain: gainParameter,
-        source: {
-          type: 'oscillator',
-          shape
-        },
-        envelope: ENVELOPE_DECLICK
+        trigger: () => [
+          {
+            envelope: ENVELOPE_DECLICK,
+            source: {
+              type: 'oscillator',
+              shape
+            }
+          }
+        ]
       })
 
       return OscillatorInstrumentType.of(instrument, {

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -93,8 +93,10 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    assert.strictEqual(instrument.source.type, 'sample')
-    assert.strictEqual(instrument.source.assetId, asset.id)
+    const voices = instrument.trigger()
+    assert.strictEqual(voices.length, 1)
+    assert.strictEqual(voices[0].source.type, 'sample')
+    assert.strictEqual(voices[0].source.assetId, asset.id)
   })
 
   it('should support import aliases', () => {
@@ -110,8 +112,10 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    assert.strictEqual(instrument.source.type, 'sample')
-    assert.strictEqual(instrument.source.assetId, asset.id)
+    const voices = instrument.trigger()
+    assert.strictEqual(voices.length, 1)
+    assert.strictEqual(voices[0].source.type, 'sample')
+    assert.strictEqual(voices[0].source.assetId, asset.id)
   })
 
   it('should support shadowing of imported names', () => {
@@ -727,8 +731,10 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.instruments.size, 1)
 
     const [instrument] = result.instruments.values()
-    assert.strictEqual(instrument.source.type, 'oscillator')
-    assert.strictEqual(instrument.source.shape, 'sine')
+    const voices = instrument.trigger()
+    assert.strictEqual(voices.length, 1)
+    assert.strictEqual(voices[0].source.type, 'oscillator')
+    assert.strictEqual(voices[0].source.shape, 'sine')
     assert.deepStrictEqual(instrument.gain.initial, numeric('db', -Infinity))
   })
 })

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -1,3 +1,4 @@
+import type { Instrument } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -82,31 +83,39 @@ describe('compiler/generator/scopes.ts', () => {
 
       const instrument0 = {
         gain: scope.allocateParameter(numeric('db', -6)),
-        source: {
-          type: 'oscillator',
-          shape: 'sine'
-        },
-        envelope: {
-          attack: numeric('s', 0.1),
-          decay: numeric('s', 0.2),
-          sustain: numeric(undefined, 0.5),
-          release: numeric('s', 0.5)
-        }
-      } as const
+        trigger: () => [
+          {
+            source: {
+              type: 'oscillator',
+              shape: 'sine'
+            },
+            envelope: {
+              attack: numeric('s', 0.1),
+              decay: numeric('s', 0.2),
+              sustain: numeric(undefined, 0.5),
+              release: numeric('s', 0.5)
+            }
+          }
+        ]
+      } satisfies Omit<Instrument, 'id'>
 
       const instrument1 = {
         gain: scope.allocateParameter(numeric('db', -3)),
-        source: {
-          type: 'oscillator',
-          shape: 'square'
-        },
-        envelope: {
-          attack: numeric('s', 0.01),
-          decay: numeric('s', 0.1),
-          sustain: numeric(undefined, 0.8),
-          release: numeric('s', 0.3)
-        }
-      } as const
+        trigger: () => [
+          {
+            source: {
+              type: 'oscillator',
+              shape: 'square'
+            },
+            envelope: {
+              attack: numeric('s', 0.01),
+              decay: numeric('s', 0.1),
+              sustain: numeric(undefined, 0.8),
+              release: numeric('s', 0.3)
+            }
+          }
+        ]
+      } satisfies Omit<Instrument, 'id'>
 
       const allocated0 = scope.allocateInstrument(instrument0)
       const allocated1 = scope.allocateInstrument(instrument1)

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -51,13 +51,19 @@ describe('library/modules/instruments.ts', () => {
         id: instrument.id,
         rootNote: 'C4',
         gain: { id: instrument.gain.id, initial: numeric('db', -3) },
-        source: {
-          type: 'sample',
-          assetId: asset.id,
-          length: numeric('s', 1.5)
-        },
-        envelope: declickEnvelope
+        trigger: instrument.trigger
       } satisfies Instrument)
+
+      assert.deepStrictEqual(instrument.trigger(), [
+        {
+          envelope: declickEnvelope,
+          source: {
+            type: 'sample',
+            assetId: asset.id,
+            length: numeric('s', 1.5)
+          }
+        }
+      ])
 
       assert.deepStrictEqual([...context.instruments], [
         [instrument.id, InstrumentFacet.get(result)]
@@ -83,13 +89,19 @@ describe('library/modules/instruments.ts', () => {
       assert.deepStrictEqual(instrument, {
         rootNote: undefined,
         gain: { id: instrument.gain.id, initial: numeric('db', 0) },
-        source: {
-          type: 'sample',
-          assetId: asset.id,
-          length: undefined
-        },
-        envelope: declickEnvelope
+        trigger: instrument.trigger
       })
+
+      assert.deepStrictEqual(instrument.trigger(), [
+        {
+          envelope: declickEnvelope,
+          source: {
+            type: 'sample',
+            assetId: asset.id,
+            length: undefined
+          }
+        }
+      ])
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -110,9 +122,18 @@ describe('library/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(instrument, {
         gain: { id: instrument.gain.id, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'sine' },
-        envelope: declickEnvelope
+        trigger: instrument.trigger
       })
+
+      assert.deepStrictEqual(instrument.trigger(), [
+        {
+          envelope: declickEnvelope,
+          source: {
+            type: 'oscillator',
+            shape: 'sine'
+          }
+        }
+      ])
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -133,9 +154,18 @@ describe('library/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(instrument, {
         gain: { id: instrument.gain.id, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'square' },
-        envelope: declickEnvelope
+        trigger: instrument.trigger
       })
+
+      assert.deepStrictEqual(instrument.trigger(), [
+        {
+          envelope: declickEnvelope,
+          source: {
+            type: 'oscillator',
+            shape: 'square'
+          }
+        }
+      ])
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -156,9 +186,18 @@ describe('library/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(instrument, {
         gain: { id: instrument.gain.id, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'saw' },
-        envelope: declickEnvelope
+        trigger: instrument.trigger
       })
+
+      assert.deepStrictEqual(instrument.trigger(), [
+        {
+          envelope: declickEnvelope,
+          source: {
+            type: 'oscillator',
+            shape: 'saw'
+          }
+        }
+      ])
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -179,9 +218,18 @@ describe('library/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(instrument, {
         gain: { id: instrument.gain.id, initial: numeric('db', 0) },
-        source: { type: 'oscillator', shape: 'triangle' },
-        envelope: declickEnvelope
+        trigger: instrument.trigger
       })
+
+      assert.deepStrictEqual(instrument.trigger(), [
+        {
+          envelope: declickEnvelope,
+          source: {
+            type: 'oscillator',
+            shape: 'triangle'
+          }
+        }
+      ])
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -38,16 +38,20 @@ const instrument: Instrument = {
   id: 1 as InstrumentId,
   rootNote: 'C4',
   gain: gainParameter,
-  source: {
-    type: 'oscillator',
-    shape: 'triangle'
-  },
-  envelope: {
-    attack: numeric('s', 0.01),
-    decay: numeric('s', 0.2),
-    sustain: numeric(undefined, 0.8),
-    release: numeric('s', 0.3)
-  }
+  trigger: () => [
+    {
+      envelope: {
+        attack: numeric('s', 0.01),
+        decay: numeric('s', 0.2),
+        sustain: numeric(undefined, 0.8),
+        release: numeric('s', 0.3)
+      },
+      source: {
+        type: 'oscillator',
+        shape: 'triangle'
+      }
+    }
+  ]
 }
 
 const part: Part = {


### PR DESCRIPTION
This patch updates the core instrument interface to not include fixed source and envelope properties. Instead, it has a `trigger` method that returns an array of voices (= source and envelope). This is in preparation for instruments becoming fully dynamic. At the moment, the envelope-to-curve conversion is still done in the audiograph package, as is deriving playback rate (samples) or frequency (oscillators) from the note. However, just moving to a function is a significant change.