### PR TITLE
refactor: Introduce core curve types

### DIFF
--- a/packages/audiograph/src/automation.ts
+++ b/packages/audiograph/src/automation.ts
@@ -1,48 +1,27 @@
-import type { AutomationPoint, Parameter, Program } from '@core'
+import type { Curve, CurvePoint, CurveShape, Parameter, Program } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
 import { dbToGain } from './constants.js'
 
-export type Curve = 'step' | 'linear' | 'exponential'
-
-export interface TimeVariant<U extends Unit> {
-  readonly initial: Numeric<U>
-  readonly points: ReadonlyArray<TimeVariantPoint<U>>
-}
-
-export interface TimeVariantPoint<U extends Unit> {
-  readonly time: Numeric<'s'>
-  readonly value: Numeric<U>
-
-  /**
-   * The curve from the previous point, or from the initial value, to this point.
-   */
-  readonly curve: Curve
-}
-
-export function timeVariant<const U extends Unit> (initial: Numeric<U>, points: ReadonlyArray<TimeVariantPoint<U>>): TimeVariant<U> {
-  return { initial, points }
-}
-
 export interface Transform<FromUnit extends Unit, ToUnit extends Unit> {
   readonly transformValue: (value: Numeric<FromUnit>) => Numeric<ToUnit>
-  readonly transformCurve: (curve: Curve) => Curve
+  readonly transformCurveShape: (curve: CurveShape) => CurveShape
 }
 
