### PR TITLE
refactor: Move pitch calculation into language

### DIFF
--- a/packages/audiograph/src/constants.ts
+++ b/packages/audiograph/src/constants.ts
@@ -1,7 +1,3 @@
-import { convertPitchToMidi } from '@core'
-
-export const DEFAULT_ROOT_NOTE = convertPitchToMidi('C5')
-
 export function dbToGain (db: number): number {
   if (Number.isNaN(db) || (db > 0 && !Number.isFinite(db))) {
     throw new Error(`Invalid gain: ${db}`)

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,11 +1,11 @@
-import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MidiNote, MixerRouting, NoteData, Oscillator, Program, Sample, Track, Voice } from '@core'
-import { calculateTotalLength, convertPitchToMidi, getMidiFrequency, renderPatternEvents, timeToSeconds } from '@core'
+import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MixerRouting, NoteData, Oscillator, Program, Sample, Track, Voice } from '@core'
+import { calculateTotalLength, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
 import { feedbackTransform, frequencyTransform, gainTransform, panTransform, timeVariant, toTimeVariant } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
-import { dbToGain, DEFAULT_ROOT_NOTE } from './constants.js'
+import { dbToGain } from './constants.js'
 import type { EntityKey } from './entities.js'
 import { createEntityKey } from './entities.js'
 import { applyEnvelope } from './envelope.js'
@@ -122,13 +122,9 @@ function createBus (program: Program, bus: Bus, builder: Builder): SubGraph {
 }
 
 function createInstrument (program: Program, instrument: Instrument, builder: Builder): SubGraph {
-  const rootNote = instrument.rootNote != null
-    ? convertPitchToMidi(instrument.rootNote)
-    : DEFAULT_ROOT_NOTE
-
   const instrumentNode = builder.addNode<InstrumentNode>('instrument', {
     trigger: (note) => {
-      return instrument.trigger(note).map((voice) => createSourceNode(program, voice, rootNote, note))
+      return instrument.trigger(note).map((voice) => createSourceNode(program, voice, note))
     }
   })
 
@@ -145,7 +141,7 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
   }
 }
 
