### PR TITLE
refactor: Use core NoteEvent also in audiograph

### DIFF
--- a/packages/audiograph/src/builder.ts
+++ b/packages/audiograph/src/builder.ts
@@ -1,7 +1,8 @@
-import type { Asset, AssetId } from '@core'
+import type { Asset, AssetId, NoteEvent } from '@core'
+import { isPitch } from '@core'
 import type { Numeric } from '@utility'
 import type { EntityKey } from './entities.js'
-import type { AnyNode, AudioGraph, Edge, Meters, NodeId, NoteOptions } from './graph.js'
+import type { AnyNode, AudioGraph, Edge, Meters, NodeId } from './graph.js'
 
 export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
   readonly addNode: <T extends TNode> (type: T['type'], node: Omit<T, 'id' | 'type'>) => T
@@ -11,7 +12,7 @@ export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
 
   readonly addAsset: (asset: Asset) => void
 
-  readonly addNoteEvents: (nodeId: NodeId, events: readonly NoteOptions[]) => void
+  readonly addNoteEvents: (nodeId: NodeId, events: readonly NoteEvent[]) => void
 
   readonly addMeters: (key: EntityKey, meters: Meters) => void
 
@@ -34,7 +35,7 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
   const edges: Edge[] = []
   const outputIds: NodeId[] = []
   const assets = new Map<AssetId, Asset>()
-  const noteEvents = new Map<NodeId, readonly NoteOptions[]>()
+  const noteEvents = new Map<NodeId, readonly NoteEvent[]>()
   const meters = new Map<EntityKey, Meters>()
 
   let nextId = 1 as NodeId
@@ -107,24 +108,24 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
   }
 }
 
