### PR TITLE
fix: Remove `id` property from node instances

### DIFF
--- a/packages/audiograph/src/builder.ts
+++ b/packages/audiograph/src/builder.ts
@@ -5,7 +5,7 @@ import type { EntityKey } from './entities.js'
 import type { AnyNode, AudioGraph, Edge, Meters, NodeId } from './graph.js'
 
 export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
-  readonly addNode: <T extends TNode> (type: T['type'], node: Omit<T, 'id' | 'type'>) => T
+  readonly addNode: <T extends TNode> (type: T['type'], node: Omit<T, 'id' | 'type'>) => NodeId
   readonly addEdge: (from: NodeId, to: NodeId) => void
   readonly addEdges: (from: readonly NodeId[], to: readonly NodeId[]) => void
   readonly setOutput: (nodeId: NodeId) => void
@@ -40,11 +40,11 @@ export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: 
 
   let nextId = 1 as NodeId
 
-  const addNode: AudioGraphBuilder<TNode>['addNode'] = <T extends TNode>(type: T['type'], node: Omit<T, 'id' | 'type'>): T => {
+  const addNode: AudioGraphBuilder<TNode>['addNode'] = <T extends TNode>(type: T['type'], node: Omit<T, 'id' | 'type'>): NodeId => {
     const id = nextId++ as NodeId
-    const newNode = { ...node, id, type } as T
+    const newNode = { ...node, type } as T
     nodes.set(id, newNode)
-    return newNode
+    return id
   }
 
   const addEdge: AudioGraphBuilder<TNode>['addEdge'] = (from, to) => {

--- a/packages/audiograph/src/graph.ts
+++ b/packages/audiograph/src/graph.ts
@@ -20,7 +20,6 @@ export interface AudioGraph<TNode = AnyNode> {
 export type NodeId = Brand<number, 'audiograph.NodeId'>
 
 export interface AnyNode {
-  readonly id: NodeId
   readonly type: string
 }
 

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -7,7 +7,7 @@ import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
 import type { EntityKey } from './entities.js'
 import { createEntityKey } from './entities.js'
-import type { AnyNode, AudioGraph, NodeId } from './graph.js'
+import type { AudioGraph, NodeId } from './graph.js'
 import type { BiquadNode, DelayNode, GainMeterNode, GainNode, IdentityNode, InstrumentNode, Node, PanNode, ReverbNode, SourceNode, WaveShaperNode, WidthNode } from './nodes.js'
 
 type Builder = AudioGraphBuilder<Node>
@@ -30,8 +30,8 @@ export function createAudioGraph (program: Program, options?: AudioGraphOptions)
     length: calculateTotalLength(program)
   })
 
-  const output = builder.addNode<IdentityNode>('identity', {})
-  builder.setOutput(output.id)
+  const outputId = builder.addNode<IdentityNode>('identity', {})
+  builder.setOutput(outputId)
 
   for (const asset of program.assets.values()) {
     builder.addAsset(asset)
@@ -53,12 +53,12 @@ export function createAudioGraph (program: Program, options?: AudioGraphOptions)
     }
   }
 
-  createRoutings(program, busSubgraphs, instrumentSubgraphs, output.id, builder)
+  createRoutings(program, busSubgraphs, instrumentSubgraphs, outputId, builder)
 
   createNoteEvents(program.track, instruments, builder)
 
   if (options?.metering != null) {
-    createMeteringNodes(busSubgraphs, instrumentSubgraphs, output.id, builder, options.metering)
+    createMeteringNodes(busSubgraphs, instrumentSubgraphs, outputId, builder, options.metering)
   }
 
   return builder.graph()
@@ -70,10 +70,10 @@ interface SubGraph {
   readonly instrument?: NodeId
 }
 
