### PR TITLE
fix: Support pitch conversion from `Cb0` to `B#10`

### DIFF
--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -547,7 +547,7 @@ describe('lowering.ts', () => {
   })
 
   it('should throw for invalid instrument root note', () => {
-    for (const rootNote of ['C-1' as Pitch, 'G10' as Pitch]) {
+    for (const rootNote of ['C-1' as Pitch, 'G11' as Pitch]) {
       const program = createProgramWithInstrument({
         id: 100 as InstrumentId,
         rootNote,

--- a/packages/core/src/midi.ts
+++ b/packages/core/src/midi.ts
@@ -1,6 +1,14 @@
 import type { Brand } from '@utility'
 import type { Pitch } from './program.js'
 
+// Note: Actual MIDI supports 0-127 (C-1 through G9), but for syntactical
+// simplicity, we instead support the range resulting from:
+//
+// "any note letter" + "any accidental" + "any octave from 0 to 10".
+//
+// This results in the range Cb0 (=B-1, MIDI 11) through B#10 (=C11, MIDI 144),
+// which has some overlap with MIDI, but is neither a subset nor a superset.
+
 export type MidiNote = Brand<number, 'core.MidiNote'>
 
 const pitchToMidi = new Map<Pitch, MidiNote>()
@@ -32,9 +40,7 @@ for (let octave = 0; octave <= 10; ++octave) {
 
       // Standard MIDI note numbers use C-1 = 0, hence the +1 octave offset.
       const midi = (octave + 1) * 12 + semitoneOffset + accidentalOffset
-      if (midi >= 0 && midi <= 127) {
-        pitchToMidi.set(pitch, midi as MidiNote)
-      }
+      pitchToMidi.set(pitch, midi as MidiNote)
     }
   }
 }

--- a/packages/core/test/midi.test.ts
+++ b/packages/core/test/midi.test.ts
@@ -13,6 +13,18 @@ describe('midi.ts', () => {
       assert.strictEqual(convertPitchToMidi('A4'), 69)
       assert.strictEqual(convertPitchToMidi('C5'), 72)
     })
+
+    it('supports octaves from 0 to 10', () => {
+      assert.strictEqual(convertPitchToMidi('Cb0'), 11)
+      assert.strictEqual(convertPitchToMidi('C0'), 12)
+
+      assert.strictEqual(convertPitchToMidi('G9'), 127)
+      assert.strictEqual(convertPitchToMidi('G#9'), 128)
+      assert.strictEqual(convertPitchToMidi('Ab9'), 128)
+
+      assert.strictEqual(convertPitchToMidi('B10'), 143)
+      assert.strictEqual(convertPitchToMidi('B#10'), 144)
+    })
   })
 
   describe('getMidiFrequency()', () => {


### PR DESCRIPTION
This patch expands the supported range for converting note names to MIDI-like pitch numbers such that it covers a wider range, including the range currently allowed by the language syntax. This avoids runtime conversion errors.