-function createSourceNode (program: Program, voice: Voice, rootNote: MidiNote, note: NoteData): SourceNode {
+function createSourceNode (program: Program, voice: Voice, note: NoteData): SourceNode {
   const envelope = (() => {
     const a = voice.envelope.attack.value
     const d = voice.envelope.decay.value
@@ -174,15 +170,15 @@ function createSourceNode (program: Program, voice: Voice, rootNote: MidiNote, n
 
   switch (voice.source.type) {
     case 'sample':
-      return createSampleSourceNode(program, voice.source, envelope, rootNote, note)
+      return createSampleSourceNode(program, voice.source, envelope, note)
 
     case 'oscillator':
-      return createOscillatorSourceNode(program, voice.source, envelope, rootNote, note)
+      return createOscillatorSourceNode(program, voice.source, envelope, note)
   }
 }
 
-function createSampleSourceNode (program: Program, sample: Sample, envelope: Envelope, rootNote: MidiNote, note: NoteData): SourceNode {
-  const { assetId } = sample
+function createSampleSourceNode (program: Program, sample: Sample, envelope: Envelope, note: NoteData): SourceNode {
+  const { assetId, playbackRate } = sample
 
   const length = (() => {
     if (sample.length == null) {
@@ -208,8 +204,9 @@ function createSampleSourceNode (program: Program, sample: Sample, envelope: Env
   const gainCurve = applyEnvelope(envelope, { velocity: note.velocity, gate })
   const duration = gate != null ? gainCurve.points.at(-1)?.time : undefined
 
-  const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNote
-  const playbackRate = Math.pow(2, (midiNote - rootNote) / 12)
+  if (playbackRate.value <= 0 || !Number.isFinite(playbackRate.value)) {
+    throw new Error(`Invalid playback rate`)
+  }
 
   return {
     id: -1 as NodeId, // TODO: avoid invalid id
@@ -221,15 +218,16 @@ function createSampleSourceNode (program: Program, sample: Sample, envelope: Env
   }
 }
 
-function createOscillatorSourceNode (program: Program, oscillator: Oscillator, envelope: Envelope, rootNote: MidiNote, note: NoteData): SourceNode {
-  const { shape } = oscillator
+function createOscillatorSourceNode (program: Program, oscillator: Oscillator, envelope: Envelope, note: NoteData): SourceNode {
+  const { shape, frequency } = oscillator
 
   const gate = note.gate != null ? timeToSeconds(note.gate, program.track.tempo) : undefined
   const gainCurve = applyEnvelope(envelope, { velocity: note.velocity, gate })
   const duration = note.gate != null ? gainCurve.points.at(-1)?.time : undefined
 
-  const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNote
-  const frequency = numeric('hz', getMidiFrequency(midiNote))
+  if (frequency.value <= 0 || !Number.isFinite(frequency.value)) {
+    throw new Error(`Invalid frequency: ${frequency.value}`)
+  }
 
   return {
     id: -1 as NodeId, // TODO: avoid invalid id

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -91,7 +91,7 @@ export interface SampleNode extends AnyNode {
   readonly gainCurve: TimeVariant<undefined>
   readonly duration?: Numeric<'s'>
   readonly assetId: AssetId
-  readonly playbackRate: number
+  readonly playbackRate: Numeric<undefined>
 }
 
 export interface OscillatorNode extends AnyNode {

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -1,4 +1,4 @@
-import type { Asset, AssetId, Bus, BusId, Effect, Envelope, Instrument, InstrumentId, InstrumentRouting, MixerRouting, NoteData, ParameterId, Pitch, Program, Track } from '@core'
+import type { Asset, AssetId, Bus, BusId, Effect, Envelope, Instrument, InstrumentId, InstrumentRouting, MixerRouting, NoteData, ParameterId, Program, Track } from '@core'
 import { beatsToSeconds, createSerialPattern } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
@@ -189,7 +189,8 @@ describe('lowering.ts', () => {
                 envelope: defaultEnvelope,
                 source: {
                   type: 'oscillator',
-                  shape: 'sine'
+                  shape: 'sine',
+                  frequency: numeric('hz', 440)
                 }
               }
             ]
@@ -324,15 +325,7 @@ describe('lowering.ts', () => {
               id: instrumentGainId,
               initial: numeric('db', -6)
             },
-            trigger: () => [
-              {
-                envelope: defaultEnvelope,
-                source: {
-                  type: 'oscillator',
-                  shape: 'sine'
-                }
-              }
-            ]
+            trigger: () => []
           } satisfies Instrument
         ]
       ]),
@@ -421,15 +414,7 @@ describe('lowering.ts', () => {
               id: 200 as ParameterId,
               initial: numeric('db', -6)
             },
-            trigger: () => [
-              {
-                envelope: defaultEnvelope,
-                source: {
-                  type: 'oscillator',
-                  shape: 'sine'
-                }
-              }
-            ]
+            trigger: () => []
           } satisfies Instrument
         ]
       ]),
@@ -509,15 +494,7 @@ describe('lowering.ts', () => {
         id: 200 as ParameterId,
         initial: numeric('db', -Infinity)
       },
-      trigger: () => [
-        {
-          envelope: defaultEnvelope,
-          source: {
-            type: 'oscillator',
-            shape: 'sine'
-          }
-        }
-      ]
+      trigger: () => []
     })
 
     assert.doesNotThrow(() => createAudioGraph(program))
@@ -531,42 +508,10 @@ describe('lowering.ts', () => {
           id: 200 as ParameterId,
           initial: numeric('db', gain)
         },
-        trigger: () => [
-          {
-            envelope: defaultEnvelope,
-            source: {
-              type: 'oscillator',
-              shape: 'sine'
-            }
-          }
-        ]
+        trigger: () => []
       })
 
       assert.throws(() => createAudioGraph(program), /Invalid gain/, `should throw for gain: ${gain}`)
-    }
-  })
-
-  it('should throw for invalid instrument root note', () => {
-    for (const rootNote of ['C-1' as Pitch, 'G11' as Pitch]) {
-      const program = createProgramWithInstrument({
-        id: 100 as InstrumentId,
-        rootNote,
-        gain: {
-          id: 200 as ParameterId,
-          initial: numeric('db', -6)
-        },
-        trigger: () => [
-          {
-            envelope: defaultEnvelope,
-            source: {
-              type: 'oscillator',
-              shape: 'sine'
-            }
-          }
-        ]
-      })
-
-      assert.throws(() => createAudioGraph(program), /Invalid pitch/, `should throw for root note: ${rootNote}`)
     }
   })
 
@@ -583,7 +528,8 @@ describe('lowering.ts', () => {
           source: {
             type: 'sample',
             assetId: 300 as AssetId,
-            length: numeric('s', -1)
+            length: numeric('s', -1),
+            playbackRate: numeric(undefined, 1)
           }
         }
       ]
@@ -614,6 +560,76 @@ describe('lowering.ts', () => {
     ]))
   })
 