-function toSubGraph (node: AnyNode): SubGraph {
+function toSubGraph (nodeId: NodeId): SubGraph {
   return {
-    inputs: [node.id],
-    outputs: [node.id]
+    inputs: [nodeId],
+    outputs: [nodeId]
   }
 }
 
@@ -106,11 +106,7 @@ function createBus (program: Program, bus: Bus, builder: Builder): SubGraph {
   const last = effectSubgraphs.at(-1)
 
   if (first == null || last == null) {
-    const throughNode = builder.addNode<IdentityNode>('identity', {})
-    return {
-      inputs: [throughNode.id],
-      outputs: [throughNode.id]
-    }
+    return toSubGraph(builder.addNode<IdentityNode>('identity', {}))
   }
 
   return {
@@ -120,7 +116,7 @@ function createBus (program: Program, bus: Bus, builder: Builder): SubGraph {
 }
 
 function createInstrument (program: Program, instrument: Instrument, builder: Builder): SubGraph {
-  const instrumentNode = builder.addNode<InstrumentNode>('instrument', {
+  const instrumentNodeId = builder.addNode<InstrumentNode>('instrument', {
     trigger: (note) => {
       const result: SourceNode[] = []
 
@@ -134,16 +130,16 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
     }
   })
 
-  const gain = builder.addNode<GainNode>('gain', {
+  const gainId = builder.addNode<GainNode>('gain', {
     gain: computeParameterCurve(instrument.gain, program, gainTransform)
   })
 
-  builder.addEdge(instrumentNode.id, gain.id)
+  builder.addEdge(instrumentNodeId, gainId)
 
   return {
-    inputs: [instrumentNode.id],
-    outputs: [gain.id],
-    instrument: instrumentNode.id
+    inputs: [instrumentNodeId],
+    outputs: [gainId],
+    instrument: instrumentNodeId
   }
 }
 
@@ -165,7 +161,6 @@ function createSampleSourceNode (voice: Voice<Sample>): SourceNode {
   }
 
   return {
-    id: -1 as NodeId, // TODO: avoid invalid id
     type: 'sample',
     gainCurve: transformCurve(voice.envelope, gainTransform),
     duration: voice.duration,
@@ -182,7 +177,6 @@ function createOscillatorSourceNode (voice: Voice<Oscillator>): SourceNode {
   }
 
   return {
-    id: -1 as NodeId, // TODO: avoid invalid id
     type: 'oscillator',
     gainCurve: transformCurve(voice.envelope, gainTransform),
     duration: voice.duration,
@@ -243,21 +237,21 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         throw new Error(`Invalid time: ${effect.time.value}`)
       }
 
-      const delayNode = builder.addNode<DelayNode>('delay', {
+      const delayNodeId = builder.addNode<DelayNode>('delay', {
         // TODO time variant
         time: timeToSeconds(effect.time, program.track.tempo)
       })
 
       if (effect.feedback.initial.value > 0 || program.automations.has(effect.feedback.id)) {
-        const feedbackGain = builder.addNode<GainNode>('gain', {
+        const feedbackGainId = builder.addNode<GainNode>('gain', {
           gain: computeParameterCurve(effect.feedback, program, feedbackTransform)
         })
 
-        builder.addEdge(delayNode.id, feedbackGain.id)
-        builder.addEdge(feedbackGain.id, delayNode.id)
+        builder.addEdge(delayNodeId, feedbackGainId)
+        builder.addEdge(feedbackGainId, delayNodeId)
       }
 
-      return createDryWetMix(delayNode, effect.mix.value, effect.wet, builder)
+      return createDryWetMix(delayNodeId, effect.mix.value, effect.wet, builder)
     }
 
     case 'reverb': {
@@ -270,12 +264,12 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         return toSubGraph(builder.addNode<IdentityNode>('identity', {}))
       }
 
-      const reverb = builder.addNode<ReverbNode>('reverb', {
+      const reverbId = builder.addNode<ReverbNode>('reverb', {
         // TODO time variant
         decay: timeToSeconds(effect.decay, program.track.tempo)
       })
 
-      return createDryWetMix(reverb, mix, effect.wet, builder)
+      return createDryWetMix(reverbId, mix, effect.wet, builder)
     }
 
     case 'clip': {
@@ -293,33 +287,33 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const thresholdGain = computeParameterCurve(effect.threshold, program, gainTransform)
 
-      const input = builder.addNode<GainNode>('gain', {
+      const inputId = builder.addNode<GainNode>('gain', {
         gain: {
           initial: invert(thresholdGain.initial),
           points: thresholdGain.points.map(({ time, value, shape }) => ({ time, value: invert(value), shape }))
         }
       })
 
-      const waveShaper = builder.addNode<WaveShaperNode>('wave_shaper', {
+      const waveShaperId = builder.addNode<WaveShaperNode>('wave_shaper', {
         curve: new Float32Array([-1, 0, 1])
       })
 
-      const output = builder.addNode<GainNode>('gain', {
+      const outputId = builder.addNode<GainNode>('gain', {
         gain: thresholdGain
       })
 
-      builder.addEdge(input.id, waveShaper.id)
-      builder.addEdge(waveShaper.id, output.id)
+      builder.addEdge(inputId, waveShaperId)
+      builder.addEdge(waveShaperId, outputId)
 
       return {
-        inputs: [input.id],
-        outputs: [output.id]
+        inputs: [inputId],
+        outputs: [outputId]
       }
     }
   }
 }
 
-function createDryWetMix (effect: Node, mix: number, wetGain: Numeric<'db'>, builder: Builder): SubGraph {
+function createDryWetMix (effectId: NodeId, mix: number, wetGain: Numeric<'db'>, builder: Builder): SubGraph {
   if (Number.isNaN(mix)) {
     throw new Error(`Invalid mix: ${mix}`)
   }
@@ -328,18 +322,18 @@ function createDryWetMix (effect: Node, mix: number, wetGain: Numeric<'db'>, bui
     return toSubGraph(builder.addNode<IdentityNode>('identity', {}))
   }
 
-  const wetLevel = createOptionalGainNode(wetGain, builder)
+  const wetLevelId = createOptionalGainNode(wetGain, builder)
 
   if (mix >= 1) {
-    if (wetLevel == null) {
-      return toSubGraph(effect)
+    if (wetLevelId == null) {
+      return toSubGraph(effectId)
     }
 
-    builder.addEdge(effect.id, wetLevel.id)
+    builder.addEdge(effectId, wetLevelId)
 
     return {
-      inputs: [effect.id],
-      outputs: [wetLevel.id]
+      inputs: [effectId],
+      outputs: [wetLevelId]
     }
   }
 
@@ -347,29 +341,29 @@ function createDryWetMix (effect: Node, mix: number, wetGain: Numeric<'db'>, bui
   // wet:       0.0 ->   0%,   0.25: 50%,   0.5...1.0: 100%
 
   const dry = Math.max(0, Math.min(1, (1 - mix) * 2))
-  const dryNode = builder.addNode<GainNode>('gain', {
+  const dryNodeId = builder.addNode<GainNode>('gain', {
     gain: { initial: numeric(undefined, dry), points: [] }
   })
 
   const wet = Math.max(0, Math.min(1, mix * 2))
-  const wetNode = builder.addNode<GainNode>('gain', {
+  const wetNodeId = builder.addNode<GainNode>('gain', {
     gain: { initial: numeric(undefined, wet), points: [] }
   })
 
-  const wetInput = wetLevel ?? effect
-  if (wetLevel != null) {
-    builder.addEdge(effect.id, wetLevel.id)
+  const wetInputId = wetLevelId ?? effectId
+  if (wetLevelId != null) {
+    builder.addEdge(effectId, wetLevelId)
   }
 
-  builder.addEdge(wetInput.id, wetNode.id)
+  builder.addEdge(wetInputId, wetNodeId)
 
   return {
-    inputs: [dryNode.id, effect.id],
-    outputs: [dryNode.id, wetNode.id]
+    inputs: [dryNodeId, effectId],
+    outputs: [dryNodeId, wetNodeId]
   }
 }
 
-function createOptionalGainNode (wetGain: Numeric<'db'>, builder: Builder): Node | undefined {
+function createOptionalGainNode (wetGain: Numeric<'db'>, builder: Builder): NodeId | undefined {
   if (wetGain.value === 0) {
     return undefined
   }
@@ -451,16 +445,13 @@ function createMeteringNodes (
   }
 
   const createMeters = (key: EntityKey, sources: readonly NodeId[]): void => {
-    const gainMeter = builder.addNode<GainMeterNode>('gain_meter', {
+    const gainMeterId = builder.addNode<GainMeterNode>('gain_meter', {
       key,
       interval: options.interval
     })
 
-    builder.addMeters(key, {
-      gainMeterId: gainMeter.id
-    })
-
-    builder.addEdges(sources, [gainMeter.id])
+    builder.addMeters(key, { gainMeterId })
+    builder.addEdges(sources, [gainMeterId])
   }
 
   {

--- a/packages/audiograph/test/builder.test.ts
+++ b/packages/audiograph/test/builder.test.ts
@@ -47,9 +47,9 @@ describe('builder.ts', () => {
     const node2 = builder.addNode('sample', { url: 'bar.wav' })
     const node3 = builder.addNode('gain', { gain: 0.5 })
 
-    assert.notStrictEqual(node1.id, node2.id)
-    assert.notStrictEqual(node1.id, node3.id)
-    assert.notStrictEqual(node2.id, node3.id)
+    assert.notStrictEqual(node1, node2)
+    assert.notStrictEqual(node1, node3)
+    assert.notStrictEqual(node2, node3)
   })
 
   it('should build a graph correctly', () => {
@@ -59,15 +59,15 @@ describe('builder.ts', () => {
     const node2 = builder.addNode('gain', { gain: 0.5 })
     const node3 = builder.addNode('pan', { pan: -0.5 })
 
-    builder.addEdge(node1.id, node2.id)
-    builder.addEdge(node2.id, node3.id)
+    builder.addEdge(node1, node2)
+    builder.addEdge(node2, node3)
 
     const graph = builder.graph()
 
     assert.strictEqual(graph.nodes.size, 3)
     assert.deepStrictEqual(graph.edges, [
-      { from: node1.id, to: node2.id },
-      { from: node2.id, to: node3.id }
+      { from: node1, to: node2 },
+      { from: node2, to: node3 }
     ])
     assert.deepStrictEqual(graph.outputIds, [])
   })
@@ -77,10 +77,10 @@ describe('builder.ts', () => {
 
     const node1 = builder.addNode('sample', { url: 'foo.wav' })
     builder.addNode('gain', { gain: 0.5 })
-    builder.setOutput(node1.id)
+    builder.setOutput(node1)
 
     const graph = builder.graph()
-    assert.deepStrictEqual(graph.outputIds, [node1.id])
+    assert.deepStrictEqual(graph.outputIds, [node1])
   })
 
   it('should add multiple edges correctly', () => {
@@ -91,16 +91,16 @@ describe('builder.ts', () => {
     const node3 = builder.addNode('pan', { pan: -0.5 })
     const node4 = builder.addNode('reverb', { roomSize: 0.8 })
 
-    builder.addEdges([node1.id, node2.id], [node3.id, node4.id])
+    builder.addEdges([node1, node2], [node3, node4])
 
     const graph = builder.graph()
 
     assert.strictEqual(graph.nodes.size, 4)
     assert.deepStrictEqual(graph.edges, [
-      { from: node1.id, to: node3.id },
-      { from: node1.id, to: node4.id },
-      { from: node2.id, to: node3.id },
-      { from: node2.id, to: node4.id }
+      { from: node1, to: node3 },
+      { from: node1, to: node4 },
+      { from: node2, to: node3 },
+      { from: node2, to: node4 }
     ])
   })
 
@@ -108,7 +108,7 @@ describe('builder.ts', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
-    builder.addNoteEvents(node1.id, [
+    builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(0.8) },
       { time: beats(1), pitch: 'C#4', velocity: scalar(0.8) },
       { time: beats(2), pitch: 'D4', velocity: scalar(0.8) }
@@ -117,7 +117,7 @@ describe('builder.ts', () => {
     const graph = builder.graph()
 
     assert.strictEqual(graph.noteEvents.size, 1)
-    assert.deepStrictEqual(graph.noteEvents.get(node1.id), [
+    assert.deepStrictEqual(graph.noteEvents.get(node1), [
       { time: beats(0), pitch: 'C4', velocity: scalar(0.8) },
       { time: beats(1), pitch: 'C#4', velocity: scalar(0.8) },
       { time: beats(2), pitch: 'D4', velocity: scalar(0.8) }
@@ -128,19 +128,19 @@ describe('builder.ts', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(-1), pitch: 'C4', velocity: scalar(0.8) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(Infinity), pitch: 'C4', velocity: scalar(0.8) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(-Infinity), pitch: 'C4', velocity: scalar(0.8) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(Number.NaN), pitch: 'C4', velocity: scalar(0.8) }
     ]))
   })
@@ -149,15 +149,15 @@ describe('builder.ts', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(-0.1) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(1.1) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(Number.NaN) }
     ]))
   })
@@ -166,11 +166,11 @@ describe('builder.ts', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'H4' as never, velocity: scalar(0.8) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C#11' as never, velocity: scalar(0.8) }
     ]))
   })
@@ -179,19 +179,19 @@ describe('builder.ts', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
 
     const node1 = builder.addNode('sampler', { url: 'foo.wav' })
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(-1) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(Infinity) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(-Infinity) }
     ]))
 
-    assert.throws(() => builder.addNoteEvents(node1.id, [
+    assert.throws(() => builder.addNoteEvents(node1, [
       { time: beats(0), pitch: 'C4', velocity: scalar(0.8), gate: beats(Number.NaN) }
     ]))
   })

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -8,7 +8,7 @@ import { gainTransform, transformCurve } from '../src/automation.js'
 import { createEntityKey } from '../src/entities.js'
 import type { NodeId } from '../src/graph.js'
 import { createAudioGraph } from '../src/lowering.js'
-import type { DelayNode, GainNode, IdentityNode, InstrumentNode, Node, OscillatorNode, ReverbNode, SourceNode, WaveShaperNode } from '../src/nodes.js'
+import type { BiquadNode, DelayNode, GainNode, IdentityNode, InstrumentNode, Node, OscillatorNode, PanNode, ReverbNode, SourceNode, WaveShaperNode, WidthNode } from '../src/nodes.js'
 
 const SIMPLE_CURVE: Curve<'s', 'db'> = {
   initial: numeric('db', -Infinity),
@@ -23,8 +23,8 @@ function toGainCurve (curve: Curve<'s', 'db'>): Curve<'s', undefined> {
   return transformCurve(curve, gainTransform)
 }
 
-function compareIds (a: Node, b: Node): number {
-  return a.id - b.id
+function compareIds (a: readonly [NodeId, Node], b: readonly [NodeId, Node]): number {
+  return a[0] - b[0]
 }
 
 function createProgramWithInstrument (instrument: Instrument, asset?: Asset): Program {
@@ -258,32 +258,40 @@ describe('lowering.ts', () => {
 
     const graph = createAudioGraph(program)
 
-    assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
-      {
-        id: 1 as NodeId,
-        type: 'identity'
-      } satisfies IdentityNode,
-      {
-        id: 2 as NodeId,
-        type: 'gain',
-        gain: {
-          initial: dbToGain(numeric('db', -3)),
-          points: []
-        }
-      } satisfies GainNode,
-      {
-        id: 3 as NodeId,
-        type: 'instrument',
-        trigger: (graph.nodes.get(3 as NodeId) as InstrumentNode).trigger
-      } satisfies InstrumentNode,
-      {
-        id: 4 as NodeId,
-        type: 'gain',
-        gain: {
-          initial: dbToGain(numeric('db', -6)),
-          points: []
-        }
-      } satisfies GainNode
+    assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
+      [
+        1,
+        {
+          type: 'identity'
+        } satisfies IdentityNode
+      ],
+      [
+        2,
+        {
+          type: 'gain',
+          gain: {
+            initial: dbToGain(numeric('db', -3)),
+            points: []
+          }
+        } satisfies GainNode
+      ],
+      [
+        3,
+        {
+          type: 'instrument',
+          trigger: (graph.nodes.get(3 as NodeId) as InstrumentNode).trigger
+        } satisfies InstrumentNode
+      ],
+      [
+        4,
+        {
+          type: 'gain',
+          gain: {
+            initial: dbToGain(numeric('db', -6)),
+            points: []
+          }
+        } satisfies GainNode
+      ]
     ])
 
     assert.deepStrictEqual(graph.edges, [
@@ -306,7 +314,6 @@ describe('lowering.ts', () => {
     const [voice] = voices
 
     assert.deepStrictEqual(voice, {
-      id: -1 as NodeId,
       type: 'oscillator',
       shape: 'sine',
       frequency: numeric('hz', 440),
@@ -384,7 +391,6 @@ describe('lowering.ts', () => {
     const graph = createAudioGraph(program)
 
     assert.deepStrictEqual(graph.nodes.get(3 as NodeId), {
-      id: 3 as NodeId,
       type: 'gain',
       gain: {
         initial: dbToGain(numeric('db', -6)),
@@ -696,13 +702,12 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'gain',
           gain: {
             initial: dbToGain(numeric('db', -3)),
             points: []
           }
-        })
+        } satisfies GainNode)
       })
 
       it('should allow negative infinity gain', () => {
@@ -714,13 +719,12 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'gain',
           gain: {
             initial: numeric(undefined, 0),
             points: []
           }
-        })
+        } satisfies GainNode)
       })
 
       it('should throw for invalid gain', () => {
@@ -746,13 +750,12 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'pan',
           pan: {
             initial: numeric(undefined, 0.5),
             points: []
           }
-        })
+        } satisfies PanNode)
       })
 
       it('should clamp pan to [-1, 1]', () => {
@@ -764,13 +767,12 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'pan',
           pan: {
             initial: numeric(undefined, 1),
             points: []
           }
-        })
+        } satisfies PanNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'pan',
@@ -780,13 +782,12 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'pan',
           pan: {
             initial: numeric(undefined, -1),
             points: []
           }
-        })
+        } satisfies PanNode)
       })
 
       it('should throw for NaN pan', () => {
@@ -810,7 +811,6 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'biquad',
           filterType: 'lowpass',
           frequency: {
@@ -818,7 +818,7 @@ describe('lowering.ts', () => {
             points: []
           },
           rolloffPerOctave: numeric('db', 12)
-        })
+        } satisfies BiquadNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'lowpass',
@@ -828,7 +828,6 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'biquad',
           filterType: 'lowpass',
           frequency: {
@@ -836,7 +835,7 @@ describe('lowering.ts', () => {
             points: []
           },
           rolloffPerOctave: numeric('db', 12)
-        })
+        } satisfies BiquadNode)
       })
 
       it('should throw for invalid lowpass frequency', () => {
@@ -862,7 +861,6 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'biquad',
           filterType: 'highpass',
           frequency: {
@@ -870,7 +868,7 @@ describe('lowering.ts', () => {
             points: []
           },
           rolloffPerOctave: numeric('db', 12)
-        })
+        } satisfies BiquadNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'highpass',
@@ -880,7 +878,6 @@ describe('lowering.ts', () => {
           }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'biquad',
           filterType: 'highpass',
           frequency: {
@@ -888,7 +885,7 @@ describe('lowering.ts', () => {
             points: []
           },
           rolloffPerOctave: numeric('db', 12)
-        })
+        } satisfies BiquadNode)
       })
 
       it('should throw for invalid highpass frequency', () => {
@@ -911,10 +908,9 @@ describe('lowering.ts', () => {
           width: numeric(undefined, 0.75)
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'width',
           width: numeric(undefined, 0.75)
-        })
+        } satisfies WidthNode)
       })
 
       it('should clamp width to [0, 1]', () => {
@@ -923,20 +919,18 @@ describe('lowering.ts', () => {
           width: numeric(undefined, Infinity)
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'width',
           width: numeric(undefined, 1)
-        })
+        } satisfies WidthNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'width',
           width: numeric(undefined, -Infinity)
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'width',
           width: numeric(undefined, 0)
-        })
+        } satisfies WidthNode)
       })
 
       it('should throw for NaN width', () => {
@@ -960,45 +954,55 @@ describe('lowering.ts', () => {
           wet: numeric('db', 0)
         }))
 
-        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+        assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
           // output node
-          {
-            id: 1 as NodeId,
-            type: 'identity'
-          } satisfies IdentityNode,
+          [
+            1,
+            {
+              type: 'identity'
+            } satisfies IdentityNode
+          ],
           // delay node
-          {
-            id: 2 as NodeId,
-            type: 'delay',
-            time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
-          } satisfies DelayNode,
+          [
+            2,
+            {
+              type: 'delay',
+              time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+            } satisfies DelayNode
+          ],
           // feedback gain node
-          {
-            id: 3 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 0.4),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            3,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 0.4),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // dry gain node
-          {
-            id: 4 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 1.0),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            4,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 1.0),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // wet gain node
-          {
-            id: 5 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 0.5),
-              points: []
-            }
-          } satisfies GainNode
+          [
+            5,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 0.5),
+                points: []
+              }
+            } satisfies GainNode
+          ]
         ])
 
         assert.deepStrictEqual(graph.edges, [
@@ -1027,27 +1031,33 @@ describe('lowering.ts', () => {
           wet: numeric('db', 0)
         }))
 
-        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+        assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
           // output node
-          {
-            id: 1 as NodeId,
-            type: 'identity'
-          } satisfies IdentityNode,
+          [
+            1,
+            {
+              type: 'identity'
+            } satisfies IdentityNode
+          ],
           // delay node
-          {
-            id: 2 as NodeId,
-            type: 'delay',
-            time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
-          } satisfies DelayNode,
+          [
+            2,
+            {
+              type: 'delay',
+              time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+            } satisfies DelayNode
+          ],
           // feedback gain node
-          {
-            id: 3 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 0.4),
-              points: []
-            }
-          } satisfies GainNode
+          [
+            3,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 0.4),
+                points: []
+              }
+            } satisfies GainNode
+          ]
         ])
       })
 
