### PR TITLE
feat: Support custom instruments and voices

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -22,7 +22,7 @@ import type { Schema, SchemaItem } from '../../type-system/schema.js'
 import type { FacetType, Type, Value } from '../../type-system/types.js'
 import { assertNever } from '../assert.js'
 import { patternBuiltins } from '../builtins/patterns.js'
-import { BUS_NAMESPACE, busSchema, mixerSchema, partSchema, stepSchema, trackSchema } from '../common.js'
+import { BUS_NAMESPACE, busSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.js'
 import { getCurveSegmentType } from '../curves.js'
 import { CompileError } from '../error.js'
 import { binaryOperations } from '../operators/binary.js'
@@ -665,12 +665,6 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
 
   return { errors, result: InstrumentFacet.type() }
 }
-
-const noteType = RecordFacet.with({
-  frequency: NumberFacet.with('hz').type(),
-  gate: NumberFacet.with('beats').type(),
-  velocity: NumberFacet.with(undefined).type()
-}).type()
 
 function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileError[] {
   const voiceScope = createLocalScope(scope, { blocking: false })

--- a/packages/language/src/compiler/common.ts
+++ b/packages/language/src/compiler/common.ts
@@ -1,5 +1,9 @@
+import { convertPitchToMidi } from '@core'
 import { NumberFacet } from '../type-system/base/number.js'
+import { RecordFacet } from '../type-system/base/record.js'
 import { makeSchema } from '../type-system/schema.js'
+
+export const DEFAULT_ROOT_NOTE = convertPitchToMidi('C5')
 
 export const BUS_NAMESPACE = 'bus'
 
@@ -48,3 +52,11 @@ export const stepSchema = makeSchema([
     required: false
   }
 ])
+
+export const noteType = RecordFacet.with({
+  frequency: NumberFacet.with('hz').type(),
+  gate: NumberFacet.with('beats').type(),
+  velocity: NumberFacet.with(undefined).type()
+}).type()
+
+export type NoteValue = ReturnType<typeof noteType.of>

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -1,6 +1,6 @@
 import { ast } from '@ast'
-import type { Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, Part, Pattern, Program, Step, Track } from '@core'
-import { concatPatterns, createParallelPattern, createSerialPattern, mergePatterns } from '@core'
+import type { Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, Part, Pattern, Program, Source, Step, Track, Voice } from '@core'
+import { concatPatterns, convertPitchToMidi, createParallelPattern, createSerialPattern, getMidiFrequency, mergePatterns } from '@core'
 import type { Numeric, Unit } from '@utility'
 import { numeric } from '@utility'
 import { getStandardModuleValue } from '../../library/modules.js'
@@ -11,21 +11,23 @@ import { NumberFacet } from '../../type-system/base/number.js'
 import { RecordFacet } from '../../type-system/base/record.js'
 import { StringFacet } from '../../type-system/base/string.js'
 import { BusFacet } from '../../type-system/domain/bus.js'
-import type { CurveSegment } from '../../type-system/domain/curve.js'
+import type { Curve, CurveSegment } from '../../type-system/domain/curve.js'
 import { CurveFacet } from '../../type-system/domain/curve.js'
 import { EffectFacet } from '../../type-system/domain/effect.js'
 import { InstrumentFacet } from '../../type-system/domain/instrument.js'
 import { ParameterFacet } from '../../type-system/domain/parameter.js'
 import { PartFacet } from '../../type-system/domain/part.js'
 import { PatternFacet } from '../../type-system/domain/pattern.js'
+import { SourceFacet } from '../../type-system/domain/source.js'
 import { makeType } from '../../type-system/factory.js'
-import { Parameters } from '../../type-system/helpers.js'
+import { Curves, Numbers, Parameters } from '../../type-system/helpers.js'
 import type { InferSchema, Schema } from '../../type-system/schema.js'
 import type { FacetType, Value } from '../../type-system/types.js'
 import { assert, assertNever, fail, nonNull } from '../assert.js'
 import { patternBuiltins } from '../builtins/patterns.js'
 import type { CheckedProgram } from '../checker/checker.js'
-import { BUS_NAMESPACE, busSchema, partSchema, stepSchema, trackSchema } from '../common.js'
+import type { NoteValue } from '../common.js'
+import { BUS_NAMESPACE, busSchema, DEFAULT_ROOT_NOTE, noteType, partSchema, stepSchema, trackSchema } from '../common.js'
 import type { RenderCurveOptions } from '../curves.js'
 import { createCurve, createCurveSegment, getCurveSegmentType, mergeCurvePoints, renderCurvePoints } from '../curves.js'
 import { binaryOperations } from '../operators/binary.js'