+  it('should throw for invalid sample playback rate', () => {
+    for (const playbackRate of [0, -1, Infinity, -Infinity, Number.NaN]) {
+      const program = createProgramWithInstrument({
+        id: 100 as InstrumentId,
+        gain: {
+          id: 200 as ParameterId,
+          initial: numeric('db', -6)
+        },
+        trigger: () => [
+          {
+            envelope: defaultEnvelope,
+            source: {
+              type: 'sample',
+              assetId: 300 as AssetId,
+              length: numeric('s', -1),
+              playbackRate: numeric(undefined, playbackRate)
+            }
+          }
+        ]
+      }, {
+        id: 300 as AssetId,
+        url: 'foo.wav'
+      })
+
+      const graph = createAudioGraph(program)
+      const instrumentNode = graph.nodes.get(2 as NodeId) as InstrumentNode
+
+      assert.throws(() => {
+        instrumentNode.trigger({
+          pitch: 'C4',
+          velocity: numeric(undefined, 1),
+          gate: numeric('beats', 1)
+        })
+      }, /Invalid playback rate/, `should throw for playback rate: ${playbackRate}`)
+    }
+  })
+
+  it('should throw for invalid oscillator frequency', () => {
+    for (const frequency of [0, -1, Infinity, -Infinity, Number.NaN]) {
+      const program = createProgramWithInstrument({
+        id: 100 as InstrumentId,
+        gain: {
+          id: 200 as ParameterId,
+          initial: numeric('db', -6)
+        },
+        trigger: () => [
+          {
+            envelope: defaultEnvelope,
+            source: {
+              type: 'oscillator',
+              shape: 'sine',
+              frequency: numeric('hz', frequency)
+            }
+          }
+        ]
+      })
+
+      const graph = createAudioGraph(program)
+      const instrumentNode = graph.nodes.get(2 as NodeId) as InstrumentNode
+
+      assert.throws(() => {
+        instrumentNode.trigger({
+          pitch: 'C4',
+          velocity: numeric(undefined, 1),
+          gate: numeric('beats', 1)
+        })
+      }, /Invalid frequency/, `should throw for frequency: ${frequency}`)
+    }
+  })
+
   it('should treat infinite sample length as valid', () => {
     const program = createProgramWithInstrument({
       id: 100 as InstrumentId,
@@ -627,7 +643,8 @@ describe('lowering.ts', () => {
           source: {
             type: 'sample',
             assetId: 300 as AssetId,
-            length: numeric('s', Infinity)
+            length: numeric('s', Infinity),
+            playbackRate: numeric(undefined, 1)
           }
         }
       ]
@@ -642,6 +659,21 @@ describe('lowering.ts', () => {
       type: 'instrument',
       trigger: (graph.nodes.get(2 as NodeId) as InstrumentNode).trigger
     } satisfies InstrumentNode)
+
+    const instrumentNode = graph.nodes.get(2 as NodeId) as InstrumentNode
+    const voices = instrumentNode.trigger({
+      pitch: 'C4',
+      velocity: numeric(undefined, 1),
+      gate: numeric('beats', 1)
+    })
+
+    assert.strictEqual(voices.length, 1)
+    const [voice] = voices
+
+    assert.deepStrictEqual(voice.gainCurve, applyEnvelope(defaultEnvelope, {
+      velocity: numeric(undefined, 1),
+      gate: beatsToSeconds(numeric('beats', 1), program.track.tempo)
+    }))
   })
 
   it('should throw for NaN sample length', () => {
@@ -657,7 +689,8 @@ describe('lowering.ts', () => {
           source: {
             type: 'sample',
             assetId: 300 as AssetId,
-            length: numeric('s', Number.NaN)
+            length: numeric('s', Number.NaN),
+            playbackRate: numeric(undefined, 1)
           }
         }
       ]
@@ -747,7 +780,8 @@ describe('lowering.ts', () => {
             envelope,
             source: {
               type: 'oscillator',
-              shape: 'sine'
+              shape: 'sine',
+              frequency: numeric('hz', 440)
             }
           }
         ]
@@ -1574,15 +1608,7 @@ describe('lowering.ts', () => {
           id: 200 as ParameterId,
           initial: numeric('db', -6)
         },
-        trigger: () => [
-          {
-            envelope: defaultEnvelope,
-            source: {
-              type: 'oscillator',
-              shape: 'sine'
-            }
-          }
-        ]
+        trigger: () => []
       }))
 
       assert.strictEqual(graph.meters.size, 0)
@@ -1603,15 +1629,7 @@ describe('lowering.ts', () => {
                 id: 200 as ParameterId,
                 initial: numeric('db', -6)
               },
-              trigger: () => [
-                {
-                  envelope: defaultEnvelope,
-                  source: {
-                    type: 'oscillator',
-                    shape: 'sine'
-                  }
-                }
-              ]
+              trigger: () => []
             } satisfies Instrument
           ]
         ]),