@@ -1092,7 +1102,6 @@ describe('lowering.ts', () => {
         }))
 
         assert.deepStrictEqual(graph.nodes.get(3 as NodeId), {
-          id: 3 as NodeId,
           type: 'gain',
           gain: {
             initial: numeric(undefined, 1),
@@ -1127,7 +1136,6 @@ describe('lowering.ts', () => {
         }))
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'delay',
           time: numeric('s', 1.5)
         } satisfies DelayNode)
@@ -1148,54 +1156,66 @@ describe('lowering.ts', () => {
         // Note: There already is a wet gain node to handle the mix level,
         // but it cannot be reused as there may be separate automations for the mix and wet parameters,
         // which would unnecessarily complicate the calculations.
-        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+        assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
           // output node
-          {
-            id: 1 as NodeId,
-            type: 'identity'
-          } satisfies IdentityNode,
+          [
+            1,
+            {
+              type: 'identity'
+            } satisfies IdentityNode
+          ],
           // delay node
-          {
-            id: 2 as NodeId,
-            type: 'delay',
-            time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
-          } satisfies DelayNode,
+          [
+            2,
+            {
+              type: 'delay',
+              time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+            } satisfies DelayNode
+          ],
           // feedback gain node
-          {
-            id: 3 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 0.4),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            3,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 0.4),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // wet gain node for wet level
-          {
-            id: 4 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: dbToGain(numeric('db', -6)),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            4,
+            {
+              type: 'gain',
+              gain: {
+                initial: dbToGain(numeric('db', -6)),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // dry gain node (mix)
-          {
-            id: 5 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 1.0),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            5,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 1.0),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // wet gain node (mix)
-          {
-            id: 6 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 0.5),
-              points: []
-            }
-          } satisfies GainNode
+          [
+            6,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 0.5),
+                points: []
+              }
+            } satisfies GainNode
+          ]
         ])
 
         assert.deepStrictEqual(graph.edges, [
@@ -1239,36 +1259,44 @@ describe('lowering.ts', () => {
           wet: numeric('db', 0)
         }))
 
-        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+        assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
           // output node
-          {
-            id: 1 as NodeId,
-            type: 'identity'
-          } satisfies IdentityNode,
+          [
+            1,
+            {
+              type: 'identity'
+            } satisfies IdentityNode
+          ],
           // reverb node
-          {
-            id: 2 as NodeId,
-            type: 'reverb',
-            decay: numeric('s', 2)
-          } satisfies ReverbNode,
+          [
+            2,
+            {
+              type: 'reverb',
+              decay: numeric('s', 2)
+            } satisfies ReverbNode
+          ],
           // dry gain node
-          {
-            id: 3 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 0.5),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            3,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 0.5),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // wet gain node
-          {
-            id: 4 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 1.0),
-              points: []
-            }
-          } satisfies GainNode
+          [
+            4,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 1.0),
+                points: []
+              }
+            } satisfies GainNode
+          ]
         ])
 
         assert.deepStrictEqual(graph.edges, [
@@ -1289,18 +1317,22 @@ describe('lowering.ts', () => {
           wet: numeric('db', 0)
         }))
 
-        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+        assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
           // output node
-          {
-            id: 1 as NodeId,
-            type: 'identity'
-          } satisfies IdentityNode,
+          [
+            1,
+            {
+              type: 'identity'
+            } satisfies IdentityNode
+          ],
           // reverb node
-          {
-            id: 2 as NodeId,
-            type: 'reverb',
-            decay: numeric('s', 2)
-          } satisfies ReverbNode
+          [
+            2,
+            {
+              type: 'reverb',
+              decay: numeric('s', 2)
+            } satisfies ReverbNode
+          ]
         ])
       })
 