@@ -34,7 +36,7 @@ import { resolveInScope } from '../resolution.js'
 import { isSyntaxUnit, toNumberValue } from '../units.js'
 import type { GenerateOptions } from './options.js'
 import type { GlobalScope, MutableNamespace, MutableScope, Scope } from './scopes.js'
-import { createGlobalScope, createLocalScope, createNamespace } from './scopes.js'
+import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from './scopes.js'
 
 /**
  * Generate a runnable program from an AST. This assumes the AST has already been
@@ -419,6 +421,10 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
   }
 }
 
+function resolveIdentifier (scope: Scope, identifier: ast.Identifier): Value {
+  return nonNull(resolveInScope(scope, identifier.name))
+}
+
 function generateString (scope: Scope, parts: ReadonlyArray<string | ast.Expression>): Value {
   const resolvedParts = parts.map((part) => {
     if (typeof part === 'string') {
@@ -520,11 +526,13 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
     generatedSegments.push(createCurveSegment(segment.curveType, resolvedParameters, length))
   }
 
-  return CurveFacet.type().of(createCurve(generatedSegments))
+  return Curves.of(createCurve(generatedSegments))
 }
 
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   const instrumentScope = createLocalScope(scope)
+
+  const voiceConstructors: Array<(note: NoteValue, tempo: Numeric<'bpm'>) => readonly Voice[]> = []
 
   for (const child of expression.children) {
     switch (child.type) {
@@ -532,8 +540,66 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
         processAssignment(instrumentScope, child)
         break
 
-      case 'VoiceStatement':
-        // TODO: voice instantiation needs to happen at runtime, not compile time
+      case 'VoiceStatement': {
+        const frozenScope = cloneScope(instrumentScope)
+        voiceConstructors.push((note, tempo) => generateVoice(frozenScope, child, note, tempo))
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  const gainParameter = scope.top.allocateParameter(numeric('db', 0))
+
+  const instrument = scope.top.allocateInstrument({
+    gain: gainParameter,
+    trigger: (note, tempo) => {
+      if (voiceConstructors.length === 0) {
+        return []
+      }
+
+      const gate = Numbers.of(note.gate ?? numeric('beats', 0))
+      const frequency = Numbers.of(
+        numeric('hz', getMidiFrequency(note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE))
+      )
+      const velocity = Numbers.of(note.velocity)
+
+      const noteBinding = noteType.of({ gate, frequency, velocity })
+
+      return voiceConstructors.flatMap((create) => create(noteBinding, tempo))
+    }
+  })
+
+  return InstrumentFacet.type().of(instrument)
+}
+
+function generateVoice (scope: Scope, voice: ast.VoiceStatement, note: NoteValue, tempo: Numeric<'bpm'>): readonly Voice[] {
+  const voiceScope = createLocalScope(scope)
+
+  if (voice.bindings.note != null) {
+    assert(!voiceScope.resolutions.has(voice.bindings.note.name))
+    voiceScope.resolutions.set(voice.bindings.note.name, note)
+  }
+
+  let envelopeValue: Curve<'db'> | undefined
+  let outputValue: Source | undefined
+
+  for (const child of voice.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(voiceScope, child)
+        break
+
+      case 'EnvelopeStatement':
+        assert(envelopeValue == null)
+        envelopeValue = CurveFacet.with('db').get(resolve(voiceScope, child.expression))
+        break
+
+      case 'OutputStatement':
+        assert(outputValue == null)
+        outputValue = SourceFacet.get(resolve(voiceScope, child.expression))
         break
 
       default:
@@ -541,33 +607,25 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
     }
   }
 
-  // TODO: Change -Infinity to 0 and expose gain on the record,
-  //       once instrument definitions are fully supported.
-  const gainValue = numeric('db', -Infinity)
-  const gainParameter = scope.top.allocateParameter(gainValue)
+  if (outputValue == null || envelopeValue == null) {
+    return []
+  }
 
-  const instrument = scope.top.allocateInstrument({
-    gain: gainParameter,
-    trigger: () => [
-      {
-        envelope: {
-          initial: numeric('db', -Infinity),
-          points: []
-        },
-        source: {
-          type: 'oscillator',
-          shape: 'sine',
-          frequency: numeric('hz', 440)
-        }
-      }
-    ]
-  })
+  const envelope = {
+    initial: numeric('db', -Infinity),
+    points: renderCurvePoints(envelopeValue, {
+      offset: numeric('beats', 0),
+      tempo
+    })
+  }
 
-  return InstrumentFacet.type().of(instrument)
-}
-
-function resolveIdentifier (scope: Scope, identifier: ast.Identifier): Value {
-  return nonNull(resolveInScope(scope, identifier.name))
+  return [
+    {
+      envelope,
+      source: outputValue,
+      duration: envelope.points.at(-1)?.time
+    }
+  ]
 }
 
 function computeUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Value {

--- a/packages/language/src/compiler/generator/scopes.ts
+++ b/packages/language/src/compiler/generator/scopes.ts
@@ -99,6 +99,14 @@ export function createLocalScope (parent: Scope): MutableScope {
   }
 }
 
+export function cloneScope (scope: Scope): MutableScope {
+  return {
+    top: scope.top,
+    parent: scope.parent,
+    resolutions: new Map(scope.resolutions)
+  }
+}
+
 export function createNamespace (): MutableNamespace {
   return {
     resolutions: new Map()

--- a/packages/language/src/type-system/factory.ts
+++ b/packages/language/src/type-system/factory.ts
@@ -33,7 +33,7 @@ export function makeFacet<const Name extends string, Data> (
 
     get: <const V extends Value>(value: V): SpecificFacetDataForValue<V, Name, Data> => {
       if (!isFacetAssignableFromType(facet, value.type)) {
-        throw new Error(`Value is not assignable to facet ${facet.name}`)
+        throw new Error(`Value is not assignable to facet: ${facet.format()}`)
       }
 
       return value.data.get(facet.name) as SpecificFacetDataForValue<V, Name, Data>

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -10,6 +10,8 @@ import { ParameterFacet } from './domain/parameter.js'
 import { makeType } from './factory.js'
 import type { Schema } from './schema.js'
 import type { Facet, FacetType, Value } from './types.js'
+import type { Curve } from './domain/curve.js'
+import { CurveFacet } from './domain/curve.js'
 
 export const Functions = {
   of: <const S extends Schema, const R extends FacetType, const Context> (value: Function<S, R, Context>): Value => {
@@ -52,5 +54,11 @@ export const Numbers = {
 export const Parameters = {
   of: <const U extends Unit> (value: Parameter<U>): Value<Facet<'parameter', Parameter<U>>> => {
     return ParameterFacet.with(value.initial.unit).type().of(value)
+  }
+}
+
+export const Curves = {
+  of: <const U extends Unit> (value: Curve<U>): Value<Facet<'curve', Curve<U>>> => {
+    return CurveFacet.with(value.unit).type().of(value)
   }
 }

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -1,4 +1,5 @@
 import type { Program } from '@core'
+import { convertPitchToMidi, getMidiFrequency } from '@core'
 import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -734,9 +735,49 @@ describe('compiler/generator/generator.ts', () => {
 
     const [instrument] = result.instruments.values()
     const voices = instrument.trigger({ velocity: numeric(undefined, 1) }, DEFAULT_TEMPO)
-    assert.strictEqual(voices.length, 1)
-    assert.strictEqual(voices[0].source.type, 'oscillator')
-    assert.strictEqual(voices[0].source.shape, 'sine')
-    assert.deepStrictEqual(instrument.gain.initial, numeric('db', -Infinity))
+    assert.strictEqual(voices.length, 0)
+  })
+
+  it('should generate instruments with voices', () => {
+    const source = [
+      'use "sources" as src',
+      'my_instrument = instrument {',
+      '  voice {',
+      '    envelope ~[lin(0.db, -60.db):1.beat]',
+      '    output src.sine(440.hz)',
+      '  }',
+      '  voice note {',
+      '    envelope ~[lin(0.db, -60.db):1.beat]',
+      '    output src.sine(note.frequency)',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.instruments.size, 1)
+
+    const pitch = 'C5' as const
+    const pitchFrequency = getMidiFrequency(convertPitchToMidi(pitch))
+
+    const [instrument] = result.instruments.values()
+    const voices = instrument.trigger({ velocity: numeric(undefined, 1), pitch }, DEFAULT_TEMPO)
+    assert.strictEqual(voices.length, 2)
+
+    const [voice0, voice1] = voices
+    assert.deepStrictEqual(voice0.envelope.points, [
+      { time: numeric('s', 0), value: numeric('db', 0), shape: 'step' },
+      { time: numeric('s', 0.5), value: numeric('db', -60), shape: 'linear' }
+    ])
+    assert.strictEqual(voice0.source.type, 'oscillator')
+    assert.strictEqual(voice0.source.shape, 'sine')
+    assert.deepStrictEqual(voice0.source.frequency, numeric('hz', 440))
+
+    assert.deepStrictEqual(voice1.envelope.points, [
+      { time: numeric('s', 0), value: numeric('db', 0), shape: 'step' },
+      { time: numeric('s', 0.5), value: numeric('db', -60), shape: 'linear' }
+    ])
+    assert.strictEqual(voice1.source.type, 'oscillator')
+    assert.strictEqual(voice1.source.shape, 'sine')
+    assert.deepStrictEqual(voice1.source.frequency, numeric('hz', pitchFrequency))
   })
 })

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -3,7 +3,7 @@ import { numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GenerateOptions } from '../../../src/compiler/generator/options.js'
-import { createGlobalScope, createLocalScope, createNamespace } from '../../../src/compiler/generator/scopes.js'
+import { createGlobalScope, cloneScope, createLocalScope, createNamespace } from '../../../src/compiler/generator/scopes.js'
 import { Numbers } from '../../../src/type-system/helpers.js'
 
 const options: GenerateOptions = {
@@ -149,6 +149,39 @@ describe('compiler/generator/scopes.ts', () => {
       assert.strictEqual(nestedLocalScope.parent, localScope)
       assert.strictEqual(nestedLocalScope.resolutions.get('foo'), undefined)
       assert.strictEqual(nestedLocalScope.resolutions.get('bar'), undefined)
+    })
+  })
+
+  describe('cloneScope()', () => {
+    it('should create a new scope with the same top and parent, and a copy of the resolutions', () => {
+      const globalScope = createGlobalScope(options, new Map([
+        ['foo', Numbers.of(numeric('db', 12))]
+      ]))
+
+      const localScope = createLocalScope(globalScope)
+      localScope.resolutions.set('bar', Numbers.of(numeric('db', 6)))
+
+      const clonedScope = cloneScope(localScope)
+
+      assert.strictEqual(clonedScope.top, globalScope)
+      assert.strictEqual(clonedScope.parent, globalScope)
+      assert.strictEqual(clonedScope.resolutions.has('foo'), false)
+      assert.strictEqual(clonedScope.resolutions.has('bar'), true)
+    })
+
+    it('should not be affected by changes to the original scope after cloning', () => {
+      const globalScope = createGlobalScope(options, new Map([
+        ['foo', Numbers.of(numeric('db', 12))]
+      ]))
+
+      const localScope = createLocalScope(globalScope)
+      localScope.resolutions.set('bar', Numbers.of(numeric('db', 6)))
+
+      const clonedScope = cloneScope(localScope)
+
+      localScope.resolutions.set('baz', Numbers.of(numeric('db', 3)))
+
+      assert.strictEqual(clonedScope.resolutions.get('baz'), undefined)
     })
   })
 

--- a/packages/language/test/type-system/type-system.test.ts
+++ b/packages/language/test/type-system/type-system.test.ts
@@ -139,8 +139,8 @@ describe('type-system', () => {
       assert.strictEqual(numberFacet.get(pairValue), 42)
       assert.deepStrictEqual(decibelFacet.get(decibelValue), numeric('db', 42))
 
-      assert.throws(() => stringFacet.get(decibelValue), /Value is not assignable to facet string/)
-      assert.throws(() => decibelFacet.get(broadNumericValue), /Value is not assignable to facet numeric/)
+      assert.throws(() => stringFacet.get(decibelValue), /Value is not assignable to facet: string/)
+      assert.throws(() => decibelFacet.get(broadNumericValue), /Value is not assignable to facet: numeric/)
     })
 
     it('should narrow values through has()', () => {


### PR DESCRIPTION
This patch finalizes the initial implementation of custom instruments. It is now possible to write:

```
use "sources" as src

my_synth = instrument {
  voice note {
    envelope ~[lin(-60.db, 0.db):3.ms hold:note.gate lin(-60.db):3.ms]
    output src.saw(note.frequency)
  }
}
```

which is roughly equivalent to the standard library constructor:

```
use "instruments" as inst

my_synth = inst.saw()
```

In other words, it is finally possible to express instrument objects in the Cadence language itself. Note that this is already more powerful than `use "instruments"`, since you can have more than one voice per instrument, and you can fully customize the envelope and oscillators.