-export function toTimeVariant<FromUnit extends Unit, ToUnit extends Unit = FromUnit> (
+export function computeParameterCurve<FromUnit extends Unit, ToUnit extends Unit = FromUnit> (
   parameter: Parameter<FromUnit>,
   program: Program,
   transform: Transform<FromUnit, ToUnit>
-): TimeVariant<ToUnit> {
+): Curve<'s', ToUnit> {
   const initial = parameter.initial
-  const points = (program.automations.get(parameter.id)?.points ?? []) as ReadonlyArray<AutomationPoint<FromUnit>>
+  const points = (program.automations.get(parameter.id)?.points ?? []) as ReadonlyArray<CurvePoint<'s', FromUnit>>
 
   return {
     initial: transform.transformValue(initial),
     points: points.map((point) => ({
       time: point.time,
       value: transform.transformValue(point.value),
-      curve: transform.transformCurve(point.curve)
+      shape: transform.transformCurveShape(point.shape)
     }))
   }
 }
@@ -50,7 +29,7 @@ export function toTimeVariant<FromUnit extends Unit, ToUnit extends Unit = FromU
 export function identityTransform<U extends Unit> (): Transform<U, U> {
   return {
     transformValue: (value) => value,
-    transformCurve: (curve) => curve
+    transformCurveShape: (curve) => curve
   }
 }
 
@@ -59,7 +38,7 @@ export const gainTransform: Transform<'db', undefined> = {
     return numeric(undefined, dbToGain(value.value))
   },
 
-  transformCurve: (curve) => {
+  transformCurveShape: (curve) => {
     switch (curve) {
       case 'step':
         return 'step'
@@ -80,7 +59,7 @@ export const panTransform: Transform<undefined, undefined> = {
     return numeric(undefined, Math.max(-1, Math.min(1, value.value)))
   },
 
-  transformCurve: (curve) => curve
+  transformCurveShape: (curve) => curve
 }
 
 export const feedbackTransform: Transform<undefined, undefined> = {
@@ -92,7 +71,7 @@ export const feedbackTransform: Transform<undefined, undefined> = {
     return numeric(undefined, Math.max(0, Math.min(1, value.value)))
   },
 
-  transformCurve: (curve) => curve
+  transformCurveShape: (curve) => curve
 }
 
 export const frequencyTransform: Transform<'hz', 'hz'> = {
@@ -108,5 +87,5 @@ export const frequencyTransform: Transform<'hz', 'hz'> = {
     return value
   },
 
-  transformCurve: (curve) => curve
+  transformCurveShape: (curve) => curve
 }

--- a/packages/audiograph/src/envelope.ts
+++ b/packages/audiograph/src/envelope.ts
@@ -1,6 +1,4 @@
-import type { TimeVariant, TimeVariantPoint } from './automation.js'
-import { timeVariant } from './automation.js'
-import type { Envelope } from '@core'
+import type { Curve, CurvePoint, Envelope } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
 
@@ -11,8 +9,8 @@ export interface EnvelopeOptions {
 
 const ZERO_GAIN = numeric(undefined, 0)
 
-export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): TimeVariant<undefined> {
-  const points: Array<TimeVariantPoint<undefined>> = []
+export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): Curve<'s', undefined> {
+  const points: Array<CurvePoint<'s', undefined>> = []
 
   // attack (silence -> peak)
   applySegment(points, options, {
@@ -33,10 +31,10 @@ export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): Ti
   // hold and release (sustain -> silence)
   applyRelease(points, envelope, options)
 
-  return timeVariant(ZERO_GAIN, points)
+  return { initial: ZERO_GAIN, points }
 }
 
-function applySegment (points: Array<TimeVariantPoint<undefined>>, options: EnvelopeOptions, segment: {
+function applySegment (points: Array<CurvePoint<'s', undefined>>, options: EnvelopeOptions, segment: {
   readonly startTime: number
   readonly startValue: number
   readonly endTime: number
@@ -52,25 +50,25 @@ function applySegment (points: Array<TimeVariantPoint<undefined>>, options: Enve
   const lastPoint = points.at(-1)
 
   if (endTime <= startTime) {
-    points.push({ time: numeric('s', startTime), value: numeric(undefined, endValue), curve: 'step' })
+    points.push({ time: numeric('s', startTime), value: numeric(undefined, endValue), shape: 'step' })
     return
   }
 
   if (lastPoint == null || lastPoint.time.value < startTime) {
-    points.push({ time: numeric('s', startTime), value: numeric(undefined, startValue), curve: 'step' })
+    points.push({ time: numeric('s', startTime), value: numeric(undefined, startValue), shape: 'step' })
   }
 
   if (gate != null && gate.value < endTime) {
     const t = (gate.value - startTime) / (endTime - startTime)
     const holdValue = startValue + t * (endValue - startValue)
-    points.push({ time: gate, value: numeric(undefined, holdValue), curve: 'linear' })
+    points.push({ time: gate, value: numeric(undefined, holdValue), shape: 'linear' })
     return
   }
 
-  points.push({ time: numeric('s', endTime), value: numeric(undefined, endValue), curve: 'linear' })
+  points.push({ time: numeric('s', endTime), value: numeric(undefined, endValue), shape: 'linear' })
 }
 
-function applyRelease (points: Array<TimeVariantPoint<undefined>>, envelope: Envelope, options: EnvelopeOptions): void {
+function applyRelease (points: Array<CurvePoint<'s', undefined>>, envelope: Envelope, options: EnvelopeOptions): void {
   const { gate } = options
   if (gate == null) {
     return
@@ -80,7 +78,7 @@ function applyRelease (points: Array<TimeVariantPoint<undefined>>, envelope: Env
   const release = envelope.release.value
 
   if (lastPoint == null || release <= 0) {
-    points.push({ time: gate, value: ZERO_GAIN, curve: 'step' })
+    points.push({ time: gate, value: ZERO_GAIN, shape: 'step' })
     return
   }
 
@@ -88,8 +86,8 @@ function applyRelease (points: Array<TimeVariantPoint<undefined>>, envelope: Env
   const releaseStartValue = lastPoint.value.value
 
   if (releaseStartTime.value > lastPoint.time.value) {
-    points.push({ time: releaseStartTime, value: numeric(undefined, releaseStartValue), curve: 'step' })
+    points.push({ time: releaseStartTime, value: numeric(undefined, releaseStartValue), shape: 'step' })
   }
 
-  points.push({ time: numeric('s', releaseStartTime.value + release), value: ZERO_GAIN, curve: 'linear' })
+  points.push({ time: numeric('s', releaseStartTime.value + release), value: ZERO_GAIN, shape: 'linear' })
 }

--- a/packages/audiograph/src/index.ts
+++ b/packages/audiograph/src/index.ts
@@ -1,6 +1,3 @@
-export type { Curve, TimeVariant, TimeVariantPoint } from './automation.js'
-export { timeVariant, toTimeVariant } from './automation.js'
-
 export { dbToGain } from './constants.js'
 
 export type * from './graph.js'

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -2,7 +2,7 @@ import type { Bus, BusId, Effect, Envelope, Instrument, InstrumentId, MixerRouti
 import { calculateTotalLength, renderPatternEvents, timeToSeconds } from '@core'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
-import { feedbackTransform, frequencyTransform, gainTransform, panTransform, timeVariant, toTimeVariant } from './automation.js'
+import { feedbackTransform, frequencyTransform, gainTransform, panTransform, computeParameterCurve } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
 import { dbToGain } from './constants.js'
@@ -129,7 +129,7 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
   })
 
   const gain = builder.addNode<GainNode>('gain', {
-    gain: toTimeVariant(instrument.gain, program, gainTransform)
+    gain: computeParameterCurve(instrument.gain, program, gainTransform)
   })
 
   builder.addEdge(instrumentNode.id, gain.id)
@@ -243,20 +243,20 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
   switch (effect.type) {
     case 'gain': {
       return toSubGraph(builder.addNode<GainNode>('gain', {
-        gain: toTimeVariant(effect.gain, program, gainTransform)
+        gain: computeParameterCurve(effect.gain, program, gainTransform)
       }))
     }
 
     case 'pan': {
       return toSubGraph(builder.addNode<PanNode>('pan', {
-        pan: toTimeVariant(effect.pan, program, panTransform)
+        pan: computeParameterCurve(effect.pan, program, panTransform)
       }))
     }
 
     case 'lowpass': {
       return toSubGraph(builder.addNode<BiquadNode>('biquad', {
         filterType: 'lowpass',
-        frequency: toTimeVariant(effect.frequency, program, frequencyTransform),
+        frequency: computeParameterCurve(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
         rolloffPerOctave: numeric('db', 12)
       }))
@@ -265,7 +265,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
     case 'highpass': {
       return toSubGraph(builder.addNode<BiquadNode>('biquad', {
         filterType: 'highpass',
-        frequency: toTimeVariant(effect.frequency, program, frequencyTransform),
+        frequency: computeParameterCurve(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
         rolloffPerOctave: numeric('db', 12)
       }))
@@ -298,7 +298,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       if (effect.feedback.initial.value > 0 || program.automations.has(effect.feedback.id)) {
         const feedbackGain = builder.addNode<GainNode>('gain', {
-          gain: toTimeVariant(effect.feedback, program, feedbackTransform)
+          gain: computeParameterCurve(effect.feedback, program, feedbackTransform)
         })
 
         builder.addEdge(delayNode.id, feedbackGain.id)
@@ -339,12 +339,12 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         return numeric(undefined, 1 / value.value)
       }
 
-      const thresholdGain = toTimeVariant(effect.threshold, program, gainTransform)
+      const thresholdGain = computeParameterCurve(effect.threshold, program, gainTransform)
 
       const input = builder.addNode<GainNode>('gain', {
         gain: {
           initial: invert(thresholdGain.initial),
-          points: thresholdGain.points.map(({ time, value, curve }) => ({ time, value: invert(value), curve }))
+          points: thresholdGain.points.map(({ time, value, shape }) => ({ time, value: invert(value), shape }))
         }
       })
 
@@ -396,12 +396,12 @@ function createDryWetMix (effect: Node, mix: number, wetGain: Numeric<'db'>, bui
 
   const dry = Math.max(0, Math.min(1, (1 - mix) * 2))
   const dryNode = builder.addNode<GainNode>('gain', {
-    gain: timeVariant(numeric(undefined, dry), [])
+    gain: { initial: numeric(undefined, dry), points: [] }
   })
 
   const wet = Math.max(0, Math.min(1, mix * 2))
   const wetNode = builder.addNode<GainNode>('gain', {
-    gain: timeVariant(numeric(undefined, wet), [])
+    gain: { initial: numeric(undefined, wet), points: [] }
   })
 
   const wetInput = wetLevel ?? effect
@@ -426,7 +426,7 @@ function createOptionalGainNode (wetGain: Numeric<'db'>, builder: Builder): Node
 
   return builder.addNode<GainNode>('gain', {
     // TODO time variant
-    gain: timeVariant(numeric(undefined, gain), [])
+    gain: { initial: numeric(undefined, gain), points: [] }
   })
 }
 

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -1,6 +1,5 @@
-import type { AssetId, NoteData } from '@core'
+import type { AssetId, Curve, NoteData } from '@core'
 import type { Numeric } from '@utility'
-import type { TimeVariant } from './automation.js'
 import type { EntityKey } from './entities.js'
 import type { AnyNode } from './graph.js'
 
@@ -40,18 +39,18 @@ export interface IdentityNode extends AnyNode {
 
 export interface GainNode extends AnyNode {
   readonly type: 'gain'
-  readonly gain: TimeVariant<undefined>
+  readonly gain: Curve<'s', undefined>
 }
 
 export interface PanNode extends AnyNode {
   readonly type: 'pan'
-  readonly pan: TimeVariant<undefined>
+  readonly pan: Curve<'s', undefined>
 }
 
 export interface BiquadNode extends AnyNode {
   readonly type: 'biquad'
   readonly filterType: 'lowpass' | 'highpass'
-  readonly frequency: TimeVariant<'hz'>
+  readonly frequency: Curve<'s', 'hz'>
   readonly rolloffPerOctave: Numeric<'db'>
 }
 
@@ -88,7 +87,7 @@ export type SourceNode = SampleNode | OscillatorNode
 
 export interface SampleNode extends AnyNode {
   readonly type: 'sample'
-  readonly gainCurve: TimeVariant<undefined>
+  readonly gainCurve: Curve<'s', undefined>
   readonly duration?: Numeric<'s'>
   readonly assetId: AssetId
   readonly playbackRate: Numeric<undefined>
@@ -96,7 +95,7 @@ export interface SampleNode extends AnyNode {
 
 export interface OscillatorNode extends AnyNode {
   readonly type: 'oscillator'
-  readonly gainCurve: TimeVariant<undefined>
+  readonly gainCurve: Curve<'s', undefined>
   readonly duration: Numeric<'s'> | undefined
   readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
   readonly frequency: Numeric<'hz'>

--- a/packages/audiograph/test/envelope.test.ts
+++ b/packages/audiograph/test/envelope.test.ts
@@ -1,4 +1,4 @@
-import type { Envelope } from '@core'
+import type { Curve, Envelope } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -23,11 +23,11 @@ describe('envelope.ts', () => {
       assert.deepStrictEqual(result, {
         initial: numeric(undefined, 0),
         points: [
-          { time: numeric('s', 0), value: numeric(undefined, 0), curve: 'step' },
-          { time: numeric('s', 1), value: numeric(undefined, 1), curve: 'linear' },
-          { time: numeric('s', 3), value: numeric(undefined, 0.5), curve: 'linear' }
+          { time: numeric('s', 0), value: numeric(undefined, 0), shape: 'step' },
+          { time: numeric('s', 1), value: numeric(undefined, 1), shape: 'linear' },
+          { time: numeric('s', 3), value: numeric(undefined, 0.5), shape: 'linear' }
         ]
-      })
+      } satisfies Curve<'s', undefined>)
     })
 
     it('handles zero-length attack by setting the peak immediately before decay', () => {
@@ -38,10 +38,10 @@ describe('envelope.ts', () => {
       assert.deepStrictEqual(result, {
         initial: numeric(undefined, 0),
         points: [
-          { time: numeric('s', 0), value: numeric(undefined, 1), curve: 'step' },
-          { time: numeric('s', 2), value: numeric(undefined, 0.5), curve: 'linear' }
+          { time: numeric('s', 0), value: numeric(undefined, 1), shape: 'step' },
+          { time: numeric('s', 2), value: numeric(undefined, 0.5), shape: 'linear' }
         ]
-      })
+      } satisfies Curve<'s', undefined>)
     })
 
     it('handles zero-length decay by setting the sustain level immediately after attack', () => {
@@ -52,11 +52,11 @@ describe('envelope.ts', () => {
       assert.deepStrictEqual(result, {
         initial: numeric(undefined, 0),
         points: [
-          { time: numeric('s', 0), value: numeric(undefined, 0), curve: 'step' },
-          { time: numeric('s', 1), value: numeric(undefined, 1), curve: 'linear' },
-          { time: numeric('s', 1), value: numeric(undefined, 0.5), curve: 'step' }
+          { time: numeric('s', 0), value: numeric(undefined, 0), shape: 'step' },
+          { time: numeric('s', 1), value: numeric(undefined, 1), shape: 'linear' },
+          { time: numeric('s', 1), value: numeric(undefined, 0.5), shape: 'step' }
         ]
-      })
+      } satisfies Curve<'s', undefined>)
     })
 
     it('starts release from the current attack level when the note ends during attack', () => {
@@ -68,11 +68,11 @@ describe('envelope.ts', () => {
       assert.deepStrictEqual(result, {
         initial: numeric(undefined, 0),
         points: [
-          { time: numeric('s', 0), value: numeric(undefined, 0), curve: 'step' },
-          { time: numeric('s', 1), value: numeric(undefined, 0.25), curve: 'linear' },
-          { time: numeric('s', 2), value: numeric(undefined, 0), curve: 'linear' }
+          { time: numeric('s', 0), value: numeric(undefined, 0), shape: 'step' },
+          { time: numeric('s', 1), value: numeric(undefined, 0.25), shape: 'linear' },
+          { time: numeric('s', 2), value: numeric(undefined, 0), shape: 'linear' }
         ]
-      })
+      } satisfies Curve<'s', undefined>)
     })
 
     it('starts release from the current decay level when the note ends during decay', () => {
@@ -84,12 +84,12 @@ describe('envelope.ts', () => {
       assert.deepStrictEqual(result, {
         initial: numeric(undefined, 0),
         points: [
-          { time: numeric('s', 0), value: numeric(undefined, 0), curve: 'step' },
-          { time: numeric('s', 1), value: numeric(undefined, 1), curve: 'linear' },
-          { time: numeric('s', 2), value: numeric(undefined, 0.75), curve: 'linear' },
-          { time: numeric('s', 3), value: numeric(undefined, 0), curve: 'linear' }
+          { time: numeric('s', 0), value: numeric(undefined, 0), shape: 'step' },
+          { time: numeric('s', 1), value: numeric(undefined, 1), shape: 'linear' },
+          { time: numeric('s', 2), value: numeric(undefined, 0.75), shape: 'linear' },
+          { time: numeric('s', 3), value: numeric(undefined, 0), shape: 'linear' }
         ]
-      })
+      } satisfies Curve<'s', undefined>)
     })
 
     it('starts release from sustain when the note ends after decay', () => {
@@ -101,13 +101,13 @@ describe('envelope.ts', () => {
       assert.deepStrictEqual(result, {
         initial: numeric(undefined, 0),
         points: [
-          { time: numeric('s', 0), value: numeric(undefined, 0), curve: 'step' },
-          { time: numeric('s', 1), value: numeric(undefined, 0.8), curve: 'linear' },
-          { time: numeric('s', 3), value: numeric(undefined, 0.4), curve: 'linear' },
-          { time: numeric('s', 5), value: numeric(undefined, 0.4), curve: 'step' },
-          { time: numeric('s', 9), value: numeric(undefined, 0), curve: 'linear' }
+          { time: numeric('s', 0), value: numeric(undefined, 0), shape: 'step' },
+          { time: numeric('s', 1), value: numeric(undefined, 0.8), shape: 'linear' },
+          { time: numeric('s', 3), value: numeric(undefined, 0.4), shape: 'linear' },
+          { time: numeric('s', 5), value: numeric(undefined, 0.4), shape: 'step' },
+          { time: numeric('s', 9), value: numeric(undefined, 0), shape: 'linear' }
         ]
-      })
+      } satisfies Curve<'s', undefined>)
     })
 
     it('handles zero-length release by setting the value to 0 immediately after hold duration', () => {
@@ -119,12 +119,12 @@ describe('envelope.ts', () => {
       assert.deepStrictEqual(result, {
         initial: numeric(undefined, 0),
         points: [
-          { time: numeric('s', 0), value: numeric(undefined, 0), curve: 'step' },
-          { time: numeric('s', 1), value: numeric(undefined, 1), curve: 'linear' },
-          { time: numeric('s', 3), value: numeric(undefined, 0.5), curve: 'linear' },
-          { time: numeric('s', 5), value: numeric(undefined, 0), curve: 'step' }
+          { time: numeric('s', 0), value: numeric(undefined, 0), shape: 'step' },
+          { time: numeric('s', 1), value: numeric(undefined, 1), shape: 'linear' },
+          { time: numeric('s', 3), value: numeric(undefined, 0.5), shape: 'linear' },
+          { time: numeric('s', 5), value: numeric(undefined, 0), shape: 'step' }
         ]
-      })
+      } satisfies Curve<'s', undefined>)
     })
   })
 })

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -3,7 +3,6 @@ import { beatsToSeconds, createSerialPattern } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { timeVariant } from '../src/automation.js'
 import { dbToGain } from '../src/constants.js'
 import { createEntityKey } from '../src/entities.js'
 import { applyEnvelope } from '../src/envelope.js'
@@ -334,18 +333,17 @@ describe('lowering.ts', () => {
         [
           instrumentGainId,
           {
-            parameterId: instrumentGainId,
-            type: 'gain',
+            initial: numeric('db', -6),
             points: [
               {
                 time: numeric('s', 0.5),
                 value: numeric('db', -3),
-                curve: 'linear'
+                shape: 'linear'
               },
               {
                 time: numeric('s', 1),
                 value: numeric('db', -12),
-                curve: 'step'
+                shape: 'step'
               }
             ]
           }
@@ -387,12 +385,12 @@ describe('lowering.ts', () => {
           {
             time: numeric('s', 0.5),
             value: numeric(undefined, dbToGain(-3)),
-            curve: 'exponential'
+            shape: 'exponential'
           },
           {
             time: numeric('s', 1),
             value: numeric(undefined, dbToGain(-12)),
-            curve: 'step'
+            shape: 'step'
           }
         ]
       }
@@ -555,9 +553,12 @@ describe('lowering.ts', () => {
     assert.strictEqual(voices.length, 1)
     const [voice] = voices
 
-    assert.deepStrictEqual(voice.gainCurve, timeVariant(numeric(undefined, 0), [
-      { time: numeric('s', 0), value: numeric(undefined, 0), curve: 'step' }
-    ]))
+    assert.deepStrictEqual(voice.gainCurve, {
+      initial: numeric(undefined, 0),
+      points: [
+        { time: numeric('s', 0), value: numeric(undefined, 0), shape: 'step' }
+      ]
+    })
   })
 
   it('should throw for invalid sample playback rate', () => {

--- a/packages/core/src/curve/types.ts
+++ b/packages/core/src/curve/types.ts
@@ -1,0 +1,19 @@
+import type { Numeric, Unit } from '@utility'
+
+export type CurveShape = 'step' | 'linear' | 'exponential'
+
+export interface Curve<T extends Unit, U extends Unit> {
+  readonly initial: Numeric<U>
+  readonly points: ReadonlyArray<CurvePoint<T, U>>
+}
+
+export interface CurvePoint<T extends Unit, U extends Unit> {
+  readonly time: Numeric<T>
+  readonly value: Numeric<U>
+
+  /**
+   * The shape of the line from the previous point, or from the initial value,
+   * to this point.
+   */
+  readonly shape: CurveShape
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 export * from './pattern/types.js'
 export * from './pattern/functions.js'
 
+export type * from './curve/types.js'
+
 export type * from './program/assets.js'
 export type * from './program/automations.js'
 export type * from './program/effects.js'

--- a/packages/core/src/program/automations.ts
+++ b/packages/core/src/program/automations.ts
@@ -6,18 +6,3 @@ export interface Parameter<U extends Unit> {
   readonly id: ParameterId
   readonly initial: Numeric<U>
 }
-
-export interface Automation<U extends Unit = Unit> {
-  readonly parameterId: ParameterId
-  readonly points: ReadonlyArray<AutomationPoint<U>>
-}
-
-export interface AutomationPoint<U extends Unit = Unit> {
-  readonly time: Numeric<'s'>
-  readonly value: Numeric<U>
-
-  /**
-   * The curve from the previous point, or from the initial value, to this point.
-   */
-  readonly curve: 'linear' | 'step'
-}

--- a/packages/core/src/program/program.ts
+++ b/packages/core/src/program/program.ts
@@ -1,5 +1,7 @@
+import type { Unit } from '@utility'
+import type { Curve } from '../curve/types.js'
 import type { Asset, AssetId } from './assets.js'
-import type { Automation, ParameterId } from './automations.js'
+import type { ParameterId } from './automations.js'
 import type { Instrument, InstrumentId } from './instruments.js'
 import type { Mixer } from './mixer.js'
 import type { Track } from './track.js'
@@ -9,7 +11,7 @@ export interface Program {
 
   readonly instruments: ReadonlyMap<InstrumentId, Instrument>
   readonly assets: ReadonlyMap<AssetId, Asset>
-  readonly automations: ReadonlyMap<ParameterId, Automation>
+  readonly automations: ReadonlyMap<ParameterId, Curve<'s', Unit>>
 
   readonly track: Track
   readonly mixer: Mixer

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -1,4 +1,4 @@
-import type { AutomationPoint } from '@core'
+import type { CurvePoint, CurveShape } from '@core'
 import { timeToSeconds } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
@@ -18,7 +18,7 @@ export interface CurveSegmentType {
   readonly create: <U extends Unit>(parameters: ReadonlyArray<Numeric<U>>, length: CurveDuration) => CurveSegment<U>
   readonly start: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
   readonly end: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
-  readonly endCurve: AutomationPoint<any>['curve']
+  readonly endShape: CurveShape
 }
 
 const curveSegmentTypes: ReadonlyMap<string, CurveSegmentType> = new Map([
@@ -31,7 +31,7 @@ const curveSegmentTypes: ReadonlyMap<string, CurveSegmentType> = new Map([
     },
     start: <U extends Unit>(segment: CurveSegment<U>) => (segment as HoldCurveSegment<U>).value,
     end: <U extends Unit>(segment: CurveSegment<U>) => (segment as HoldCurveSegment<U>).value,
-    endCurve: 'step'
+    endShape: 'step'
   }],
 
   [SEGMENT_TYPE_LINEAR, {
@@ -43,7 +43,7 @@ const curveSegmentTypes: ReadonlyMap<string, CurveSegmentType> = new Map([
     },
     start: <U extends Unit>(segment: CurveSegment<U>) => (segment as LinearCurveSegment<U>).start,
     end: <U extends Unit>(segment: CurveSegment<U>) => (segment as LinearCurveSegment<U>).end,
-    endCurve: 'linear'
+    endShape: 'linear'
   }]
 ])
 
@@ -73,13 +73,13 @@ export interface RenderCurveOptions {
   readonly tempo: Numeric<'bpm'>
 }
 
-export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: RenderCurveOptions): ReadonlyArray<AutomationPoint<U>> {
+export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: RenderCurveOptions): ReadonlyArray<CurvePoint<'s', U>> {
   const segments = curve.segments
   if (segments.length === 0 || (options.limit != null && options.limit.value <= 0)) {
     return []
   }
 
-  const points: Array<AutomationPoint<U>> = []
+  const points: Array<CurvePoint<'s', U>> = []
 
   const offsetSeconds = timeToSeconds(options.offset, options.tempo)
   let currentTime: Numeric<'s'> = offsetSeconds
@@ -97,11 +97,11 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
     points.push({
       time: startTime,
       value: definition.start(segment),
-      curve: 'step'
+      shape: 'step'
     }, {
       time: endTime,
       value: definition.end(segment),
-      curve: segmentLength.value <= 0 ? 'step' : definition.endCurve
+      shape: segmentLength.value <= 0 ? 'step' : definition.endShape
     })
 
     currentTime = endTime
@@ -120,34 +120,38 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
   return simplifiedPoints
 }
 
-function interpolatePoint<U extends Unit> (start: AutomationPoint<U>, end: AutomationPoint<U>, time: Numeric<'s'>): AutomationPoint<U> {
+function interpolatePoint<U extends Unit> (start: CurvePoint<'s', U>, end: CurvePoint<'s', U>, time: Numeric<'s'>): CurvePoint<'s', U> {
   assert(time.value >= start.time.value && time.value <= end.time.value)
 
   const deltaTime = end.time.value - start.time.value
   if (deltaTime < TIME_EPSILON) {
-    return { time, value: start.value, curve: 'step' }
+    return { time, value: start.value, shape: 'step' }
   }
 
   const t = (time.value - start.time.value) / deltaTime
 
-  switch (end.curve) {
+  switch (end.shape) {
     case 'step':
-      return { time, value: start.value, curve: 'step' }
+      return { time, value: start.value, shape: 'step' }
 
     case 'linear': {
       const value = {
         unit: start.value.unit,
         value: start.value.value + t * (end.value.value - start.value.value)
       }
-      return { time, value, curve: 'linear' }
+      return { time, value, shape: 'linear' }
     }
+
+    case 'exponential':
+      // TODO implement
+      throw new Error('Not implemented')
   }
 }
 
 export function mergeCurvePoints<U extends Unit> (
-  first: ReadonlyArray<AutomationPoint<U>>,
-  second: ReadonlyArray<AutomationPoint<U>>
-): ReadonlyArray<AutomationPoint<U>> {
+  first: ReadonlyArray<CurvePoint<'s', U>>,
+  second: ReadonlyArray<CurvePoint<'s', U>>
+): ReadonlyArray<CurvePoint<'s', U>> {
   if (first.length === 0) {
     return second
   }
@@ -169,10 +173,10 @@ export function mergeCurvePoints<U extends Unit> (
 }
 
 function takePointsBefore<U extends Unit> (
-  points: ReadonlyArray<AutomationPoint<U>>,
+  points: ReadonlyArray<CurvePoint<'s', U>>,
   time: Numeric<'s'>
-): ReadonlyArray<AutomationPoint<U>> {
-  const result: Array<AutomationPoint<U>> = []
+): ReadonlyArray<CurvePoint<'s', U>> {
+  const result: Array<CurvePoint<'s', U>> = []
 
   for (let i = 0; i < points.length; ++i) {
     const point = points[i]
@@ -203,9 +207,9 @@ function takePointsBefore<U extends Unit> (
 }
 
 function takePointsAfter<U extends Unit> (
-  points: ReadonlyArray<AutomationPoint<U>>,
+  points: ReadonlyArray<CurvePoint<'s', U>>,
   time: Numeric<'s'>
-): ReadonlyArray<AutomationPoint<U>> {
+): ReadonlyArray<CurvePoint<'s', U>> {
   for (let i = 0; i < points.length; ++i) {
     const point = points[i]
 
@@ -238,8 +242,8 @@ function compareTimes (left: Numeric<'s'>, right: Numeric<'s'>): number {
   return difference < 0 ? -1 : 1
 }
 
-function simplifyCurvePoints<U extends Unit> (points: ReadonlyArray<AutomationPoint<U>>): ReadonlyArray<AutomationPoint<U>> {
-  const simplified: Array<AutomationPoint<U>> = []
+function simplifyCurvePoints<U extends Unit> (points: ReadonlyArray<CurvePoint<'s', U>>): ReadonlyArray<CurvePoint<'s', U>> {
+  const simplified: Array<CurvePoint<'s', U>> = []
 
   for (const point of points) {
     const previous = simplified.at(-1)
@@ -256,11 +260,11 @@ function simplifyCurvePoints<U extends Unit> (points: ReadonlyArray<AutomationPo
     // not first, same time, different values: the point should be emitted as a step
 
     // repetitive step points should be avoided
-    if (previous.curve === 'step') {
+    if (previous.shape === 'step') {
       simplified.pop()
     }
 
-    simplified.push({ ...point, curve: 'step' })
+    simplified.push({ ...point, shape: 'step' })
   }
 
   return simplified

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -228,11 +228,7 @@ function generateAutomation (scope: Scope, statement: ast.AutomateStatement, opt
   const existing = nonNull(scope.top.automations.get(target.id), 'Parameter allocated incorrectly')
 
   const points = mergeCurvePoints(existing.points, rendered)
-
-  scope.top.automations.set(target.id, {
-    parameterId: target.id,
-    points
-  })
+  scope.top.automations.set(target.id, { ...existing, points })
 }
 
 function generateMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: MutableNamespace): Mixer {

--- a/packages/language/src/compiler/generator/scopes.ts
+++ b/packages/language/src/compiler/generator/scopes.ts
@@ -1,4 +1,4 @@
-import type { Asset, AssetId, Automation, Bus, BusId, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
+import type { Asset, AssetId, Bus, BusId, Curve, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
 import type { Numeric, Unit } from '@utility'
 import type { Value } from '../../type-system/types.js'
 import type { GenerateOptions } from './options.js'
@@ -39,7 +39,7 @@ export interface GlobalScope extends Scope, Context {
 
   readonly buses: Map<BusId, Bus>
   readonly instruments: Map<InstrumentId, Instrument>
-  readonly automations: Map<ParameterId, Automation>
+  readonly automations: Map<ParameterId, Curve<'s', Unit>>
   readonly assets: Map<AssetId, Asset>
 }
 
@@ -118,11 +118,7 @@ function allocateBus (scope: GlobalScope, data: Omit<Bus, 'id'>): Bus {
 
 function allocateParameter<U extends Unit> (scope: GlobalScope, initial: Numeric<U>): Parameter<U> {
   const id = scope.automations.size as ParameterId
-
-  scope.automations.set(id, {
-    parameterId: id,
-    points: []
-  })
+  scope.automations.set(id, { initial, points: [] })
 
   return { id, initial }
 }

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -321,8 +321,8 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 4), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 4), value: numeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -343,9 +343,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 4), value: numeric('db', -30), curve: 'linear' },
-      { time: numeric('s', 6), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 4), value: numeric('db', -30), shape: 'linear' },
+      { time: numeric('s', 6), value: numeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -366,9 +366,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 10), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 16), value: numeric('db', -30), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 10), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 16), value: numeric('db', -30), shape: 'linear' }
     ])
   })
 
@@ -389,9 +389,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 12), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 16), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 12), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 16), value: numeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -412,9 +412,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 12), value: numeric('db', -30), curve: 'linear' },
-      { time: numeric('s', 16), value: numeric('db', -30), curve: 'step' }
+      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 12), value: numeric('db', -30), shape: 'linear' },
+      { time: numeric('s', 16), value: numeric('db', -30), shape: 'step' }
     ])
   })
 
@@ -435,8 +435,8 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -30), curve: 'step' },
-      { time: numeric('s', 8), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -30), shape: 'step' },
+      { time: numeric('s', 8), value: numeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -460,10 +460,10 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), curve: 'step' },
-      { time: numeric('s', 4), value: numeric('db', 0), curve: 'linear' },
-      { time: numeric('s', 4), value: numeric('db', -15), curve: 'step' },
-      { time: numeric('s', 8), value: numeric('db', -30), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
+      { time: numeric('s', 4), value: numeric('db', 0), shape: 'linear' },
+      { time: numeric('s', 4), value: numeric('db', -15), shape: 'step' },
+      { time: numeric('s', 8), value: numeric('db', -30), shape: 'linear' }
     ])
   })
 
@@ -485,8 +485,8 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -15), curve: 'step' },
-      { time: numeric('s', 4), value: numeric('db', -15), curve: 'step' }
+      { time: numeric('s', 0), value: numeric('db', -15), shape: 'step' },
+      { time: numeric('s', 4), value: numeric('db', -15), shape: 'step' }
     ])
   })
 