@@ -1333,7 +1365,6 @@ describe('lowering.ts', () => {
         }))
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
-          id: 2 as NodeId,
           type: 'reverb',
           decay: beatsToSeconds(numeric('beats', 2), numeric('bpm', 120))
         } satisfies ReverbNode)
@@ -1350,45 +1381,55 @@ describe('lowering.ts', () => {
         // Note: There already is a wet gain node to handle the mix level,
         // but it cannot be reused as there may be separate automations for the mix and wet parameters,
         // which would unnecessarily complicate the calculations.
-        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+        assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
           // output node
-          {
-            id: 1 as NodeId,
-            type: 'identity'
-          } satisfies IdentityNode,
+          [
+            1,
+            {
+              type: 'identity'
+            } satisfies IdentityNode
+          ],
           // reverb node
-          {
-            id: 2 as NodeId,
-            type: 'reverb',
-            decay: numeric('s', 2)
-          } satisfies ReverbNode,
+          [
+            2,
+            {
+              type: 'reverb',
+              decay: numeric('s', 2)
+            } satisfies ReverbNode
+          ],
           // wet gain node for wet level
-          {
-            id: 3 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: dbToGain(numeric('db', -6)),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            3,
+            {
+              type: 'gain',
+              gain: {
+                initial: dbToGain(numeric('db', -6)),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // dry gain node (mix)
-          {
-            id: 4 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 1.0),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            4,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 1.0),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // wet gain node (mix)
-          {
-            id: 5 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 0.5),
-              points: []
-            }
-          } satisfies GainNode
+          [
+            5,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 0.5),
+                points: []
+              }
+            } satisfies GainNode
+          ]
         ])
 
         assert.deepStrictEqual(graph.edges, [
@@ -1427,36 +1468,44 @@ describe('lowering.ts', () => {
           }
         }))
 