@@ -1705,15 +1723,7 @@ describe('lowering.ts', () => {
         id: 200 as ParameterId,
         initial: numeric('db', -6)
       },
-      trigger: () => [
-        {
-          envelope: defaultEnvelope,
-          source: {
-            type: 'oscillator',
-            shape: 'sine'
-          }
-        }
-      ]
+      trigger: () => []
     })
 
     for (const interval of [Infinity, -Infinity, Number.NaN, 0, -1]) {

--- a/packages/core/src/program.ts
+++ b/packages/core/src/program.ts
@@ -108,7 +108,6 @@ export type InstrumentId = Brand<number, 'core.InstrumentId'>
 
 export interface Instrument {
   readonly id: InstrumentId
-  readonly rootNote?: Pitch
   readonly gain: Parameter<'db'>
   readonly trigger: (note: NoteData) => readonly Voice[]
 }
@@ -124,11 +123,13 @@ export interface Sample {
   readonly type: 'sample'
   readonly assetId: AssetId
   readonly length?: Numeric<'s'>
+  readonly playbackRate: Numeric<undefined>
 }
 
 export interface Oscillator {
   readonly type: 'oscillator'
   readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
+  readonly frequency: Numeric<'hz'>
 }
 
 export interface Envelope {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -562,7 +562,8 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
         },
         source: {
           type: 'oscillator',
-          shape: 'sine'
+          shape: 'sine',
+          frequency: numeric('hz', 440)
         }
       }
     ]

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -1,5 +1,5 @@
 import type { Envelope, Oscillator } from '@core'
-import { isPitch } from '@core'
+import { convertPitchToMidi, getMidiFrequency, isPitch } from '@core'
 import { numeric } from '@utility'
 import type { AssetContext, InstrumentContext, ParameterContext } from '../../compiler/generator/scopes.js'
 import { NumberFacet } from '../../type-system/base/number.js'