@@ -508,9 +508,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -15), curve: 'step' },
-      { time: numeric('s', 2), value: numeric('db', -30), curve: 'step' },
-      { time: numeric('s', 4), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -15), shape: 'step' },
+      { time: numeric('s', 2), value: numeric('db', -30), shape: 'step' },
+      { time: numeric('s', 4), value: numeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -531,8 +531,8 @@ describe('compiler/generator/generator.ts', () => {
     const automation = result.automations.get(result.mixer.buses[0].gain.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -20), curve: 'step' },
-      { time: numeric('s', 8), value: numeric('db', 0), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('db', -20), shape: 'step' },
+      { time: numeric('s', 8), value: numeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -560,8 +560,8 @@ describe('compiler/generator/generator.ts', () => {
     const automation = result.automations.get(effect.frequency.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('hz', 100), curve: 'step' },
-      { time: numeric('s', 8), value: numeric('hz', 4000), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('hz', 100), shape: 'step' },
+      { time: numeric('s', 8), value: numeric('hz', 4000), shape: 'linear' }
     ])
   })
 
@@ -590,8 +590,8 @@ describe('compiler/generator/generator.ts', () => {
     const automation = result.automations.get(effect.frequency.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('hz', 500), curve: 'step' },
-      { time: numeric('s', 8), value: numeric('hz', 1000), curve: 'linear' }
+      { time: numeric('s', 0), value: numeric('hz', 500), shape: 'step' },
+      { time: numeric('s', 8), value: numeric('hz', 1000), shape: 'linear' }
     ])
   })
 

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -73,8 +73,8 @@ describe('compiler/generator/scopes.ts', () => {
       assert.strictEqual(parameter1.id, 1)
 
       assert.deepStrictEqual([...scope.automations], [
-        [0, { parameterId: 0, points: [] }],
-        [1, { parameterId: 1, points: [] }]
+        [0, { initial: numeric('db', 12), points: [] }],
+        [1, { initial: numeric('db', 6), points: [] }]
       ])
     })
 