-        assert.deepStrictEqual([...graph.nodes.values()].sort(compareIds), [
+        assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
           // output node
-          {
-            id: 1 as NodeId,
-            type: 'identity'
-          } satisfies IdentityNode,
+          [
+            1,
+            {
+              type: 'identity'
+            } satisfies IdentityNode
+          ],
           // pre-gain to set the threshold
-          {
-            id: 2 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: numeric(undefined, 1 / dbToGain(threshold).value),
-              points: []
-            }
-          } satisfies GainNode,
+          [
+            2,
+            {
+              type: 'gain',
+              gain: {
+                initial: numeric(undefined, 1 / dbToGain(threshold).value),
+                points: []
+              }
+            } satisfies GainNode
+          ],
           // wave shaper
-          {
-            id: 3 as NodeId,
-            type: 'wave_shaper',
-            curve: new Float32Array([-1, 0, 1])
-          } satisfies WaveShaperNode,
+          [
+            3,
+            {
+              type: 'wave_shaper',
+              curve: new Float32Array([-1, 0, 1])
+            } satisfies WaveShaperNode
+          ],
           // makeup gain
-          {
-            id: 4 as NodeId,
-            type: 'gain',
-            gain: {
-              initial: dbToGain(threshold),
-              points: []
-            }
-          } satisfies GainNode
+          [
+            4,
+            {
+              type: 'gain',
+              gain: {
+                initial: dbToGain(threshold),
+                points: []
+              }
+            } satisfies GainNode
+          ]
         ])
 
         assert.deepStrictEqual(graph.edges, [

--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -50,7 +50,7 @@ export async function createWebAudioGraph (
   const instances = new Map<NodeId, Instance>()
   const instancePromises = new Map<NodeId, Promise<void>>()
 
-  for (const node of graph.nodes.values()) {
+  for (const [nodeId, node] of graph.nodes) {
     const promise = Promise.resolve().then(() => {
       return createNodeInstance(node, transport, assets, meterCallbacks)
     }).then((instance) => {
@@ -59,10 +59,10 @@ export async function createWebAudioGraph (
         return
       }
 
-      instances.set(node.id, instance)
+      instances.set(nodeId, instance)
     })
 
-    instancePromises.set(node.id, promise)
+    instancePromises.set(nodeId, promise)
   }
 
   try {

--- a/packages/webaudio/test-browser/graph/effect.test.ts
+++ b/packages/webaudio/test-browser/graph/effect.test.ts
@@ -1,4 +1,3 @@
-import type { NodeId } from '@audiograph'
 import type { Numeric } from '@utility'
 import { numeric } from '@utility'
 import { describe, expect, it } from 'vitest'
@@ -31,14 +30,8 @@ async function renderWidth (options: {
   readonly output: AudioBuffer
 }> {
   const { width, inputChannels, fill } = options
-
   const { ctx, transport } = createTestTransport()
-
-  const instance = createWidthInstance({
-    id: 42 as NodeId,
-    type: 'width',
-    width
-  }, transport)
+  const instance = createWidthInstance({ type: 'width', width }, transport)
 
   try {
     const input = ctx.createBuffer(inputChannels, length, sampleRate)
@@ -80,11 +73,7 @@ async function renderDelay (options: {
     schedule: (_time, onSchedule) => onSchedule(0)
   }
 
-  const instance = createDelayInstance({
-    id: 42 as NodeId,
-    type: 'delay',
-    time
-  }, transport)
+  const instance = createDelayInstance({ type: 'delay', time }, transport)
 
   try {
     const source = ctx.createBufferSource()


### PR DESCRIPTION
By removing the `id` from the node itself, we can generate dynamic nodes without having to assign a nonsensical `id` to them. For compile-time nodes, the `id` is available via the node map keys.