-function validateNoteEvent (event: NoteOptions): void {
-  if (!Number.isFinite(event.time) || event.time < 0) {
+function validateNoteEvent (event: NoteEvent): void {
+  if (!Number.isFinite(event.time.value) || event.time.value < 0) {
     throw invalidNoteEvent(event)
   }
 
-  if (event.pitch != null && (!Number.isFinite(event.pitch) || event.pitch < 0 || event.pitch > 127)) {
+  if (event.pitch != null && !isPitch(event.pitch)) {
     throw invalidNoteEvent(event)
   }
 
-  if (!Number.isFinite(event.velocity) || event.velocity < 0 || event.velocity > 1) {
+  if (!Number.isFinite(event.velocity.value) || event.velocity.value < 0 || event.velocity.value > 1) {
     throw invalidNoteEvent(event)
   }
 
-  if (event.duration != null && (!Number.isFinite(event.duration) || event.duration < 0)) {
+  if (event.gate?.value != null && (!Number.isFinite(event.gate.value) || event.gate.value < 0)) {
     throw invalidNoteEvent(event)
   }
 }
 
-function invalidNoteEvent (event: NoteOptions): Error {
+function invalidNoteEvent (event: NoteEvent): Error {
   return new Error(`Invalid note event: ${JSON.stringify(event)}`)
 }

--- a/packages/audiograph/src/envelope.ts
+++ b/packages/audiograph/src/envelope.ts
@@ -1,11 +1,12 @@
 import type { TimeVariant, TimeVariantPoint } from './automation.js'
 import { timeVariant } from './automation.js'
 import type { Envelope } from '@core'
+import type { Numeric } from '@utility'
 import { numeric } from '@utility'
 
 export interface EnvelopeOptions {
-  readonly velocity: number
-  readonly duration?: number
+  readonly velocity: Numeric<undefined>
+  readonly gate?: Numeric<'s'>
 }
 
 const ZERO_GAIN = numeric(undefined, 0)
@@ -18,15 +19,15 @@ export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): Ti
     startTime: 0,
     startValue: 0,
     endTime: envelope.attack.value,
-    endValue: options.velocity
+    endValue: options.velocity.value
   })
 
   // decay (peak -> sustain)
   applySegment(points, options, {
     startTime: envelope.attack.value,
-    startValue: options.velocity,
+    startValue: options.velocity.value,
     endTime: envelope.attack.value + envelope.decay.value,
-    endValue: envelope.sustain.value * options.velocity
+    endValue: envelope.sustain.value * options.velocity.value
   })
 
   // hold and release (sustain -> silence)
@@ -41,10 +42,10 @@ function applySegment (points: Array<TimeVariantPoint<undefined>>, options: Enve
   readonly endTime: number
   readonly endValue: number
 }): void {
-  const { duration } = options
+  const { gate } = options
   const { startTime, startValue, endTime, endValue } = segment
 
-  if (duration != null && duration <= startTime) {
+  if (gate != null && gate.value <= startTime) {
     return
   }
 
@@ -59,10 +60,10 @@ function applySegment (points: Array<TimeVariantPoint<undefined>>, options: Enve
     points.push({ time: numeric('s', startTime), value: numeric(undefined, startValue), curve: 'step' })
   }
 
-  if (duration != null && duration < endTime) {
-    const t = (duration - startTime) / (endTime - startTime)
+  if (gate != null && gate.value < endTime) {
+    const t = (gate.value - startTime) / (endTime - startTime)
     const holdValue = startValue + t * (endValue - startValue)
-    points.push({ time: numeric('s', duration), value: numeric(undefined, holdValue), curve: 'linear' })
+    points.push({ time: gate, value: numeric(undefined, holdValue), curve: 'linear' })
     return
   }
 
@@ -70,8 +71,8 @@ function applySegment (points: Array<TimeVariantPoint<undefined>>, options: Enve
 }
 
 function applyRelease (points: Array<TimeVariantPoint<undefined>>, envelope: Envelope, options: EnvelopeOptions): void {
-  const { duration } = options
-  if (duration == null) {
+  const { gate } = options
+  if (gate == null) {
     return
   }
 
@@ -79,16 +80,16 @@ function applyRelease (points: Array<TimeVariantPoint<undefined>>, envelope: Env
   const release = envelope.release.value
 
   if (lastPoint == null || release <= 0) {
-    points.push({ time: numeric('s', duration), value: ZERO_GAIN, curve: 'step' })
+    points.push({ time: gate, value: ZERO_GAIN, curve: 'step' })
     return
   }
 
-  const releaseStartTime = duration
+  const releaseStartTime = gate
   const releaseStartValue = lastPoint.value.value
 
-  if (releaseStartTime > lastPoint.time.value) {
-    points.push({ time: numeric('s', releaseStartTime), value: numeric(undefined, releaseStartValue), curve: 'step' })
+  if (releaseStartTime.value > lastPoint.time.value) {
+    points.push({ time: releaseStartTime, value: numeric(undefined, releaseStartValue), curve: 'step' })
   }
 
-  points.push({ time: numeric('s', releaseStartTime + release), value: ZERO_GAIN, curve: 'linear' })
+  points.push({ time: numeric('s', releaseStartTime.value + release), value: ZERO_GAIN, curve: 'linear' })
 }

--- a/packages/audiograph/src/graph.ts
+++ b/packages/audiograph/src/graph.ts
@@ -1,4 +1,4 @@
-import type { Asset, AssetId, MidiNote } from '@core'
+import type { Asset, AssetId, NoteEvent } from '@core'
 import type { Brand, Numeric } from '@utility'
 import type { EntityKey } from './entities.js'
 
@@ -12,7 +12,7 @@ export interface AudioGraph<TNode = AnyNode> {
 
   readonly assets: ReadonlyMap<AssetId, Asset>
 
-  readonly noteEvents: ReadonlyMap<NodeId, readonly NoteOptions[]>
+  readonly noteEvents: ReadonlyMap<NodeId, readonly NoteEvent[]>
 
   readonly meters: ReadonlyMap<EntityKey, Meters>
 }
@@ -27,13 +27,6 @@ export interface AnyNode {
 export interface Edge {
   readonly from: NodeId
   readonly to: NodeId
-}
-
-export interface NoteOptions {
-  readonly time: number
-  readonly pitch?: MidiNote
-  readonly velocity: number
-  readonly duration?: number
 }
 
 export interface Meters {

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,5 +1,5 @@
-import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MidiNote, MixerRouting, Oscillator, Program, Sample, Track, Voice } from '@core'
-import { beatsToSeconds, calculateTotalLength, convertPitchToMidi, getMidiFrequency, renderPatternEvents, timeToSeconds } from '@core'
+import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MidiNote, MixerRouting, NoteData, Oscillator, Program, Sample, Track, Voice } from '@core'
+import { calculateTotalLength, convertPitchToMidi, getMidiFrequency, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
 import { feedbackTransform, frequencyTransform, gainTransform, panTransform, timeVariant, toTimeVariant } from './automation.js'
@@ -9,7 +9,7 @@ import { dbToGain, DEFAULT_ROOT_NOTE } from './constants.js'
 import type { EntityKey } from './entities.js'
 import { createEntityKey } from './entities.js'
 import { applyEnvelope } from './envelope.js'
-import type { AnyNode, AudioGraph, NodeId, NoteOptions } from './graph.js'
+import type { AnyNode, AudioGraph, NodeId } from './graph.js'
 import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, InstrumentNode, Node, PanNode, ReverbNode, SourceNode, WaveShaperNode, WidthNode } from './nodes.js'
 
 type Builder = AudioGraphBuilder<Node>
@@ -128,7 +128,7 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
 
   const instrumentNode = builder.addNode<InstrumentNode>('instrument', {
     trigger: (note) => {
-      return instrument.trigger().map((voice) => createSourceNode(voice, rootNote, note))
+      return instrument.trigger(note).map((voice) => createSourceNode(program, voice, rootNote, note))
     }
   })
 
@@ -145,7 +145,7 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
   }
 }
 
-function createSourceNode (voice: Voice, rootNote: MidiNote, note: Omit<NoteOptions, 'time'>): SourceNode {
+function createSourceNode (program: Program, voice: Voice, rootNote: MidiNote, note: NoteData): SourceNode {
   const envelope = (() => {
     const a = voice.envelope.attack.value
     const d = voice.envelope.decay.value
@@ -174,14 +174,14 @@ function createSourceNode (voice: Voice, rootNote: MidiNote, note: Omit<NoteOpti
 
   switch (voice.source.type) {
     case 'sample':
-      return createSampleSourceNode(voice.source, envelope, rootNote, note)
+      return createSampleSourceNode(program, voice.source, envelope, rootNote, note)
 
     case 'oscillator':
-      return createOscillatorSourceNode(voice.source, envelope, rootNote, note)
+      return createOscillatorSourceNode(program, voice.source, envelope, rootNote, note)
   }
 }
 
-function createSampleSourceNode (sample: Sample, envelope: Envelope, rootNote: MidiNote, note: Omit<NoteOptions, 'time'>): SourceNode {
+function createSampleSourceNode (program: Program, sample: Sample, envelope: Envelope, rootNote: MidiNote, note: NoteData): SourceNode {
   const { assetId } = sample
 
   const length = (() => {
@@ -197,19 +197,19 @@ function createSampleSourceNode (sample: Sample, envelope: Envelope, rootNote: M
     return value < 0 ? numeric('s', 0) : !Number.isFinite(value) ? undefined : numeric('s', value)
   })()
 
-  const holdDuration = (() => {
-    if (note.duration == null || length == null) {
-      return note.duration ?? length?.value
+  const gate: Numeric<'s'> | undefined = (() => {
+    if (note.gate == null) {
+      return length
     }
-    return Math.min(note.duration, length.value)
+    const gateSeconds = timeToSeconds(note.gate, program.track.tempo)
+    return length == null ? gateSeconds : numeric('s', Math.min(gateSeconds.value, length.value))
   })()
 
-  const gainCurve = applyEnvelope(envelope, { ...note, duration: holdDuration })
-  const duration = holdDuration != null
-    ? gainCurve.points.at(-1)?.time
-    : undefined
+  const gainCurve = applyEnvelope(envelope, { velocity: note.velocity, gate })
+  const duration = gate != null ? gainCurve.points.at(-1)?.time : undefined
 
-  const playbackRate = Math.pow(2, ((note.pitch ?? rootNote) - rootNote) / 12)
+  const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNote
+  const playbackRate = Math.pow(2, (midiNote - rootNote) / 12)
 
   return {
     id: -1 as NodeId, // TODO: avoid invalid id
@@ -221,15 +221,15 @@ function createSampleSourceNode (sample: Sample, envelope: Envelope, rootNote: M
   }
 }
 
-function createOscillatorSourceNode (oscillator: Oscillator, envelope: Envelope, rootNote: MidiNote, note: Omit<NoteOptions, 'time'>): SourceNode {
+function createOscillatorSourceNode (program: Program, oscillator: Oscillator, envelope: Envelope, rootNote: MidiNote, note: NoteData): SourceNode {
   const { shape } = oscillator
 
-  const gainCurve = applyEnvelope(envelope, note)
-  const duration = note.duration != null
-    ? gainCurve.points.at(-1)?.time
-    : undefined
+  const gate = note.gate != null ? timeToSeconds(note.gate, program.track.tempo) : undefined
+  const gainCurve = applyEnvelope(envelope, { velocity: note.velocity, gate })
+  const duration = note.gate != null ? gainCurve.points.at(-1)?.time : undefined
 
-  const frequency = numeric('hz', getMidiFrequency(note.pitch ?? rootNote))
+  const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNote
+  const frequency = numeric('hz', getMidiFrequency(midiNote))
 
   return {
     id: -1 as NodeId, // TODO: avoid invalid id
@@ -467,8 +467,6 @@ function createRoutings (
 }
 
 function createNoteEvents (track: Track, instruments: ReadonlyMap<InstrumentId, NodeId>, builder: Builder): void {
-  const timePerBeat = beatsToSeconds(numeric('beats', 1), track.tempo).value
-
   let offsetBeats = 0
 
   for (const part of track.parts) {
@@ -478,11 +476,9 @@ function createNoteEvents (track: Track, instruments: ReadonlyMap<InstrumentId, 
         continue
       }
 
-      const events: readonly NoteOptions[] = renderPatternEvents(routing.source.value, part.length).map((event) => ({
-        time: (offsetBeats + event.time.value) * timePerBeat,
-        pitch: event.pitch != null ? convertPitchToMidi(event.pitch) : undefined,
-        velocity: event.velocity.value,
-        duration: event.gate != null ? event.gate.value * timePerBeat : undefined
+      const events = renderPatternEvents(routing.source.value, part.length).map((event) => ({
+        ...event,
+        time: numeric('beats', event.time.value + offsetBeats)
       }))
 
       builder.addNoteEvents(nodeId, events)

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -1,8 +1,8 @@
-import type { AssetId } from '@core'
+import type { AssetId, NoteData } from '@core'
 import type { Numeric } from '@utility'
 import type { TimeVariant } from './automation.js'
 import type { EntityKey } from './entities.js'
-import type { AnyNode, NoteOptions } from './graph.js'
+import type { AnyNode } from './graph.js'
 
 export interface NodeTypeMap {
   // utility
@@ -79,7 +79,7 @@ export interface WaveShaperNode extends AnyNode {
 
 export interface InstrumentNode extends AnyNode {
   readonly type: 'instrument'
-  readonly trigger: (note: Omit<NoteOptions, 'time'>) => readonly SourceNode[]
+  readonly trigger: (note: NoteData) => readonly SourceNode[]
 }
 
 // sources

--- a/packages/audiograph/test/builder.test.ts
+++ b/packages/audiograph/test/builder.test.ts
@@ -1,4 +1,4 @@
-import type { BusId, InstrumentId, MidiNote } from '@core'
+import type { BusId, InstrumentId } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -9,6 +9,8 @@ import type { NodeId } from '../src/graph.js'
 describe('builder.ts', () => {
   const tempo = numeric('bpm', 120)
   const length = numeric('beats', 16)
+  const beats = (value: number) => numeric('beats', value)
+  const scalar = (value: number) => numeric(undefined, value)
 
   it('should maintain tempo and length', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
@@ -107,18 +109,18 @@ describe('builder.ts', () => {
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
     builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: 0.8 },
-      { time: 1, pitch: 61 as MidiNote, velocity: 0.8 },
-      { time: 2, pitch: 62 as MidiNote, velocity: 0.8 }
+      { time: beats(0), pitch: 'C4', velocity: scalar(0.8) },
+      { time: beats(1), pitch: 'C#4', velocity: scalar(0.8) },
+      { time: beats(2), pitch: 'D4', velocity: scalar(0.8) }
     ])
 
     const graph = builder.graph()
 
     assert.strictEqual(graph.noteEvents.size, 1)
     assert.deepStrictEqual(graph.noteEvents.get(node1.id), [
-      { time: 0, pitch: 60, velocity: 0.8 },
-      { time: 1, pitch: 61, velocity: 0.8 },
-      { time: 2, pitch: 62, velocity: 0.8 }
+      { time: beats(0), pitch: 'C4', velocity: scalar(0.8) },
+      { time: beats(1), pitch: 'C#4', velocity: scalar(0.8) },
+      { time: beats(2), pitch: 'D4', velocity: scalar(0.8) }
     ])
   })
 
@@ -127,19 +129,19 @@ describe('builder.ts', () => {
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: -1, pitch: 60 as MidiNote, velocity: 0.8 }
+      { time: beats(-1), pitch: 'C4', velocity: scalar(0.8) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: Infinity, pitch: 60 as MidiNote, velocity: 0.8 }
+      { time: beats(Infinity), pitch: 'C4', velocity: scalar(0.8) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: -Infinity, pitch: 60 as MidiNote, velocity: 0.8 }
+      { time: beats(-Infinity), pitch: 'C4', velocity: scalar(0.8) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: Number.NaN, pitch: 60 as MidiNote, velocity: 0.8 }
+      { time: beats(Number.NaN), pitch: 'C4', velocity: scalar(0.8) }
     ]))
   })
 
@@ -148,15 +150,15 @@ describe('builder.ts', () => {
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: -0.1 }
+      { time: beats(0), pitch: 'C4', velocity: scalar(-0.1) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: 1.1 }
+      { time: beats(0), pitch: 'C4', velocity: scalar(1.1) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: Number.NaN }
+      { time: beats(0), pitch: 'C4', velocity: scalar(Number.NaN) }
     ]))
   })
 
@@ -165,32 +167,32 @@ describe('builder.ts', () => {
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: -1 as MidiNote, velocity: 0.8 }
+      { time: beats(0), pitch: 'H4' as never, velocity: scalar(0.8) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 128 as MidiNote, velocity: 0.8 }
+      { time: beats(0), pitch: 'C#11' as never, velocity: scalar(0.8) }
     ]))
   })
 
-  it('should throw for note events with invalid duration', () => {
+  it('should throw for note events with invalid gate', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: 0.8, duration: -1 }
+      { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(-1) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: 0.8, duration: Infinity }
+      { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(Infinity) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: 0.8, duration: -Infinity }
+      { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(-Infinity) }
     ]))
 
     assert.throws(() => builder.addNoteEvents(node1.id, [
-      { time: 0, pitch: 60 as MidiNote, velocity: 0.8, duration: Number.NaN }
+      { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(Number.NaN) }
     ]))
   })
 

--- a/packages/audiograph/test/envelope.test.ts
+++ b/packages/audiograph/test/envelope.test.ts
@@ -17,7 +17,7 @@ describe('envelope.ts', () => {
   describe('applyEnvelope()', () => {
     it('emits attack and decay without release when hold duration is absent', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 3 }), {
-        velocity: 1
+        velocity: numeric(undefined, 1)
       })
 
       assert.deepStrictEqual(result, {
@@ -32,7 +32,7 @@ describe('envelope.ts', () => {
 
     it('handles zero-length attack by setting the peak immediately before decay', () => {
       const result = applyEnvelope(createEnvelope({ attack: 0, decay: 2, sustain: 0.5, release: 3 }), {
-        velocity: 1
+        velocity: numeric(undefined, 1)
       })
 
       assert.deepStrictEqual(result, {
@@ -46,7 +46,7 @@ describe('envelope.ts', () => {
 
     it('handles zero-length decay by setting the sustain level immediately after attack', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 0, sustain: 0.5, release: 3 }), {
-        velocity: 1
+        velocity: numeric(undefined, 1)
       })
 
       assert.deepStrictEqual(result, {
@@ -61,8 +61,8 @@ describe('envelope.ts', () => {
 
     it('starts release from the current attack level when the note ends during attack', () => {
       const result = applyEnvelope(createEnvelope({ attack: 4, decay: 2, sustain: 0.5, release: 1 }), {
-        velocity: 1,
-        duration: 1
+        velocity: numeric(undefined, 1),
+        gate: numeric('s', 1)
       })
 
       assert.deepStrictEqual(result, {
@@ -77,8 +77,8 @@ describe('envelope.ts', () => {
 
     it('starts release from the current decay level when the note ends during decay', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 1 }), {
-        velocity: 1,
-        duration: 2
+        velocity: numeric(undefined, 1),
+        gate: numeric('s', 2)
       })
 
       assert.deepStrictEqual(result, {
@@ -94,8 +94,8 @@ describe('envelope.ts', () => {
 
     it('starts release from sustain when the note ends after decay', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 4 }), {
-        velocity: 0.8,
-        duration: 5
+        velocity: numeric(undefined, 0.8),
+        gate: numeric('s', 5)
       })
 
       assert.deepStrictEqual(result, {
@@ -112,8 +112,8 @@ describe('envelope.ts', () => {
 
     it('handles zero-length release by setting the value to 0 immediately after hold duration', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: 0.5, release: 0 }), {
-        velocity: 1,
-        duration: 5
+        velocity: numeric(undefined, 1),
+        gate: numeric('s', 5)
       })
 
       assert.deepStrictEqual(result, {

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -1,4 +1,4 @@
-import type { Asset, AssetId, Bus, BusId, Effect, Envelope, Instrument, InstrumentId, InstrumentRouting, MidiNote, MixerRouting, ParameterId, Pitch, Program, Track } from '@core'
+import type { Asset, AssetId, Bus, BusId, Effect, Envelope, Instrument, InstrumentId, InstrumentRouting, MixerRouting, NoteData, ParameterId, Pitch, Program, Track } from '@core'
 import { beatsToSeconds, createSerialPattern } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
@@ -290,9 +290,9 @@ describe('lowering.ts', () => {
 
     const instrumentNode = graph.nodes.get(3 as NodeId) as InstrumentNode
     const voices = instrumentNode.trigger({
-      pitch: 69 as MidiNote,
-      velocity: 1.0,
-      duration: 0.5
+      pitch: 'A4',
+      velocity: numeric(undefined, 1),
+      gate: numeric('beats', 1)
     })
 
     assert.strictEqual(voices.length, 1)
@@ -493,10 +493,10 @@ describe('lowering.ts', () => {
       [
         2 as NodeId,
         [
-          { time: 0, pitch: 60, velocity: 1.0, duration: 0.5 },
-          { time: 0.5, pitch: 64, velocity: 0.75, duration: 0.5 },
-          { time: 2, pitch: 67, velocity: 1.0, duration: 0.5 },
-          { time: 2.5, pitch: 71, velocity: 1.0, duration: 0.5 }
+          { time: numeric('beats', 0), pitch: 'C4', velocity: numeric(undefined, 1), gate: numeric('beats', 1) },
+          { time: numeric('beats', 1), pitch: 'E4', velocity: numeric(undefined, 0.75), gate: numeric('beats', 1) },
+          { time: numeric('beats', 4), pitch: 'G4', velocity: numeric(undefined, 1), gate: numeric('beats', 1) },
+          { time: numeric('beats', 5), pitch: 'B4', velocity: numeric(undefined, 1), gate: numeric('beats', 1) }
         ]
       ]
     ])
@@ -601,9 +601,9 @@ describe('lowering.ts', () => {
 
     const instrumentNode = graph.nodes.get(2 as NodeId) as InstrumentNode
     const voices = instrumentNode.trigger({
-      pitch: 60 as MidiNote,
-      velocity: 1.0,
-      duration: 0.5
+      pitch: 'C4',
+      velocity: numeric(undefined, 1),
+      gate: numeric('beats', 1)
     })
 
     assert.strictEqual(voices.length, 1)
@@ -671,9 +671,9 @@ describe('lowering.ts', () => {
     assert.throws(() => {
       const instrumentNode = graph.nodes.get(2 as NodeId) as InstrumentNode
       instrumentNode.trigger({
-        pitch: 60 as MidiNote,
-        velocity: 1.0,
-        duration: 0.5
+        pitch: 'C4',
+        velocity: numeric(undefined, 1),
+        gate: numeric('beats', 1)
       })
     }, /Invalid length/)
   })
@@ -729,9 +729,10 @@ describe('lowering.ts', () => {
       }
     ]
 
-    const note = {
-      velocity: 1,
-      duration: 10
+    const note: NoteData = {
+      pitch: 'C4',
+      velocity: numeric(undefined, 1),
+      gate: numeric('beats', 16)
     }
 
     for (const { envelope, expected } of testCases) {
@@ -760,7 +761,10 @@ describe('lowering.ts', () => {
       assert.strictEqual(voices.length, 1)
       const [voice] = voices
 
-      assert.deepStrictEqual(voice.gainCurve, applyEnvelope(expected, note), `test case: ${JSON.stringify(envelope)}`)
+      assert.deepStrictEqual(voice.gainCurve, applyEnvelope(expected, {
+        velocity: note.velocity,
+        gate: beatsToSeconds(note.gate ?? numeric('beats', 0), program.track.tempo)
+      }), `test case: ${JSON.stringify(envelope)}`)
     }
   })
 

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -26,24 +26,29 @@ export interface Step {
   readonly velocity?: Numeric<undefined>
 }
 
-export interface NoteEvent {
-  readonly time: Numeric<'beats'>
-
+export interface NoteData {
   /**
-   * The gate (duration) of the note event in beats. If undefined, the note is never released (held indefinitely),
+   * The gate (duration) of the note in beats. If undefined, the note is never released (held indefinitely),
    * and may or may not be cut off by subsequent notes depending on the instrument's behavior.
    */
   readonly gate?: Numeric<'beats'>
 
   /**
-   * The pitch associated with the event. If undefined, indicates that the instrument's default pitch should be used.
+   * The pitch associated with the note. If undefined, indicates that the instrument's default pitch should be used.
    */
   readonly pitch?: Pitch
 
   /**
-   * The velocity of the note event, in the range [0, 1].
+   * The velocity of the note, in the range [0, 1].
    */
   readonly velocity: Numeric<undefined>
+}
+
+export interface NoteEvent extends NoteData {
+  /**
+   * The time at which the note event occurs.
+   */
+  readonly time: Numeric<'beats'>
 }
 
 export interface Pattern {
@@ -105,7 +110,7 @@ export interface Instrument {
   readonly id: InstrumentId
   readonly rootNote?: Pitch
   readonly gain: Parameter<'db'>
-  readonly trigger: () => readonly Voice[]
+  readonly trigger: (note: NoteData) => readonly Voice[]
 }
 
 export interface Voice {

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -93,7 +93,7 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger()
+    const voices = instrument.trigger({ velocity: numeric(undefined, 1) })
     assert.strictEqual(voices.length, 1)
     assert.strictEqual(voices[0].source.type, 'sample')
     assert.strictEqual(voices[0].source.assetId, asset.id)
@@ -112,7 +112,7 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger()
+    const voices = instrument.trigger({ velocity: numeric(undefined, 1) })
     assert.strictEqual(voices.length, 1)
     assert.strictEqual(voices[0].source.type, 'sample')
     assert.strictEqual(voices[0].source.assetId, asset.id)
@@ -731,7 +731,7 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.instruments.size, 1)
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger()
+    const voices = instrument.trigger({ velocity: numeric(undefined, 1) })
     assert.strictEqual(voices.length, 1)
     assert.strictEqual(voices[0].source.type, 'oscillator')
     assert.strictEqual(voices[0].source.shape, 'sine')

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -54,7 +54,7 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       } satisfies Instrument)
 
-      assert.deepStrictEqual(instrument.trigger(), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
@@ -92,7 +92,7 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger(), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
@@ -125,7 +125,7 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger(), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
@@ -157,7 +157,7 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger(), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
@@ -189,7 +189,7 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger(), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
@@ -221,7 +221,7 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger(), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {

--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -104,7 +104,7 @@ function scheduleNoteEvents (graph: AudioGraph<Node>, instances: Map<NodeId, Ins
   for (const [nodeId, options] of graph.noteEvents) {
     const instance = instances.get(nodeId)
     for (const event of options) {
-      instance?.triggerNote?.(event)
+      instance?.triggerNote?.(event, graph.tempo)
     }
   }
 }

--- a/packages/webaudio/src/graph/instance.ts
+++ b/packages/webaudio/src/graph/instance.ts
@@ -1,4 +1,5 @@
-import type { NoteOptions } from '@audiograph'
+import type { NoteEvent } from '@core'
+import type { Numeric } from '@utility'
 
 export interface Instance {
   readonly dispose: () => void
@@ -6,5 +7,5 @@ export interface Instance {
   readonly input?: AudioNode
   readonly output?: AudioNode
 
-  readonly triggerNote?: (options: NoteOptions) => void
+  readonly triggerNote?: (note: NoteEvent, tempo: Numeric<'bpm'>) => void
 }

--- a/packages/webaudio/src/graph/instruments/instrument.ts
+++ b/packages/webaudio/src/graph/instruments/instrument.ts
@@ -1,4 +1,7 @@
-import type { InstrumentNode, NoteOptions, SourceNode } from '@audiograph'
+import type { InstrumentNode, SourceNode } from '@audiograph'
+import type { NoteEvent } from '@core'
+import { timeToSeconds } from '@core'
+import type { Numeric } from '@utility'
 import type { Transport } from '../../transport/transport.js'
 import { applyAutomationPoints } from '../automation.js'
 import type { Assets } from '../factory.js'
@@ -16,14 +19,19 @@ export function createInstrumentInstance (
   const sources = new Set<ActiveSource>()
   const output = ctx.createGain()
 
-  const dispose = () => {
+  const dispose: Instance['dispose'] = () => {
     output.disconnect()
     for (const source of sources) {
       disposeActiveSource(source)
     }
   }
 
-  const triggerNote = (note: NoteOptions) => transport.schedule(note.time, (time) => {
+  const scheduleAtNote = (note: NoteEvent, tempo: Numeric<'bpm'>, callback: (time: number) => void) => {
+    const time = timeToSeconds(note.time, tempo).value
+    transport.schedule(time, callback)
+  }
+
+  const triggerNote: Instance['triggerNote'] = (note, tempo) => scheduleAtNote(note, tempo, (time) => {
     if (time < 0) {
       return
     }


### PR DESCRIPTION
Replaces usages of NoteOptions with NoteEvent. This removes one of the transformation steps, thereby simplifying the overall flow of data, but is also a necessary step for dynamic instrument support, as during interpretation, the plain note data is still needed.