--- a/packages/webaudio/src/graph/automation.ts
+++ b/packages/webaudio/src/graph/automation.ts
@@ -1,8 +1,8 @@
-import type { Curve, TimeVariant } from '@audiograph'
+import type { Curve, CurveShape } from '@core'
 import type { Unit } from '@utility'
 import type { Transport } from '../transport/transport.js'
 
-export function automate<U extends Unit> (transport: Transport, param: AudioParam, source: TimeVariant<U>): void {
+export function automate<U extends Unit> (transport: Transport, param: AudioParam, source: Curve<'s', U>): void {
   param.value = source.initial.value
 
   const points = source.points
@@ -53,7 +53,7 @@ export function automate<U extends Unit> (transport: Transport, param: AudioPara
       const nextPointTime = pointTimes[pointIndex + 1]
 
       const t = (0 - pointTime) / (nextPointTime - pointTime)
-      const value = evaluateCurve(nextPoint.curve, t, point.value.value, nextPoint.value.value)
+      const value = evaluateCurve(nextPoint.shape, t, point.value.value, nextPoint.value.value)
 
       param.setValueAtTime(value, 0)
       previousValue = value
@@ -64,10 +64,10 @@ export function automate<U extends Unit> (transport: Transport, param: AudioPara
     // Schedule remaining points (guaranteed to be in the future)
     for (let i = pointIndex; i < points.length; ++i) {
       const pointTime = pointTimes[i]
-      const { value: { value }, curve } = points[i]
+      const { value: { value }, shape } = points[i]
 
       scheduleToPoint(transport, param, {
-        curve,
+        shape,
         time: pointTime,
         value,
         previousTime,
@@ -80,7 +80,7 @@ export function automate<U extends Unit> (transport: Transport, param: AudioPara
   })
 }
 
-export function applyAutomationPoints<U extends Unit> (time: number, transport: Transport, param: AudioParam, source: TimeVariant<U>): void {
+export function applyAutomationPoints<U extends Unit> (time: number, transport: Transport, param: AudioParam, source: Curve<'s', U>): void {
   param.value = source.initial.value
 
   const points = source.points
@@ -95,10 +95,10 @@ export function applyAutomationPoints<U extends Unit> (time: number, transport: 
 
   for (const point of points) {
     const pointTime = time + point.time.value
-    const { value: { value }, curve } = point
+    const { value: { value }, shape: shape } = point
 
     scheduleToPoint(transport, param, {
-      curve,
+      shape,
       time: pointTime,
       value,
       previousTime,
@@ -110,7 +110,7 @@ export function applyAutomationPoints<U extends Unit> (time: number, transport: 
   }
 }
 
-function evaluateCurve (curve: Curve, t: number, startValue: number, endValue: number): number {
+function evaluateCurve (shape: CurveShape, t: number, startValue: number, endValue: number): number {
   if (t <= 0) {
     return startValue
   }
@@ -119,7 +119,7 @@ function evaluateCurve (curve: Curve, t: number, startValue: number, endValue: n
     return endValue
   }
 
-  switch (curve) {
+  switch (shape) {
     case 'step':
       return startValue
 
@@ -149,21 +149,21 @@ function scheduleToPoint (
   transport: Transport,
   param: AudioParam,
   options: {
-    readonly curve: Curve
+    readonly shape: CurveShape
     readonly time: number
     readonly value: number
     readonly previousTime: number
     readonly previousValue: number
   }
 ): void {
-  const { curve, time, value, previousTime, previousValue } = options
+  const { shape, time, value, previousTime, previousValue } = options
 
   if (time === previousTime) {
     param.setValueAtTime(value, time)
     return
   }
 
-  switch (curve) {
+  switch (shape) {
     case 'step':
       param.setValueAtTime(value, time)
       return


### PR DESCRIPTION
This patch removes both the core package's `Automation` type and the audiograph package's `TimeVariant` type and replaces them with a new unified `Curve` type in the core package.