@@ -11,6 +11,8 @@ import { makeType } from '../../type-system/factory.js'
 import { Functions, Modules, Parameters } from '../../type-system/helpers.js'
 import { makeSchema } from '../../type-system/schema.js'
 import type { Value } from '../../type-system/types.js'
+
+const DEFAULT_ROOT_NOTE = convertPitchToMidi('C5')
 
 const UNITY_GAIN = numeric('db', 0)
 
@@ -45,8 +47,11 @@ const sample = Functions.of({
   invoke: (context: ParameterContext & InstrumentContext & AssetContext, { url, gain, root_note, length }) => {
     const urlValue = StringFacet.get(url)
     const gainValue = gain != null ? NumberFacet.get(gain) : UNITY_GAIN
+    const rootNote = (() => {
     // eslint-disable-next-line camelcase
-    const rootNoteValue = root_note != null ? StringFacet.get(root_note) : undefined
+      const string = root_note != null ? StringFacet.get(root_note) : undefined
+      return string != null && isPitch(string) ? string : undefined
+    })()
     const lengthValue = length != null ? NumberFacet.get(length) : undefined
 
     const gainParameter = context.allocateParameter(gainValue)
@@ -55,19 +60,26 @@ const sample = Functions.of({
       url: urlValue
     })
 
+    const rootNoteMidi = rootNote != null ? convertPitchToMidi(rootNote) : DEFAULT_ROOT_NOTE
+
     const instrument = context.allocateInstrument({
       gain: gainParameter,
-      rootNote: rootNoteValue != null && isPitch(rootNoteValue) ? rootNoteValue : undefined,
-      trigger: () => [
-        {
-          envelope: ENVELOPE_DECLICK,
-          source: {
-            type: 'sample',
-            assetId: asset.id,
-            length: lengthValue
+      trigger: (note) => {
+        const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNoteMidi
+        const playbackRate = Math.pow(2, (midiNote - rootNoteMidi) / 12)
+
+        return [
+          {
+            envelope: ENVELOPE_DECLICK,
+            source: {
+              type: 'sample',
+              assetId: asset.id,
+              length: lengthValue,
+              playbackRate: numeric(undefined, playbackRate)
+            }
           }
-        }
-      ]
+        ]
+      }
     })
 
     return SampleInstrumentType.of(instrument, {
@@ -92,15 +104,21 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
 
       const instrument = context.allocateInstrument({
         gain: gainParameter,
-        trigger: () => [
-          {
-            envelope: ENVELOPE_DECLICK,
-            source: {
-              type: 'oscillator',
-              shape
+        trigger: (note) => {
+          const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE
+          const frequency = numeric('hz', getMidiFrequency(midiNote))
+
+          return [
+            {
+              envelope: ENVELOPE_DECLICK,
+              source: {
+                type: 'oscillator',
+                shape,
+                frequency
+              }
             }
-          }
-        ]
+          ]
+        }
       })
 
       return OscillatorInstrumentType.of(instrument, {

--- a/packages/language/src/library/modules/sources.ts
+++ b/packages/language/src/library/modules/sources.ts
@@ -16,13 +16,10 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
     effects: { blocking: false },
 
     invoke: (context, { frequency }) => {
-      const frequencyValue = NumberFacet.get(frequency)
-
-      void frequencyValue // TODO: Use frequency value to create an oscillator source
-
       return SourceFacet.type().of({
         type: 'oscillator',
-        shape
+        shape,
+        frequency: NumberFacet.get(frequency)
       })
     }
   })

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -83,38 +83,12 @@ describe('compiler/generator/scopes.ts', () => {
 
       const instrument0 = {
         gain: scope.allocateParameter(numeric('db', -6)),
-        trigger: () => [
-          {
-            source: {
-              type: 'oscillator',
-              shape: 'sine'
-            },
-            envelope: {
-              attack: numeric('s', 0.1),
-              decay: numeric('s', 0.2),
-              sustain: numeric(undefined, 0.5),
-              release: numeric('s', 0.5)
-            }
-          }
-        ]
+        trigger: () => []
       } satisfies Omit<Instrument, 'id'>
 
       const instrument1 = {
         gain: scope.allocateParameter(numeric('db', -3)),
-        trigger: () => [
-          {
-            source: {
-              type: 'oscillator',
-              shape: 'square'
-            },
-            envelope: {
-              attack: numeric('s', 0.01),
-              decay: numeric('s', 0.1),
-              sustain: numeric(undefined, 0.8),
-              release: numeric('s', 0.3)
-            }
-          }
-        ]
+        trigger: () => []
       } satisfies Omit<Instrument, 'id'>
 
       const allocated0 = scope.allocateInstrument(instrument0)

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -49,7 +49,6 @@ describe('library/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(instrument, {
         id: instrument.id,
-        rootNote: 'C4',
         gain: { id: instrument.gain.id, initial: numeric('db', -3) },
         trigger: instrument.trigger
       } satisfies Instrument)
@@ -60,7 +59,8 @@ describe('library/modules/instruments.ts', () => {
           source: {
             type: 'sample',
             assetId: asset.id,
-            length: numeric('s', 1.5)
+            length: numeric('s', 1.5),
+            playbackRate: numeric(undefined, 1)
           }
         }
       ])
@@ -87,7 +87,6 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
-        rootNote: undefined,
         gain: { id: instrument.gain.id, initial: numeric('db', 0) },
         trigger: instrument.trigger
       })
@@ -98,7 +97,8 @@ describe('library/modules/instruments.ts', () => {
           source: {
             type: 'sample',
             assetId: asset.id,
-            length: undefined
+            length: undefined,
+            playbackRate: numeric(undefined, 1)
           }
         }
       ])
@@ -125,12 +125,13 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
             type: 'oscillator',
-            shape: 'sine'
+            shape: 'sine',
+            frequency: numeric('hz', 440)
           }
         }
       ])
@@ -157,12 +158,13 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
             type: 'oscillator',
-            shape: 'square'
+            shape: 'square',
+            frequency: numeric('hz', 440)
           }
         }
       ])
@@ -189,12 +191,13 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
             type: 'oscillator',
-            shape: 'saw'
+            shape: 'saw',
+            frequency: numeric('hz', 440)
           }
         }
       ])
@@ -221,12 +224,13 @@ describe('library/modules/instruments.ts', () => {
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }), [
         {
           envelope: declickEnvelope,
           source: {
             type: 'oscillator',
-            shape: 'triangle'
+            shape: 'triangle',
+            frequency: numeric('hz', 440)
           }
         }
       ])

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -36,22 +36,8 @@ const effect: Effect = {
 
 const instrument: Instrument = {
   id: 1 as InstrumentId,
-  rootNote: 'C4',
   gain: gainParameter,
-  trigger: () => [
-    {
-      envelope: {
-        attack: numeric('s', 0.01),
-        decay: numeric('s', 0.2),
-        sustain: numeric(undefined, 0.8),
-        release: numeric('s', 0.3)
-      },
-      source: {
-        type: 'oscillator',
-        shape: 'triangle'
-      }
-    }
-  ]
+  trigger: () => []
 }
 
 const part: Part = {

--- a/packages/webaudio/src/graph/instruments/sample.ts
+++ b/packages/webaudio/src/graph/instruments/sample.ts
@@ -27,7 +27,7 @@ export function createSampleSource (
 
   const sourceNode = transport.ctx.createBufferSource()
   sourceNode.buffer = sampleBuffer
-  sourceNode.playbackRate.value = node.playbackRate
+  sourceNode.playbackRate.value = node.playbackRate.value
 
   return sourceNode
 }


### PR DESCRIPTION
We no longer compute an oscillator's frequency, or a sample's playback rate, in the audiograph package. Instead, this information is now provided by the instrument's trigger function, such that the language package can compute it dynamically in the future.