### PR TITLE
refactor: Split Numeric and RuntimeNumeric

### DIFF
--- a/packages/app/src/compilation/CompilationContext.tsx
+++ b/packages/app/src/compilation/CompilationContext.tsx
@@ -1,6 +1,6 @@
 import { useDebouncedValue, useLatestRef, useProjectSource, useSafeContext } from '@editor'
 import type { GenerateOptions } from '@language'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { FunctionComponent, PropsWithChildren } from 'react'
 import { createContext, useCallback, useMemo } from 'react'
 import type { CompileResult } from './compiler.js'
@@ -14,7 +14,7 @@ export interface CompilationState {
 
 const CompilationContext = createContext<CompilationState | undefined>(undefined)
 
-const COMPILE_DEBOUNCE = runtimeNumeric('s', 0.25)
+const COMPILE_DEBOUNCE = 0.25 as Numeric<'s'>
 
 export const CompilationProvider: FunctionComponent<PropsWithChildren<{
   compileOptions: GenerateOptions

--- a/packages/app/src/compilation/CompilationContext.tsx
+++ b/packages/app/src/compilation/CompilationContext.tsx
@@ -1,6 +1,6 @@
 import { useDebouncedValue, useLatestRef, useProjectSource, useSafeContext } from '@editor'
 import type { GenerateOptions } from '@language'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { FunctionComponent, PropsWithChildren } from 'react'
 import { createContext, useCallback, useMemo } from 'react'
 import type { CompileResult } from './compiler.js'
@@ -14,7 +14,7 @@ export interface CompilationState {
 
 const CompilationContext = createContext<CompilationState | undefined>(undefined)
 
-const COMPILE_DEBOUNCE = numeric('s', 0.25)
+const COMPILE_DEBOUNCE = runtimeNumeric('s', 0.25)
 
 export const CompilationProvider: FunctionComponent<PropsWithChildren<{
   compileOptions: GenerateOptions

--- a/packages/app/src/components/gain-slider/GainIcon.tsx
+++ b/packages/app/src/components/gain-slider/GainIcon.tsx
@@ -1,15 +1,15 @@
 import { VolumeDownOutlined, VolumeOffOutlined, VolumeUpOutlined } from '@mui/icons-material'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { FunctionComponent } from 'react'
 
 export const GainIcon: FunctionComponent<{
-  gain: RuntimeNumeric<'db'>
+  gain: Numeric<'db'>
 }> = ({ gain }) => {
-  if (gain.value < -48) {
+  if (gain < -48) {
     return <VolumeOffOutlined />
   }
 
-  if (gain.value < -18) {
+  if (gain < -18) {
     return <VolumeDownOutlined />
   }
 

--- a/packages/app/src/components/gain-slider/GainIcon.tsx
+++ b/packages/app/src/components/gain-slider/GainIcon.tsx
@@ -1,9 +1,9 @@
 import { VolumeDownOutlined, VolumeOffOutlined, VolumeUpOutlined } from '@mui/icons-material'
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import type { FunctionComponent } from 'react'
 
 export const GainIcon: FunctionComponent<{
-  gain: Numeric<'db'>
+  gain: RuntimeNumeric<'db'>
 }> = ({ gain }) => {
   if (gain.value < -48) {
     return <VolumeOffOutlined />

--- a/packages/app/src/components/gain-slider/GainSlider.tsx
+++ b/packages/app/src/components/gain-slider/GainSlider.tsx
@@ -1,13 +1,12 @@
-import type { RuntimeNumeric } from '@utility'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import clsx from 'clsx'
 import type { FunctionComponent } from 'react'
 import { Slider } from '../slider/Slider.js'
 import { GainIcon } from './GainIcon.js'
 
 export const GainSlider: FunctionComponent<{
-  gain: RuntimeNumeric<'db'>
-  onChange: (gain: RuntimeNumeric<'db'>) => void
+  gain: Numeric<'db'>
+  onChange: (gain: Numeric<'db'>) => void
   label: string
   orientation?: 'horizontal' | 'vertical'
   collapsible?: boolean
@@ -20,14 +19,14 @@ export const GainSlider: FunctionComponent<{
       orientation={orientation}
       min={-60}
       max={0}
-      value={gain.value}
-      onChange={(value) => onChange(runtimeNumeric('db', value))}
+      value={gain}
+      onChange={(value) => onChange(value as Numeric<'db'>)}
       step={1}
       icon={<GainIcon gain={gain} />}
       collapsible={collapsible}
     >
       <span className={clsx('text-right text-nowrap', vertical ? 'text-sm' : 'w-12')}>
-        {gain.value.toFixed() + (vertical ? '' : ' dB')}
+        {gain.toFixed() + (vertical ? '' : ' dB')}
       </span>
     </Slider>
   )

--- a/packages/app/src/components/gain-slider/GainSlider.tsx
+++ b/packages/app/src/components/gain-slider/GainSlider.tsx
@@ -1,13 +1,13 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import clsx from 'clsx'
 import type { FunctionComponent } from 'react'
 import { Slider } from '../slider/Slider.js'
 import { GainIcon } from './GainIcon.js'
 
 export const GainSlider: FunctionComponent<{
-  gain: Numeric<'db'>
-  onChange: (gain: Numeric<'db'>) => void
+  gain: RuntimeNumeric<'db'>
+  onChange: (gain: RuntimeNumeric<'db'>) => void
   label: string
   orientation?: 'horizontal' | 'vertical'
   collapsible?: boolean
@@ -21,7 +21,7 @@ export const GainSlider: FunctionComponent<{
       min={-60}
       max={0}
       value={gain.value}
-      onChange={(value) => onChange(numeric('db', value))}
+      onChange={(value) => onChange(runtimeNumeric('db', value))}
       step={1}
       icon={<GainIcon gain={gain} />}
       collapsible={collapsible}

--- a/packages/app/src/components/timeline/Timeline.tsx
+++ b/packages/app/src/components/timeline/Timeline.tsx
@@ -2,8 +2,8 @@ import type { Part, Program } from '@core'
 import { calculateTotalLength } from '@core'
 import { useGlobalMouseMove, useGlobalMouseUp } from '@editor'
 import { Warning } from '@mui/icons-material'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { BeatRange } from '@webaudio'
 import clsx from 'clsx'
 import type { FunctionComponent } from 'react'
@@ -38,7 +38,7 @@ export const Timeline: FunctionComponent<{
   program: Program
   selection: BeatRange
   setSelection: (range: BeatRange) => void
-  playbackPosition?: Numeric<'beats'>
+  playbackPosition?: RuntimeNumeric<'beats'>
 }> = ({ program, selection, setSelection, playbackPosition }) => {
   const trackLength = calculateTotalLength(program)
 
@@ -114,7 +114,7 @@ export const Timeline: FunctionComponent<{
 
 const TimeRuler: FunctionComponent<{
   beatsPerBar: number
-  trackLength: Numeric<'beats'>
+  trackLength: RuntimeNumeric<'beats'>
   beatWidth: number
   selection: BeatRange
   onSelect: (range: BeatRange) => void
@@ -159,9 +159,9 @@ const TimeRuler: FunctionComponent<{
 
   const timelineRef = useRef<HTMLDivElement>(null)
   const [isSelecting, setIsSelecting] = useState(false)
-  const [selectionStart, setSelectionStart] = useState<Numeric<'beats'> | undefined>(undefined)
+  const [selectionStart, setSelectionStart] = useState<RuntimeNumeric<'beats'> | undefined>(undefined)
 
-  const computeTimeFromEvent = useCallback((event: MouseEvent | React.MouseEvent): Numeric<'beats'> | undefined => {
+  const computeTimeFromEvent = useCallback((event: MouseEvent | React.MouseEvent): RuntimeNumeric<'beats'> | undefined => {
     const rect = timelineRef.current?.getBoundingClientRect()
     if (rect == null || beatWidth <= 0) {
       return undefined
@@ -177,7 +177,7 @@ const TimeRuler: FunctionComponent<{
     const snappedIndex = Math.round(positionInBeats / granularityBeats) * granularityBeats
     const clampedIndex = Math.max(0, Math.min(snappedIndex, trackLength.value))
 
-    return numeric('beats', clampedIndex)
+    return runtimeNumeric('beats', clampedIndex)
   }, [beatsPerBar, beatWidth, trackLength])
 
   const updateSelection = useCallback((event: MouseEvent | React.MouseEvent) => {
@@ -346,8 +346,8 @@ const markerPathData = {
 
 const TimelineMarker: FunctionComponent<{
   variant: 'cursor' | 'start' | 'end'
-  position: Numeric<'beats'>
-  trackLength: Numeric<'beats'>
+  position: RuntimeNumeric<'beats'>
+  trackLength: RuntimeNumeric<'beats'>
   dimmed: boolean
 }> = ({ variant, position, trackLength, dimmed }) => {
   return (

--- a/packages/app/src/components/timeline/Timeline.tsx
+++ b/packages/app/src/components/timeline/Timeline.tsx
@@ -2,8 +2,7 @@ import type { Part, Program } from '@core'
 import { calculateTotalLength } from '@core'
 import { useGlobalMouseMove, useGlobalMouseUp } from '@editor'
 import { Warning } from '@mui/icons-material'
-import type { RuntimeNumeric } from '@utility'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { BeatRange } from '@webaudio'
 import clsx from 'clsx'
 import type { FunctionComponent } from 'react'
@@ -38,7 +37,7 @@ export const Timeline: FunctionComponent<{
   program: Program
   selection: BeatRange
   setSelection: (range: BeatRange) => void
-  playbackPosition?: RuntimeNumeric<'beats'>
+  playbackPosition?: Numeric<'beats'>
 }> = ({ program, selection, setSelection, playbackPosition }) => {
   const trackLength = calculateTotalLength(program)
 
@@ -56,8 +55,8 @@ export const Timeline: FunctionComponent<{
     setBeatWidth((prev) => Math.min(TIMELINE_ZOOM_MAX, Math.max(TIMELINE_ZOOM_MIN, prev - delta)))
   }, [])
 
-  const isRangeSelection = selection.end != null && selection.end.value > selection.start.value
-  const showSelection = trackLength.value > 0 && (isRangeSelection || selection.start.value > 0)
+  const isRangeSelection = selection.end != null && selection.end > selection.start
+  const showSelection = trackLength > 0 && (isRangeSelection || selection.start > 0)
 
   return (
     <div className='h-full' onWheel={onWheel}>
@@ -103,7 +102,7 @@ export const Timeline: FunctionComponent<{
           <div
             className='absolute top-0 bottom-0 w-1 -ml-0.5 bg-accent-100 pointer-events-none'
             style={{
-              left: `${(playbackPosition.value / trackLength.value) * 100}%`
+              left: `${(playbackPosition / trackLength) * 100}%`
             }}
           />
         )}
@@ -114,12 +113,12 @@ export const Timeline: FunctionComponent<{
 
 const TimeRuler: FunctionComponent<{
   beatsPerBar: number
-  trackLength: RuntimeNumeric<'beats'>
+  trackLength: Numeric<'beats'>
   beatWidth: number
   selection: BeatRange
   onSelect: (range: BeatRange) => void
 }> = ({ beatsPerBar, trackLength, beatWidth, selection, onSelect }) => {
-  const totalBeats = Math.ceil(trackLength.value)
+  const totalBeats = Math.ceil(trackLength)
 
   const limited = totalBeats > RENDERING_LIMIT_BEATS
 
@@ -159,9 +158,9 @@ const TimeRuler: FunctionComponent<{
 
   const timelineRef = useRef<HTMLDivElement>(null)
   const [isSelecting, setIsSelecting] = useState(false)
-  const [selectionStart, setSelectionStart] = useState<RuntimeNumeric<'beats'> | undefined>(undefined)
+  const [selectionStart, setSelectionStart] = useState<Numeric<'beats'> | undefined>(undefined)
 
-  const computeTimeFromEvent = useCallback((event: MouseEvent | React.MouseEvent): RuntimeNumeric<'beats'> | undefined => {
+  const computeTimeFromEvent = useCallback((event: MouseEvent | React.MouseEvent): Numeric<'beats'> | undefined => {
     const rect = timelineRef.current?.getBoundingClientRect()
     if (rect == null || beatWidth <= 0) {
       return undefined
@@ -175,9 +174,9 @@ const TimeRuler: FunctionComponent<{
     const positionInBeats = positionInPixels / beatWidth
 
     const snappedIndex = Math.round(positionInBeats / granularityBeats) * granularityBeats
-    const clampedIndex = Math.max(0, Math.min(snappedIndex, trackLength.value))
+    const clampedIndex = Math.max(0, Math.min(snappedIndex, trackLength))
 
-    return runtimeNumeric('beats', clampedIndex)
+    return clampedIndex as Numeric<'beats'>
   }, [beatsPerBar, beatWidth, trackLength])
 
   const updateSelection = useCallback((event: MouseEvent | React.MouseEvent) => {
@@ -186,14 +185,14 @@ const TimeRuler: FunctionComponent<{
       return
     }
 
-    if (selectionStart.value === position.value) {
+    if (selectionStart === position) {
       onSelect({ start: position })
       return
     }
 
     onSelect({
-      start: position.value < selectionStart.value ? position : selectionStart,
-      end: position.value >= selectionStart.value ? position : selectionStart
+      start: position < selectionStart ? position : selectionStart,
+      end: position >= selectionStart ? position : selectionStart
     })
   }, [onSelect, selectionStart, computeTimeFromEvent])
 
@@ -229,12 +228,12 @@ const TimeRuler: FunctionComponent<{
       ref={timelineRef}
       onMouseDown={onMouseDown}
     >
-      {trackLength.value > 0 && selection.end != null && (
+      {trackLength > 0 && selection.end != null && (
         <div
           className='absolute top-0 h-[calc(100%+0.5rem)] bg-accent-100 opacity-40 pointer-events-none -z-10'
           style={{
-            left: `${(selection.start.value / trackLength.value) * 100}%`,
-            width: `${((selection.end.value - selection.start.value) / trackLength.value) * 100}%`
+            left: `${(selection.start / trackLength) * 100}%`,
+            width: `${((selection.end - selection.start) / trackLength) * 100}%`
           }}
         />
       )}
@@ -289,8 +288,8 @@ const TimelinePart: FunctionComponent<{
 
   const [lengthShort, lengthLong] = useMemo(() => {
     return [
-      formatBeatDuration(part.length, beatsPerBar),
-      formatBeatDurationAsWords(part.length, beatsPerBar)
+      formatBeatDuration(part.length.value, beatsPerBar),
+      formatBeatDurationAsWords(part.length.value, beatsPerBar)
     ]
   }, [part, beatsPerBar])
 
@@ -346,8 +345,8 @@ const markerPathData = {
 
 const TimelineMarker: FunctionComponent<{
   variant: 'cursor' | 'start' | 'end'
-  position: RuntimeNumeric<'beats'>
-  trackLength: RuntimeNumeric<'beats'>
+  position: Numeric<'beats'>
+  trackLength: Numeric<'beats'>
   dimmed: boolean
 }> = ({ variant, position, trackLength, dimmed }) => {
   return (
@@ -357,7 +356,7 @@ const TimelineMarker: FunctionComponent<{
         dimmed ? 'text-content-50' : 'text-content-100'
       )}
       style={{
-        left: `${(position.value / trackLength.value) * 100}%`
+        left: `${(position / trackLength) * 100}%`
       }}
     >
       <svg className='w-5 h-2.5 -ml-2.5' viewBox='0 0 16 8' fill='none' xmlns='http://www.w3.org/2000/svg'>

--- a/packages/app/src/modules/export/ExportDialog.tsx
+++ b/packages/app/src/modules/export/ExportDialog.tsx
@@ -1,7 +1,7 @@
 import { createAudioGraph } from '@audiograph'
 import { AIFFFormat, createLeadingSilenceTransform, WAVFormat } from '@codecs'
 import { Field, Label } from '@headlessui/react'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { FunctionComponent, PropsWithChildren } from 'react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
@@ -69,7 +69,7 @@ export const ExportDialog: FunctionComponent<{
 
     return computeExportMetrics(program, {
       sampleRate,
-      leadingSilence: numeric('s', Number.parseFloat(leadingSilence)),
+      leadingSilence: runtimeNumeric('s', Number.parseFloat(leadingSilence)),
       type,
       wavFormat,
       aiffFormat
@@ -88,7 +88,7 @@ export const ExportDialog: FunctionComponent<{
     const format = type === 'wav' ? wavFormat : aiffFormat
 
     const transforms = [
-      createLeadingSilenceTransform(numeric('s', Number.parseFloat(leadingSilence)))
+      createLeadingSilenceTransform(runtimeNumeric('s', Number.parseFloat(leadingSilence)))
     ]
 
     const token = ++tokenRef.current

--- a/packages/app/src/modules/export/ExportDialog.tsx
+++ b/packages/app/src/modules/export/ExportDialog.tsx
@@ -1,6 +1,7 @@
 import { createAudioGraph } from '@audiograph'
 import { AIFFFormat, createLeadingSilenceTransform, WAVFormat } from '@codecs'
 import { Field, Label } from '@headlessui/react'
+import type { Numeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import type { FunctionComponent, PropsWithChildren } from 'react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
@@ -69,14 +70,14 @@ export const ExportDialog: FunctionComponent<{
 
     return computeExportMetrics(program, {
       sampleRate,
-      leadingSilence: runtimeNumeric('s', Number.parseFloat(leadingSilence)),
+      leadingSilence: Number.parseFloat(leadingSilence) as Numeric<'s'>,
       type,
       wavFormat,
       aiffFormat
     })
   }, [program, sampleRate, leadingSilence, type, wavFormat, aiffFormat])
 
-  const exceedsMaxDuration = metrics != null && metrics.duration.value > MAX_EXPORT_DURATION.value
+  const exceedsMaxDuration = metrics != null && metrics.duration > MAX_EXPORT_DURATION
 
   const onExport = useCallback(() => {
     if (program == null || exceedsMaxDuration) {

--- a/packages/app/src/modules/export/ExportDialog.tsx
+++ b/packages/app/src/modules/export/ExportDialog.tsx
@@ -2,7 +2,6 @@ import { createAudioGraph } from '@audiograph'
 import { AIFFFormat, createLeadingSilenceTransform, WAVFormat } from '@codecs'
 import { Field, Label } from '@headlessui/react'
 import type { Numeric } from '@utility'
-import { runtimeNumeric } from '@utility'
 import type { FunctionComponent, PropsWithChildren } from 'react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
@@ -89,7 +88,7 @@ export const ExportDialog: FunctionComponent<{
     const format = type === 'wav' ? wavFormat : aiffFormat
 
     const transforms = [
-      createLeadingSilenceTransform(runtimeNumeric('s', Number.parseFloat(leadingSilence)))
+      createLeadingSilenceTransform(Number.parseFloat(leadingSilence) as Numeric<'s'>)
     ]
 
     const token = ++tokenRef.current

--- a/packages/app/src/modules/export/export.ts
+++ b/packages/app/src/modules/export/export.ts
@@ -3,15 +3,15 @@ import type { AIFFEncodingOptions, AIFFFormat, AudioBufferTransform, WAVEncoding
 import { AudioBufferLike, AudioDescription, encodeAIFF, encodeWAV, estimateAIFFSize, estimateWAVSize } from '@codecs'
 import type { Program } from '@core'
 import { beatsToSeconds, calculateTotalLength } from '@core'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { createAudioRenderer } from '@webaudio'
 import type { Option } from '../../components/dropdown/Dropdown.js'
 import { saveFile } from '../../utilities/files.js'
 
-const ASSET_LOAD_TIMEOUT = numeric('s', 30)
+const ASSET_LOAD_TIMEOUT = runtimeNumeric('s', 30)
 
-export const MAX_EXPORT_DURATION = numeric('s', 60 * 60) // 1 hour
+export const MAX_EXPORT_DURATION = runtimeNumeric('s', 60 * 60) // 1 hour
 export const RENDER_CHANNELS = 2 // stereo
 
 export type FileType = 'wav' | 'aiff'
@@ -20,7 +20,7 @@ export type SampleRate = '44100' | '48000' | '96000'
 interface ExportFileType<TEncodingOptions = never> {
   readonly extension: string
   readonly mimeType: string
-  readonly estimateSize: (audio: AudioDescription, options: TEncodingOptions) => Numeric<'bytes'>
+  readonly estimateSize: (audio: AudioDescription, options: TEncodingOptions) => RuntimeNumeric<'bytes'>
   readonly encode: (audio: AudioBufferLike, options: TEncodingOptions) => ArrayBuffer
 }
 
@@ -86,8 +86,8 @@ export async function renderAndSave<TEncodingOptions> (
   const renderer = createAudioRenderer({
     assetLoadTimeout: ASSET_LOAD_TIMEOUT,
     cacheLimits: {
-      arrayBuffer: numeric('bytes', 0),
-      audioBuffer: numeric('bytes', 0)
+      arrayBuffer: runtimeNumeric('bytes', 0),
+      audioBuffer: runtimeNumeric('bytes', 0)
     }
   })
 
@@ -113,37 +113,37 @@ export async function renderAndSave<TEncodingOptions> (
 }
 
 export interface ExportMetrics {
-  readonly duration: Numeric<'s'>
-  readonly fileSize: Numeric<'bytes'>
+  readonly duration: RuntimeNumeric<'s'>
+  readonly fileSize: RuntimeNumeric<'bytes'>
 }
 
 export function computeExportMetrics (program: Program, options: {
   readonly sampleRate: SampleRate
-  readonly leadingSilence: Numeric<'s'>
+  readonly leadingSilence: RuntimeNumeric<'s'>
   readonly type: FileType
   readonly wavFormat: WAVFormat
   readonly aiffFormat: AIFFFormat
 }): ExportMetrics {
   const trackLength = computeTrackDuration(program)
-  const duration = numeric('s', trackLength.value + options.leadingSilence.value)
+  const duration = runtimeNumeric('s', trackLength.value + options.leadingSilence.value)
 
   const fileSize = estimateFileSize({ ...options, duration })
 
   return { duration, fileSize }
 }
 
-function computeTrackDuration (program: Program): Numeric<'s'> {
+function computeTrackDuration (program: Program): RuntimeNumeric<'s'> {
   const lengthInBeats = calculateTotalLength(program)
   return beatsToSeconds(lengthInBeats, program.track.tempo)
 }
 
 function estimateFileSize (options: {
-  readonly duration: Numeric<'s'>
+  readonly duration: RuntimeNumeric<'s'>
   readonly sampleRate: SampleRate
   readonly type: FileType
   readonly wavFormat: WAVFormat
   readonly aiffFormat: AIFFFormat
-}): Numeric<'bytes'> {
+}): RuntimeNumeric<'bytes'> {
   const { duration, sampleRate, type, wavFormat, aiffFormat } = options
 
   const exportType = type === 'wav' ? WAV : AIFF

--- a/packages/app/src/modules/export/export.ts
+++ b/packages/app/src/modules/export/export.ts
@@ -3,15 +3,14 @@ import type { AIFFEncodingOptions, AIFFFormat, AudioBufferTransform, WAVEncoding
 import { AudioBufferLike, AudioDescription, encodeAIFF, encodeWAV, estimateAIFFSize, estimateWAVSize } from '@codecs'
 import type { Program } from '@core'
 import { beatsToSeconds, calculateTotalLength } from '@core'
-import type { RuntimeNumeric } from '@utility'
-import { runtimeNumeric } from '@utility'
+import type { Numeric, RuntimeNumeric } from '@utility'
 import { createAudioRenderer } from '@webaudio'
 import type { Option } from '../../components/dropdown/Dropdown.js'
 import { saveFile } from '../../utilities/files.js'
 
-const ASSET_LOAD_TIMEOUT = runtimeNumeric('s', 30)
+const ASSET_LOAD_TIMEOUT = 30 as Numeric<'s'>
 
-export const MAX_EXPORT_DURATION = runtimeNumeric('s', 60 * 60) // 1 hour
+export const MAX_EXPORT_DURATION = (60 * 60) as Numeric<'s'> // 1 hour
 export const RENDER_CHANNELS = 2 // stereo
 
 export type FileType = 'wav' | 'aiff'
@@ -86,8 +85,8 @@ export async function renderAndSave<TEncodingOptions> (
   const renderer = createAudioRenderer({
     assetLoadTimeout: ASSET_LOAD_TIMEOUT,
     cacheLimits: {
-      arrayBuffer: runtimeNumeric('bytes', 0),
-      audioBuffer: runtimeNumeric('bytes', 0)
+      arrayBuffer: 0 as Numeric<'bytes'>,
+      audioBuffer: 0 as Numeric<'bytes'>
     }
   })
 
@@ -113,46 +112,46 @@ export async function renderAndSave<TEncodingOptions> (
 }
 
 export interface ExportMetrics {
-  readonly duration: RuntimeNumeric<'s'>
-  readonly fileSize: RuntimeNumeric<'bytes'>
+  readonly duration: Numeric<'s'>
+  readonly fileSize: Numeric<'bytes'>
 }
 
 export function computeExportMetrics (program: Program, options: {
   readonly sampleRate: SampleRate
-  readonly leadingSilence: RuntimeNumeric<'s'>
+  readonly leadingSilence: Numeric<'s'>
   readonly type: FileType
   readonly wavFormat: WAVFormat
   readonly aiffFormat: AIFFFormat
 }): ExportMetrics {
   const trackLength = computeTrackDuration(program)
-  const duration = runtimeNumeric('s', trackLength.value + options.leadingSilence.value)
+  const duration = (trackLength + options.leadingSilence) as Numeric<'s'>
 
   const fileSize = estimateFileSize({ ...options, duration })
 
   return { duration, fileSize }
 }
 
-function computeTrackDuration (program: Program): RuntimeNumeric<'s'> {
+function computeTrackDuration (program: Program): Numeric<'s'> {
   const lengthInBeats = calculateTotalLength(program)
-  return beatsToSeconds(lengthInBeats, program.track.tempo)
+  return beatsToSeconds(lengthInBeats, program.track.tempo.value)
 }
 
 function estimateFileSize (options: {
-  readonly duration: RuntimeNumeric<'s'>
+  readonly duration: Numeric<'s'>
   readonly sampleRate: SampleRate
   readonly type: FileType
   readonly wavFormat: WAVFormat
   readonly aiffFormat: AIFFFormat
-}): RuntimeNumeric<'bytes'> {
+}): Numeric<'bytes'> {
   const { duration, sampleRate, type, wavFormat, aiffFormat } = options
 
   const exportType = type === 'wav' ? WAV : AIFF
   const format = type === 'wav' ? wavFormat : aiffFormat
 
   const description: AudioDescription = {
-    length: Math.ceil(duration.value * Number.parseInt(sampleRate, 10)),
+    length: Math.ceil(duration * Number.parseInt(sampleRate, 10)),
     numberOfChannels: RENDER_CHANNELS
   }
 
-  return exportType.estimateSize(description, { format })
+  return exportType.estimateSize(description, { format }).value
 }

--- a/packages/app/src/modules/export/export.ts
+++ b/packages/app/src/modules/export/export.ts
@@ -3,7 +3,7 @@ import type { AIFFEncodingOptions, AIFFFormat, AudioBufferTransform, WAVEncoding
 import { AudioBufferLike, AudioDescription, encodeAIFF, encodeWAV, estimateAIFFSize, estimateWAVSize } from '@codecs'
 import type { Program } from '@core'
 import { beatsToSeconds, calculateTotalLength } from '@core'
-import type { Numeric, RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { createAudioRenderer } from '@webaudio'
 import type { Option } from '../../components/dropdown/Dropdown.js'
 import { saveFile } from '../../utilities/files.js'
@@ -19,7 +19,7 @@ export type SampleRate = '44100' | '48000' | '96000'
 interface ExportFileType<TEncodingOptions = never> {
   readonly extension: string
   readonly mimeType: string
-  readonly estimateSize: (audio: AudioDescription, options: TEncodingOptions) => RuntimeNumeric<'bytes'>
+  readonly estimateSize: (audio: AudioDescription, options: TEncodingOptions) => Numeric<'bytes'>
   readonly encode: (audio: AudioBufferLike, options: TEncodingOptions) => ArrayBuffer
 }
 
@@ -153,5 +153,5 @@ function estimateFileSize (options: {
     numberOfChannels: RENDER_CHANNELS
   }
 
-  return exportType.estimateSize(description, { format }).value
+  return exportType.estimateSize(description, { format })
 }

--- a/packages/app/src/modules/playback/index.ts
+++ b/packages/app/src/modules/playback/index.ts
@@ -2,6 +2,7 @@ import type { AudioGraphOptions } from '@audiograph'
 import { createAudioGraph } from '@audiograph'
 import type { CommandId, MenuSectionId, Module, ModuleId, PanelId, Problem } from '@editor'
 import { activateTabOfType, useLatestRef, useLayoutDispatch, useNotificationService, useObservable, useProvideProblems, useRegisterCommand, useRegisterService } from '@editor'
+import type { Numeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
@@ -19,7 +20,7 @@ const PLAYBACK_ERROR_TIMEOUT = runtimeNumeric('s', 5)
 
 const AUDIO_GRAPH_OPTIONS: AudioGraphOptions = {
   metering: {
-    interval: runtimeNumeric('s', 0.1)
+    interval: 0.1 as Numeric<'s'>
   }
 }
 

--- a/packages/app/src/modules/playback/index.ts
+++ b/packages/app/src/modules/playback/index.ts
@@ -2,7 +2,7 @@ import type { AudioGraphOptions } from '@audiograph'
 import { createAudioGraph } from '@audiograph'
 import type { CommandId, MenuSectionId, Module, ModuleId, PanelId, Problem } from '@editor'
 import { activateTabOfType, useLatestRef, useLayoutDispatch, useNotificationService, useObservable, useProvideProblems, useRegisterCommand, useRegisterService } from '@editor'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
@@ -15,11 +15,11 @@ import { PlaybackProvider, useAudioEngine } from './provider.js'
 import { METERING_SERVICE_ID, MeteringService } from './services/metering.js'
 
 const PLAYBACK_ERROR_MESSAGE = 'Cannot play: Program contains errors.'
-const PLAYBACK_ERROR_TIMEOUT = numeric('s', 5)
+const PLAYBACK_ERROR_TIMEOUT = runtimeNumeric('s', 5)
 
 const AUDIO_GRAPH_OPTIONS: AudioGraphOptions = {
   metering: {
-    interval: numeric('s', 0.1)
+    interval: runtimeNumeric('s', 0.1)
   }
 }
 

--- a/packages/app/src/modules/playback/index.ts
+++ b/packages/app/src/modules/playback/index.ts
@@ -3,7 +3,6 @@ import { createAudioGraph } from '@audiograph'
 import type { CommandId, MenuSectionId, Module, ModuleId, PanelId, Problem } from '@editor'
 import { activateTabOfType, useLatestRef, useLayoutDispatch, useNotificationService, useObservable, useProvideProblems, useRegisterCommand, useRegisterService } from '@editor'
 import type { Numeric } from '@utility'
-import { runtimeNumeric } from '@utility'
 import type { FunctionComponent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useCompilationState } from '../../compilation/CompilationContext.js'
@@ -16,7 +15,7 @@ import { PlaybackProvider, useAudioEngine } from './provider.js'
 import { METERING_SERVICE_ID, MeteringService } from './services/metering.js'
 
 const PLAYBACK_ERROR_MESSAGE = 'Cannot play: Program contains errors.'
-const PLAYBACK_ERROR_TIMEOUT = runtimeNumeric('s', 5)
+const PLAYBACK_ERROR_TIMEOUT = 5 as Numeric<'s'>
 
 const AUDIO_GRAPH_OPTIONS: AudioGraphOptions = {
   metering: {

--- a/packages/app/src/modules/playback/persistence.ts
+++ b/packages/app/src/modules/playback/persistence.ts
@@ -1,20 +1,20 @@
 import type { PersistenceDomain } from '@editor'
 import { useObservable, usePersistentBinding } from '@editor'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { Struct } from 'superstruct'
 import { type } from 'superstruct'
-import { validateNumeric } from '../../utilities/validation.js'
+import { validateRuntimeNumeric } from '../../utilities/validation.js'
 import { useAudioEngine } from './provider.js'
 
-export const defaultOutputGain = numeric('db', -12)
+export const defaultOutputGain = runtimeNumeric('db', -12)
 
 interface PlaybackSettings {
-  readonly outputGain: Numeric<'db'>
+  readonly outputGain: RuntimeNumeric<'db'>
 }
 
 const playbackSettingsSchema: Struct<PlaybackSettings> = type({
-  outputGain: validateNumeric('db')
+  outputGain: validateRuntimeNumeric('db')
 })
 
 const playbackSettingsDefaults: PlaybackSettings = {

--- a/packages/app/src/modules/playback/persistence.ts
+++ b/packages/app/src/modules/playback/persistence.ts
@@ -33,7 +33,9 @@ export function usePlaybackSettingsSync (): void {
   const audioEngine = useAudioEngine()
   const outputGain = useObservable(audioEngine.outputGain)
 
-  usePersistentBinding(outputGainDomain, { outputGain }, (persisted) => {
-    audioEngine.outputGain.set(persisted.outputGain)
+  usePersistentBinding(outputGainDomain, {
+    outputGain: runtimeNumeric('db', outputGain)
+  }, (persisted) => {
+    audioEngine.outputGain.set(persisted.outputGain.value)
   }, { onConflict: 'accept-remote' })
 }

--- a/packages/app/src/modules/playback/provider.tsx
+++ b/packages/app/src/modules/playback/provider.tsx
@@ -1,5 +1,5 @@
 import { useSafeContext } from '@editor'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { AudioEngine, AudioEngineOptions } from '@webaudio'
 import { createAudioEngine } from '@webaudio'
 import type { FunctionComponent, PropsWithChildren } from 'react'
@@ -10,21 +10,21 @@ import { defaultOutputGain } from './persistence.js'
 const AudioEngineContext = createContext<AudioEngine | undefined>(undefined)
 
 const audioEngineOptions = {
-  assetLoadTimeout: runtimeNumeric('s', 5),
+  assetLoadTimeout: 5 as Numeric<'s'>,
   cacheLimits: isLowMemoryDevice() === true || isLikelyMobile()
     ? {
-        arrayBuffer: runtimeNumeric('bytes', 60 * 1024 * 1024), // compressed: 60 MB
-        audioBuffer: runtimeNumeric('bytes', 30 * 1024 * 1024) // decompressed: 30 MB
+        arrayBuffer: (60 * 1024 * 1024) as Numeric<'bytes'>, // compressed: 60 MB
+        audioBuffer: (30 * 1024 * 1024) as Numeric<'bytes'> // decompressed: 30 MB
       }
     : {
-        arrayBuffer: runtimeNumeric('bytes', 200 * 1024 * 1024), // compressed: 200 MB
-        audioBuffer: runtimeNumeric('bytes', 100 * 1024 * 1024) // decompressed: 100 MB
+        arrayBuffer: (200 * 1024 * 1024) as Numeric<'bytes'>, // compressed: 200 MB
+        audioBuffer: (100 * 1024 * 1024) as Numeric<'bytes'> // decompressed: 100 MB
       }
 } satisfies Partial<AudioEngineOptions>
 
 const engine = createAudioEngine({
   ...audioEngineOptions,
-  outputGain: defaultOutputGain
+  outputGain: defaultOutputGain.value
 })
 
 export const PlaybackProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {

--- a/packages/app/src/modules/playback/provider.tsx
+++ b/packages/app/src/modules/playback/provider.tsx
@@ -1,5 +1,5 @@
 import { useSafeContext } from '@editor'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { AudioEngine, AudioEngineOptions } from '@webaudio'
 import { createAudioEngine } from '@webaudio'
 import type { FunctionComponent, PropsWithChildren } from 'react'
@@ -10,15 +10,15 @@ import { defaultOutputGain } from './persistence.js'
 const AudioEngineContext = createContext<AudioEngine | undefined>(undefined)
 
 const audioEngineOptions = {
-  assetLoadTimeout: numeric('s', 5),
+  assetLoadTimeout: runtimeNumeric('s', 5),
   cacheLimits: isLowMemoryDevice() === true || isLikelyMobile()
     ? {
-        arrayBuffer: numeric('bytes', 60 * 1024 * 1024), // compressed: 60 MB
-        audioBuffer: numeric('bytes', 30 * 1024 * 1024) // decompressed: 30 MB
+        arrayBuffer: runtimeNumeric('bytes', 60 * 1024 * 1024), // compressed: 60 MB
+        audioBuffer: runtimeNumeric('bytes', 30 * 1024 * 1024) // decompressed: 30 MB
       }
     : {
-        arrayBuffer: numeric('bytes', 200 * 1024 * 1024), // compressed: 200 MB
-        audioBuffer: numeric('bytes', 100 * 1024 * 1024) // decompressed: 100 MB
+        arrayBuffer: runtimeNumeric('bytes', 200 * 1024 * 1024), // compressed: 200 MB
+        audioBuffer: runtimeNumeric('bytes', 100 * 1024 * 1024) // decompressed: 100 MB
       }
 } satisfies Partial<AudioEngineOptions>
 

--- a/packages/app/src/theme.ts
+++ b/packages/app/src/theme.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { useEffect, useState } from 'react'
 
 const DARK_THEME = 'dark'
@@ -13,7 +13,7 @@ export type Theme = typeof themes[number]
 export const themeSettings = Object.freeze([DARK_THEME, LIGHT_THEME, SYSTEM_THEME] as const)
 export type ThemeSetting = typeof themeSettings[number]
 
-const THEME_TRANSITION_DURATION = numeric('s', 0.2)
+const THEME_TRANSITION_DURATION = runtimeNumeric('s', 0.2)
 
 const prefersLightColorScheme = window.matchMedia('(prefers-color-scheme: light)')
 prefersLightColorScheme.addEventListener('change', () => updateEffectiveTheme())

--- a/packages/app/src/utilities/format.ts
+++ b/packages/app/src/utilities/format.ts
@@ -1,13 +1,13 @@
-import type { Numeric, RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 
 export function pluralize (count: number, singular: string, plural = singular.at(-1) === 's' ? `${singular}es` : `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`
 }
 
-export function formatDuration (duration: RuntimeNumeric<'s'>): string {
-  const sign = duration.value < 0 ? '-' : ''
+export function formatDuration (duration: Numeric<'s'>): string {
+  const sign = duration < 0 ? '-' : ''
 
-  const millis = Math.round(Math.abs(duration.value) * 1000)
+  const millis = Math.round(Math.abs(duration) * 1000)
 
   const hours = Math.floor(millis / (60 * 60 * 1000))
   const minutes = Math.floor((millis % (60 * 60 * 1000)) / (60 * 1000))
@@ -35,9 +35,9 @@ interface BeatDurationParts {
   readonly beats: number
 }
 
-function getBeatDurationParts (duration: RuntimeNumeric<'beats'>, beatsPerBar: number): BeatDurationParts {
-  const sign = Math.sign(duration.value)
-  let remainingBeats = Math.abs(duration.value)
+function getBeatDurationParts (duration: Numeric<'beats'>, beatsPerBar: number): BeatDurationParts {
+  const sign = Math.sign(duration)
+  let remainingBeats = Math.abs(duration)
 
   const bars = Math.floor(remainingBeats / beatsPerBar)
   remainingBeats -= bars * beatsPerBar
@@ -49,12 +49,12 @@ function getBeatDurationParts (duration: RuntimeNumeric<'beats'>, beatsPerBar: n
   }
 }
 
-export function formatBeatDuration (duration: RuntimeNumeric<'beats'>, beatsPerBar: number): string {
+export function formatBeatDuration (duration: Numeric<'beats'>, beatsPerBar: number): string {
   const { sign, bars, beats } = getBeatDurationParts(duration, beatsPerBar)
   return `${sign < 0 ? '-' : ''}${bars}:${beats.toFixed(2)}`
 }
 
-export function formatBeatDurationAsWords (duration: RuntimeNumeric<'beats'>, beatsPerBar: number): string {
+export function formatBeatDurationAsWords (duration: Numeric<'beats'>, beatsPerBar: number): string {
   const { sign, bars, beats } = getBeatDurationParts(duration, beatsPerBar)
   const parts: string[] = []
 
@@ -73,9 +73,7 @@ export function formatBeatDurationAsWords (duration: RuntimeNumeric<'beats'>, be
   return `${sign < 0 ? '-' : ''}${parts.join(' ')}`
 }
 
-export function formatBytes (bytes: RuntimeNumeric<'bytes'>): string {
-  let { value } = bytes
-
+export function formatBytes (value: Numeric<'bytes'>): string {
   if (value < 1024) {
     return `${value} B`
   }

--- a/packages/app/src/utilities/format.ts
+++ b/packages/app/src/utilities/format.ts
@@ -1,10 +1,10 @@
-import type { Numeric } from '@utility'
+import type { Numeric, RuntimeNumeric } from '@utility'
 
 export function pluralize (count: number, singular: string, plural = singular.at(-1) === 's' ? `${singular}es` : `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`
 }
 
-export function formatDuration (duration: Numeric<'s'>): string {
+export function formatDuration (duration: RuntimeNumeric<'s'>): string {
   const sign = duration.value < 0 ? '-' : ''
 
   const millis = Math.round(Math.abs(duration.value) * 1000)
@@ -35,7 +35,7 @@ interface BeatDurationParts {
   readonly beats: number
 }
 
-function getBeatDurationParts (duration: Numeric<'beats'>, beatsPerBar: number): BeatDurationParts {
+function getBeatDurationParts (duration: RuntimeNumeric<'beats'>, beatsPerBar: number): BeatDurationParts {
   const sign = Math.sign(duration.value)
   let remainingBeats = Math.abs(duration.value)
 
@@ -49,12 +49,12 @@ function getBeatDurationParts (duration: Numeric<'beats'>, beatsPerBar: number):
   }
 }
 
-export function formatBeatDuration (duration: Numeric<'beats'>, beatsPerBar: number): string {
+export function formatBeatDuration (duration: RuntimeNumeric<'beats'>, beatsPerBar: number): string {
   const { sign, bars, beats } = getBeatDurationParts(duration, beatsPerBar)
   return `${sign < 0 ? '-' : ''}${bars}:${beats.toFixed(2)}`
 }
 
-export function formatBeatDurationAsWords (duration: Numeric<'beats'>, beatsPerBar: number): string {
+export function formatBeatDurationAsWords (duration: RuntimeNumeric<'beats'>, beatsPerBar: number): string {
   const { sign, bars, beats } = getBeatDurationParts(duration, beatsPerBar)
   const parts: string[] = []
 
@@ -73,7 +73,7 @@ export function formatBeatDurationAsWords (duration: Numeric<'beats'>, beatsPerB
   return `${sign < 0 ? '-' : ''}${parts.join(' ')}`
 }
 
-export function formatBytes (bytes: Numeric<'bytes'>): string {
+export function formatBytes (bytes: RuntimeNumeric<'bytes'>): string {
   let { value } = bytes
 
   if (value < 1024) {
@@ -84,7 +84,7 @@ export function formatBytes (bytes: Numeric<'bytes'>): string {
   let unitIndex = -1
 
   do {
-    value /= 1024
+    value = (value / 1024) as Numeric<'bytes'>
     ++unitIndex
   } while (value >= 1024 && unitIndex < units.length - 1)
 

--- a/packages/app/src/utilities/validation.ts
+++ b/packages/app/src/utilities/validation.ts
@@ -1,4 +1,4 @@
-import type { Unit } from '@utility'
+import type { Numeric, Unit } from '@utility'
 import type { Struct, StructError } from 'superstruct'
 import { literal, number, object, string } from 'superstruct'
 
@@ -9,9 +9,9 @@ export function readonly<T, S> (struct: Struct<T, S>): Struct<Readonly<T>, S> {
   return struct
 }
 
-export const validateNumeric = <const U extends Unit> (unit: U) => object({
+export const validateRuntimeNumeric = <const U extends Unit> (unit: U) => object({
   unit: literal(unit),
-  value: number()
+  value: number() as unknown as Struct<Numeric<U>, null>
 })
 
 export const brandedString = <T extends string> (): Struct<T & (string & { [K in keyof T]: T[K] }), null> => {

--- a/packages/app/test/utilities/format.test.ts
+++ b/packages/app/test/utilities/format.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { formatBytes, formatDuration } from '../../src/utilities/format.js'
@@ -24,7 +24,7 @@ describe('utilities/format.ts', () => {
       ]
 
       for (const { input, expected } of testCases) {
-        const result = formatDuration(numeric('s', input))
+        const result = formatDuration(runtimeNumeric('s', input))
         assert.strictEqual(result, expected, `Expected formatDuration(${input}) to return "${expected}", got "${result}"`)
       }
     })
@@ -53,7 +53,7 @@ describe('utilities/format.ts', () => {
       ]
 
       for (const { input, expected } of testCases) {
-        const result = formatBytes(numeric('bytes', input))
+        const result = formatBytes(runtimeNumeric('bytes', input))
         assert.strictEqual(result, expected, `Expected formatBytes(${input}) to return "${expected}", got "${result}"`)
       }
     })

--- a/packages/app/test/utilities/format.test.ts
+++ b/packages/app/test/utilities/format.test.ts
@@ -1,4 +1,4 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { formatBytes, formatDuration } from '../../src/utilities/format.js'
@@ -24,7 +24,7 @@ describe('utilities/format.ts', () => {
       ]
 
       for (const { input, expected } of testCases) {
-        const result = formatDuration(runtimeNumeric('s', input))
+        const result = formatDuration(input as Numeric<'s'>)
         assert.strictEqual(result, expected, `Expected formatDuration(${input}) to return "${expected}", got "${result}"`)
       }
     })
@@ -53,7 +53,7 @@ describe('utilities/format.ts', () => {
       ]
 
       for (const { input, expected } of testCases) {
-        const result = formatBytes(runtimeNumeric('bytes', input))
+        const result = formatBytes(input as Numeric<'bytes'>)
         assert.strictEqual(result, expected, `Expected formatBytes(${input}) to return "${expected}", got "${result}"`)
       }
     })

--- a/packages/audiograph/src/automation.ts
+++ b/packages/audiograph/src/automation.ts
@@ -1,10 +1,10 @@
 import type { Curve, CurvePoint, CurveShape, Parameter, Program } from '@core'
 import { dbToGain } from '@core'
-import type { Numeric, Unit } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric, Unit } from '@utility'
+import { runtimeNumeric } from '@utility'
 
 export interface Transform<FromUnit extends Unit, ToUnit extends Unit> {
-  readonly transformValue: (value: Numeric<FromUnit>) => Numeric<ToUnit>
+  readonly transformValue: (value: RuntimeNumeric<FromUnit>) => RuntimeNumeric<ToUnit>
   readonly transformCurveShape: (curve: CurveShape) => CurveShape
 }
 
@@ -70,7 +70,7 @@ export const panTransform: Transform<undefined, undefined> = {
       throw new Error(`Invalid pan: ${value.value}`)
     }
 
-    return numeric(undefined, Math.max(-1, Math.min(1, value.value)))
+    return runtimeNumeric(undefined, Math.max(-1, Math.min(1, value.value)))
   },
 
   transformCurveShape: (curve) => curve
@@ -82,7 +82,7 @@ export const feedbackTransform: Transform<undefined, undefined> = {
       throw new Error(`Invalid feedback: ${value.value}`)
     }
 
-    return numeric(undefined, Math.max(0, Math.min(1, value.value)))
+    return runtimeNumeric(undefined, Math.max(0, Math.min(1, value.value)))
   },
 
   transformCurveShape: (curve) => curve
@@ -95,7 +95,7 @@ export const frequencyTransform: Transform<'hz', 'hz'> = {
     }
 
     if (value.value < 0) {
-      return numeric('hz', 0)
+      return runtimeNumeric('hz', 0)
     }
 
     return value

--- a/packages/audiograph/src/automation.ts
+++ b/packages/audiograph/src/automation.ts
@@ -49,7 +49,7 @@ export function identityTransform<U extends Unit> (): Transform<U, U> {
 
 export const gainTransform: Transform<'db', undefined> = {
   transformValue: (value) => {
-    return dbToGain(value)
+    return runtimeNumeric(undefined, dbToGain(value.value))
   },
 
   transformCurveShape: (curve) => {

--- a/packages/audiograph/src/builder.ts
+++ b/packages/audiograph/src/builder.ts
@@ -1,6 +1,6 @@
 import type { Asset, AssetId, NoteEvent } from '@core'
 import { isPitch } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { EntityKey } from './entities.js'
 import type { AnyNode, AudioGraph, Edge, Meters, NodeId } from './graph.js'
 
@@ -20,15 +20,15 @@ export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
 }
 
 export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: {
-  readonly tempo: RuntimeNumeric<'bpm'>
-  readonly length: RuntimeNumeric<'beats'>
+  readonly tempo: Numeric<'bpm'>
+  readonly length: Numeric<'beats'>
 }): AudioGraphBuilder<TNode> {
-  if (!Number.isFinite(meta.tempo.value) || meta.tempo.value <= 0) {
-    throw new Error(`Invalid tempo: ${meta.tempo.value}`)
+  if (!Number.isFinite(meta.tempo) || meta.tempo <= 0) {
+    throw new Error(`Invalid tempo: ${meta.tempo}`)
   }
 
-  if (!Number.isFinite(meta.length.value) || meta.length.value < 0) {
-    throw new Error(`Invalid length: ${meta.length.value}`)
+  if (!Number.isFinite(meta.length) || meta.length < 0) {
+    throw new Error(`Invalid length: ${meta.length}`)
   }
 
   const nodes = new Map<NodeId, TNode>()

--- a/packages/audiograph/src/builder.ts
+++ b/packages/audiograph/src/builder.ts
@@ -1,6 +1,6 @@
 import type { Asset, AssetId, NoteEvent } from '@core'
 import { isPitch } from '@core'
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import type { EntityKey } from './entities.js'
 import type { AnyNode, AudioGraph, Edge, Meters, NodeId } from './graph.js'
 
@@ -20,8 +20,8 @@ export interface AudioGraphBuilder<TNode extends AnyNode = AnyNode> {
 }
 
 export function createAudioGraphBuilder<TNode extends AnyNode = AnyNode> (meta: {
-  readonly tempo: Numeric<'bpm'>
-  readonly length: Numeric<'beats'>
+  readonly tempo: RuntimeNumeric<'bpm'>
+  readonly length: RuntimeNumeric<'beats'>
 }): AudioGraphBuilder<TNode> {
   if (!Number.isFinite(meta.tempo.value) || meta.tempo.value <= 0) {
     throw new Error(`Invalid tempo: ${meta.tempo.value}`)

--- a/packages/audiograph/src/graph.ts
+++ b/packages/audiograph/src/graph.ts
@@ -1,5 +1,5 @@
 import type { Asset, AssetId, NoteEvent } from '@core'
-import type { Brand, RuntimeNumeric } from '@utility'
+import type { Brand, Numeric } from '@utility'
 import type { EntityKey } from './entities.js'
 
 export interface AudioGraph<TNode = AnyNode> {
@@ -7,8 +7,8 @@ export interface AudioGraph<TNode = AnyNode> {
   readonly edges: readonly Edge[]
   readonly outputIds: readonly NodeId[]
 
-  readonly tempo: RuntimeNumeric<'bpm'>
-  readonly length: RuntimeNumeric<'beats'>
+  readonly tempo: Numeric<'bpm'>
+  readonly length: Numeric<'beats'>
 
   readonly assets: ReadonlyMap<AssetId, Asset>
 

--- a/packages/audiograph/src/graph.ts
+++ b/packages/audiograph/src/graph.ts
@@ -1,5 +1,5 @@
 import type { Asset, AssetId, NoteEvent } from '@core'
-import type { Brand, Numeric } from '@utility'
+import type { Brand, RuntimeNumeric } from '@utility'
 import type { EntityKey } from './entities.js'
 
 export interface AudioGraph<TNode = AnyNode> {
@@ -7,8 +7,8 @@ export interface AudioGraph<TNode = AnyNode> {
   readonly edges: readonly Edge[]
   readonly outputIds: readonly NodeId[]
 
-  readonly tempo: Numeric<'bpm'>
-  readonly length: Numeric<'beats'>
+  readonly tempo: RuntimeNumeric<'bpm'>
+  readonly length: RuntimeNumeric<'beats'>
 
   readonly assets: ReadonlyMap<AssetId, Asset>
 

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,7 +1,7 @@
 import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Oscillator, Program, Sample, Track, Voice } from '@core'
 import { calculateTotalLength, dbToGain, renderPatternEvents, timeToSeconds } from '@core'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { computeParameterCurve, feedbackTransform, frequencyTransform, gainTransform, panTransform, transformCurve } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
 import { createAudioGraphBuilder } from './builder.js'
@@ -21,7 +21,7 @@ export interface AudioGraphOptions {
 }
 
 interface MeteringOptions {
-  readonly interval: Numeric<'s'>
+  readonly interval: RuntimeNumeric<'s'>
 }
 
 export function createAudioGraph (program: Program, options?: AudioGraphOptions): AudioGraph<Node> {
@@ -204,7 +204,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         filterType: 'lowpass',
         frequency: computeParameterCurve(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
-        rolloffPerOctave: numeric('db', 12)
+        rolloffPerOctave: runtimeNumeric('db', 12)
       }))
     }
 
@@ -213,7 +213,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         filterType: 'highpass',
         frequency: computeParameterCurve(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
-        rolloffPerOctave: numeric('db', 12)
+        rolloffPerOctave: runtimeNumeric('db', 12)
       }))
     }
 
@@ -224,7 +224,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       return toSubGraph(builder.addNode<WidthNode>('width', {
         // TODO time variant
-        width: numeric(undefined, Math.max(0, Math.min(1, effect.width.value)))
+        width: runtimeNumeric(undefined, Math.max(0, Math.min(1, effect.width.value)))
       }))
     }
 
@@ -277,12 +277,12 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
       // one in front of the wave shaper with gain of -threshold, and one after with gain of +threshold to compensate.
       // If the threshold is -Infinity, we must of course not apply a +Infinity gain, which would be illegal.
 
-      const invert = (value: Numeric<undefined>): Numeric<undefined> => {
+      const invert = (value: RuntimeNumeric<undefined>): RuntimeNumeric<undefined> => {
         if (value.value === 0) {
           throw new Error('Invalid gain')
         }
 
-        return numeric(undefined, 1 / value.value)
+        return runtimeNumeric(undefined, 1 / value.value)
       }
 
       const thresholdGain = computeParameterCurve(effect.threshold, program, gainTransform)
@@ -313,7 +313,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
   }
 }
 
-function createDryWetMix (effectId: NodeId, mix: number, wetGain: Numeric<'db'>, builder: Builder): SubGraph {
+function createDryWetMix (effectId: NodeId, mix: number, wetGain: RuntimeNumeric<'db'>, builder: Builder): SubGraph {
   if (Number.isNaN(mix)) {
     throw new Error(`Invalid mix: ${mix}`)
   }
@@ -342,12 +342,12 @@ function createDryWetMix (effectId: NodeId, mix: number, wetGain: Numeric<'db'>,
 
   const dry = Math.max(0, Math.min(1, (1 - mix) * 2))
   const dryNodeId = builder.addNode<GainNode>('gain', {
-    gain: { initial: numeric(undefined, dry), points: [] }
+    gain: { initial: runtimeNumeric(undefined, dry), points: [] }
   })
 
   const wet = Math.max(0, Math.min(1, mix * 2))
   const wetNodeId = builder.addNode<GainNode>('gain', {
-    gain: { initial: numeric(undefined, wet), points: [] }
+    gain: { initial: runtimeNumeric(undefined, wet), points: [] }
   })
 
   const wetInputId = wetLevelId ?? effectId
@@ -363,7 +363,7 @@ function createDryWetMix (effectId: NodeId, mix: number, wetGain: Numeric<'db'>,
   }
 }
 
-function createOptionalGainNode (wetGain: Numeric<'db'>, builder: Builder): NodeId | undefined {
+function createOptionalGainNode (wetGain: RuntimeNumeric<'db'>, builder: Builder): NodeId | undefined {
   if (wetGain.value === 0) {
     return undefined
   }
@@ -422,7 +422,7 @@ function createNoteEvents (track: Track, instruments: ReadonlyMap<InstrumentId, 
 
       const events = renderPatternEvents(routing.source.value, part.length).map((event) => ({
         ...event,
-        time: numeric('beats', event.time.value + offsetBeats)
+        time: runtimeNumeric('beats', event.time.value + offsetBeats)
       }))
 
       builder.addNoteEvents(nodeId, events)

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -239,7 +239,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const delayNodeId = builder.addNode<DelayNode>('delay', {
         // TODO time variant
-        time: timeToSeconds(effect.time, program.track.tempo.value).value
+        time: timeToSeconds(effect.time, program.track.tempo.value)
       })
 
       if (effect.feedback.initial.value > 0 || program.automations.has(effect.feedback.id)) {
@@ -266,7 +266,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const reverbId = builder.addNode<ReverbNode>('reverb', {
         // TODO time variant
-        decay: timeToSeconds(effect.decay, program.track.tempo.value).value
+        decay: timeToSeconds(effect.decay, program.track.tempo.value)
       })
 
       return createDryWetMix(reverbId, mix, effect.wet.value, builder)

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,6 +1,6 @@
 import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Oscillator, Program, Sample, Track, Voice } from '@core'
 import { calculateTotalLength, dbToGain, renderPatternEvents, timeToSeconds } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric, RuntimeNumeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import { computeParameterCurve, feedbackTransform, frequencyTransform, gainTransform, panTransform, transformCurve } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
@@ -27,7 +27,7 @@ interface MeteringOptions {
 export function createAudioGraph (program: Program, options?: AudioGraphOptions): AudioGraph<Node> {
   const builder = createAudioGraphBuilder<Node>({
     tempo: program.track.tempo,
-    length: calculateTotalLength(program)
+    length: runtimeNumeric('beats', calculateTotalLength(program))
   })
 
   const outputId = builder.addNode<IdentityNode>('identity', {})
@@ -239,7 +239,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const delayNodeId = builder.addNode<DelayNode>('delay', {
         // TODO time variant
-        time: timeToSeconds(effect.time, program.track.tempo)
+        time: timeToSeconds(effect.time, program.track.tempo.value)
       })
 
       if (effect.feedback.initial.value > 0 || program.automations.has(effect.feedback.id)) {
@@ -251,7 +251,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         builder.addEdge(feedbackGainId, delayNodeId)
       }
 
-      return createDryWetMix(delayNodeId, effect.mix.value, effect.wet, builder)
+      return createDryWetMix(delayNodeId, effect.mix.value, effect.wet.value, builder)
     }
 
     case 'reverb': {
@@ -266,10 +266,10 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const reverbId = builder.addNode<ReverbNode>('reverb', {
         // TODO time variant
-        decay: timeToSeconds(effect.decay, program.track.tempo)
+        decay: timeToSeconds(effect.decay, program.track.tempo.value)
       })
 
-      return createDryWetMix(reverbId, mix, effect.wet, builder)
+      return createDryWetMix(reverbId, mix, effect.wet.value, builder)
     }
 
     case 'clip': {
@@ -313,7 +313,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
   }
 }
 
-function createDryWetMix (effectId: NodeId, mix: number, wetGain: RuntimeNumeric<'db'>, builder: Builder): SubGraph {
+function createDryWetMix (effectId: NodeId, mix: number, wetGain: Numeric<'db'>, builder: Builder): SubGraph {
   if (Number.isNaN(mix)) {
     throw new Error(`Invalid mix: ${mix}`)
   }
@@ -363,12 +363,12 @@ function createDryWetMix (effectId: NodeId, mix: number, wetGain: RuntimeNumeric
   }
 }
 
-function createOptionalGainNode (wetGain: RuntimeNumeric<'db'>, builder: Builder): NodeId | undefined {
-  if (wetGain.value === 0) {
+function createOptionalGainNode (wetGain: Numeric<'db'>, builder: Builder): NodeId | undefined {
+  if (wetGain === 0) {
     return undefined
   }
 
-  const gain = dbToGain(wetGain)
+  const gain = runtimeNumeric(undefined, dbToGain(wetGain))
 
   return builder.addNode<GainNode>('gain', {
     // TODO time variant

--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,6 +1,6 @@
 import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Oscillator, Program, Sample, Track, Voice } from '@core'
 import { calculateTotalLength, dbToGain, renderPatternEvents, timeToSeconds } from '@core'
-import type { Numeric, RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import { computeParameterCurve, feedbackTransform, frequencyTransform, gainTransform, panTransform, transformCurve } from './automation.js'
 import type { AudioGraphBuilder } from './builder.js'
@@ -21,13 +21,13 @@ export interface AudioGraphOptions {
 }
 
 interface MeteringOptions {
-  readonly interval: RuntimeNumeric<'s'>
+  readonly interval: Numeric<'s'>
 }
 
 export function createAudioGraph (program: Program, options?: AudioGraphOptions): AudioGraph<Node> {
   const builder = createAudioGraphBuilder<Node>({
-    tempo: program.track.tempo,
-    length: runtimeNumeric('beats', calculateTotalLength(program))
+    tempo: program.track.tempo.value,
+    length: calculateTotalLength(program)
   })
 
   const outputId = builder.addNode<IdentityNode>('identity', {})
@@ -163,9 +163,9 @@ function createSampleSourceNode (voice: Voice<Sample>): SourceNode {
   return {
     type: 'sample',
     gainCurve: transformCurve(voice.envelope, gainTransform),
-    duration: voice.duration,
+    duration: voice.duration?.value,
     assetId,
-    playbackRate
+    playbackRate: playbackRate.value
   }
 }
 
@@ -179,9 +179,9 @@ function createOscillatorSourceNode (voice: Voice<Oscillator>): SourceNode {
   return {
     type: 'oscillator',
     gainCurve: transformCurve(voice.envelope, gainTransform),
-    duration: voice.duration,
+    duration: voice.duration?.value,
     shape,
-    frequency
+    frequency: frequency.value
   }
 }
 
@@ -204,7 +204,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         filterType: 'lowpass',
         frequency: computeParameterCurve(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
-        rolloffPerOctave: runtimeNumeric('db', 12)
+        rolloffPerOctave: 12 as Numeric<'db'>
       }))
     }
 
@@ -213,7 +213,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
         filterType: 'highpass',
         frequency: computeParameterCurve(effect.frequency, program, frequencyTransform),
         // TODO configurable rolloff
-        rolloffPerOctave: runtimeNumeric('db', 12)
+        rolloffPerOctave: 12 as Numeric<'db'>
       }))
     }
 
@@ -224,7 +224,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       return toSubGraph(builder.addNode<WidthNode>('width', {
         // TODO time variant
-        width: runtimeNumeric(undefined, Math.max(0, Math.min(1, effect.width.value)))
+        width: Math.max(0, Math.min(1, effect.width.value)) as Numeric<undefined>
       }))
     }
 
@@ -239,7 +239,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const delayNodeId = builder.addNode<DelayNode>('delay', {
         // TODO time variant
-        time: timeToSeconds(effect.time, program.track.tempo.value)
+        time: timeToSeconds(effect.time, program.track.tempo.value).value
       })
 
       if (effect.feedback.initial.value > 0 || program.automations.has(effect.feedback.id)) {
@@ -266,7 +266,7 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
 
       const reverbId = builder.addNode<ReverbNode>('reverb', {
         // TODO time variant
-        decay: timeToSeconds(effect.decay, program.track.tempo.value)
+        decay: timeToSeconds(effect.decay, program.track.tempo.value).value
       })
 
       return createDryWetMix(reverbId, mix, effect.wet.value, builder)
@@ -277,20 +277,20 @@ function createEffect (program: Program, effect: Effect, builder: Builder): SubG
       // one in front of the wave shaper with gain of -threshold, and one after with gain of +threshold to compensate.
       // If the threshold is -Infinity, we must of course not apply a +Infinity gain, which would be illegal.
 
-      const invert = (value: RuntimeNumeric<undefined>): RuntimeNumeric<undefined> => {
-        if (value.value === 0) {
+      const invert = (value: Numeric<undefined>): Numeric<undefined> => {
+        if (value === 0) {
           throw new Error('Invalid gain')
         }
 
-        return runtimeNumeric(undefined, 1 / value.value)
+        return (1 / value) as Numeric<undefined>
       }
 
       const thresholdGain = computeParameterCurve(effect.threshold, program, gainTransform)
 
       const inputId = builder.addNode<GainNode>('gain', {
         gain: {
-          initial: invert(thresholdGain.initial),
-          points: thresholdGain.points.map(({ time, value, shape }) => ({ time, value: invert(value), shape }))
+          initial: runtimeNumeric(undefined, invert(thresholdGain.initial.value)),
+          points: thresholdGain.points.map(({ time, value, shape }) => ({ time, value: runtimeNumeric(undefined, invert(value.value)), shape }))
         }
       })
 
@@ -439,9 +439,9 @@ function createMeteringNodes (
   builder: Builder,
   options: MeteringOptions
 ): void {
-  const intervalSeconds = options.interval.value
+  const intervalSeconds = options.interval
   if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) {
-    throw new Error(`Invalid metering interval: ${options.interval.value}`)
+    throw new Error(`Invalid metering interval: ${options.interval}`)
   }
 
   const createMeters = (key: EntityKey, sources: readonly NodeId[]): void => {

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -1,5 +1,5 @@
 import type { AssetId, Curve, NoteData } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { EntityKey } from './entities.js'
 import type { AnyNode } from './graph.js'
 
@@ -51,22 +51,22 @@ export interface BiquadNode extends AnyNode {
   readonly type: 'biquad'
   readonly filterType: 'lowpass' | 'highpass'
   readonly frequency: Curve<'s', 'hz'>
-  readonly rolloffPerOctave: RuntimeNumeric<'db'>
+  readonly rolloffPerOctave: Numeric<'db'>
 }
 
 export interface WidthNode extends AnyNode {
   readonly type: 'width'
-  readonly width: RuntimeNumeric<undefined>
+  readonly width: Numeric<undefined>
 }
 
 export interface DelayNode extends AnyNode {
   readonly type: 'delay'
-  readonly time: RuntimeNumeric<'s'>
+  readonly time: Numeric<'s'>
 }
 
 export interface ReverbNode extends AnyNode {
   readonly type: 'reverb'
-  readonly decay: RuntimeNumeric<'s'>
+  readonly decay: Numeric<'s'>
 }
 
 export interface WaveShaperNode extends AnyNode {
@@ -88,17 +88,17 @@ export type SourceNode = SampleNode | OscillatorNode
 export interface SampleNode extends AnyNode {
   readonly type: 'sample'
   readonly gainCurve: Curve<'s', undefined>
-  readonly duration?: RuntimeNumeric<'s'>
+  readonly duration?: Numeric<'s'>
   readonly assetId: AssetId
-  readonly playbackRate: RuntimeNumeric<undefined>
+  readonly playbackRate: Numeric<undefined>
 }
 
 export interface OscillatorNode extends AnyNode {
   readonly type: 'oscillator'
   readonly gainCurve: Curve<'s', undefined>
-  readonly duration: RuntimeNumeric<'s'> | undefined
+  readonly duration: Numeric<'s'> | undefined
   readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
-  readonly frequency: RuntimeNumeric<'hz'>
+  readonly frequency: Numeric<'hz'>
 }
 
 // metering
@@ -114,5 +114,5 @@ export interface GainMeterNode extends AnyNode {
   /**
    * The approximate interval, in seconds, at which the gain meter should post updates.
    */
-  readonly interval: RuntimeNumeric<'s'>
+  readonly interval: Numeric<'s'>
 }

--- a/packages/audiograph/src/nodes.ts
+++ b/packages/audiograph/src/nodes.ts
@@ -1,5 +1,5 @@
 import type { AssetId, Curve, NoteData } from '@core'
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import type { EntityKey } from './entities.js'
 import type { AnyNode } from './graph.js'
 
@@ -51,22 +51,22 @@ export interface BiquadNode extends AnyNode {
   readonly type: 'biquad'
   readonly filterType: 'lowpass' | 'highpass'
   readonly frequency: Curve<'s', 'hz'>
-  readonly rolloffPerOctave: Numeric<'db'>
+  readonly rolloffPerOctave: RuntimeNumeric<'db'>
 }
 
 export interface WidthNode extends AnyNode {
   readonly type: 'width'
-  readonly width: Numeric<undefined>
+  readonly width: RuntimeNumeric<undefined>
 }
 
 export interface DelayNode extends AnyNode {
   readonly type: 'delay'
-  readonly time: Numeric<'s'>
+  readonly time: RuntimeNumeric<'s'>
 }
 
 export interface ReverbNode extends AnyNode {
   readonly type: 'reverb'
-  readonly decay: Numeric<'s'>
+  readonly decay: RuntimeNumeric<'s'>
 }
 
 export interface WaveShaperNode extends AnyNode {
@@ -88,17 +88,17 @@ export type SourceNode = SampleNode | OscillatorNode
 export interface SampleNode extends AnyNode {
   readonly type: 'sample'
   readonly gainCurve: Curve<'s', undefined>
-  readonly duration?: Numeric<'s'>
+  readonly duration?: RuntimeNumeric<'s'>
   readonly assetId: AssetId
-  readonly playbackRate: Numeric<undefined>
+  readonly playbackRate: RuntimeNumeric<undefined>
 }
 
 export interface OscillatorNode extends AnyNode {
   readonly type: 'oscillator'
   readonly gainCurve: Curve<'s', undefined>
-  readonly duration: Numeric<'s'> | undefined
+  readonly duration: RuntimeNumeric<'s'> | undefined
   readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
-  readonly frequency: Numeric<'hz'>
+  readonly frequency: RuntimeNumeric<'hz'>
 }
 
 // metering
@@ -114,5 +114,5 @@ export interface GainMeterNode extends AnyNode {
   /**
    * The approximate interval, in seconds, at which the gain meter should post updates.
    */
-  readonly interval: Numeric<'s'>
+  readonly interval: RuntimeNumeric<'s'>
 }

--- a/packages/audiograph/test/builder.test.ts
+++ b/packages/audiograph/test/builder.test.ts
@@ -1,5 +1,5 @@
 import type { BusId, InstrumentId } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { createAudioGraphBuilder } from '../src/builder.js'
@@ -7,10 +7,10 @@ import { createEntityKey } from '../src/entities.js'
 import type { NodeId } from '../src/graph.js'
 
 describe('builder.ts', () => {
-  const tempo = numeric('bpm', 120)
-  const length = numeric('beats', 16)
-  const beats = (value: number) => numeric('beats', value)
-  const scalar = (value: number) => numeric(undefined, value)
+  const tempo = runtimeNumeric('bpm', 120)
+  const length = runtimeNumeric('beats', 16)
+  const beats = (value: number) => runtimeNumeric('beats', value)
+  const scalar = (value: number) => runtimeNumeric(undefined, value)
 
   it('should maintain tempo and length', () => {
     const builder = createAudioGraphBuilder({ tempo, length })
@@ -22,22 +22,22 @@ describe('builder.ts', () => {
   })
 
   it('should throw for infinite tempo', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo: numeric('bpm', Infinity), length }))
-    assert.throws(() => createAudioGraphBuilder({ tempo: numeric('bpm', -Infinity), length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', Infinity), length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', -Infinity), length }))
   })
 
   it('should throw for non-positive tempo', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo: numeric('bpm', 0), length }))
-    assert.throws(() => createAudioGraphBuilder({ tempo: numeric('bpm', -120), length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', 0), length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', -120), length }))
   })
 
   it('should throw for negative length', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo, length: numeric('beats', -1) }))
+    assert.throws(() => createAudioGraphBuilder({ tempo, length: runtimeNumeric('beats', -1) }))
   })
 
   it('should throw for NaN tempo and length', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo: numeric('bpm', Number.NaN), length }))
-    assert.throws(() => createAudioGraphBuilder({ tempo, length: numeric('beats', Number.NaN) }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', Number.NaN), length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo, length: runtimeNumeric('beats', Number.NaN) }))
   })
 
   it('should assign unique IDs to nodes', () => {

--- a/packages/audiograph/test/builder.test.ts
+++ b/packages/audiograph/test/builder.test.ts
@@ -1,4 +1,5 @@
 import type { BusId, InstrumentId } from '@core'
+import type { Numeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -7,8 +8,8 @@ import { createEntityKey } from '../src/entities.js'
 import type { NodeId } from '../src/graph.js'
 
 describe('builder.ts', () => {
-  const tempo = runtimeNumeric('bpm', 120)
-  const length = runtimeNumeric('beats', 16)
+  const tempo = 120 as Numeric<'bpm'>
+  const length = 16 as Numeric<'beats'>
   const beats = (value: number) => runtimeNumeric('beats', value)
   const scalar = (value: number) => runtimeNumeric(undefined, value)
 
@@ -22,22 +23,22 @@ describe('builder.ts', () => {
   })
 
   it('should throw for infinite tempo', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', Infinity), length }))
-    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', -Infinity), length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: Infinity as Numeric<'bpm'>, length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: -Infinity as Numeric<'bpm'>, length }))
   })
 
   it('should throw for non-positive tempo', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', 0), length }))
-    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', -120), length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: 0 as Numeric<'bpm'>, length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: -120 as Numeric<'bpm'>, length }))
   })
 
   it('should throw for negative length', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo, length: runtimeNumeric('beats', -1) }))
+    assert.throws(() => createAudioGraphBuilder({ tempo, length: -1 as Numeric<'beats'> }))
   })
 
   it('should throw for NaN tempo and length', () => {
-    assert.throws(() => createAudioGraphBuilder({ tempo: runtimeNumeric('bpm', Number.NaN), length }))
-    assert.throws(() => createAudioGraphBuilder({ tempo, length: runtimeNumeric('beats', Number.NaN) }))
+    assert.throws(() => createAudioGraphBuilder({ tempo: Number.NaN as Numeric<'bpm'>, length }))
+    assert.throws(() => createAudioGraphBuilder({ tempo, length: Number.NaN as Numeric<'beats'> }))
   })
 
   it('should assign unique IDs to nodes', () => {

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -1,6 +1,6 @@
 import type { Asset, AssetId, Bus, BusId, Curve, Effect, Instrument, InstrumentId, InstrumentRouting, MixerRouting, NoteData, ParameterId, Program, Track } from '@core'
 import { beatsToSeconds, createSerialPattern, dbToGain } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric, RuntimeNumeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -270,7 +270,7 @@ describe('lowering.ts', () => {
         {
           type: 'gain',
           gain: {
-            initial: dbToGain(runtimeNumeric('db', -3)),
+            initial: runtimeNumeric(undefined, dbToGain(-3 as Numeric<'db'>)),
             points: []
           }
         } satisfies GainNode
@@ -287,7 +287,7 @@ describe('lowering.ts', () => {
         {
           type: 'gain',
           gain: {
-            initial: dbToGain(runtimeNumeric('db', -6)),
+            initial: runtimeNumeric(undefined, dbToGain(-6 as Numeric<'db'>)),
             points: []
           }
         } satisfies GainNode
@@ -393,16 +393,16 @@ describe('lowering.ts', () => {
     assert.deepStrictEqual(graph.nodes.get(3 as NodeId), {
       type: 'gain',
       gain: {
-        initial: dbToGain(runtimeNumeric('db', -6)),
+        initial: runtimeNumeric(undefined, dbToGain(-6 as Numeric<'db'>)),
         points: [
           {
             time: runtimeNumeric('s', 0.5),
-            value: dbToGain(runtimeNumeric('db', -3)),
+            value: runtimeNumeric(undefined, dbToGain(-3 as Numeric<'db'>)),
             shape: 'exponential'
           },
           {
             time: runtimeNumeric('s', 1),
-            value: dbToGain(runtimeNumeric('db', -12)),
+            value: runtimeNumeric(undefined, dbToGain(-12 as Numeric<'db'>)),
             shape: 'step'
           }
         ]
@@ -704,7 +704,7 @@ describe('lowering.ts', () => {
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'gain',
           gain: {
-            initial: dbToGain(runtimeNumeric('db', -3)),
+            initial: runtimeNumeric(undefined, dbToGain(-3 as Numeric<'db'>)),
             points: []
           }
         } satisfies GainNode)
@@ -967,7 +967,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: beatsToSeconds(runtimeNumeric('beats', 0.5), runtimeNumeric('bpm', 120))
+              time: runtimeNumeric('s', beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1044,7 +1044,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: beatsToSeconds(runtimeNumeric('beats', 0.5), runtimeNumeric('bpm', 120))
+              time: runtimeNumeric('s', beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1169,7 +1169,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: beatsToSeconds(runtimeNumeric('beats', 0.5), runtimeNumeric('bpm', 120))
+              time: runtimeNumeric('s', beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1189,7 +1189,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: dbToGain(runtimeNumeric('db', -6)),
+                initial: runtimeNumeric(undefined, dbToGain(-6 as Numeric<'db'>)),
                 points: []
               }
             } satisfies GainNode
@@ -1366,7 +1366,7 @@ describe('lowering.ts', () => {
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'reverb',
-          decay: beatsToSeconds(runtimeNumeric('beats', 2), runtimeNumeric('bpm', 120))
+          decay: runtimeNumeric('s', beatsToSeconds(2 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
         } satisfies ReverbNode)
       })
 
@@ -1403,7 +1403,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: dbToGain(runtimeNumeric('db', -6)),
+                initial: runtimeNumeric(undefined, dbToGain(-6 as Numeric<'db'>)),
                 points: []
               }
             } satisfies GainNode
@@ -1482,7 +1482,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: runtimeNumeric(undefined, 1 / dbToGain(threshold).value),
+                initial: runtimeNumeric(undefined, 1 / dbToGain(threshold.value)),
                 points: []
               }
             } satisfies GainNode
@@ -1501,7 +1501,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: dbToGain(threshold),
+                initial: runtimeNumeric(undefined, dbToGain(threshold.value)),
                 points: []
               }
             } satisfies GainNode

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -316,8 +316,8 @@ describe('lowering.ts', () => {
     assert.deepStrictEqual(voice, {
       type: 'oscillator',
       shape: 'sine',
-      frequency: runtimeNumeric('hz', 440),
-      duration: runtimeNumeric('s', 1.0), // 0.5s for the note + 0.5s for the release
+      frequency: 440 as Numeric<'hz'>,
+      duration: 1 as Numeric<'s'>, // 0.5s for the note + 0.5s for the release
       gainCurve: (voice as OscillatorNode).gainCurve
     } satisfies SourceNode)
   })
@@ -617,7 +617,7 @@ describe('lowering.ts', () => {
 
     assert.deepStrictEqual(
       voices.map((voice) => voice.type === 'oscillator' ? voice.frequency : undefined),
-      [runtimeNumeric('hz', 300), runtimeNumeric('hz', 400)]
+      [300, 400]
     )
   })
 
@@ -817,7 +817,7 @@ describe('lowering.ts', () => {
             initial: runtimeNumeric('hz', 1000),
             points: []
           },
-          rolloffPerOctave: runtimeNumeric('db', 12)
+          rolloffPerOctave: 12 as Numeric<'db'>
         } satisfies BiquadNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
@@ -834,7 +834,7 @@ describe('lowering.ts', () => {
             initial: runtimeNumeric('hz', 0),
             points: []
           },
-          rolloffPerOctave: runtimeNumeric('db', 12)
+          rolloffPerOctave: 12 as Numeric<'db'>
         } satisfies BiquadNode)
       })
 
@@ -867,7 +867,7 @@ describe('lowering.ts', () => {
             initial: runtimeNumeric('hz', 500),
             points: []
           },
-          rolloffPerOctave: runtimeNumeric('db', 12)
+          rolloffPerOctave: 12 as Numeric<'db'>
         } satisfies BiquadNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
@@ -884,7 +884,7 @@ describe('lowering.ts', () => {
             initial: runtimeNumeric('hz', 0),
             points: []
           },
-          rolloffPerOctave: runtimeNumeric('db', 12)
+          rolloffPerOctave: 12 as Numeric<'db'>
         } satisfies BiquadNode)
       })
 
@@ -909,7 +909,7 @@ describe('lowering.ts', () => {
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'width',
-          width: runtimeNumeric(undefined, 0.75)
+          width: 0.75 as Numeric<undefined>
         } satisfies WidthNode)
       })
 
@@ -920,7 +920,7 @@ describe('lowering.ts', () => {
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'width',
-          width: runtimeNumeric(undefined, 1)
+          width: 1 as Numeric<undefined>
         } satisfies WidthNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
@@ -929,7 +929,7 @@ describe('lowering.ts', () => {
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           type: 'width',
-          width: runtimeNumeric(undefined, 0)
+          width: 0 as Numeric<undefined>
         } satisfies WidthNode)
       })
 
@@ -967,7 +967,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: runtimeNumeric('s', beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
+              time: beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>)
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1044,7 +1044,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: runtimeNumeric('s', beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
+              time: beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>)
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1137,7 +1137,7 @@ describe('lowering.ts', () => {
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'delay',
-          time: runtimeNumeric('s', 1.5)
+          time: 1.5 as Numeric<'s'>
         } satisfies DelayNode)
       })
 
@@ -1169,7 +1169,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: runtimeNumeric('s', beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
+              time: beatsToSeconds(0.5 as Numeric<'beats'>, 120 as Numeric<'bpm'>)
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1272,7 +1272,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'reverb',
-              decay: runtimeNumeric('s', 2)
+              decay: 2 as Numeric<'s'>
             } satisfies ReverbNode
           ],
           // dry gain node
@@ -1330,7 +1330,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'reverb',
-              decay: runtimeNumeric('s', 2)
+              decay: 2 as Numeric<'s'>
             } satisfies ReverbNode
           ]
         ])
@@ -1366,7 +1366,7 @@ describe('lowering.ts', () => {
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'reverb',
-          decay: runtimeNumeric('s', beatsToSeconds(2 as Numeric<'beats'>, 120 as Numeric<'bpm'>))
+          decay: beatsToSeconds(2 as Numeric<'beats'>, 120 as Numeric<'bpm'>)
         } satisfies ReverbNode)
       })
 
@@ -1394,7 +1394,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'reverb',
-              decay: runtimeNumeric('s', 2)
+              decay: 2 as Numeric<'s'>
             } satisfies ReverbNode
           ],
           // wet gain node for wet level
@@ -1613,7 +1613,7 @@ describe('lowering.ts', () => {
         }
       }
 
-      const interval = runtimeNumeric('s', 0.123)
+      const interval = 0.123 as Numeric<'s'>
 
       const graph = createAudioGraph(program, {
         metering: { interval }
@@ -1661,7 +1661,7 @@ describe('lowering.ts', () => {
     for (const interval of [Infinity, -Infinity, Number.NaN, 0, -1]) {
       const options = {
         metering: {
-          interval: runtimeNumeric('s', interval)
+          interval: interval as Numeric<'s'>
         }
       }
 

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -1,7 +1,7 @@
 import type { Asset, AssetId, Bus, BusId, Curve, Effect, Instrument, InstrumentId, InstrumentRouting, MixerRouting, NoteData, ParameterId, Program, Track } from '@core'
 import { beatsToSeconds, createSerialPattern, dbToGain } from '@core'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { gainTransform, transformCurve } from '../src/automation.js'
@@ -11,11 +11,11 @@ import { createAudioGraph } from '../src/lowering.js'
 import type { BiquadNode, DelayNode, GainNode, IdentityNode, InstrumentNode, Node, OscillatorNode, PanNode, ReverbNode, SourceNode, WaveShaperNode, WidthNode } from '../src/nodes.js'
 
 const SIMPLE_CURVE: Curve<'s', 'db'> = {
-  initial: numeric('db', -Infinity),
+  initial: runtimeNumeric('db', -Infinity),
   points: [
-    { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
-    { time: numeric('s', 0.5), value: numeric('db', 0), shape: 'linear' },
-    { time: numeric('s', 1), value: numeric('db', -6), shape: 'step' }
+    { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -60), shape: 'step' },
+    { time: runtimeNumeric('s', 0.5), value: runtimeNumeric('db', 0), shape: 'linear' },
+    { time: runtimeNumeric('s', 1), value: runtimeNumeric('db', -6), shape: 'step' }
   ]
 }
 
@@ -39,7 +39,7 @@ function createProgramWithInstrument (instrument: Instrument, asset?: Asset): Pr
     automations: new Map(),
     assets,
     track: {
-      tempo: numeric('bpm', 120),
+      tempo: runtimeNumeric('bpm', 120),
       parts: []
     },
     mixer: {
@@ -67,7 +67,7 @@ function createProgramWithEffect (effect: Effect): Program {
     automations: new Map(),
     assets: new Map(),
     track: {
-      tempo: numeric('bpm', 120),
+      tempo: runtimeNumeric('bpm', 120),
       parts: []
     },
     mixer: {
@@ -77,11 +77,11 @@ function createProgramWithEffect (effect: Effect): Program {
           name: 'Bus 1',
           gain: {
             id: 400 as ParameterId,
-            initial: numeric('db', 0)
+            initial: runtimeNumeric('db', 0)
           },
           pan: {
             id: 500 as ParameterId,
-            initial: numeric(undefined, 0)
+            initial: runtimeNumeric(undefined, 0)
           },
           effects: [effect]
         }
@@ -110,7 +110,7 @@ describe('lowering.ts', () => {
       automations: new Map(),
       assets: new Map(),
       track: {
-        tempo: numeric('bpm', 120),
+        tempo: runtimeNumeric('bpm', 120),
         parts: []
       },
       mixer: {
@@ -149,7 +149,7 @@ describe('lowering.ts', () => {
         ]
       ]),
       track: {
-        tempo: numeric('bpm', 120),
+        tempo: runtimeNumeric('bpm', 120),
         parts: []
       },
       mixer: {
@@ -187,7 +187,7 @@ describe('lowering.ts', () => {
             id: instrumentId,
             gain: {
               id: instrumentGainId,
-              initial: numeric('db', -6)
+              initial: runtimeNumeric('db', -6)
             },
             trigger: () => [
               {
@@ -195,9 +195,9 @@ describe('lowering.ts', () => {
                 source: {
                   type: 'oscillator',
                   shape: 'sine',
-                  frequency: numeric('hz', 440)
+                  frequency: runtimeNumeric('hz', 440)
                 },
-                duration: numeric('s', 1)
+                duration: runtimeNumeric('s', 1)
               }
             ]
           } satisfies Instrument
@@ -208,7 +208,7 @@ describe('lowering.ts', () => {
       assets: new Map(),
 
       track: {
-        tempo: numeric('bpm', 120),
+        tempo: runtimeNumeric('bpm', 120),
         parts: []
       } satisfies Track,
 
@@ -219,11 +219,11 @@ describe('lowering.ts', () => {
             name: 'Bus 1',
             gain: {
               id: busGainId,
-              initial: numeric('db', -3)
+              initial: runtimeNumeric('db', -3)
             },
             pan: {
               id: 500 as ParameterId,
-              initial: numeric(undefined, 0)
+              initial: runtimeNumeric(undefined, 0)
             },
             effects: []
           } satisfies Bus
@@ -270,7 +270,7 @@ describe('lowering.ts', () => {
         {
           type: 'gain',
           gain: {
-            initial: dbToGain(numeric('db', -3)),
+            initial: dbToGain(runtimeNumeric('db', -3)),
             points: []
           }
         } satisfies GainNode
@@ -287,7 +287,7 @@ describe('lowering.ts', () => {
         {
           type: 'gain',
           gain: {
-            initial: dbToGain(numeric('db', -6)),
+            initial: dbToGain(runtimeNumeric('db', -6)),
             points: []
           }
         } satisfies GainNode
@@ -306,8 +306,8 @@ describe('lowering.ts', () => {
     const instrumentNode = graph.nodes.get(3 as NodeId) as InstrumentNode
     const voices = instrumentNode.trigger({
       pitch: 'A4',
-      velocity: numeric(undefined, 1),
-      gate: numeric('beats', 1)
+      velocity: runtimeNumeric(undefined, 1),
+      gate: runtimeNumeric('beats', 1)
     })
 
     assert.strictEqual(voices.length, 1)
@@ -316,8 +316,8 @@ describe('lowering.ts', () => {
     assert.deepStrictEqual(voice, {
       type: 'oscillator',
       shape: 'sine',
-      frequency: numeric('hz', 440),
-      duration: numeric('s', 1.0), // 0.5s for the note + 0.5s for the release
+      frequency: runtimeNumeric('hz', 440),
+      duration: runtimeNumeric('s', 1.0), // 0.5s for the note + 0.5s for the release
       gainCurve: (voice as OscillatorNode).gainCurve
     } satisfies SourceNode)
   })
@@ -336,7 +336,7 @@ describe('lowering.ts', () => {
             id: instrumentId,
             gain: {
               id: instrumentGainId,
-              initial: numeric('db', -6)
+              initial: runtimeNumeric('db', -6)
             },
             trigger: () => []
           } satisfies Instrument
@@ -347,16 +347,16 @@ describe('lowering.ts', () => {
         [
           instrumentGainId,
           {
-            initial: numeric('db', -6),
+            initial: runtimeNumeric('db', -6),
             points: [
               {
-                time: numeric('s', 0.5),
-                value: numeric('db', -3),
+                time: runtimeNumeric('s', 0.5),
+                value: runtimeNumeric('db', -3),
                 shape: 'linear'
               },
               {
-                time: numeric('s', 1),
-                value: numeric('db', -12),
+                time: runtimeNumeric('s', 1),
+                value: runtimeNumeric('db', -12),
                 shape: 'step'
               }
             ]
@@ -367,7 +367,7 @@ describe('lowering.ts', () => {
       assets: new Map(),
 
       track: {
-        tempo: numeric('bpm', 120),
+        tempo: runtimeNumeric('bpm', 120),
         parts: []
       } satisfies Track,
 
@@ -393,16 +393,16 @@ describe('lowering.ts', () => {
     assert.deepStrictEqual(graph.nodes.get(3 as NodeId), {
       type: 'gain',
       gain: {
-        initial: dbToGain(numeric('db', -6)),
+        initial: dbToGain(runtimeNumeric('db', -6)),
         points: [
           {
-            time: numeric('s', 0.5),
-            value: dbToGain(numeric('db', -3)),
+            time: runtimeNumeric('s', 0.5),
+            value: dbToGain(runtimeNumeric('db', -3)),
             shape: 'exponential'
           },
           {
-            time: numeric('s', 1),
-            value: dbToGain(numeric('db', -12)),
+            time: runtimeNumeric('s', 1),
+            value: dbToGain(runtimeNumeric('db', -12)),
             shape: 'step'
           }
         ]
@@ -423,7 +423,7 @@ describe('lowering.ts', () => {
             id: instrumentId,
             gain: {
               id: 200 as ParameterId,
-              initial: numeric('db', -6)
+              initial: runtimeNumeric('db', -6)
             },
             trigger: () => []
           } satisfies Instrument
@@ -434,18 +434,18 @@ describe('lowering.ts', () => {
       assets: new Map(),
 
       track: {
-        tempo: numeric('bpm', 120),
+        tempo: runtimeNumeric('bpm', 120),
         parts: [
           {
             name: 'Part 1',
-            length: numeric('beats', 4),
+            length: runtimeNumeric('beats', 4),
             routings: [
               {
                 source: {
                   type: 'pattern',
                   value: createSerialPattern([
                     { value: 'C4' },
-                    { value: 'E4', velocity: numeric(undefined, 0.75) }
+                    { value: 'E4', velocity: runtimeNumeric(undefined, 0.75) }
                   ])
                 },
                 destination: {
@@ -457,7 +457,7 @@ describe('lowering.ts', () => {
           },
           {
             name: 'Part 2',
-            length: numeric('beats', 4),
+            length: runtimeNumeric('beats', 4),
             routings: [
               {
                 source: {
@@ -489,10 +489,10 @@ describe('lowering.ts', () => {
       [
         2 as NodeId,
         [
-          { time: numeric('beats', 0), pitch: 'C4', velocity: numeric(undefined, 1), gate: numeric('beats', 1) },
-          { time: numeric('beats', 1), pitch: 'E4', velocity: numeric(undefined, 0.75), gate: numeric('beats', 1) },
-          { time: numeric('beats', 4), pitch: 'G4', velocity: numeric(undefined, 1), gate: numeric('beats', 1) },
-          { time: numeric('beats', 5), pitch: 'B4', velocity: numeric(undefined, 1), gate: numeric('beats', 1) }
+          { time: runtimeNumeric('beats', 0), pitch: 'C4', velocity: runtimeNumeric(undefined, 1), gate: runtimeNumeric('beats', 1) },
+          { time: runtimeNumeric('beats', 1), pitch: 'E4', velocity: runtimeNumeric(undefined, 0.75), gate: runtimeNumeric('beats', 1) },
+          { time: runtimeNumeric('beats', 4), pitch: 'G4', velocity: runtimeNumeric(undefined, 1), gate: runtimeNumeric('beats', 1) },
+          { time: runtimeNumeric('beats', 5), pitch: 'B4', velocity: runtimeNumeric(undefined, 1), gate: runtimeNumeric('beats', 1) }
         ]
       ]
     ])
@@ -503,7 +503,7 @@ describe('lowering.ts', () => {
       id: 100 as InstrumentId,
       gain: {
         id: 200 as ParameterId,
-        initial: numeric('db', -Infinity)
+        initial: runtimeNumeric('db', -Infinity)
       },
       trigger: () => []
     })
@@ -517,7 +517,7 @@ describe('lowering.ts', () => {
         id: 100 as InstrumentId,
         gain: {
           id: 200 as ParameterId,
-          initial: numeric('db', gain)
+          initial: runtimeNumeric('db', gain)
         },
         trigger: () => []
       })
@@ -529,16 +529,16 @@ describe('lowering.ts', () => {
   it('should lower dB curves into gain space', () => {
     const testCases: Array<Curve<'s', 'db'>> = [
       {
-        initial: numeric('db', -Infinity),
+        initial: runtimeNumeric('db', -Infinity),
         points: [
-          { time: numeric('s', 0), value: numeric('db', 0), shape: 'step' }
+          { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', 0), shape: 'step' }
         ]
       },
       {
-        initial: numeric('db', -12),
+        initial: runtimeNumeric('db', -12),
         points: [
-          { time: numeric('s', 0.25), value: numeric('db', -6), shape: 'linear' },
-          { time: numeric('s', 0.5), value: numeric('db', -18), shape: 'step' }
+          { time: runtimeNumeric('s', 0.25), value: runtimeNumeric('db', -6), shape: 'linear' },
+          { time: runtimeNumeric('s', 0.5), value: runtimeNumeric('db', -18), shape: 'step' }
         ]
       },
       SIMPLE_CURVE
@@ -546,8 +546,8 @@ describe('lowering.ts', () => {
 
     const note: NoteData = {
       pitch: 'C4',
-      velocity: numeric(undefined, 1),
-      gate: numeric('beats', 16)
+      velocity: runtimeNumeric(undefined, 1),
+      gate: runtimeNumeric('beats', 16)
     }
 
     for (const curve of testCases) {
@@ -555,7 +555,7 @@ describe('lowering.ts', () => {
         id: 100 as InstrumentId,
         gain: {
           id: 200 as ParameterId,
-          initial: numeric('db', -6)
+          initial: runtimeNumeric('db', -6)
         },
         trigger: () => [
           {
@@ -563,7 +563,7 @@ describe('lowering.ts', () => {
             source: {
               type: 'oscillator',
               shape: 'sine',
-              frequency: numeric('hz', 440)
+              frequency: runtimeNumeric('hz', 440)
             }
           }
         ]
@@ -582,7 +582,7 @@ describe('lowering.ts', () => {
   })
 
   it('should skip voices with negative or zero duration', () => {
-    const makeVoice = (frequency: Numeric<'hz'>, duration: Numeric<'s'> | undefined) => ({
+    const makeVoice = (frequency: RuntimeNumeric<'hz'>, duration: RuntimeNumeric<'s'> | undefined) => ({
       envelope: SIMPLE_CURVE,
       source: {
         type: 'oscillator',
@@ -596,13 +596,13 @@ describe('lowering.ts', () => {
       id: 100 as InstrumentId,
       gain: {
         id: 200 as ParameterId,
-        initial: numeric('db', -6)
+        initial: runtimeNumeric('db', -6)
       },
       trigger: () => [
-        makeVoice(numeric('hz', 100), numeric('s', -1)),
-        makeVoice(numeric('hz', 200), numeric('s', 0)),
-        makeVoice(numeric('hz', 300), numeric('s', 1)),
-        makeVoice(numeric('hz', 400), undefined)
+        makeVoice(runtimeNumeric('hz', 100), runtimeNumeric('s', -1)),
+        makeVoice(runtimeNumeric('hz', 200), runtimeNumeric('s', 0)),
+        makeVoice(runtimeNumeric('hz', 300), runtimeNumeric('s', 1)),
+        makeVoice(runtimeNumeric('hz', 400), undefined)
       ]
     })
 
@@ -611,13 +611,13 @@ describe('lowering.ts', () => {
     const instrumentNode = graph.nodes.get(2 as NodeId) as InstrumentNode
     const voices = instrumentNode.trigger({
       pitch: 'C4',
-      velocity: numeric(undefined, 1),
-      gate: numeric('beats', 1)
+      velocity: runtimeNumeric(undefined, 1),
+      gate: runtimeNumeric('beats', 1)
     })
 
     assert.deepStrictEqual(
       voices.map((voice) => voice.type === 'oscillator' ? voice.frequency : undefined),
-      [numeric('hz', 300), numeric('hz', 400)]
+      [runtimeNumeric('hz', 300), runtimeNumeric('hz', 400)]
     )
   })
 
@@ -627,7 +627,7 @@ describe('lowering.ts', () => {
         id: 100 as InstrumentId,
         gain: {
           id: 200 as ParameterId,
-          initial: numeric('db', -6)
+          initial: runtimeNumeric('db', -6)
         },
         trigger: () => [
           {
@@ -635,8 +635,8 @@ describe('lowering.ts', () => {
             source: {
               type: 'sample',
               assetId: 300 as AssetId,
-              length: numeric('s', -1),
-              playbackRate: numeric(undefined, playbackRate)
+              length: runtimeNumeric('s', -1),
+              playbackRate: runtimeNumeric(undefined, playbackRate)
             }
           }
         ]
@@ -651,8 +651,8 @@ describe('lowering.ts', () => {
       assert.throws(() => {
         instrumentNode.trigger({
           pitch: 'C4',
-          velocity: numeric(undefined, 1),
-          gate: numeric('beats', 1)
+          velocity: runtimeNumeric(undefined, 1),
+          gate: runtimeNumeric('beats', 1)
         })
       }, /Invalid playback rate/, `should throw for playback rate: ${playbackRate}`)
     }
@@ -664,7 +664,7 @@ describe('lowering.ts', () => {
         id: 100 as InstrumentId,
         gain: {
           id: 200 as ParameterId,
-          initial: numeric('db', -6)
+          initial: runtimeNumeric('db', -6)
         },
         trigger: () => [
           {
@@ -672,7 +672,7 @@ describe('lowering.ts', () => {
             source: {
               type: 'oscillator',
               shape: 'sine',
-              frequency: numeric('hz', frequency)
+              frequency: runtimeNumeric('hz', frequency)
             }
           }
         ]
@@ -684,8 +684,8 @@ describe('lowering.ts', () => {
       assert.throws(() => {
         instrumentNode.trigger({
           pitch: 'C4',
-          velocity: numeric(undefined, 1),
-          gate: numeric('beats', 1)
+          velocity: runtimeNumeric(undefined, 1),
+          gate: runtimeNumeric('beats', 1)
         })
       }, /Invalid frequency/, `should throw for frequency: ${frequency}`)
     }
@@ -698,13 +698,13 @@ describe('lowering.ts', () => {
           type: 'gain',
           gain: {
             id: 400 as ParameterId,
-            initial: numeric('db', -3)
+            initial: runtimeNumeric('db', -3)
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'gain',
           gain: {
-            initial: dbToGain(numeric('db', -3)),
+            initial: dbToGain(runtimeNumeric('db', -3)),
             points: []
           }
         } satisfies GainNode)
@@ -715,13 +715,13 @@ describe('lowering.ts', () => {
           type: 'gain',
           gain: {
             id: 400 as ParameterId,
-            initial: numeric('db', -Infinity)
+            initial: runtimeNumeric('db', -Infinity)
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'gain',
           gain: {
-            initial: numeric(undefined, 0),
+            initial: runtimeNumeric(undefined, 0),
             points: []
           }
         } satisfies GainNode)
@@ -733,7 +733,7 @@ describe('lowering.ts', () => {
             type: 'gain',
             gain: {
               id: 400 as ParameterId,
-              initial: numeric('db', gain)
+              initial: runtimeNumeric('db', gain)
             }
           })), /Invalid gain/, `should throw for gain: ${gain}`)
         }
@@ -746,13 +746,13 @@ describe('lowering.ts', () => {
           type: 'pan',
           pan: {
             id: 500 as ParameterId,
-            initial: numeric(undefined, 0.5)
+            initial: runtimeNumeric(undefined, 0.5)
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'pan',
           pan: {
-            initial: numeric(undefined, 0.5),
+            initial: runtimeNumeric(undefined, 0.5),
             points: []
           }
         } satisfies PanNode)
@@ -763,13 +763,13 @@ describe('lowering.ts', () => {
           type: 'pan',
           pan: {
             id: 500 as ParameterId,
-            initial: numeric(undefined, Infinity)
+            initial: runtimeNumeric(undefined, Infinity)
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'pan',
           pan: {
-            initial: numeric(undefined, 1),
+            initial: runtimeNumeric(undefined, 1),
             points: []
           }
         } satisfies PanNode)
@@ -778,13 +778,13 @@ describe('lowering.ts', () => {
           type: 'pan',
           pan: {
             id: 500 as ParameterId,
-            initial: numeric(undefined, -Infinity)
+            initial: runtimeNumeric(undefined, -Infinity)
           }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           type: 'pan',
           pan: {
-            initial: numeric(undefined, -1),
+            initial: runtimeNumeric(undefined, -1),
             points: []
           }
         } satisfies PanNode)
@@ -795,7 +795,7 @@ describe('lowering.ts', () => {
           type: 'pan',
           pan: {
             id: 500 as ParameterId,
-            initial: numeric(undefined, Number.NaN)
+            initial: runtimeNumeric(undefined, Number.NaN)
           }
         })), /Invalid pan/)
       })
@@ -807,34 +807,34 @@ describe('lowering.ts', () => {
           type: 'lowpass',
           frequency: {
             id: 600 as ParameterId,
-            initial: numeric('hz', 1000)
+            initial: runtimeNumeric('hz', 1000)
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'biquad',
           filterType: 'lowpass',
           frequency: {
-            initial: numeric('hz', 1000),
+            initial: runtimeNumeric('hz', 1000),
             points: []
           },
-          rolloffPerOctave: numeric('db', 12)
+          rolloffPerOctave: runtimeNumeric('db', 12)
         } satisfies BiquadNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'lowpass',
           frequency: {
             id: 600 as ParameterId,
-            initial: numeric('hz', -100)
+            initial: runtimeNumeric('hz', -100)
           }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           type: 'biquad',
           filterType: 'lowpass',
           frequency: {
-            initial: numeric('hz', 0),
+            initial: runtimeNumeric('hz', 0),
             points: []
           },
-          rolloffPerOctave: numeric('db', 12)
+          rolloffPerOctave: runtimeNumeric('db', 12)
         } satisfies BiquadNode)
       })
 
@@ -844,7 +844,7 @@ describe('lowering.ts', () => {
             type: 'lowpass',
             frequency: {
               id: 600 as ParameterId,
-              initial: numeric('hz', frequency)
+              initial: runtimeNumeric('hz', frequency)
             }
           })), /Invalid frequency/, `should throw for frequency: ${frequency}`)
         }
@@ -857,34 +857,34 @@ describe('lowering.ts', () => {
           type: 'highpass',
           frequency: {
             id: 600 as ParameterId,
-            initial: numeric('hz', 500)
+            initial: runtimeNumeric('hz', 500)
           }
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'biquad',
           filterType: 'highpass',
           frequency: {
-            initial: numeric('hz', 500),
+            initial: runtimeNumeric('hz', 500),
             points: []
           },
-          rolloffPerOctave: numeric('db', 12)
+          rolloffPerOctave: runtimeNumeric('db', 12)
         } satisfies BiquadNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'highpass',
           frequency: {
             id: 600 as ParameterId,
-            initial: numeric('hz', -100)
+            initial: runtimeNumeric('hz', -100)
           }
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           type: 'biquad',
           filterType: 'highpass',
           frequency: {
-            initial: numeric('hz', 0),
+            initial: runtimeNumeric('hz', 0),
             points: []
           },
-          rolloffPerOctave: numeric('db', 12)
+          rolloffPerOctave: runtimeNumeric('db', 12)
         } satisfies BiquadNode)
       })
 
@@ -894,7 +894,7 @@ describe('lowering.ts', () => {
             type: 'highpass',
             frequency: {
               id: 600 as ParameterId,
-              initial: numeric('hz', frequency)
+              initial: runtimeNumeric('hz', frequency)
             }
           })), /Invalid frequency/, `should throw for frequency: ${frequency}`)
         }
@@ -905,38 +905,38 @@ describe('lowering.ts', () => {
       it('should handle width', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'width',
-          width: numeric(undefined, 0.75)
+          width: runtimeNumeric(undefined, 0.75)
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'width',
-          width: numeric(undefined, 0.75)
+          width: runtimeNumeric(undefined, 0.75)
         } satisfies WidthNode)
       })
 
       it('should clamp width to [0, 1]', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'width',
-          width: numeric(undefined, Infinity)
+          width: runtimeNumeric(undefined, Infinity)
         }))
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'width',
-          width: numeric(undefined, 1)
+          width: runtimeNumeric(undefined, 1)
         } satisfies WidthNode)
 
         const graph2 = createAudioGraph(createProgramWithEffect({
           type: 'width',
-          width: numeric(undefined, -Infinity)
+          width: runtimeNumeric(undefined, -Infinity)
         }))
         assert.deepStrictEqual(graph2.nodes.get(2 as NodeId), {
           type: 'width',
-          width: numeric(undefined, 0)
+          width: runtimeNumeric(undefined, 0)
         } satisfies WidthNode)
       })
 
       it('should throw for NaN width', () => {
         assert.throws(() => createAudioGraph(createProgramWithEffect({
           type: 'width',
-          width: numeric(undefined, Number.NaN)
+          width: runtimeNumeric(undefined, Number.NaN)
         })), /Invalid width/)
       })
     })
@@ -945,13 +945,13 @@ describe('lowering.ts', () => {
       it('should handle delay', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'delay',
-          mix: numeric(undefined, 0.25),
-          time: numeric('beats', 0.5),
+          mix: runtimeNumeric(undefined, 0.25),
+          time: runtimeNumeric('beats', 0.5),
           feedback: {
             id: 400 as ParameterId,
-            initial: numeric(undefined, 0.4)
+            initial: runtimeNumeric(undefined, 0.4)
           },
-          wet: numeric('db', 0)
+          wet: runtimeNumeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
@@ -967,7 +967,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+              time: beatsToSeconds(runtimeNumeric('beats', 0.5), runtimeNumeric('bpm', 120))
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -976,7 +976,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 0.4),
+                initial: runtimeNumeric(undefined, 0.4),
                 points: []
               }
             } satisfies GainNode
@@ -987,7 +987,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 1.0),
+                initial: runtimeNumeric(undefined, 1.0),
                 points: []
               }
             } satisfies GainNode
@@ -998,7 +998,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 0.5),
+                initial: runtimeNumeric(undefined, 0.5),
                 points: []
               }
             } satisfies GainNode
@@ -1022,13 +1022,13 @@ describe('lowering.ts', () => {
       it('should clamp delay mix to [0, 1]', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'delay',
-          mix: numeric(undefined, Infinity),
-          time: numeric('beats', 0.5),
+          mix: runtimeNumeric(undefined, Infinity),
+          time: runtimeNumeric('beats', 0.5),
           feedback: {
             id: 400 as ParameterId,
-            initial: numeric(undefined, 0.4)
+            initial: runtimeNumeric(undefined, 0.4)
           },
-          wet: numeric('db', 0)
+          wet: runtimeNumeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
@@ -1044,7 +1044,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+              time: beatsToSeconds(runtimeNumeric('beats', 0.5), runtimeNumeric('bpm', 120))
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1053,7 +1053,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 0.4),
+                initial: runtimeNumeric(undefined, 0.4),
                 points: []
               }
             } satisfies GainNode
@@ -1064,13 +1064,13 @@ describe('lowering.ts', () => {
       it('should throw for NaN delay mix', () => {
         assert.throws(() => createAudioGraph(createProgramWithEffect({
           type: 'delay',
-          mix: numeric(undefined, Number.NaN),
-          time: numeric('beats', 0.5),
+          mix: runtimeNumeric(undefined, Number.NaN),
+          time: runtimeNumeric('beats', 0.5),
           feedback: {
             id: 400 as ParameterId,
-            initial: numeric(undefined, 0.4)
+            initial: runtimeNumeric(undefined, 0.4)
           },
-          wet: numeric('db', 0)
+          wet: runtimeNumeric('db', 0)
         })), /Invalid mix/)
       })
 
@@ -1078,13 +1078,13 @@ describe('lowering.ts', () => {
         for (const time of [Infinity, -Infinity, Number.NaN]) {
           assert.throws(() => createAudioGraph(createProgramWithEffect({
             type: 'delay',
-            mix: numeric(undefined, 0.25),
-            time: numeric('beats', time),
+            mix: runtimeNumeric(undefined, 0.25),
+            time: runtimeNumeric('beats', time),
             feedback: {
               id: 400 as ParameterId,
-              initial: numeric(undefined, 0.4)
+              initial: runtimeNumeric(undefined, 0.4)
             },
-            wet: numeric('db', 0)
+            wet: runtimeNumeric('db', 0)
           })), /Invalid time/, `should throw for time: ${time}`)
         }
       })
@@ -1092,19 +1092,19 @@ describe('lowering.ts', () => {
       it('should clamp delay feedback to [0, 1]', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'delay',
-          mix: numeric(undefined, 0.25),
-          time: numeric('beats', 0.5),
+          mix: runtimeNumeric(undefined, 0.25),
+          time: runtimeNumeric('beats', 0.5),
           feedback: {
             id: 400 as ParameterId,
-            initial: numeric(undefined, Infinity)
+            initial: runtimeNumeric(undefined, Infinity)
           },
-          wet: numeric('db', 0)
+          wet: runtimeNumeric('db', 0)
         }))
 
         assert.deepStrictEqual(graph.nodes.get(3 as NodeId), {
           type: 'gain',
           gain: {
-            initial: numeric(undefined, 1),
+            initial: runtimeNumeric(undefined, 1),
             points: []
           }
         } satisfies GainNode)
@@ -1113,44 +1113,44 @@ describe('lowering.ts', () => {
       it('should throw for NaN delay feedback', () => {
         assert.throws(() => createAudioGraph(createProgramWithEffect({
           type: 'delay',
-          mix: numeric(undefined, 0.25),
-          time: numeric('beats', 0.5),
+          mix: runtimeNumeric(undefined, 0.25),
+          time: runtimeNumeric('beats', 0.5),
           feedback: {
             id: 400 as ParameterId,
-            initial: numeric(undefined, Number.NaN)
+            initial: runtimeNumeric(undefined, Number.NaN)
           },
-          wet: numeric('db', 0)
+          wet: runtimeNumeric('db', 0)
         })), /Invalid feedback/)
       })
 
       it('should handle delay specified in seconds', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'delay',
-          mix: numeric(undefined, 0.25),
-          time: numeric('s', 1.5),
+          mix: runtimeNumeric(undefined, 0.25),
+          time: runtimeNumeric('s', 1.5),
           feedback: {
             id: 400 as ParameterId,
-            initial: numeric(undefined, 0.4)
+            initial: runtimeNumeric(undefined, 0.4)
           },
-          wet: numeric('db', 0)
+          wet: runtimeNumeric('db', 0)
         }))
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'delay',
-          time: numeric('s', 1.5)
+          time: runtimeNumeric('s', 1.5)
         } satisfies DelayNode)
       })
 
       it('should add a gain node for non-zero wet level', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'delay',
-          mix: numeric(undefined, 0.25),
-          time: numeric('beats', 0.5),
+          mix: runtimeNumeric(undefined, 0.25),
+          time: runtimeNumeric('beats', 0.5),
           feedback: {
             id: 400 as ParameterId,
-            initial: numeric(undefined, 0.4)
+            initial: runtimeNumeric(undefined, 0.4)
           },
-          wet: numeric('db', -6)
+          wet: runtimeNumeric('db', -6)
         }))
 
         // Note: There already is a wet gain node to handle the mix level,
@@ -1169,7 +1169,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'delay',
-              time: beatsToSeconds(numeric('beats', 0.5), numeric('bpm', 120))
+              time: beatsToSeconds(runtimeNumeric('beats', 0.5), runtimeNumeric('bpm', 120))
             } satisfies DelayNode
           ],
           // feedback gain node
@@ -1178,7 +1178,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 0.4),
+                initial: runtimeNumeric(undefined, 0.4),
                 points: []
               }
             } satisfies GainNode
@@ -1189,7 +1189,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: dbToGain(numeric('db', -6)),
+                initial: dbToGain(runtimeNumeric('db', -6)),
                 points: []
               }
             } satisfies GainNode
@@ -1200,7 +1200,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 1.0),
+                initial: runtimeNumeric(undefined, 1.0),
                 points: []
               }
             } satisfies GainNode
@@ -1211,7 +1211,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 0.5),
+                initial: runtimeNumeric(undefined, 0.5),
                 points: []
               }
             } satisfies GainNode
@@ -1238,13 +1238,13 @@ describe('lowering.ts', () => {
         for (const wet of [Infinity, Number.NaN]) {
           assert.throws(() => createAudioGraph(createProgramWithEffect({
             type: 'delay',
-            mix: numeric(undefined, 0.25),
-            time: numeric('beats', 0.5),
+            mix: runtimeNumeric(undefined, 0.25),
+            time: runtimeNumeric('beats', 0.5),
             feedback: {
               id: 400 as ParameterId,
-              initial: numeric(undefined, 0.4)
+              initial: runtimeNumeric(undefined, 0.4)
             },
-            wet: numeric('db', wet)
+            wet: runtimeNumeric('db', wet)
           })), /Invalid gain/, `should throw for wet level: ${wet}`)
         }
       })
@@ -1254,9 +1254,9 @@ describe('lowering.ts', () => {
       it('should handle reverb', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'reverb',
-          mix: numeric(undefined, 0.75),
-          decay: numeric('s', 2),
-          wet: numeric('db', 0)
+          mix: runtimeNumeric(undefined, 0.75),
+          decay: runtimeNumeric('s', 2),
+          wet: runtimeNumeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
@@ -1272,7 +1272,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'reverb',
-              decay: numeric('s', 2)
+              decay: runtimeNumeric('s', 2)
             } satisfies ReverbNode
           ],
           // dry gain node
@@ -1281,7 +1281,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 0.5),
+                initial: runtimeNumeric(undefined, 0.5),
                 points: []
               }
             } satisfies GainNode
@@ -1292,7 +1292,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 1.0),
+                initial: runtimeNumeric(undefined, 1.0),
                 points: []
               }
             } satisfies GainNode
@@ -1312,9 +1312,9 @@ describe('lowering.ts', () => {
       it('should clamp reverb mix to [0, 1]', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'reverb',
-          mix: numeric(undefined, 1.5),
-          decay: numeric('s', 2),
-          wet: numeric('db', 0)
+          mix: runtimeNumeric(undefined, 1.5),
+          decay: runtimeNumeric('s', 2),
+          wet: runtimeNumeric('db', 0)
         }))
 
         assert.deepStrictEqual([...graph.nodes].sort(compareIds), [
@@ -1330,7 +1330,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'reverb',
-              decay: numeric('s', 2)
+              decay: runtimeNumeric('s', 2)
             } satisfies ReverbNode
           ]
         ])
@@ -1339,9 +1339,9 @@ describe('lowering.ts', () => {
       it('should throw for NaN reverb mix', () => {
         assert.throws(() => createAudioGraph(createProgramWithEffect({
           type: 'reverb',
-          mix: numeric(undefined, Number.NaN),
-          decay: numeric('s', 2),
-          wet: numeric('db', 0)
+          mix: runtimeNumeric(undefined, Number.NaN),
+          decay: runtimeNumeric('s', 2),
+          wet: runtimeNumeric('db', 0)
         })), /Invalid mix/)
       })
 
@@ -1349,9 +1349,9 @@ describe('lowering.ts', () => {
         for (const decay of [Infinity, -Infinity, Number.NaN]) {
           assert.throws(() => createAudioGraph(createProgramWithEffect({
             type: 'reverb',
-            mix: numeric(undefined, 0.75),
-            decay: numeric('s', decay),
-            wet: numeric('db', 0)
+            mix: runtimeNumeric(undefined, 0.75),
+            decay: runtimeNumeric('s', decay),
+            wet: runtimeNumeric('db', 0)
           })), /Invalid decay/, `should throw for decay: ${decay}`)
         }
       })
@@ -1359,23 +1359,23 @@ describe('lowering.ts', () => {
       it('should handle reverb specified in beats', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'reverb',
-          mix: numeric(undefined, 0.75),
-          decay: numeric('beats', 2),
-          wet: numeric('db', 0)
+          mix: runtimeNumeric(undefined, 0.75),
+          decay: runtimeNumeric('beats', 2),
+          wet: runtimeNumeric('db', 0)
         }))
 
         assert.deepStrictEqual(graph.nodes.get(2 as NodeId), {
           type: 'reverb',
-          decay: beatsToSeconds(numeric('beats', 2), numeric('bpm', 120))
+          decay: beatsToSeconds(runtimeNumeric('beats', 2), runtimeNumeric('bpm', 120))
         } satisfies ReverbNode)
       })
 
       it('should add a gain node for non-zero wet level', () => {
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'reverb',
-          mix: numeric(undefined, 0.25),
-          decay: numeric('s', 2),
-          wet: numeric('db', -6)
+          mix: runtimeNumeric(undefined, 0.25),
+          decay: runtimeNumeric('s', 2),
+          wet: runtimeNumeric('db', -6)
         }))
 
         // Note: There already is a wet gain node to handle the mix level,
@@ -1394,7 +1394,7 @@ describe('lowering.ts', () => {
             2,
             {
               type: 'reverb',
-              decay: numeric('s', 2)
+              decay: runtimeNumeric('s', 2)
             } satisfies ReverbNode
           ],
           // wet gain node for wet level
@@ -1403,7 +1403,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: dbToGain(numeric('db', -6)),
+                initial: dbToGain(runtimeNumeric('db', -6)),
                 points: []
               }
             } satisfies GainNode
@@ -1414,7 +1414,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 1.0),
+                initial: runtimeNumeric(undefined, 1.0),
                 points: []
               }
             } satisfies GainNode
@@ -1425,7 +1425,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 0.5),
+                initial: runtimeNumeric(undefined, 0.5),
                 points: []
               }
             } satisfies GainNode
@@ -1448,9 +1448,9 @@ describe('lowering.ts', () => {
         for (const wet of [Infinity, Number.NaN]) {
           assert.throws(() => createAudioGraph(createProgramWithEffect({
             type: 'reverb',
-            mix: numeric(undefined, 0.75),
-            decay: numeric('s', 2),
-            wet: numeric('db', wet)
+            mix: runtimeNumeric(undefined, 0.75),
+            decay: runtimeNumeric('s', 2),
+            wet: runtimeNumeric('db', wet)
           })), /Invalid gain/, `should throw for wet level: ${wet}`)
         }
       })
@@ -1458,7 +1458,7 @@ describe('lowering.ts', () => {
 
     describe('clip effect', () => {
       it('should create gain, wave shaper, and makeup nodes', () => {
-        const threshold = numeric('db', -6)
+        const threshold = runtimeNumeric('db', -6)
 
         const graph = createAudioGraph(createProgramWithEffect({
           type: 'clip',
@@ -1482,7 +1482,7 @@ describe('lowering.ts', () => {
             {
               type: 'gain',
               gain: {
-                initial: numeric(undefined, 1 / dbToGain(threshold).value),
+                initial: runtimeNumeric(undefined, 1 / dbToGain(threshold).value),
                 points: []
               }
             } satisfies GainNode
@@ -1524,7 +1524,7 @@ describe('lowering.ts', () => {
             type: 'clip',
             threshold: {
               id: 400 as ParameterId,
-              initial: numeric('db', threshold)
+              initial: runtimeNumeric('db', threshold)
             }
           })), /Invalid gain/, `should throw for threshold: ${threshold}`)
         }
@@ -1538,7 +1538,7 @@ describe('lowering.ts', () => {
         id: 100 as InstrumentId,
         gain: {
           id: 200 as ParameterId,
-          initial: numeric('db', -6)
+          initial: runtimeNumeric('db', -6)
         },
         trigger: () => []
       }))
@@ -1559,7 +1559,7 @@ describe('lowering.ts', () => {
               id: instrumentId,
               gain: {
                 id: 200 as ParameterId,
-                initial: numeric('db', -6)
+                initial: runtimeNumeric('db', -6)
               },
               trigger: () => []
             } satisfies Instrument
@@ -1568,7 +1568,7 @@ describe('lowering.ts', () => {
         automations: new Map(),
         assets: new Map(),
         track: {
-          tempo: numeric('bpm', 120),
+          tempo: runtimeNumeric('bpm', 120),
           parts: []
         },
         mixer: {
@@ -1578,11 +1578,11 @@ describe('lowering.ts', () => {
               name: 'Bus 1',
               gain: {
                 id: 201 as ParameterId,
-                initial: numeric('db', -3)
+                initial: runtimeNumeric('db', -3)
               },
               pan: {
                 id: 202 as ParameterId,
-                initial: numeric(undefined, 0)
+                initial: runtimeNumeric(undefined, 0)
               },
               effects: []
             } satisfies Bus
@@ -1613,7 +1613,7 @@ describe('lowering.ts', () => {
         }
       }
 
-      const interval = numeric('s', 0.123)
+      const interval = runtimeNumeric('s', 0.123)
 
       const graph = createAudioGraph(program, {
         metering: { interval }
@@ -1653,7 +1653,7 @@ describe('lowering.ts', () => {
       id: 100 as InstrumentId,
       gain: {
         id: 200 as ParameterId,
-        initial: numeric('db', -6)
+        initial: runtimeNumeric('db', -6)
       },
       trigger: () => []
     })
@@ -1661,7 +1661,7 @@ describe('lowering.ts', () => {
     for (const interval of [Infinity, -Infinity, Number.NaN, 0, -1]) {
       const options = {
         metering: {
-          interval: numeric('s', interval)
+          interval: runtimeNumeric('s', interval)
         }
       }
 

--- a/packages/codecs/src/pcm/aiff.ts
+++ b/packages/codecs/src/pcm/aiff.ts
@@ -1,5 +1,5 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { AudioBufferLike, AudioDescription } from '../common/types.js'
 import type { FloatSampleBits, PCMFormat, PCMSampleBits } from './pcm-io.js'
 import { getBitsPerSample, writeAudioData, writeExtended80, writeStringData, writeUint16BE, writeUint32BE } from './pcm-io.js'
@@ -27,7 +27,7 @@ const toPCMFormat = (format: AIFFFormat): PCMFormat => `${format}be`
 /**
  * Estimate the size of an AIFF/AIFC file given information about the audio data and encoding options.
  */
-export function estimateAIFFSize (audio: AudioDescription, options: AIFFEncodingOptions): Numeric<'bytes'> {
+export function estimateAIFFSize (audio: AudioDescription, options: AIFFEncodingOptions): RuntimeNumeric<'bytes'> {
   const numChannels = audio.numberOfChannels
   const bitsPerSample = getBitsPerSample(toPCMFormat(options.format))
   const dataSize = audio.length * numChannels * (bitsPerSample / 8)
@@ -45,7 +45,7 @@ export function estimateAIFFSize (audio: AudioDescription, options: AIFFEncoding
   // FORM chunk: 'FORM'(4) + size(4) + formType(4) + chunks...
   const fileSize = 12 + fverSize + (8 + commChunkSize + commPad) + (8 + ssndChunkSize + ssndPad)
 
-  return numeric('bytes', fileSize)
+  return runtimeNumeric('bytes', fileSize)
 }
 
 /**

--- a/packages/codecs/src/pcm/aiff.ts
+++ b/packages/codecs/src/pcm/aiff.ts
@@ -1,5 +1,4 @@
-import type { RuntimeNumeric } from '@utility'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { AudioBufferLike, AudioDescription } from '../common/types.js'
 import type { FloatSampleBits, PCMFormat, PCMSampleBits } from './pcm-io.js'
 import { getBitsPerSample, writeAudioData, writeExtended80, writeStringData, writeUint16BE, writeUint32BE } from './pcm-io.js'
@@ -27,7 +26,7 @@ const toPCMFormat = (format: AIFFFormat): PCMFormat => `${format}be`
 /**
  * Estimate the size of an AIFF/AIFC file given information about the audio data and encoding options.
  */
-export function estimateAIFFSize (audio: AudioDescription, options: AIFFEncodingOptions): RuntimeNumeric<'bytes'> {
+export function estimateAIFFSize (audio: AudioDescription, options: AIFFEncodingOptions): Numeric<'bytes'> {
   const numChannels = audio.numberOfChannels
   const bitsPerSample = getBitsPerSample(toPCMFormat(options.format))
   const dataSize = audio.length * numChannels * (bitsPerSample / 8)
@@ -45,7 +44,7 @@ export function estimateAIFFSize (audio: AudioDescription, options: AIFFEncoding
   // FORM chunk: 'FORM'(4) + size(4) + formType(4) + chunks...
   const fileSize = 12 + fverSize + (8 + commChunkSize + commPad) + (8 + ssndChunkSize + ssndPad)
 
-  return runtimeNumeric('bytes', fileSize)
+  return fileSize as Numeric<'bytes'>
 }
 
 /**

--- a/packages/codecs/src/pcm/wav.ts
+++ b/packages/codecs/src/pcm/wav.ts
@@ -1,5 +1,5 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { AudioBufferLike, AudioDescription } from '../common/types.js'
 import type { FloatSampleBits, PCMFormat, PCMSampleBits } from './pcm-io.js'
 import { getBitsPerSample, writeAudioData, writeStringData, writeUint16LE, writeUint32LE } from './pcm-io.js'
@@ -22,7 +22,7 @@ const toPCMFormat = (format: WAVFormat): PCMFormat => `${format}le`
 /**
  * Estimate the size of a WAV file (in bytes) given information about the audio data and encoding options.
  */
-export function estimateWAVSize (audio: AudioDescription, options: WAVEncodingOptions): Numeric<'bytes'> {
+export function estimateWAVSize (audio: AudioDescription, options: WAVEncodingOptions): RuntimeNumeric<'bytes'> {
   const bitsPerSample = getBitsPerSample(toPCMFormat(options.format))
   const blockAlign = audio.numberOfChannels * bitsPerSample / 8
   const dataSize = audio.length * blockAlign
@@ -30,7 +30,7 @@ export function estimateWAVSize (audio: AudioDescription, options: WAVEncodingOp
   // headers size (RIFF chunk + fmt subchunk + data subchunk)
   const headersSize = 44
 
-  return numeric('bytes', headersSize + dataSize)
+  return runtimeNumeric('bytes', headersSize + dataSize)
 }
 
 /**

--- a/packages/codecs/src/pcm/wav.ts
+++ b/packages/codecs/src/pcm/wav.ts
@@ -1,5 +1,4 @@
-import type { RuntimeNumeric } from '@utility'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { AudioBufferLike, AudioDescription } from '../common/types.js'
 import type { FloatSampleBits, PCMFormat, PCMSampleBits } from './pcm-io.js'
 import { getBitsPerSample, writeAudioData, writeStringData, writeUint16LE, writeUint32LE } from './pcm-io.js'
@@ -22,7 +21,7 @@ const toPCMFormat = (format: WAVFormat): PCMFormat => `${format}le`
 /**
  * Estimate the size of a WAV file (in bytes) given information about the audio data and encoding options.
  */
-export function estimateWAVSize (audio: AudioDescription, options: WAVEncodingOptions): RuntimeNumeric<'bytes'> {
+export function estimateWAVSize (audio: AudioDescription, options: WAVEncodingOptions): Numeric<'bytes'> {
   const bitsPerSample = getBitsPerSample(toPCMFormat(options.format))
   const blockAlign = audio.numberOfChannels * bitsPerSample / 8
   const dataSize = audio.length * blockAlign
@@ -30,7 +29,7 @@ export function estimateWAVSize (audio: AudioDescription, options: WAVEncodingOp
   // headers size (RIFF chunk + fmt subchunk + data subchunk)
   const headersSize = 44
 
-  return runtimeNumeric('bytes', headersSize + dataSize)
+  return (headersSize + dataSize) as Numeric<'bytes'>
 }
 
 /**

--- a/packages/codecs/src/transforms/leading-silence.ts
+++ b/packages/codecs/src/transforms/leading-silence.ts
@@ -1,11 +1,11 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import { ConcatenatedAudioBuffer } from '../common/concatenated-audio-buffer.js'
 import { ConstantAudioBuffer } from '../common/constant-audio-buffer.js'
 import type { AudioBufferTransform } from '../common/types.js'
 
 const identity: AudioBufferTransform = (input) => input
 
-export function createLeadingSilenceTransform (duration: Numeric<'s'>): AudioBufferTransform {
+export function createLeadingSilenceTransform (duration: RuntimeNumeric<'s'>): AudioBufferTransform {
   if (duration.value < 0) {
     throw new Error('Duration must be non-negative.')
   }

--- a/packages/codecs/src/transforms/leading-silence.ts
+++ b/packages/codecs/src/transforms/leading-silence.ts
@@ -1,16 +1,16 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { ConcatenatedAudioBuffer } from '../common/concatenated-audio-buffer.js'
 import { ConstantAudioBuffer } from '../common/constant-audio-buffer.js'
 import type { AudioBufferTransform } from '../common/types.js'
 
 const identity: AudioBufferTransform = (input) => input
 
-export function createLeadingSilenceTransform (duration: RuntimeNumeric<'s'>): AudioBufferTransform {
-  if (duration.value < 0) {
+export function createLeadingSilenceTransform (duration: Numeric<'s'>): AudioBufferTransform {
+  if (duration < 0) {
     throw new Error('Duration must be non-negative.')
   }
 
-  if (duration.value === 0) {
+  if (duration === 0) {
     return identity
   }
 
@@ -18,7 +18,7 @@ export function createLeadingSilenceTransform (duration: RuntimeNumeric<'s'>): A
     const silence = new ConstantAudioBuffer({
       sampleRate: input.sampleRate,
       numberOfChannels: input.numberOfChannels,
-      length: Math.ceil(duration.value * input.sampleRate),
+      length: Math.ceil(duration * input.sampleRate),
       value: 0
     })
 

--- a/packages/codecs/test/pcm/aiff.test.ts
+++ b/packages/codecs/test/pcm/aiff.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { SimpleAudioBuffer } from '../../src/common/simple-audio-buffer.js'
@@ -13,12 +13,12 @@ describe('pcm/aiff.ts', () => {
     }
 
     // AIFF: FORM(12) + COMM(8 + 18) + SSND(8 + 8 + data)
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm16' }), numeric('bytes', 54 + 441_000 * 2 * 2))
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm24' }), numeric('bytes', 54 + 441_000 * 2 * 3))
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm32' }), numeric('bytes', 54 + 441_000 * 2 * 4))
+    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm16' }), runtimeNumeric('bytes', 54 + 441_000 * 2 * 2))
+    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm24' }), runtimeNumeric('bytes', 54 + 441_000 * 2 * 3))
+    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm32' }), runtimeNumeric('bytes', 54 + 441_000 * 2 * 4))
 
     // AIFC adds FVER (12 bytes) + compression info to COMM; with our settings this makes the header 24 bytes larger.
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'float32' }), numeric('bytes', 78 + 441_000 * 2 * 4))
+    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'float32' }), runtimeNumeric('bytes', 78 + 441_000 * 2 * 4))
   })
 
   it('encodes pcm16 correctly (big-endian)', () => {

--- a/packages/codecs/test/pcm/aiff.test.ts
+++ b/packages/codecs/test/pcm/aiff.test.ts
@@ -1,4 +1,3 @@
-import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { SimpleAudioBuffer } from '../../src/common/simple-audio-buffer.js'
@@ -13,12 +12,12 @@ describe('pcm/aiff.ts', () => {
     }
 
     // AIFF: FORM(12) + COMM(8 + 18) + SSND(8 + 8 + data)
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm16' }), runtimeNumeric('bytes', 54 + 441_000 * 2 * 2))
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm24' }), runtimeNumeric('bytes', 54 + 441_000 * 2 * 3))
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'pcm32' }), runtimeNumeric('bytes', 54 + 441_000 * 2 * 4))
+    assert.strictEqual(estimateAIFFSize(stereo10s, { format: 'pcm16' }), 54 + 441_000 * 2 * 2)
+    assert.strictEqual(estimateAIFFSize(stereo10s, { format: 'pcm24' }), 54 + 441_000 * 2 * 3)
+    assert.strictEqual(estimateAIFFSize(stereo10s, { format: 'pcm32' }), 54 + 441_000 * 2 * 4)
 
     // AIFC adds FVER (12 bytes) + compression info to COMM; with our settings this makes the header 24 bytes larger.
-    assert.deepStrictEqual(estimateAIFFSize(stereo10s, { format: 'float32' }), runtimeNumeric('bytes', 78 + 441_000 * 2 * 4))
+    assert.strictEqual(estimateAIFFSize(stereo10s, { format: 'float32' }), 78 + 441_000 * 2 * 4)
   })
 
   it('encodes pcm16 correctly (big-endian)', () => {

--- a/packages/codecs/test/pcm/wav.test.ts
+++ b/packages/codecs/test/pcm/wav.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { SimpleAudioBuffer } from '../../src/common/simple-audio-buffer.js'
@@ -12,10 +12,10 @@ describe('pcm/wav.ts', () => {
       length: 441_000 // 10 seconds at 44.1kHz
     }
 
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm16' }), numeric('bytes', 44 + 441_000 * 2 * 2))
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm24' }), numeric('bytes', 44 + 441_000 * 2 * 3))
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm32' }), numeric('bytes', 44 + 441_000 * 2 * 4))
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'float32' }), numeric('bytes', 44 + 441_000 * 2 * 4))
+    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm16' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 2))
+    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm24' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 3))
+    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm32' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 4))
+    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'float32' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 4))
   })
 
   it('encodes pcm16 correctly', () => {

--- a/packages/codecs/test/pcm/wav.test.ts
+++ b/packages/codecs/test/pcm/wav.test.ts
@@ -1,4 +1,3 @@
-import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { SimpleAudioBuffer } from '../../src/common/simple-audio-buffer.js'
@@ -12,10 +11,10 @@ describe('pcm/wav.ts', () => {
       length: 441_000 // 10 seconds at 44.1kHz
     }
 
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm16' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 2))
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm24' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 3))
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'pcm32' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 4))
-    assert.deepStrictEqual(estimateWAVSize(stereo10s, { format: 'float32' }), runtimeNumeric('bytes', 44 + 441_000 * 2 * 4))
+    assert.strictEqual(estimateWAVSize(stereo10s, { format: 'pcm16' }), 44 + 441_000 * 2 * 2)
+    assert.strictEqual(estimateWAVSize(stereo10s, { format: 'pcm24' }), 44 + 441_000 * 2 * 3)
+    assert.strictEqual(estimateWAVSize(stereo10s, { format: 'pcm32' }), 44 + 441_000 * 2 * 4)
+    assert.strictEqual(estimateWAVSize(stereo10s, { format: 'float32' }), 44 + 441_000 * 2 * 4)
   })
 
   it('encodes pcm16 correctly', () => {

--- a/packages/codecs/test/transforms/leading-silence.test.ts
+++ b/packages/codecs/test/transforms/leading-silence.test.ts
@@ -1,4 +1,4 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { SimpleAudioBuffer } from '../../src/common/simple-audio-buffer.js'
@@ -6,7 +6,7 @@ import { createLeadingSilenceTransform } from '../../src/transforms/leading-sile
 
 describe('transforms/leading-silence.ts', () => {
   it('transforms audio by adding leading silence', () => {
-    const transform = createLeadingSilenceTransform(runtimeNumeric('s', 0.1))
+    const transform = createLeadingSilenceTransform(0.1 as Numeric<'s'>)
     const input = new SimpleAudioBuffer(1000, [new Float32Array([1, 1, 1, 1, 1])])
     const output = transform(input)
 
@@ -25,17 +25,17 @@ describe('transforms/leading-silence.ts', () => {
   })
 
   it('throws if duration is negative', () => {
-    assert.throws(() => createLeadingSilenceTransform(runtimeNumeric('s', -0.1)), /non-negative/)
+    assert.throws(() => createLeadingSilenceTransform(-0.1 as Numeric<'s'>), /non-negative/)
   })
 
   it('handles zero duration by returning an identity transform', () => {
-    const transform = createLeadingSilenceTransform(runtimeNumeric('s', 0))
+    const transform = createLeadingSilenceTransform(0 as Numeric<'s'>)
     const input = new SimpleAudioBuffer(1000, [new Float32Array([1, 1, 1])])
     assert.strictEqual(transform(input), input)
   })
 
   it('handles non-integer sample counts by rounding up to nearest sample', () => {
-    const transform = createLeadingSilenceTransform(runtimeNumeric('s', 0.0011)) // 1.1 samples at 1000 Hz
+    const transform = createLeadingSilenceTransform(0.0011 as Numeric<'s'>) // 1.1 samples at 1000 Hz
     const input = new SimpleAudioBuffer(1000, [new Float32Array([1, 1, 1])])
     const output = transform(input)
 

--- a/packages/codecs/test/transforms/leading-silence.test.ts
+++ b/packages/codecs/test/transforms/leading-silence.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { SimpleAudioBuffer } from '../../src/common/simple-audio-buffer.js'
@@ -6,7 +6,7 @@ import { createLeadingSilenceTransform } from '../../src/transforms/leading-sile
 
 describe('transforms/leading-silence.ts', () => {
   it('transforms audio by adding leading silence', () => {
-    const transform = createLeadingSilenceTransform(numeric('s', 0.1))
+    const transform = createLeadingSilenceTransform(runtimeNumeric('s', 0.1))
     const input = new SimpleAudioBuffer(1000, [new Float32Array([1, 1, 1, 1, 1])])
     const output = transform(input)
 
@@ -25,17 +25,17 @@ describe('transforms/leading-silence.ts', () => {
   })
 
   it('throws if duration is negative', () => {
-    assert.throws(() => createLeadingSilenceTransform(numeric('s', -0.1)), /non-negative/)
+    assert.throws(() => createLeadingSilenceTransform(runtimeNumeric('s', -0.1)), /non-negative/)
   })
 
   it('handles zero duration by returning an identity transform', () => {
-    const transform = createLeadingSilenceTransform(numeric('s', 0))
+    const transform = createLeadingSilenceTransform(runtimeNumeric('s', 0))
     const input = new SimpleAudioBuffer(1000, [new Float32Array([1, 1, 1])])
     assert.strictEqual(transform(input), input)
   })
 
   it('handles non-integer sample counts by rounding up to nearest sample', () => {
-    const transform = createLeadingSilenceTransform(numeric('s', 0.0011)) // 1.1 samples at 1000 Hz
+    const transform = createLeadingSilenceTransform(runtimeNumeric('s', 0.0011)) // 1.1 samples at 1000 Hz
     const input = new SimpleAudioBuffer(1000, [new Float32Array([1, 1, 1])])
     const output = transform(input)
 

--- a/packages/core/src/conversion/gain.ts
+++ b/packages/core/src/conversion/gain.ts
@@ -1,18 +1,18 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 
-export function dbToGain ({ value }: Numeric<'db'>): Numeric<undefined> {
+export function dbToGain ({ value }: RuntimeNumeric<'db'>): RuntimeNumeric<undefined> {
   if (Number.isNaN(value) || (value > 0 && !Number.isFinite(value))) {
     throw new Error(`Invalid gain: ${value}`)
   }
 
-  return numeric(undefined, Math.pow(10, value / 20))
+  return runtimeNumeric(undefined, Math.pow(10, value / 20))
 }
 
-export function gainToDb ({ value }: Numeric<undefined>): Numeric<'db'> {
+export function gainToDb ({ value }: RuntimeNumeric<undefined>): RuntimeNumeric<'db'> {
   if (value <= 0) {
-    return numeric('db', -Infinity)
+    return runtimeNumeric('db', -Infinity)
   }
 
-  return numeric('db', 20 * Math.log10(value))
+  return runtimeNumeric('db', 20 * Math.log10(value))
 }

--- a/packages/core/src/conversion/gain.ts
+++ b/packages/core/src/conversion/gain.ts
@@ -1,18 +1,17 @@
-import type { RuntimeNumeric } from '@utility'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 
-export function dbToGain ({ value }: RuntimeNumeric<'db'>): RuntimeNumeric<undefined> {
+export function dbToGain (value: Numeric<'db'>): Numeric<undefined> {
   if (Number.isNaN(value) || (value > 0 && !Number.isFinite(value))) {
     throw new Error(`Invalid gain: ${value}`)
   }
 
-  return runtimeNumeric(undefined, Math.pow(10, value / 20))
+  return Math.pow(10, value / 20) as Numeric<undefined>
 }
 
-export function gainToDb ({ value }: RuntimeNumeric<undefined>): RuntimeNumeric<'db'> {
+export function gainToDb (value: Numeric<undefined>): Numeric<'db'> {
   if (value <= 0) {
-    return runtimeNumeric('db', -Infinity)
+    return -Infinity as Numeric<'db'>
   }
 
-  return runtimeNumeric('db', 20 * Math.log10(value))
+  return (20 * Math.log10(value)) as Numeric<'db'>
 }

--- a/packages/core/src/conversion/time.ts
+++ b/packages/core/src/conversion/time.ts
@@ -1,5 +1,4 @@
 import type { Numeric, RuntimeNumeric } from '@utility'
-import { runtimeNumeric } from '@utility'
 import type { Program } from '../program/program.js'
 
 export function beatsToSeconds (
@@ -12,8 +11,8 @@ export function beatsToSeconds (
 export function timeToSeconds (
   time: RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>,
   tempo: Numeric<'bpm'>
-): RuntimeNumeric<'s'> {
-  return time.unit === 's' ? time : runtimeNumeric('s', beatsToSeconds(time.value, tempo))
+): Numeric<'s'> {
+  return time.unit === 's' ? time.value : beatsToSeconds(time.value, tempo)
 }
 
 export function calculateTotalLength (program: Program): Numeric<'beats'> {

--- a/packages/core/src/conversion/time.ts
+++ b/packages/core/src/conversion/time.ts
@@ -1,23 +1,23 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { Program } from '../program/program.js'
 
 export function beatsToSeconds (
-  beats: Numeric<'beats'>,
-  tempo: Numeric<'bpm'>
-): Numeric<'s'> {
-  return numeric('s', (beats.value * 60) / tempo.value)
+  beats: RuntimeNumeric<'beats'>,
+  tempo: RuntimeNumeric<'bpm'>
+): RuntimeNumeric<'s'> {
+  return runtimeNumeric('s', (beats.value * 60) / tempo.value)
 }
 
 export function timeToSeconds (
-  time: Numeric<'beats'> | Numeric<'s'>,
-  tempo: Numeric<'bpm'>
-): Numeric<'s'> {
+  time: RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>,
+  tempo: RuntimeNumeric<'bpm'>
+): RuntimeNumeric<'s'> {
   return time.unit === 's' ? time : beatsToSeconds(time, tempo)
 }
 
-export function calculateTotalLength (program: Program): Numeric<'beats'> {
-  return numeric(
+export function calculateTotalLength (program: Program): RuntimeNumeric<'beats'> {
+  return runtimeNumeric(
     'beats',
     program.track.parts.reduce((total, part) => total + part.length.value, 0)
   )

--- a/packages/core/src/conversion/time.ts
+++ b/packages/core/src/conversion/time.ts
@@ -1,24 +1,21 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric, RuntimeNumeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import type { Program } from '../program/program.js'
 
 export function beatsToSeconds (
-  beats: RuntimeNumeric<'beats'>,
-  tempo: RuntimeNumeric<'bpm'>
-): RuntimeNumeric<'s'> {
-  return runtimeNumeric('s', (beats.value * 60) / tempo.value)
+  beats: Numeric<'beats'>,
+  tempo: Numeric<'bpm'>
+): Numeric<'s'> {
+  return ((beats * 60) / tempo) as Numeric<'s'>
 }
 
 export function timeToSeconds (
   time: RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>,
-  tempo: RuntimeNumeric<'bpm'>
+  tempo: Numeric<'bpm'>
 ): RuntimeNumeric<'s'> {
-  return time.unit === 's' ? time : beatsToSeconds(time, tempo)
+  return time.unit === 's' ? time : runtimeNumeric('s', beatsToSeconds(time.value, tempo))
 }
 
-export function calculateTotalLength (program: Program): RuntimeNumeric<'beats'> {
-  return runtimeNumeric(
-    'beats',
-    program.track.parts.reduce((total, part) => total + part.length.value, 0)
-  )
+export function calculateTotalLength (program: Program): Numeric<'beats'> {
+  return program.track.parts.reduce((total, part) => total + part.length.value, 0) as Numeric<'beats'>
 }

--- a/packages/core/src/curve/types.ts
+++ b/packages/core/src/curve/types.ts
@@ -1,15 +1,15 @@
-import type { Numeric, Unit } from '@utility'
+import type { RuntimeNumeric, Unit } from '@utility'
 
 export type CurveShape = 'step' | 'linear' | 'exponential'
 
 export interface Curve<T extends Unit, U extends Unit> {
-  readonly initial: Numeric<U>
+  readonly initial: RuntimeNumeric<U>
   readonly points: ReadonlyArray<CurvePoint<T, U>>
 }
 
 export interface CurvePoint<T extends Unit, U extends Unit> {
-  readonly time: Numeric<T>
-  readonly value: Numeric<U>
+  readonly time: RuntimeNumeric<T>
+  readonly value: RuntimeNumeric<U>
 
   /**
    * The shape of the line from the previous point, or from the initial value,

--- a/packages/core/src/pattern/functions.ts
+++ b/packages/core/src/pattern/functions.ts
@@ -1,9 +1,9 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { NoteEvent, Pattern, Step } from './types.js'
 
-const zeroBeats = numeric('beats', 0)
-const defaultVelocity = numeric(undefined, 1)
+const zeroBeats = runtimeNumeric('beats', 0)
+const defaultVelocity = runtimeNumeric(undefined, 1)
 
 const emptyPattern: Pattern = {
   length: zeroBeats,
@@ -25,7 +25,7 @@ function getSumOfLengths (patterns: readonly Pattern[]): Pattern['length'] {
     sum += pattern.length.value
   }
 
-  return numeric('beats', sum)
+  return runtimeNumeric('beats', sum)
 }
 
 function getMaxLength (patterns: readonly Pattern[]): Pattern['length'] {
@@ -38,7 +38,7 @@ function getMaxLength (patterns: readonly Pattern[]): Pattern['length'] {
     max = Math.max(max, pattern.length.value)
   }
 
-  return numeric('beats', max)
+  return runtimeNumeric('beats', max)
 }
 
 function pushStepEvent (events: NoteEvent[], step: Step, offset: number): void {
@@ -46,10 +46,10 @@ function pushStepEvent (events: NoteEvent[], step: Step, offset: number): void {
     return
   }
 
-  const time = numeric('beats', offset)
+  const time = runtimeNumeric('beats', offset)
 
   const stepGate = step.gate?.value ?? step.length?.value ?? 1
-  const gate = numeric('beats', stepGate)
+  const gate = runtimeNumeric('beats', stepGate)
   const velocity = step.velocity ?? defaultVelocity
 
   events.push(
@@ -81,7 +81,7 @@ export function createSerialPattern (steps: readonly Step[]): Pattern {
   }
 
   return {
-    length: numeric('beats', offset),
+    length: runtimeNumeric('beats', offset),
     evaluate: () => events
   }
 }
@@ -109,7 +109,7 @@ export function createParallelPattern (steps: readonly Step[]): Pattern {
   }
 
   return {
-    length: numeric('beats', maxLength),
+    length: runtimeNumeric('beats', maxLength),
     evaluate: () => events
   }
 }
@@ -149,7 +149,7 @@ export function concatPatterns (patterns: readonly Pattern[]): Pattern {
         for (const event of pattern.evaluate()) {
           yield {
             ...event,
-            time: numeric('beats', event.time.value + offset)
+            time: runtimeNumeric('beats', event.time.value + offset)
           }
         }
       }
@@ -211,7 +211,7 @@ export function mergePatterns (patterns: readonly Pattern[]): Pattern {
  * - Patterns that are longer than the specified duration will be truncated.
  * - Patterns that are shorter than the specified duration will be repeated (and possibly truncated) to fit.
  */
-export function loopPattern (pattern: Pattern, duration?: Numeric<'beats'>): Pattern {
+export function loopPattern (pattern: Pattern, duration?: RuntimeNumeric<'beats'>): Pattern {
   const patternLength = pattern.length?.value
 
   // Looping an empty pattern always results in an empty pattern
@@ -238,7 +238,7 @@ export function loopPattern (pattern: Pattern, duration?: Numeric<'beats'>): Pat
             hasEvents = true
             yield {
               ...event,
-              time: numeric('beats', event.time.value + offset)
+              time: runtimeNumeric('beats', event.time.value + offset)
             }
           }
 
@@ -272,9 +272,9 @@ export function loopPattern (pattern: Pattern, duration?: Numeric<'beats'>): Pat
           hasEvents = true
           yield {
             ...event,
-            time: numeric('beats', eventTime),
+            time: runtimeNumeric('beats', eventTime),
             gate: event.gate != null && event.gate.value > remainingDuration
-              ? numeric('beats', remainingDuration)
+              ? runtimeNumeric('beats', remainingDuration)
               : event.gate
           }
         }
@@ -287,7 +287,7 @@ export function loopPattern (pattern: Pattern, duration?: Numeric<'beats'>): Pat
 }
 
 /**
- * Multiply a pattern by a numeric factor, keeping the sequence of events the same but adjusting their timing.
+ * Multiply a pattern by a runtimeNumeric factor, keeping the sequence of events the same but adjusting their timing.
  *
  * For example, multiplying a pattern of length 2 by 3 will produce a pattern of length 6 where each event occurs
  * at three times the original time.
@@ -312,15 +312,15 @@ export function multiplyPattern (pattern: Pattern, times: number): Pattern {
 
   return {
     // infinite pattern remains infinite, otherwise scale length
-    length: pattern.length != null ? numeric('beats', pattern.length.value * times) : undefined,
+    length: pattern.length != null ? runtimeNumeric('beats', pattern.length.value * times) : undefined,
 
     evaluate: function* () {
       for (const event of pattern.evaluate()) {
         yield {
           ...event,
-          time: numeric('beats', event.time.value * times),
+          time: runtimeNumeric('beats', event.time.value * times),
           gate: event.gate != null
-            ? numeric('beats', event.gate.value * times)
+            ? runtimeNumeric('beats', event.gate.value * times)
             : undefined
         }
       }
@@ -332,7 +332,7 @@ export function multiplyPattern (pattern: Pattern, times: number): Pattern {
  * Render a pattern to up to a specific time. Longer patterns will be truncated,
  * while shorter patterns will stay as-is (no additional events are produced).
  */
-export function renderPatternEvents (pattern: Pattern, end: Numeric<'beats'>): readonly NoteEvent[] {
+export function renderPatternEvents (pattern: Pattern, end: RuntimeNumeric<'beats'>): readonly NoteEvent[] {
   if (!isPositiveFiniteNumber(end.value)) {
     return []
   }
@@ -348,7 +348,7 @@ export function renderPatternEvents (pattern: Pattern, end: Numeric<'beats'>): r
     events.push({
       ...event,
       gate: event.gate != null && event.gate.value > remainingDuration
-        ? numeric('beats', remainingDuration)
+        ? runtimeNumeric('beats', remainingDuration)
         : event.gate
     })
   }

--- a/packages/core/src/pattern/types.ts
+++ b/packages/core/src/pattern/types.ts
@@ -1,4 +1,4 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 
 export type Note = `${'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G'}${'' | '#' | 'b'}`
 export type Octave = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
@@ -13,17 +13,17 @@ export interface Step {
   /**
     * The duration of the step. Defaults to 1.
    */
-  readonly length?: Numeric<undefined>
+  readonly length?: RuntimeNumeric<undefined>
 
   /**
     * The gate (duration) of the step. If undefined, the gate is equal to the step's length.
    */
-  readonly gate?: Numeric<undefined>
+  readonly gate?: RuntimeNumeric<undefined>
 
   /**
    * The velocity of the step, in the range [0, 1]. Defaults to 1.
    */
-  readonly velocity?: Numeric<undefined>
+  readonly velocity?: RuntimeNumeric<undefined>
 }
 
 export interface NoteData {
@@ -31,7 +31,7 @@ export interface NoteData {
    * The gate (duration) of the note in beats. If undefined, the note is never released (held indefinitely),
    * and may or may not be cut off by subsequent notes depending on the instrument's behavior.
    */
-  readonly gate?: Numeric<'beats'>
+  readonly gate?: RuntimeNumeric<'beats'>
 
   /**
    * The pitch associated with the note. If undefined, indicates that the instrument's default pitch should be used.
@@ -41,14 +41,14 @@ export interface NoteData {
   /**
    * The velocity of the note, in the range [0, 1].
    */
-  readonly velocity: Numeric<undefined>
+  readonly velocity: RuntimeNumeric<undefined>
 }
 
 export interface NoteEvent extends NoteData {
   /**
    * The time at which the note event occurs.
    */
-  readonly time: Numeric<'beats'>
+  readonly time: RuntimeNumeric<'beats'>
 }
 
 export interface Pattern {
@@ -56,7 +56,7 @@ export interface Pattern {
    * The length of the pattern. This may be any non-negative value (not necessarily an integer).
    * If undefined, the pattern is infinite.
    */
-  readonly length?: Numeric<'beats'>
+  readonly length?: RuntimeNumeric<'beats'>
 
   /**
    * Obtain all note events in the pattern, starting at time 0 and increasing monotonically.

--- a/packages/core/src/program/automations.ts
+++ b/packages/core/src/program/automations.ts
@@ -1,8 +1,8 @@
-import type { Brand, Unit, Numeric } from '@utility'
+import type { Brand, Unit, RuntimeNumeric } from '@utility'
 
 export type ParameterId = Brand<number, 'core.ParameterId'>
 
 export interface Parameter<U extends Unit> {
   readonly id: ParameterId
-  readonly initial: Numeric<U>
+  readonly initial: RuntimeNumeric<U>
 }

--- a/packages/core/src/program/effects.ts
+++ b/packages/core/src/program/effects.ts
@@ -1,4 +1,4 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import type { Parameter } from './automations.js'
 
 export type Effect =
@@ -33,22 +33,22 @@ export interface HighpassEffect {
 
 export interface WidthEffect {
   readonly type: 'width'
-  readonly width: Numeric<undefined>
+  readonly width: RuntimeNumeric<undefined>
 }
 
 export interface DelayEffect {
   readonly type: 'delay'
-  readonly mix: Numeric<undefined>
-  readonly time: Numeric<'beats'> | Numeric<'s'>
+  readonly mix: RuntimeNumeric<undefined>
+  readonly time: RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>
   readonly feedback: Parameter<undefined>
-  readonly wet: Numeric<'db'>
+  readonly wet: RuntimeNumeric<'db'>
 }
 
 export interface ReverbEffect {
   readonly type: 'reverb'
-  readonly mix: Numeric<undefined>
-  readonly decay: Numeric<'beats'> | Numeric<'s'>
-  readonly wet: Numeric<'db'>
+  readonly mix: RuntimeNumeric<undefined>
+  readonly decay: RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>
+  readonly wet: RuntimeNumeric<'db'>
 }
 
 export interface ClipEffect {

--- a/packages/core/src/program/instruments.ts
+++ b/packages/core/src/program/instruments.ts
@@ -1,4 +1,4 @@
-import type { Brand, Numeric } from '@utility'
+import type { Brand, RuntimeNumeric } from '@utility'
 import type { Curve } from '../curve/types.js'
 import type { NoteData } from '../pattern/types.js'
 import type { AssetId } from './assets.js'
@@ -9,13 +9,13 @@ export type InstrumentId = Brand<number, 'core.InstrumentId'>
 export interface Instrument {
   readonly id: InstrumentId
   readonly gain: Parameter<'db'>
-  readonly trigger: (note: NoteData, tempo: Numeric<'bpm'>) => readonly Voice[]
+  readonly trigger: (note: NoteData, tempo: RuntimeNumeric<'bpm'>) => readonly Voice[]
 }
 
 export interface Voice<S extends Source = Source> {
   readonly source: S
   readonly envelope: Curve<'s', 'db'>
-  readonly duration?: Numeric<'s'>
+  readonly duration?: RuntimeNumeric<'s'>
 }
 
 export type Source = Sample | Oscillator
@@ -23,12 +23,12 @@ export type Source = Sample | Oscillator
 export interface Sample {
   readonly type: 'sample'
   readonly assetId: AssetId
-  readonly length?: Numeric<'s'>
-  readonly playbackRate: Numeric<undefined>
+  readonly length?: RuntimeNumeric<'s'>
+  readonly playbackRate: RuntimeNumeric<undefined>
 }
 
 export interface Oscillator {
   readonly type: 'oscillator'
   readonly shape: 'sine' | 'square' | 'saw' | 'triangle'
-  readonly frequency: Numeric<'hz'>
+  readonly frequency: RuntimeNumeric<'hz'>
 }

--- a/packages/core/src/program/track.ts
+++ b/packages/core/src/program/track.ts
@@ -1,15 +1,15 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import type { Pattern } from '../pattern/types.js'
 import type { InstrumentId } from './instruments.js'
 
 export interface Track {
-  readonly tempo: Numeric<'bpm'>
+  readonly tempo: RuntimeNumeric<'bpm'>
   readonly parts: readonly Part[]
 }
 
 export interface Part {
   readonly name?: string
-  readonly length: Numeric<'beats'>
+  readonly length: RuntimeNumeric<'beats'>
   readonly routings: readonly InstrumentRouting[]
 }
 

--- a/packages/core/test/conversion/gain.test.ts
+++ b/packages/core/test/conversion/gain.test.ts
@@ -1,63 +1,49 @@
+import type { Numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { dbToGain, gainToDb } from '../../src/conversion/gain.js'
-import { runtimeNumeric } from '@utility'
 
 describe('conversion/gain.ts', () => {
   describe('dbToGain', () => {
     it('should convert decibels to gain correctly', () => {
-      assert.deepStrictEqual(
-        dbToGain(runtimeNumeric('db', 0)),
-        runtimeNumeric(undefined, 1)
-      )
+      assert.strictEqual(dbToGain(0 as Numeric<'db'>), 1)
+      assert.strictEqual(dbToGain(-Infinity as Numeric<'db'>), 0)
 
-      assert.deepStrictEqual(
-        dbToGain(runtimeNumeric('db', -Infinity)),
-        runtimeNumeric(undefined, 0)
-      )
+      const gain6 = dbToGain(6 as Numeric<'db'>)
+      assert.ok(Math.abs(gain6 - 1.9952623149688795) < 1e-10)
 
-      const gain6 = dbToGain(runtimeNumeric('db', 6))
-      assert.ok(Math.abs(gain6.value - 1.9952623149688795) < 1e-10)
+      const gainNeg6 = dbToGain(-6 as Numeric<'db'>)
+      assert.ok(Math.abs(gainNeg6 - 0.5011872336272722) < 1e-10)
 
-      const gainNeg6 = dbToGain(runtimeNumeric('db', -6))
-      assert.ok(Math.abs(gainNeg6.value - 0.5011872336272722) < 1e-10)
+      const gain20 = dbToGain(20 as Numeric<'db'>)
+      assert.ok(Math.abs(gain20 - 10) < 1e-10)
 
-      const gain20 = dbToGain(runtimeNumeric('db', 20))
-      assert.ok(Math.abs(gain20.value - 10) < 1e-10)
-
-      const gainNeg20 = dbToGain(runtimeNumeric('db', -20))
-      assert.ok(Math.abs(gainNeg20.value - 0.1) < 1e-10)
+      const gainNeg20 = dbToGain(-20 as Numeric<'db'>)
+      assert.ok(Math.abs(gainNeg20 - 0.1) < 1e-10)
     })
 
     it('should throw for invalid input', () => {
-      assert.throws(() => dbToGain(runtimeNumeric('db', Number.NaN)), /Invalid gain/)
-      assert.throws(() => dbToGain(runtimeNumeric('db', Infinity)), /Invalid gain/)
+      assert.throws(() => dbToGain(Number.NaN as Numeric<'db'>), /Invalid gain/)
+      assert.throws(() => dbToGain(Infinity as Numeric<'db'>), /Invalid gain/)
     })
   })
 
   describe('gainToDb', () => {
     it('should convert gain to decibels correctly', () => {
-      assert.deepStrictEqual(
-        gainToDb(runtimeNumeric(undefined, 1)),
-        runtimeNumeric('db', 0)
-      )
+      assert.strictEqual(gainToDb(1 as Numeric<undefined>), 0)
+      assert.strictEqual(gainToDb(0 as Numeric<undefined>), -Infinity)
 
-      assert.deepStrictEqual(
-        gainToDb(runtimeNumeric(undefined, 0)),
-        runtimeNumeric('db', -Infinity)
-      )
+      const db6 = gainToDb(1.9952623149688795 as Numeric<undefined>)
+      assert.ok(Math.abs(db6 - 6) < 1e-10)
 
-      const db6 = gainToDb(runtimeNumeric(undefined, 1.9952623149688795))
-      assert.ok(Math.abs(db6.value - 6) < 1e-10)
+      const dbNeg6 = gainToDb(0.5011872336272722 as Numeric<undefined>)
+      assert.ok(Math.abs(dbNeg6 + 6) < 1e-10)
 
-      const dbNeg6 = gainToDb(runtimeNumeric(undefined, 0.5011872336272722))
-      assert.ok(Math.abs(dbNeg6.value + 6) < 1e-10)
+      const db20 = gainToDb(10 as Numeric<undefined>)
+      assert.ok(Math.abs(db20 - 20) < 1e-10)
 
-      const db20 = gainToDb(runtimeNumeric(undefined, 10))
-      assert.ok(Math.abs(db20.value - 20) < 1e-10)
-
-      const dbNeg20 = gainToDb(runtimeNumeric(undefined, 0.1))
-      assert.ok(Math.abs(dbNeg20.value + 20) < 1e-10)
+      const dbNeg20 = gainToDb(0.1 as Numeric<undefined>)
+      assert.ok(Math.abs(dbNeg20 + 20) < 1e-10)
     })
   })
 })

--- a/packages/core/test/conversion/gain.test.ts
+++ b/packages/core/test/conversion/gain.test.ts
@@ -1,62 +1,62 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { dbToGain, gainToDb } from '../../src/conversion/gain.js'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 
 describe('conversion/gain.ts', () => {
   describe('dbToGain', () => {
     it('should convert decibels to gain correctly', () => {
       assert.deepStrictEqual(
-        dbToGain(numeric('db', 0)),
-        numeric(undefined, 1)
+        dbToGain(runtimeNumeric('db', 0)),
+        runtimeNumeric(undefined, 1)
       )
 
       assert.deepStrictEqual(
-        dbToGain(numeric('db', -Infinity)),
-        numeric(undefined, 0)
+        dbToGain(runtimeNumeric('db', -Infinity)),
+        runtimeNumeric(undefined, 0)
       )
 
-      const gain6 = dbToGain(numeric('db', 6))
+      const gain6 = dbToGain(runtimeNumeric('db', 6))
       assert.ok(Math.abs(gain6.value - 1.9952623149688795) < 1e-10)
 
-      const gainNeg6 = dbToGain(numeric('db', -6))
+      const gainNeg6 = dbToGain(runtimeNumeric('db', -6))
       assert.ok(Math.abs(gainNeg6.value - 0.5011872336272722) < 1e-10)
 
-      const gain20 = dbToGain(numeric('db', 20))
+      const gain20 = dbToGain(runtimeNumeric('db', 20))
       assert.ok(Math.abs(gain20.value - 10) < 1e-10)
 
-      const gainNeg20 = dbToGain(numeric('db', -20))
+      const gainNeg20 = dbToGain(runtimeNumeric('db', -20))
       assert.ok(Math.abs(gainNeg20.value - 0.1) < 1e-10)
     })
 
     it('should throw for invalid input', () => {
-      assert.throws(() => dbToGain(numeric('db', Number.NaN)), /Invalid gain/)
-      assert.throws(() => dbToGain(numeric('db', Infinity)), /Invalid gain/)
+      assert.throws(() => dbToGain(runtimeNumeric('db', Number.NaN)), /Invalid gain/)
+      assert.throws(() => dbToGain(runtimeNumeric('db', Infinity)), /Invalid gain/)
     })
   })
 
   describe('gainToDb', () => {
     it('should convert gain to decibels correctly', () => {
       assert.deepStrictEqual(
-        gainToDb(numeric(undefined, 1)),
-        numeric('db', 0)
+        gainToDb(runtimeNumeric(undefined, 1)),
+        runtimeNumeric('db', 0)
       )
 
       assert.deepStrictEqual(
-        gainToDb(numeric(undefined, 0)),
-        numeric('db', -Infinity)
+        gainToDb(runtimeNumeric(undefined, 0)),
+        runtimeNumeric('db', -Infinity)
       )
 
-      const db6 = gainToDb(numeric(undefined, 1.9952623149688795))
+      const db6 = gainToDb(runtimeNumeric(undefined, 1.9952623149688795))
       assert.ok(Math.abs(db6.value - 6) < 1e-10)
 
-      const dbNeg6 = gainToDb(numeric(undefined, 0.5011872336272722))
+      const dbNeg6 = gainToDb(runtimeNumeric(undefined, 0.5011872336272722))
       assert.ok(Math.abs(dbNeg6.value + 6) < 1e-10)
 
-      const db20 = gainToDb(numeric(undefined, 10))
+      const db20 = gainToDb(runtimeNumeric(undefined, 10))
       assert.ok(Math.abs(db20.value - 20) < 1e-10)
 
-      const dbNeg20 = gainToDb(numeric(undefined, 0.1))
+      const dbNeg20 = gainToDb(runtimeNumeric(undefined, 0.1))
       assert.ok(Math.abs(dbNeg20.value + 20) < 1e-10)
     })
   })

--- a/packages/core/test/pattern/pattern.test.ts
+++ b/packages/core/test/pattern/pattern.test.ts
@@ -1,12 +1,12 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { concatPatterns, createParallelPattern, createSerialPattern, loopPattern, mergePatterns, multiplyPattern, renderPatternEvents } from '../../src/pattern/functions.js'
 
 describe('pattern/functions.ts', () => {
-  // helper to create Numeric<'beats'>
-  const beats = (value: number) => numeric('beats', value)
-  const unitless = (value: number) => numeric(undefined, value)
+  // helper to create RuntimeNumeric<'beats'>
+  const beats = (value: number) => runtimeNumeric('beats', value)
+  const unitless = (value: number) => runtimeNumeric(undefined, value)
 
   describe('createSerialPattern()', () => {
     it('should create a finite pattern with the correct length and events', () => {
@@ -30,9 +30,9 @@ describe('pattern/functions.ts', () => {
 
     it('should handle steps with custom lengths', () => {
       const pattern = createSerialPattern([
-        { value: 'x', length: numeric(undefined, 2) },
+        { value: 'x', length: runtimeNumeric(undefined, 2) },
         { value: '-' },
-        { value: 'x', length: numeric(undefined, 0.5) }
+        { value: 'x', length: runtimeNumeric(undefined, 0.5) }
       ])
       assert.strictEqual(pattern.length?.value, 3.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
@@ -43,8 +43,8 @@ describe('pattern/functions.ts', () => {
 
     it('should skip steps with non-positive lengths', () => {
       const pattern = createSerialPattern([
-        { value: 'C1', length: numeric(undefined, 0) },
-        { value: 'C2', length: numeric(undefined, -1) },
+        { value: 'C1', length: runtimeNumeric(undefined, 0) },
+        { value: 'C2', length: runtimeNumeric(undefined, -1) },
         { value: 'C3' }
       ])
       assert.strictEqual(pattern.length?.value, 1)
@@ -55,9 +55,9 @@ describe('pattern/functions.ts', () => {
 
     it('should handle steps with custom gates', () => {
       const pattern = createSerialPattern([
-        { value: 'x', gate: numeric(undefined, 0.5) },
+        { value: 'x', gate: runtimeNumeric(undefined, 0.5) },
         { value: '-' },
-        { value: 'x', gate: numeric(undefined, 0.25) }
+        { value: 'x', gate: runtimeNumeric(undefined, 0.25) }
       ])
       assert.strictEqual(pattern.length?.value, 3)
       assert.deepStrictEqual([...pattern.evaluate()], [
@@ -68,9 +68,9 @@ describe('pattern/functions.ts', () => {
 
     it('should handle steps with both custom lengths and gates', () => {
       const pattern = createSerialPattern([
-        { value: 'x', length: numeric(undefined, 2), gate: numeric(undefined, 1.5) },
+        { value: 'x', length: runtimeNumeric(undefined, 2), gate: runtimeNumeric(undefined, 1.5) },
         { value: '-' },
-        { value: 'x', length: numeric(undefined, 0.5), gate: numeric(undefined, 0.1) }
+        { value: 'x', length: runtimeNumeric(undefined, 0.5), gate: runtimeNumeric(undefined, 0.1) }
       ])
       assert.strictEqual(pattern.length?.value, 3.5)
       assert.deepStrictEqual([...pattern.evaluate()], [
@@ -83,16 +83,16 @@ describe('pattern/functions.ts', () => {
       const pattern = createSerialPattern([
         {
           value: 'x',
-          length: numeric(undefined, 2),
-          gate: numeric(undefined, 1.5),
-          velocity: numeric(undefined, 0.8)
+          length: runtimeNumeric(undefined, 2),
+          gate: runtimeNumeric(undefined, 1.5),
+          velocity: runtimeNumeric(undefined, 0.8)
         },
         { value: '-' },
         {
           value: 'A#6',
-          length: numeric(undefined, 0.5),
-          gate: numeric(undefined, 0.1),
-          velocity: numeric(undefined, 0.5)
+          length: runtimeNumeric(undefined, 0.5),
+          gate: runtimeNumeric(undefined, 0.1),
+          velocity: runtimeNumeric(undefined, 0.5)
         }
       ])
 
@@ -126,9 +126,9 @@ describe('pattern/functions.ts', () => {
 
     it('should use the maximum step length as the pattern length', () => {
       const pattern = createParallelPattern([
-        { value: 'x', length: numeric(undefined, 2) },
+        { value: 'x', length: runtimeNumeric(undefined, 2) },
         { value: '-' },
-        { value: 'x', length: numeric(undefined, 0.5) }
+        { value: 'x', length: runtimeNumeric(undefined, 0.5) }
       ])
       assert.strictEqual(pattern.length?.value, 2)
       assert.deepStrictEqual([...pattern.evaluate()], [
@@ -139,9 +139,9 @@ describe('pattern/functions.ts', () => {
 
     it('should handle steps with custom gates', () => {
       const pattern = createParallelPattern([
-        { value: 'x', gate: numeric(undefined, 0.5) },
+        { value: 'x', gate: runtimeNumeric(undefined, 0.5) },
         { value: '-' },
-        { value: 'x', gate: numeric(undefined, 0.25) }
+        { value: 'x', gate: runtimeNumeric(undefined, 0.25) }
       ])
       assert.strictEqual(pattern.length?.value, 1)
       assert.deepStrictEqual([...pattern.evaluate()], [
@@ -152,9 +152,9 @@ describe('pattern/functions.ts', () => {
 
     it('should handle steps with both custom lengths and gates', () => {
       const pattern = createParallelPattern([
-        { value: 'x', length: numeric(undefined, 2), gate: numeric(undefined, 1.5) },
+        { value: 'x', length: runtimeNumeric(undefined, 2), gate: runtimeNumeric(undefined, 1.5) },
         { value: '-' },
-        { value: 'x', length: numeric(undefined, 0.5), gate: numeric(undefined, 0.1) }
+        { value: 'x', length: runtimeNumeric(undefined, 0.5), gate: runtimeNumeric(undefined, 0.1) }
       ])
       assert.strictEqual(pattern.length?.value, 2)
       assert.deepStrictEqual([...pattern.evaluate()], [
@@ -167,16 +167,16 @@ describe('pattern/functions.ts', () => {
       const pattern = createParallelPattern([
         {
           value: 'x',
-          length: numeric(undefined, 2),
-          gate: numeric(undefined, 1.5),
-          velocity: numeric(undefined, 0.8)
+          length: runtimeNumeric(undefined, 2),
+          gate: runtimeNumeric(undefined, 1.5),
+          velocity: runtimeNumeric(undefined, 0.8)
         },
         { value: '-' },
         {
           value: 'x',
-          length: numeric(undefined, 0.5),
-          gate: numeric(undefined, 0.1),
-          velocity: numeric(undefined, 0.5)
+          length: runtimeNumeric(undefined, 0.5),
+          gate: runtimeNumeric(undefined, 0.1),
+          velocity: runtimeNumeric(undefined, 0.5)
         }
       ])
 
@@ -205,9 +205,9 @@ describe('pattern/functions.ts', () => {
       const concatenated = concatPatterns([
         createSerialPattern([{ value: 'x' }, { value: '-' }]),
         createSerialPattern([
-          { value: '-', length: numeric(undefined, 0.5) },
-          { value: 'x', length: numeric(undefined, 0.5) },
-          { value: 'x', length: numeric(undefined, 0.5), velocity: unitless(0.5) }
+          { value: '-', length: runtimeNumeric(undefined, 0.5) },
+          { value: 'x', length: runtimeNumeric(undefined, 0.5) },
+          { value: 'x', length: runtimeNumeric(undefined, 0.5), velocity: unitless(0.5) }
         ])
       ])
       assert.strictEqual(concatenated.length?.value, 3.5)
@@ -305,12 +305,12 @@ describe('pattern/functions.ts', () => {
         createSerialPattern([{ value: 'x' }, { value: '-' }, { value: 'x' }]),
         createSerialPattern([{ value: '-' }, { value: '-' }, { value: 'x' }]),
         createSerialPattern([
-          { value: 'x', length: numeric(undefined, 0.25) },
-          { value: 'x', length: numeric(undefined, 0.25) }
+          { value: 'x', length: runtimeNumeric(undefined, 0.25) },
+          { value: 'x', length: runtimeNumeric(undefined, 0.25) }
         ]),
         createSerialPattern([
-          { value: 'x', length: numeric(undefined, 0.5) },
-          { value: 'x', length: numeric(undefined, 0.5) }
+          { value: 'x', length: runtimeNumeric(undefined, 0.5) },
+          { value: 'x', length: runtimeNumeric(undefined, 0.5) }
         ])
       ])
       assert.strictEqual(parallel.length?.value, 3)
@@ -329,9 +329,9 @@ describe('pattern/functions.ts', () => {
   describe('loopPattern()', () => {
     it('should create an infinite pattern when no duration is provided', () => {
       const pattern = createSerialPattern([
-        { value: 'x', velocity: unitless(0.75), length: numeric(undefined, 0.5) },
-        { value: '-', length: numeric(undefined, 0.5) },
-        { value: '-', length: numeric(undefined, 0.5) }
+        { value: 'x', velocity: unitless(0.75), length: runtimeNumeric(undefined, 0.5) },
+        { value: '-', length: runtimeNumeric(undefined, 0.5) },
+        { value: '-', length: runtimeNumeric(undefined, 0.5) }
       ])
       const looped = loopPattern(pattern)
 
@@ -368,8 +368,8 @@ describe('pattern/functions.ts', () => {
 
     it('should trim gates that extend beyond the target duration', () => {
       const pattern = createSerialPattern([
-        { value: 'A4', gate: numeric(undefined, 3) },
-        { value: 'B4', gate: numeric(undefined, 5) }
+        { value: 'A4', gate: runtimeNumeric(undefined, 3) },
+        { value: 'B4', gate: runtimeNumeric(undefined, 5) }
       ])
       const looped = loopPattern(pattern, beats(4))
 
@@ -573,8 +573,8 @@ describe('pattern/functions.ts', () => {
 
     it('should trim gates that extend beyond the render end', () => {
       const pattern = createSerialPattern([
-        { value: 'A4', gate: numeric(undefined, 3) },
-        { value: 'B4', gate: numeric(undefined, 5) }
+        { value: 'A4', gate: runtimeNumeric(undefined, 3) },
+        { value: 'B4', gate: runtimeNumeric(undefined, 5) }
       ])
 
       assert.deepStrictEqual(

--- a/packages/editor/src/hooks/change-origin.tsx
+++ b/packages/editor/src/hooks/change-origin.tsx
@@ -1,4 +1,4 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { useCallback, useEffect, useRef } from 'react'
 
 export type PushOrigin<T> = (origin: T) => boolean
@@ -9,7 +9,7 @@ export type PushOrigin<T> = (origin: T) => boolean
  * Otherwise, it returns false.
  * Any call to the function resets the time window.
  */
-export function useChangeOrigin<T extends string> (windowDuration: RuntimeNumeric<'s'>): PushOrigin<T> {
+export function useChangeOrigin<T extends string> (windowDuration: Numeric<'s'>): PushOrigin<T> {
   const originRef = useRef<T | undefined>(undefined)
   const pendingResetRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
@@ -32,7 +32,7 @@ export function useChangeOrigin<T extends string> (windowDuration: RuntimeNumeri
       pendingResetRef.current = setTimeout(() => {
         originRef.current = undefined
         pendingResetRef.current = undefined
-      }, windowDuration.value * 1000)
+      }, windowDuration * 1000)
     }
 
     scheduleReset()

--- a/packages/editor/src/hooks/change-origin.tsx
+++ b/packages/editor/src/hooks/change-origin.tsx
@@ -1,4 +1,4 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import { useCallback, useEffect, useRef } from 'react'
 
 export type PushOrigin<T> = (origin: T) => boolean
@@ -9,7 +9,7 @@ export type PushOrigin<T> = (origin: T) => boolean
  * Otherwise, it returns false.
  * Any call to the function resets the time window.
  */
-export function useChangeOrigin<T extends string> (windowDuration: Numeric<'s'>): PushOrigin<T> {
+export function useChangeOrigin<T extends string> (windowDuration: RuntimeNumeric<'s'>): PushOrigin<T> {
   const originRef = useRef<T | undefined>(undefined)
   const pendingResetRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 

--- a/packages/editor/src/hooks/debounced-value.ts
+++ b/packages/editor/src/hooks/debounced-value.ts
@@ -1,10 +1,10 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { useEffect, useState } from 'react'
 
-export function useDebouncedValue<T> (value: T, delay: RuntimeNumeric<'s'>): T {
+export function useDebouncedValue<T> (value: T, delay: Numeric<'s'>): T {
   const [debouncedValue, setDebouncedValue] = useState(value)
 
-  const delayMs = delay.value * 1000
+  const delayMs = delay * 1000
 
   useEffect(() => {
     const timeout = window.setTimeout(() => setDebouncedValue(value), delayMs)

--- a/packages/editor/src/hooks/debounced-value.ts
+++ b/packages/editor/src/hooks/debounced-value.ts
@@ -1,7 +1,7 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import { useEffect, useState } from 'react'
 
-export function useDebouncedValue<T> (value: T, delay: Numeric<'s'>): T {
+export function useDebouncedValue<T> (value: T, delay: RuntimeNumeric<'s'>): T {
   const [debouncedValue, setDebouncedValue] = useState(value)
 
   const delayMs = delay.value * 1000

--- a/packages/editor/src/layout/components/SplitNodeView.tsx
+++ b/packages/editor/src/layout/components/SplitNodeView.tsx
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { CSSProperties, FunctionComponent } from 'react'
 import { Fragment, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { Layout } from 'react-resizable-panels'
@@ -11,7 +11,7 @@ import type { LayoutNodeViewProps } from './LayoutNodeView.js'
 import { LayoutNodeView } from './LayoutNodeView.js'
 
 // The interval during which layout changes are considered part of the same change stack.
-const CHANGE_STACK_WINDOW = numeric('s', 0.05)
+const CHANGE_STACK_WINDOW = runtimeNumeric('s', 0.05)
 
 type LayoutChangeOrigin = 'library' | 'self'
 

--- a/packages/editor/src/layout/components/SplitNodeView.tsx
+++ b/packages/editor/src/layout/components/SplitNodeView.tsx
@@ -1,4 +1,4 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { CSSProperties, FunctionComponent } from 'react'
 import { Fragment, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { Layout } from 'react-resizable-panels'
@@ -11,7 +11,7 @@ import type { LayoutNodeViewProps } from './LayoutNodeView.js'
 import { LayoutNodeView } from './LayoutNodeView.js'
 
 // The interval during which layout changes are considered part of the same change stack.
-const CHANGE_STACK_WINDOW = runtimeNumeric('s', 0.05)
+const CHANGE_STACK_WINDOW = 0.05 as Numeric<'s'>
 
 type LayoutChangeOrigin = 'library' | 'self'
 

--- a/packages/editor/src/notifications/components/NotificationContext.tsx
+++ b/packages/editor/src/notifications/components/NotificationContext.tsx
@@ -36,7 +36,7 @@ export const NotificationProvider: FunctionComponent<PropsWithChildren> = ({ chi
     setEntries((entries) => [{ id, kind, component, props }, ...entries] as NotificationEntry[])
 
     const timeoutHandle = options?.timeout != null
-      ? setTimeout(() => closeNotification(id), options.timeout.value * 1000)
+      ? setTimeout(() => closeNotification(id), options.timeout * 1000)
       : undefined
 
     return () => {

--- a/packages/editor/src/notifications/types.ts
+++ b/packages/editor/src/notifications/types.ts
@@ -1,4 +1,4 @@
-import type { Brand, Numeric } from '@utility'
+import type { Brand, RuntimeNumeric } from '@utility'
 import type { ComponentType } from 'react'
 
 export type NotificationId = Brand<string, 'editor.NotificationId'>
@@ -20,7 +20,7 @@ export interface NotificationOptions {
    */
   readonly kind?: string
 
-  readonly timeout?: Numeric<'s'>
+  readonly timeout?: RuntimeNumeric<'s'>
 }
 
 type DisposeNotification = () => void

--- a/packages/editor/src/notifications/types.ts
+++ b/packages/editor/src/notifications/types.ts
@@ -1,4 +1,4 @@
-import type { Brand, RuntimeNumeric } from '@utility'
+import type { Brand, Numeric } from '@utility'
 import type { ComponentType } from 'react'
 
 export type NotificationId = Brand<string, 'editor.NotificationId'>
@@ -20,7 +20,7 @@ export interface NotificationOptions {
    */
   readonly kind?: string
 
-  readonly timeout?: RuntimeNumeric<'s'>
+  readonly timeout?: Numeric<'s'>
 }
 
 type DisposeNotification = () => void

--- a/packages/editor/src/persistence/binding.ts
+++ b/packages/editor/src/persistence/binding.ts
@@ -1,11 +1,11 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLatestRef } from '../hooks/latest-ref.js'
 import { usePersistenceContext } from './components/PersistenceContext.js'
 import type { PersistenceDomain, PersistenceEvent } from './types.js'
 
-const STORAGE_DEBOUNCE = runtimeNumeric('s', 0.25)
+const STORAGE_DEBOUNCE = 0.25 as Numeric<'s'>
 
 export interface UsePersistentBindingOptions {
   readonly onConflict?: PersistentStateConflictPolicy
@@ -118,7 +118,7 @@ export function usePersistentBinding<T> (
             setMeta((prevMeta) => ({ ...prevMeta, error: castError(err) }))
           }
         })
-    }, STORAGE_DEBOUNCE.value * 1000)
+    }, STORAGE_DEBOUNCE * 1000)
 
     return () => {
       cancelled = true

--- a/packages/editor/src/persistence/binding.ts
+++ b/packages/editor/src/persistence/binding.ts
@@ -1,11 +1,11 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLatestRef } from '../hooks/latest-ref.js'
 import { usePersistenceContext } from './components/PersistenceContext.js'
 import type { PersistenceDomain, PersistenceEvent } from './types.js'
 
-const STORAGE_DEBOUNCE = numeric('s', 0.25)
+const STORAGE_DEBOUNCE = runtimeNumeric('s', 0.25)
 
 export interface UsePersistentBindingOptions {
   readonly onConflict?: PersistentStateConflictPolicy

--- a/packages/editor/test/hooks/debounced-value.spec.tsx
+++ b/packages/editor/test/hooks/debounced-value.spec.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { describe, expect, it, vi } from 'vitest'
 import { useDebouncedValue } from '../../src/hooks/debounced-value.js'
 
@@ -9,7 +9,7 @@ describe('hooks/debounced-value.ts', () => {
 
     try {
       const { result, rerender } = renderHook(({ value }) => {
-        return useDebouncedValue(value, runtimeNumeric('s', 0.25))
+        return useDebouncedValue(value, 0.25 as Numeric<'s'>)
       }, {
         initialProps: { value: 'alpha' }
       })

--- a/packages/editor/test/hooks/debounced-value.spec.tsx
+++ b/packages/editor/test/hooks/debounced-value.spec.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { describe, expect, it, vi } from 'vitest'
 import { useDebouncedValue } from '../../src/hooks/debounced-value.js'
 
@@ -9,7 +9,7 @@ describe('hooks/debounced-value.ts', () => {
 
     try {
       const { result, rerender } = renderHook(({ value }) => {
-        return useDebouncedValue(value, numeric('s', 0.25))
+        return useDebouncedValue(value, runtimeNumeric('s', 0.25))
       }, {
         initialProps: { value: 'alpha' }
       })

--- a/packages/language/src/compiler/builtins/patterns.ts
+++ b/packages/language/src/compiler/builtins/patterns.ts
@@ -1,6 +1,6 @@
 import type { Pattern } from '@core'
 import { createSerialPattern, loopPattern } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { FunctionFacet } from '../../type-system/base/function.js'
 import { NumberFacet } from '../../type-system/base/number.js'
 import { PatternFacet } from '../../type-system/domain/pattern.js'
@@ -46,7 +46,7 @@ const loop: PatternBuiltin = {
         return PatternFacet.type().of(loopPattern(pattern))
       }
 
-      const duration = numeric('beats', pattern.length.value * factor)
+      const duration = runtimeNumeric('beats', pattern.length.value * factor)
 
       return PatternFacet.type().of(loopPattern(pattern, duration))
     }

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -82,17 +82,17 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
   const points: Array<CurvePoint<'s', U>> = []
 
   const offsetSeconds = timeToSeconds(options.offset, options.tempo.value)
-  let currentTime: RuntimeNumeric<'s'> = offsetSeconds
+  let currentTime = offsetSeconds
 
   for (const segment of segments) {
     const segmentLength = segment.length.value > 0
       ? timeToSeconds(segment.length, options.tempo.value)
-      : ZERO_SECONDS
+      : ZERO_SECONDS.value
 
     const definition = nonNull(getCurveSegmentType(segment.type), `Unknown curve segment type: ${segment.type}`)
 
-    const startTime = currentTime
-    const endTime = runtimeNumeric('s', currentTime.value + segmentLength.value)
+    const startTime = runtimeNumeric('s', currentTime)
+    const endTime = runtimeNumeric('s', currentTime + segmentLength)
 
     points.push({
       time: startTime,
@@ -101,19 +101,19 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
     }, {
       time: endTime,
       value: definition.end(segment),
-      shape: segmentLength.value <= 0 ? 'step' : definition.endShape
+      shape: segmentLength <= 0 ? 'step' : definition.endShape
     })
 
-    currentTime = endTime
+    currentTime = endTime.value
   }
 
   const simplifiedPoints = simplifyCurvePoints(points)
 
   const endTime = options.limit != null
-    ? runtimeNumeric('s', offsetSeconds.value + timeToSeconds(options.limit, options.tempo.value).value)
+    ? runtimeNumeric('s', offsetSeconds + timeToSeconds(options.limit, options.tempo.value))
     : undefined
 
-  if (endTime != null && currentTime.value > endTime.value) {
+  if (endTime != null && currentTime > endTime.value) {
     return takePointsBefore(simplifiedPoints, endTime)
   }
 

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -81,12 +81,12 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
 
   const points: Array<CurvePoint<'s', U>> = []
 
-  const offsetSeconds = timeToSeconds(options.offset, options.tempo)
+  const offsetSeconds = timeToSeconds(options.offset, options.tempo.value)
   let currentTime: RuntimeNumeric<'s'> = offsetSeconds
 
   for (const segment of segments) {
     const segmentLength = segment.length.value > 0
-      ? timeToSeconds(segment.length, options.tempo)
+      ? timeToSeconds(segment.length, options.tempo.value)
       : ZERO_SECONDS
 
     const definition = nonNull(getCurveSegmentType(segment.type), `Unknown curve segment type: ${segment.type}`)
@@ -110,7 +110,7 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
   const simplifiedPoints = simplifyCurvePoints(points)
 
   const endTime = options.limit != null
-    ? runtimeNumeric('s', offsetSeconds.value + timeToSeconds(options.limit, options.tempo).value)
+    ? runtimeNumeric('s', offsetSeconds.value + timeToSeconds(options.limit, options.tempo.value).value)
     : undefined
 
   if (endTime != null && currentTime.value > endTime.value) {

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -1,23 +1,23 @@
 import type { CurvePoint, CurveShape } from '@core'
 import { timeToSeconds } from '@core'
-import type { Numeric, Unit } from '@utility'
-import { numeric } from '@utility'
+import type { Numeric, RuntimeNumeric, Unit } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { Curve, CurveDuration, CurveSegment, HoldCurveSegment, LinearCurveSegment } from '../type-system/domain/curve.js'
 import { assert, nonNull } from './assert.js'
 
 const SEGMENT_TYPE_HOLD = 'hold'
 const SEGMENT_TYPE_LINEAR = 'lin'
 
-const ZERO_SECONDS = numeric('s', 0)
+const ZERO_SECONDS = runtimeNumeric('s', 0)
 
 const TIME_EPSILON = 1e-6 // 1 microsecond, which is less than 1 sample at 96 kHz
 
 export interface CurveSegmentType {
   readonly type: CurveSegment<any>['type']
   readonly parameterCount: number
-  readonly create: <U extends Unit>(parameters: ReadonlyArray<Numeric<U>>, length: CurveDuration) => CurveSegment<U>
-  readonly start: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
-  readonly end: <U extends Unit>(segment: CurveSegment<U>) => Numeric<U>
+  readonly create: <U extends Unit>(parameters: ReadonlyArray<RuntimeNumeric<U>>, length: CurveDuration) => CurveSegment<U>
+  readonly start: <U extends Unit>(segment: CurveSegment<U>) => RuntimeNumeric<U>
+  readonly end: <U extends Unit>(segment: CurveSegment<U>) => RuntimeNumeric<U>
   readonly endShape: CurveShape
 }
 
@@ -58,7 +58,7 @@ export function createCurve<U extends Unit> (segments: ReadonlyArray<CurveSegmen
 
 export function createCurveSegment<U extends Unit> (
   type: string,
-  parameters: ReadonlyArray<Numeric<U>>,
+  parameters: ReadonlyArray<RuntimeNumeric<U>>,
   length: CurveDuration
 ): CurveSegment<U> {
   const definition = nonNull(curveSegmentTypes.get(type), `Unknown curve segment type: ${type}`)
@@ -70,7 +70,7 @@ export function createCurveSegment<U extends Unit> (
 export interface RenderCurveOptions {
   readonly offset: CurveDuration
   readonly limit?: CurveDuration
-  readonly tempo: Numeric<'bpm'>
+  readonly tempo: RuntimeNumeric<'bpm'>
 }
 
 export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: RenderCurveOptions): ReadonlyArray<CurvePoint<'s', U>> {
@@ -82,7 +82,7 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
   const points: Array<CurvePoint<'s', U>> = []
 
   const offsetSeconds = timeToSeconds(options.offset, options.tempo)
-  let currentTime: Numeric<'s'> = offsetSeconds
+  let currentTime: RuntimeNumeric<'s'> = offsetSeconds
 
   for (const segment of segments) {
     const segmentLength = segment.length.value > 0
@@ -92,7 +92,7 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
     const definition = nonNull(getCurveSegmentType(segment.type), `Unknown curve segment type: ${segment.type}`)
 
     const startTime = currentTime
-    const endTime = numeric('s', currentTime.value + segmentLength.value)
+    const endTime = runtimeNumeric('s', currentTime.value + segmentLength.value)
 
     points.push({
       time: startTime,
@@ -110,7 +110,7 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
   const simplifiedPoints = simplifyCurvePoints(points)
 
   const endTime = options.limit != null
-    ? numeric('s', offsetSeconds.value + timeToSeconds(options.limit, options.tempo).value)
+    ? runtimeNumeric('s', offsetSeconds.value + timeToSeconds(options.limit, options.tempo).value)
     : undefined
 
   if (endTime != null && currentTime.value > endTime.value) {
@@ -120,7 +120,7 @@ export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: Ren
   return simplifiedPoints
 }
 
-function interpolatePoint<U extends Unit> (start: CurvePoint<'s', U>, end: CurvePoint<'s', U>, time: Numeric<'s'>): CurvePoint<'s', U> {
+function interpolatePoint<U extends Unit> (start: CurvePoint<'s', U>, end: CurvePoint<'s', U>, time: RuntimeNumeric<'s'>): CurvePoint<'s', U> {
   assert(time.value >= start.time.value && time.value <= end.time.value)
 
   const deltaTime = end.time.value - start.time.value
@@ -137,7 +137,7 @@ function interpolatePoint<U extends Unit> (start: CurvePoint<'s', U>, end: Curve
     case 'linear': {
       const value = {
         unit: start.value.unit,
-        value: start.value.value + t * (end.value.value - start.value.value)
+        value: (start.value.value + t * (end.value.value - start.value.value)) as Numeric<U>
       }
       return { time, value, shape: 'linear' }
     }
@@ -174,7 +174,7 @@ export function mergeCurvePoints<U extends Unit> (
 
 function takePointsBefore<U extends Unit> (
   points: ReadonlyArray<CurvePoint<'s', U>>,
-  time: Numeric<'s'>
+  time: RuntimeNumeric<'s'>
 ): ReadonlyArray<CurvePoint<'s', U>> {
   const result: Array<CurvePoint<'s', U>> = []
 
@@ -208,7 +208,7 @@ function takePointsBefore<U extends Unit> (
 
 function takePointsAfter<U extends Unit> (
   points: ReadonlyArray<CurvePoint<'s', U>>,
-  time: Numeric<'s'>
+  time: RuntimeNumeric<'s'>
 ): ReadonlyArray<CurvePoint<'s', U>> {
   for (let i = 0; i < points.length; ++i) {
     const point = points[i]
@@ -233,7 +233,7 @@ function takePointsAfter<U extends Unit> (
   return []
 }
 
-function compareTimes (left: Numeric<'s'>, right: Numeric<'s'>): number {
+function compareTimes (left: RuntimeNumeric<'s'>, right: RuntimeNumeric<'s'>): number {
   const difference = left.value - right.value
   if (Math.abs(difference) <= TIME_EPSILON) {
     return 0

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -1,8 +1,8 @@
 import { ast } from '@ast'
 import type { Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, Part, Pattern, Program, Source, Step, Track, Voice } from '@core'
 import { concatPatterns, convertPitchToMidi, createParallelPattern, createSerialPattern, getMidiFrequency, mergePatterns } from '@core'
-import type { Numeric, Unit } from '@utility'
-import { numeric } from '@utility'
+import type { Numeric, RuntimeNumeric, Unit } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { getStandardModuleValue } from '../../library/modules.js'
 import type { Function } from '../../type-system/base/function.js'
 import { FunctionFacet } from '../../type-system/base/function.js'
@@ -75,7 +75,7 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
   }
 
   mixer ??= { buses: [], routings: [] }
-  track ??= { tempo: numeric('bpm', options.tempo.default), parts: [] }
+  track ??= { tempo: runtimeNumeric('bpm', options.tempo.default), parts: [] }
 
   // Implicit output routings for unrouted buses and instruments
   mixer = {
@@ -95,14 +95,14 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
   }
 }
 
-function clamped<U extends Unit> (value: Numeric<U>, minimum: number, maximum: number): Numeric<U> {
+function clamped<U extends Unit> (value: RuntimeNumeric<U>, minimum: number, maximum: number): RuntimeNumeric<U> {
   if (value.value >= minimum && value.value <= maximum) {
     return value
   }
 
   return {
     unit: value.unit,
-    value: Math.min(Math.max(value.value, minimum), maximum)
+    value: Math.min(Math.max(value.value, minimum), maximum) as Numeric<U>
   }
 }
 
@@ -147,12 +147,12 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
 
   const tempo = properties.tempo != null
     ? clamped(NumberFacet.get(properties.tempo), options.tempo.minimum, options.tempo.maximum)
-    : numeric('bpm', options.tempo.default)
+    : runtimeNumeric('bpm', options.tempo.default)
 
   const trackScope = createLocalScope(scope)
   const parts: Part[] = []
 
-  let currentTime = numeric('beats', 0)
+  let currentTime = runtimeNumeric('beats', 0)
 
   for (const child of track.children) {
     switch (child.type) {
@@ -169,7 +169,7 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
           trackScope.resolutions.set(part.name, PartFacet.type().of(part))
         }
 
-        currentTime = numeric('beats', currentTime.value + part.length.value)
+        currentTime = runtimeNumeric('beats', currentTime.value + part.length.value)
         break
       }
 
@@ -181,7 +181,7 @@ function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
   return { tempo, parts }
 }
 
-function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric<'beats'>, tempo: Numeric<'bpm'>): Part {
+function generatePart (scope: Scope, part: ast.PartStatement, startTime: RuntimeNumeric<'beats'>, tempo: RuntimeNumeric<'bpm'>): Part {
   const partScope = createLocalScope(scope)
 
   const name = part.name?.name
@@ -353,8 +353,8 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
 
   // These must always be allocated even if not explicitly set,
   // as they could still be automated.
-  const gainData = properties.gain != null ? NumberFacet.get(properties.gain) : numeric('db', 0)
-  const panData = properties.pan != null ? NumberFacet.get(properties.pan) : numeric(undefined, 0)
+  const gainData = properties.gain != null ? NumberFacet.get(properties.gain) : runtimeNumeric('db', 0)
+  const panData = properties.pan != null ? NumberFacet.get(properties.pan) : runtimeNumeric(undefined, 0)
 
   const gain = scope.top.allocateParameter(gainData)
   valueRecord.gain = Parameters.of(gain)
@@ -501,7 +501,7 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
 
   const generatedSegments: Array<CurveSegment<Unit>> = []
 
-  const getPreviousSegmentEnd = (): Numeric<Unit> => {
+  const getPreviousSegmentEnd = (): RuntimeNumeric<Unit> => {
     const previous = nonNull(generatedSegments.at(-1))
     const definition = nonNull(getCurveSegmentType(previous.type))
     return definition.end(previous)
@@ -515,7 +515,7 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
     const length = (() => {
       const value = NumberFacet.get(resolve(scope, segment.length))
       assert(value.unit === 'beats' || value.unit === 's')
-      return value as Numeric<'beats'> | Numeric<'s'>
+      return value as RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>
     })()
 
     const { parameterCount } = nonNull(getCurveSegmentType(segment.curveType))
@@ -532,7 +532,7 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   const instrumentScope = createLocalScope(scope)
 
-  const voiceConstructors: Array<(note: NoteValue, tempo: Numeric<'bpm'>) => readonly Voice[]> = []
+  const voiceConstructors: Array<(note: NoteValue, tempo: RuntimeNumeric<'bpm'>) => readonly Voice[]> = []
 
   for (const child of expression.children) {
     switch (child.type) {
@@ -551,7 +551,7 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
     }
   }
 
-  const gainParameter = scope.top.allocateParameter(numeric('db', 0))
+  const gainParameter = scope.top.allocateParameter(runtimeNumeric('db', 0))
 
   const instrument = scope.top.allocateInstrument({
     gain: gainParameter,
@@ -560,9 +560,9 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
         return []
       }
 
-      const gate = Numbers.of(note.gate ?? numeric('beats', 0))
+      const gate = Numbers.of(note.gate ?? runtimeNumeric('beats', 0))
       const frequency = Numbers.of(
-        numeric('hz', getMidiFrequency(note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE))
+        runtimeNumeric('hz', getMidiFrequency(note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE))
       )
       const velocity = Numbers.of(note.velocity)
 
@@ -575,7 +575,7 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   return InstrumentFacet.type().of(instrument)
 }
 
-function generateVoice (scope: Scope, voice: ast.VoiceStatement, note: NoteValue, tempo: Numeric<'bpm'>): readonly Voice[] {
+function generateVoice (scope: Scope, voice: ast.VoiceStatement, note: NoteValue, tempo: RuntimeNumeric<'bpm'>): readonly Voice[] {
   const voiceScope = createLocalScope(scope)
 
   if (voice.bindings.note != null) {
@@ -612,9 +612,9 @@ function generateVoice (scope: Scope, voice: ast.VoiceStatement, note: NoteValue
   }
 
   const envelope = {
-    initial: numeric('db', -Infinity),
+    initial: runtimeNumeric('db', -Infinity),
     points: renderCurvePoints(envelopeValue, {
-      offset: numeric('beats', 0),
+      offset: runtimeNumeric('beats', 0),
       tempo
     })
   }

--- a/packages/language/src/compiler/generator/scopes.ts
+++ b/packages/language/src/compiler/generator/scopes.ts
@@ -1,5 +1,5 @@
 import type { Asset, AssetId, Bus, BusId, Curve, Instrument, InstrumentId, Parameter, ParameterId } from '@core'
-import type { Numeric, Unit } from '@utility'
+import type { RuntimeNumeric, Unit } from '@utility'
 import type { Value } from '../../type-system/types.js'
 import type { GenerateOptions } from './options.js'
 
@@ -12,7 +12,7 @@ export interface BusContext {
 }
 
 export interface ParameterContext {
-  readonly allocateParameter: <U extends Unit>(initial: Numeric<U>) => Parameter<U>
+  readonly allocateParameter: <U extends Unit>(initial: RuntimeNumeric<U>) => Parameter<U>
 }
 
 export interface InstrumentContext {
@@ -124,7 +124,7 @@ function allocateBus (scope: GlobalScope, data: Omit<Bus, 'id'>): Bus {
   return bus
 }
 
-function allocateParameter<U extends Unit> (scope: GlobalScope, initial: Numeric<U>): Parameter<U> {
+function allocateParameter<U extends Unit> (scope: GlobalScope, initial: RuntimeNumeric<U>): Parameter<U> {
   const id = scope.automations.size as ParameterId
   scope.automations.set(id, { initial, points: [] })
 

--- a/packages/language/src/compiler/operators/binary.ts
+++ b/packages/language/src/compiler/operators/binary.ts
@@ -1,5 +1,6 @@
 import type { ast } from '@ast'
 import { concatPatterns, multiplyPattern } from '@core'
+import type { Numeric, Unit } from '@utility'
 import { NumberFacet } from '../../type-system/base/number.js'
 import { StringFacet } from '../../type-system/base/string.js'
 import { PatternFacet } from '../../type-system/domain/pattern.js'
@@ -52,7 +53,10 @@ const add: BinaryOperation = {
     if (NumberFacet.has(left) && NumberFacet.has(right)) {
       const leftData = NumberFacet.get(left)
       const rightData = NumberFacet.get(right)
-      return Numbers.of({ unit: leftData.unit, value: leftData.value + rightData.value })
+      return Numbers.of({
+        unit: leftData.unit,
+        value: (leftData.value + rightData.value) as Numeric<Unit>
+      })
     }
 
     fail()
@@ -78,7 +82,10 @@ const subtract: BinaryOperation = {
     if (NumberFacet.has(left) && NumberFacet.has(right)) {
       const leftData = NumberFacet.get(left)
       const rightData = NumberFacet.get(right)
-      return Numbers.of({ unit: leftData.unit, value: leftData.value - rightData.value })
+      return Numbers.of({
+        unit: leftData.unit,
+        value: (leftData.value - rightData.value) as Numeric<Unit>
+      })
     }
 
     fail()
@@ -111,7 +118,10 @@ const multiply: BinaryOperation = {
     if (NumberFacet.has(left) && NumberFacet.has(right)) {
       const leftData = NumberFacet.get(left)
       const rightData = NumberFacet.get(right)
-      return Numbers.of({ unit: leftData.unit ?? rightData.unit, value: leftData.value * rightData.value })
+      return Numbers.of({
+        unit: leftData.unit ?? rightData.unit,
+        value: (leftData.value * rightData.value) as Numeric<Unit>
+      })
     }
 
     if (PatternFacet.has(left) && NumberFacet.has(right)) {
@@ -161,7 +171,10 @@ const divide: BinaryOperation = {
       const rightData = NumberFacet.get(right)
       // Equal units cancel out
       const unit = leftData.unit === rightData.unit ? undefined : leftData.unit
-      return Numbers.of({ unit, value: leftData.value / rightData.value })
+      return Numbers.of({
+        unit,
+        value: (leftData.value / rightData.value) as Numeric<Unit>
+      })
     }
 
     if (PatternFacet.has(left) && NumberFacet.has(right)) {

--- a/packages/language/src/compiler/operators/unary.ts
+++ b/packages/language/src/compiler/operators/unary.ts
@@ -1,7 +1,8 @@
 import type { ast } from '@ast'
-import type { FacetType, Value } from '../../type-system/types.js'
+import type { Numeric, Unit } from '@utility'
 import { NumberFacet } from '../../type-system/base/number.js'
 import { Numbers } from '../../type-system/helpers.js'
+import type { FacetType, Value } from '../../type-system/types.js'
 
 export interface UnaryOperation {
   readonly operator: ast.UnaryOperator
@@ -21,7 +22,7 @@ export const unaryOperations: Readonly<Record<ast.UnaryOperator, UnaryOperation>
     check: (operand) => NumberFacet.is(operand) ? operand : undefined,
     compute: (operand) => {
       const { unit, value } = NumberFacet.get(operand)
-      return Numbers.of({ unit, value: -value })
+      return Numbers.of({ unit, value: -(value as number) as Numeric<Unit> })
     }
   }
 }

--- a/packages/language/src/compiler/units.ts
+++ b/packages/language/src/compiler/units.ts
@@ -1,4 +1,4 @@
-import type { Unit } from '@utility'
+import type { Numeric, Unit } from '@utility'
 import type { Value } from '../type-system/types.js'
 import { Numbers } from '../type-system/helpers.js'
 
@@ -31,15 +31,15 @@ export function toNumberValue (constants: Constants, unit: SyntaxUnit | undefine
     case 'db':
     case 'hz':
     case 's':
-      return Numbers.of({ unit, value })
+      return Numbers.of({ unit, value: value as Numeric<typeof unit> })
     case 'ms':
-      return Numbers.of({ unit: 's', value: value / 1000 })
+      return Numbers.of({ unit: 's', value: (value / 1000) as Numeric<'s'> })
     case 'beat':
     case 'beats':
-      return Numbers.of({ unit: 'beats', value })
+      return Numbers.of({ unit: 'beats', value: value as Numeric<'beats'> })
     case 'bar':
     case 'bars':
-      return Numbers.of({ unit: 'beats', value: value * constants.beatsPerBar })
+      return Numbers.of({ unit: 'beats', value: (value * constants.beatsPerBar) as Numeric<'beats'> })
   }
 }
 

--- a/packages/language/src/library/envelope.ts
+++ b/packages/language/src/library/envelope.ts
@@ -1,28 +1,28 @@
 import type { Curve, CurvePoint } from '@core'
 import { gainToDb } from '@core'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 
 export interface Envelope {
-  readonly attack: Numeric<'s'>
-  readonly decay: Numeric<'s'>
-  readonly sustain: Numeric<'db'>
-  readonly release: Numeric<'s'>
+  readonly attack: RuntimeNumeric<'s'>
+  readonly decay: RuntimeNumeric<'s'>
+  readonly sustain: RuntimeNumeric<'db'>
+  readonly release: RuntimeNumeric<'s'>
 }
 
 export interface EnvelopeOptions {
-  readonly velocity: Numeric<undefined>
-  readonly gate: Numeric<'s'> | undefined
+  readonly velocity: RuntimeNumeric<undefined>
+  readonly gate: RuntimeNumeric<'s'> | undefined
 }
 
-const NEGATIVE_INFINITY_DB = numeric('db', -Infinity)
-const RELATIVE_SILENCE_DB = numeric('db', -60)
+const NEGATIVE_INFINITY_DB = runtimeNumeric('db', -Infinity)
+const RELATIVE_SILENCE_DB = runtimeNumeric('db', -60)
 
 export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): Curve<'s', 'db'> {
   const points: Array<CurvePoint<'s', 'db'>> = []
   const velocityDb = gainToDb(options.velocity)
 
-  const startTime = numeric('s', 0)
+  const startTime = runtimeNumeric('s', 0)
   const startValue = NEGATIVE_INFINITY_DB
 
   addStep(points, startTime, startValue)
@@ -39,8 +39,8 @@ export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): Cu
   applySegment(points, options, {
     startTime: envelope.attack,
     startValue: velocityDb,
-    endTime: numeric('s', envelope.attack.value + envelope.decay.value),
-    endValue: numeric('db', velocityDb.value + envelope.sustain.value)
+    endTime: runtimeNumeric('s', envelope.attack.value + envelope.decay.value),
+    endValue: runtimeNumeric('db', velocityDb.value + envelope.sustain.value)
   })
 
   // hold and release (sustain -> silence)
@@ -50,10 +50,10 @@ export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): Cu
 }
 
 function applySegment (points: Array<CurvePoint<'s', 'db'>>, options: EnvelopeOptions, segment: {
-  readonly startTime: Numeric<'s'>
-  readonly startValue: Numeric<'db'>
-  readonly endTime: Numeric<'s'>
-  readonly endValue: Numeric<'db'>
+  readonly startTime: RuntimeNumeric<'s'>
+  readonly startValue: RuntimeNumeric<'db'>
+  readonly endTime: RuntimeNumeric<'s'>
+  readonly endValue: RuntimeNumeric<'db'>
 }): void {
   const { gate } = options
   const { startTime, startValue, endTime, endValue } = segment
@@ -81,13 +81,13 @@ function applySegment (points: Array<CurvePoint<'s', 'db'>>, options: EnvelopeOp
 
   const finiteStartValue = Number.isFinite(startValue.value)
     ? startValue
-    : numeric('db', endValue.value + RELATIVE_SILENCE_DB.value)
+    : runtimeNumeric('db', endValue.value + RELATIVE_SILENCE_DB.value)
 
   const finiteEndValue = Number.isFinite(endValue.value)
     ? endValue
-    : numeric('db', startValue.value + RELATIVE_SILENCE_DB.value)
+    : runtimeNumeric('db', startValue.value + RELATIVE_SILENCE_DB.value)
 
-  const interpolatedValue = numeric('db', finiteStartValue.value + t * (finiteEndValue.value - finiteStartValue.value))
+  const interpolatedValue = runtimeNumeric('db', finiteStartValue.value + t * (finiteEndValue.value - finiteStartValue.value))
   addLinearSegment(points, startTime, finiteStartValue, gate, interpolatedValue)
 }
 
@@ -102,13 +102,13 @@ function applyRelease (points: Array<CurvePoint<'s', 'db'>>, envelope: Envelope,
   const releaseStartTime = gate
   const releaseStartValue = lastPoint.value
 
-  const releaseEndTime = numeric('s', releaseStartTime.value + envelope.release.value)
+  const releaseEndTime = runtimeNumeric('s', releaseStartTime.value + envelope.release.value)
   const releaseEndValue = NEGATIVE_INFINITY_DB
 
   addLinearSegment(points, releaseStartTime, releaseStartValue, releaseEndTime, releaseEndValue)
 }
 
-function addStep (points: Array<CurvePoint<'s', 'db'>>, time: Numeric<'s'>, value: Numeric<'db'>): void {
+function addStep (points: Array<CurvePoint<'s', 'db'>>, time: RuntimeNumeric<'s'>, value: RuntimeNumeric<'db'>): void {
   const lastPoint = points.at(-1)
 
   // only add points that change either value or time
@@ -124,7 +124,7 @@ function addStep (points: Array<CurvePoint<'s', 'db'>>, time: Numeric<'s'>, valu
   points.push({ time, value, shape: 'step' })
 }
 
-function addLinearSegment (points: Array<CurvePoint<'s', 'db'>>, startTime: Numeric<'s'>, startValue: Numeric<'db'>, endTime: Numeric<'s'>, endValue: Numeric<'db'>): void {
+function addLinearSegment (points: Array<CurvePoint<'s', 'db'>>, startTime: RuntimeNumeric<'s'>, startValue: RuntimeNumeric<'db'>, endTime: RuntimeNumeric<'s'>, endValue: RuntimeNumeric<'db'>): void {
   // if the segment has zero length, we can just add a single point at the end time
   if (endTime.value <= startTime.value) {
     addStep(points, endTime, endValue)
@@ -139,11 +139,11 @@ function addLinearSegment (points: Array<CurvePoint<'s', 'db'>>, startTime: Nume
     points.push({ time: endTime, value: endValue, shape: 'linear' })
   } else if (isStartFinite) {
     addStep(points, startTime, startValue)
-    const finiteEndValue = numeric('db', startValue.value + RELATIVE_SILENCE_DB.value)
+    const finiteEndValue = runtimeNumeric('db', startValue.value + RELATIVE_SILENCE_DB.value)
     points.push({ time: endTime, value: finiteEndValue, shape: 'linear' })
     addStep(points, endTime, endValue)
   } else if (isEndFinite) {
-    const finiteStartValue = numeric('db', endValue.value + RELATIVE_SILENCE_DB.value)
+    const finiteStartValue = runtimeNumeric('db', endValue.value + RELATIVE_SILENCE_DB.value)
     addStep(points, startTime, finiteStartValue)
     points.push({ time: endTime, value: endValue, shape: 'linear' })
   } else {

--- a/packages/language/src/library/envelope.ts
+++ b/packages/language/src/library/envelope.ts
@@ -20,7 +20,7 @@ const RELATIVE_SILENCE_DB = runtimeNumeric('db', -60)
 
 export function applyEnvelope (envelope: Envelope, options: EnvelopeOptions): Curve<'s', 'db'> {
   const points: Array<CurvePoint<'s', 'db'>> = []
-  const velocityDb = gainToDb(options.velocity)
+  const velocityDb = runtimeNumeric('db', gainToDb(options.velocity.value))
 
   const startTime = runtimeNumeric('s', 0)
   const startValue = NEGATIVE_INFINITY_DB

--- a/packages/language/src/library/modules/effects.ts
+++ b/packages/language/src/library/modules/effects.ts
@@ -1,5 +1,5 @@
 import type { Effect } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { ParameterContext } from '../../compiler/generator/scopes.js'
 import { NumberFacet } from '../../type-system/base/number.js'
 import { RecordFacet } from '../../type-system/base/record.js'
@@ -10,7 +10,7 @@ import { Functions, Modules, Parameters } from '../../type-system/helpers.js'
 import { makeSchema } from '../../type-system/schema.js'
 import type { Value } from '../../type-system/types.js'
 
-const UNITY_GAIN = numeric('db', 0)
+const UNITY_GAIN = runtimeNumeric('db', 0)
 
 // types
 

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -82,7 +82,7 @@ const sample = Functions.of({
           if (note.gate == null) {
             return lengthValue
           }
-          const gateSeconds = timeToSeconds(note.gate, tempo)
+          const gateSeconds = timeToSeconds(note.gate, tempo.value)
           return lengthValue == null ? gateSeconds : runtimeNumeric('s', Math.min(gateSeconds.value, lengthValue.value))
         })()
 
@@ -131,7 +131,7 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
           const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE
           const frequency = runtimeNumeric('hz', getMidiFrequency(midiNote))
 
-          const gate = note.gate != null ? timeToSeconds(note.gate, tempo) : undefined
+          const gate = note.gate != null ? timeToSeconds(note.gate, tempo.value) : undefined
           const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
           const duration = gate != null ? envelope.points.at(-1)?.time : undefined
 

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -1,7 +1,7 @@
 import type { Oscillator } from '@core'
 import { convertPitchToMidi, getMidiFrequency, isPitch, timeToSeconds } from '@core'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import type { AssetContext, InstrumentContext, ParameterContext } from '../../compiler/generator/scopes.js'
 import { NumberFacet } from '../../type-system/base/number.js'
 import { RecordFacet } from '../../type-system/base/record.js'
@@ -17,13 +17,13 @@ import { applyEnvelope } from '../envelope.js'
 
 const DEFAULT_ROOT_NOTE = convertPitchToMidi('C5')
 
-const UNITY_GAIN = numeric('db', 0)
+const UNITY_GAIN = runtimeNumeric('db', 0)
 
 const ENVELOPE_DECLICK: Envelope = {
-  attack: numeric('s', 0.003),
-  decay: numeric('s', 0),
-  sustain: numeric('db', 0),
-  release: numeric('s', 0.003)
+  attack: runtimeNumeric('s', 0.003),
+  decay: runtimeNumeric('s', 0),
+  sustain: runtimeNumeric('db', 0),
+  release: runtimeNumeric('s', 0.003)
 }
 
 const SampleInstrumentType = makeType(InstrumentFacet, RecordFacet.with({
@@ -76,14 +76,14 @@ const sample = Functions.of({
         }
 
         const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNoteMidi
-        const playbackRate = numeric(undefined, Math.pow(2, (midiNote - rootNoteMidi) / 12))
+        const playbackRate = runtimeNumeric(undefined, Math.pow(2, (midiNote - rootNoteMidi) / 12))
 
-        const gate: Numeric<'s'> | undefined = (() => {
+        const gate: RuntimeNumeric<'s'> | undefined = (() => {
           if (note.gate == null) {
             return lengthValue
           }
           const gateSeconds = timeToSeconds(note.gate, tempo)
-          return lengthValue == null ? gateSeconds : numeric('s', Math.min(gateSeconds.value, lengthValue.value))
+          return lengthValue == null ? gateSeconds : runtimeNumeric('s', Math.min(gateSeconds.value, lengthValue.value))
         })()
 
         const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
@@ -129,7 +129,7 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
 
         trigger: (note, tempo) => {
           const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE
-          const frequency = numeric('hz', getMidiFrequency(midiNote))
+          const frequency = runtimeNumeric('hz', getMidiFrequency(midiNote))
 
           const gate = note.gate != null ? timeToSeconds(note.gate, tempo) : undefined
           const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -83,7 +83,7 @@ const sample = Functions.of({
             return lengthValue
           }
           const gateSeconds = timeToSeconds(note.gate, tempo.value)
-          return lengthValue == null ? gateSeconds : runtimeNumeric('s', Math.min(gateSeconds.value, lengthValue.value))
+          return runtimeNumeric('s', lengthValue == null ? gateSeconds : Math.min(gateSeconds, lengthValue.value))
         })()
 
         const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
@@ -131,7 +131,7 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
           const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE
           const frequency = runtimeNumeric('hz', getMidiFrequency(midiNote))
 
-          const gate = note.gate != null ? timeToSeconds(note.gate, tempo.value) : undefined
+          const gate = note.gate != null ? runtimeNumeric('s', timeToSeconds(note.gate, tempo.value)) : undefined
           const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
           const duration = gate != null ? envelope.points.at(-1)?.time : undefined
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -403,7 +403,7 @@ const unaryExpression_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
     p.eitherOr(literal('+'), literal('-')),
     p.recursive(() => unaryExpression_),
     (op, expr) => {
-      // If it's a numeric literal, fold the unary operator directly
+      // If it's a runtimeNumeric literal, fold the unary operator directly
       if (expr.type === 'Number') {
         return ast.make('Number', combineSourceRanges(op, expr), {
           value: op.text === '+' ? expr.value : -expr.value

--- a/packages/language/src/type-system/base/number.ts
+++ b/packages/language/src/type-system/base/number.ts
@@ -1,19 +1,19 @@
-import type { Numeric, Unit } from '@utility'
+import type { RuntimeNumeric, Unit } from '@utility'
 import { makeFacet } from '../factory.js'
 import type { Facet, FacetType } from '../types.js'
 
 const FACET_NAME = 'number'
 
-const cache = new Map<Unit, Facet<typeof FACET_NAME, Numeric<Unit>>>()
+const cache = new Map<Unit, Facet<typeof FACET_NAME, RuntimeNumeric<Unit>>>()
 
 export const NumberFacet = {
-  ...makeFacet<typeof FACET_NAME, Numeric<Unit>>(FACET_NAME, {}),
+  ...makeFacet<typeof FACET_NAME, RuntimeNumeric<Unit>>(FACET_NAME, {}),
 
   with: <const U extends Unit> (unit: U) => {
-    let cached = cache.get(unit) as Facet<typeof FACET_NAME, Numeric<U>> | undefined
+    let cached = cache.get(unit) as Facet<typeof FACET_NAME, RuntimeNumeric<U>> | undefined
 
     if (cached == null) {
-      cached = makeFacet<typeof FACET_NAME, Numeric<U>>(FACET_NAME, { unit }, {
+      cached = makeFacet<typeof FACET_NAME, RuntimeNumeric<U>>(FACET_NAME, { unit }, {
         format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
       })
       cache.set(unit, cached)

--- a/packages/language/src/type-system/domain/curve.ts
+++ b/packages/language/src/type-system/domain/curve.ts
@@ -1,8 +1,8 @@
-import type { Numeric, Unit } from '@utility'
+import type { RuntimeNumeric, Unit } from '@utility'
 import { makeFacet } from '../factory.js'
 import type { Facet, FacetType } from '../types.js'
 
-export type CurveDuration = Numeric<'beats'> | Numeric<'s'>
+export type CurveDuration = RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>
 
 export interface Curve<U extends Unit> {
   readonly unit: U
@@ -15,15 +15,15 @@ export interface HoldCurveSegment<U extends Unit> {
   readonly type: 'hold'
   readonly length: CurveDuration
   readonly unit: U
-  readonly value: Numeric<U>
+  readonly value: RuntimeNumeric<U>
 }
 
 export interface LinearCurveSegment<U extends Unit> {
   readonly type: 'lin'
   readonly length: CurveDuration
   readonly unit: U
-  readonly start: Numeric<U>
-  readonly end: Numeric<U>
+  readonly start: RuntimeNumeric<U>
+  readonly end: RuntimeNumeric<U>
 }
 
 const FACET_NAME = 'curve'

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -1,5 +1,5 @@
 import type { Parameter } from '@core'
-import type { Numeric, Unit } from '@utility'
+import type { RuntimeNumeric, Unit } from '@utility'
 import type { Function } from './base/function.js'
 import { FunctionFacet } from './base/function.js'
 import type { Module } from './base/module.js'
@@ -46,7 +46,7 @@ export const Modules = {
 }
 
 export const Numbers = {
-  of: <const U extends Unit> (value: Numeric<U>): Value<Facet<'number', Numeric<U>>> => {
+  of: <const U extends Unit> (value: RuntimeNumeric<U>): Value<Facet<'number', RuntimeNumeric<U>>> => {
     return NumberFacet.with(value.unit).type().of(value)
   }
 }

--- a/packages/language/test/compiler/builtins/patterns.test.ts
+++ b/packages/language/test/compiler/builtins/patterns.test.ts
@@ -1,6 +1,6 @@
 import type { Pattern } from '@core'
 import { createSerialPattern, loopPattern, renderPatternEvents } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { PatternBuiltin } from '../../../src/compiler/builtins/patterns.js'
@@ -38,17 +38,17 @@ function invoke (builtin: PatternBuiltin, self: Value<Facet<'pattern', Pattern>>
 }
 
 describe('library/modules/patterns.ts', () => {
-  // helper to create Numeric<'beats'>
-  const beats = (value: number) => numeric('beats', value)
-  const half = numeric(undefined, 0.5)
-  const quarter = numeric(undefined, 0.25)
+  // helper to create RuntimeNumeric<'beats'>
+  const beats = (value: number) => runtimeNumeric('beats', value)
+  const half = runtimeNumeric(undefined, 0.5)
+  const quarter = runtimeNumeric(undefined, 0.25)
 
   describe('loop', () => {
     const loop = getPatternBuiltin('loop')
 
     it('should loop finite patterns infinitely', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'x', velocity: numeric(undefined, 0.5), length: quarter },
+        { value: 'x', velocity: runtimeNumeric(undefined, 0.5), length: quarter },
         { value: '-', length: quarter },
         { value: '-', length: quarter },
         { value: 'G5', length: quarter }
@@ -61,10 +61,10 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(2.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.25), velocity: numeric(undefined, 0.5) },
-        { time: beats(0.75), gate: beats(0.25), pitch: 'G5', velocity: numeric(undefined, 1) },
-        { time: beats(1), gate: beats(0.25), velocity: numeric(undefined, 0.5) },
-        { time: beats(1.75), gate: beats(0.25), pitch: 'G5', velocity: numeric(undefined, 1) }
+        { time: beats(0), gate: beats(0.25), velocity: runtimeNumeric(undefined, 0.5) },
+        { time: beats(0.75), gate: beats(0.25), pitch: 'G5', velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.25), velocity: runtimeNumeric(undefined, 0.5) },
+        { time: beats(1.75), gate: beats(0.25), pitch: 'G5', velocity: runtimeNumeric(undefined, 1) }
       ])
     })
 
@@ -82,9 +82,9 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(2.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
-        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) }
+        { time: beats(0), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1.5), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) }
       ])
     })
 
@@ -107,7 +107,7 @@ describe('library/modules/patterns.ts', () => {
       ]))
 
       const result = invoke(loop, pattern, {
-        times: Numbers.of(numeric(undefined, 3))
+        times: Numbers.of(runtimeNumeric(undefined, 3))
       })
       const resultPattern = PatternFacet.get(result)
       assert.deepStrictEqual(resultPattern.length, beats(1.5 * 3))
@@ -115,12 +115,12 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(5.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
-        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) },
-        { time: beats(2.5), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
-        { time: beats(3.0), gate: beats(0.5), velocity: numeric(undefined, 1) },
-        { time: beats(4.0), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) }
+        { time: beats(0), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1.5), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(2.5), gate: beats(0.5), pitch: 'C4', velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(3.0), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(4.0), gate: beats(0.5), pitch: 'C4', velocity: runtimeNumeric(undefined, 1) }
       ])
     })
 
@@ -132,7 +132,7 @@ describe('library/modules/patterns.ts', () => {
       ]))
 
       const result = invoke(loop, pattern, {
-        times: Numbers.of(numeric(undefined, 0))
+        times: Numbers.of(runtimeNumeric(undefined, 0))
       })
       const resultPattern = PatternFacet.get(result)
       assert.deepStrictEqual(resultPattern.length?.value, 0)
@@ -149,7 +149,7 @@ describe('library/modules/patterns.ts', () => {
       ]))
 
       const result = invoke(loop, pattern, {
-        times: Numbers.of(numeric(undefined, -2))
+        times: Numbers.of(runtimeNumeric(undefined, -2))
       })
       const resultPattern = PatternFacet.get(result)
       assert.deepStrictEqual(resultPattern.length?.value, 0)
@@ -166,7 +166,7 @@ describe('library/modules/patterns.ts', () => {
       ]))
 
       const result = invoke(loop, pattern, {
-        times: Numbers.of(numeric(undefined, 0.5))
+        times: Numbers.of(runtimeNumeric(undefined, 0.5))
       })
       const resultPattern = PatternFacet.get(result)
       assert.deepStrictEqual(resultPattern.length, beats(1.5 * 0.5))
@@ -174,7 +174,7 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(2.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) }
+        { time: beats(0), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) }
       ])
     })
   })
@@ -186,7 +186,7 @@ describe('library/modules/patterns.ts', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
         { value: 'x', length: half },
         { value: '-', length: half },
-        { value: 'C4', velocity: numeric(undefined, 0.5), length: half }
+        { value: 'C4', velocity: runtimeNumeric(undefined, 0.5), length: half }
       ]))
 
       const result = invoke(fill, pattern, {
@@ -198,9 +198,9 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(5.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 0.5) },
-        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) }
+        { time: beats(0), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: runtimeNumeric(undefined, 0.5) },
+        { time: beats(1.5), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) }
       ])
     })
 
@@ -220,9 +220,9 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(5.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(0.5), velocity: numeric(undefined, 1) },
-        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: numeric(undefined, 1) },
-        { time: beats(1.5), gate: beats(0.5), velocity: numeric(undefined, 1) }
+        { time: beats(0), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1), gate: beats(0.5), pitch: 'C4', velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1.5), gate: beats(0.5), velocity: runtimeNumeric(undefined, 1) }
       ])
     })
 
@@ -292,8 +292,8 @@ describe('library/modules/patterns.ts', () => {
 
     it('should trim notes with gate that extends beyond the duration', () => {
       const pattern = PatternFacet.type().of(createSerialPattern([
-        { value: 'A4', gate: numeric(undefined, 3) },
-        { value: 'B4', gate: numeric(undefined, 5), velocity: numeric(undefined, 0.5) }
+        { value: 'A4', gate: runtimeNumeric(undefined, 3) },
+        { value: 'B4', gate: runtimeNumeric(undefined, 5), velocity: runtimeNumeric(undefined, 0.5) }
       ]))
 
       const result = invoke(fill, pattern, {
@@ -305,10 +305,10 @@ describe('library/modules/patterns.ts', () => {
       const events = renderPatternEvents(resultPattern, beats(4.0))
 
       assert.deepStrictEqual(events, [
-        { time: beats(0), gate: beats(3.0), pitch: 'A4', velocity: numeric(undefined, 1) },
-        { time: beats(1), gate: beats(3.0), pitch: 'B4', velocity: numeric(undefined, 0.5) },
-        { time: beats(2), gate: beats(2.0), pitch: 'A4', velocity: numeric(undefined, 1) },
-        { time: beats(3), gate: beats(1.0), pitch: 'B4', velocity: numeric(undefined, 0.5) }
+        { time: beats(0), gate: beats(3.0), pitch: 'A4', velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(1), gate: beats(3.0), pitch: 'B4', velocity: runtimeNumeric(undefined, 0.5) },
+        { time: beats(2), gate: beats(2.0), pitch: 'A4', velocity: runtimeNumeric(undefined, 1) },
+        { time: beats(3), gate: beats(1.0), pitch: 'B4', velocity: runtimeNumeric(undefined, 0.5) }
       ])
     })
   })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -1,6 +1,6 @@
 import type { Program } from '@core'
 import { convertPitchToMidi, getMidiFrequency } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { check } from '../../../src/compiler/checker/checker.js'
@@ -9,7 +9,7 @@ import { lex } from '../../../src/lexer/lexer.js'
 import { parse } from '../../../src/parser/parser.js'
 import { assertResultComplete } from '../../test-utils.js'
 
-const DEFAULT_TEMPO = numeric('bpm', 120)
+const DEFAULT_TEMPO = runtimeNumeric('bpm', 120)
 
 function generateSource (source: string) {
   const tokens = lex(source)
@@ -40,7 +40,7 @@ describe('compiler/generator/generator.ts', () => {
       automations: new Map(),
       assets: new Map(),
       track: {
-        tempo: numeric('bpm', 120),
+        tempo: runtimeNumeric('bpm', 120),
         parts: []
       },
       mixer: {
@@ -52,12 +52,12 @@ describe('compiler/generator/generator.ts', () => {
 
   it('should set track tempo from AST', () => {
     const result = generateSource('track (tempo: 140.bpm) {}')
-    assert.deepStrictEqual(result.track.tempo, numeric('bpm', 140))
+    assert.deepStrictEqual(result.track.tempo, runtimeNumeric('bpm', 140))
   })
 
   it('should clamp track tempo to maximum', () => {
     const result = generateSource('track (tempo: 400.bpm) {}')
-    assert.deepStrictEqual(result.track.tempo, numeric('bpm', 300))
+    assert.deepStrictEqual(result.track.tempo, runtimeNumeric('bpm', 300))
   })
 
   it('should support tempo from a variable', () => {
@@ -68,7 +68,7 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.track.tempo, numeric('bpm', 180))
+    assert.deepStrictEqual(result.track.tempo, runtimeNumeric('bpm', 180))
   })
 
   it('should use tempo variable from outer scope', () => {
@@ -80,7 +80,7 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.track.tempo, numeric('bpm', 90))
+    assert.deepStrictEqual(result.track.tempo, runtimeNumeric('bpm', 90))
   })
 
   it('should support imported names', () => {
@@ -96,7 +96,7 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: numeric(undefined, 1) }, DEFAULT_TEMPO)
+    const voices = instrument.trigger({ velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO)
     assert.strictEqual(voices.length, 1)
     assert.strictEqual(voices[0].source.type, 'sample')
     assert.strictEqual(voices[0].source.assetId, asset.id)
@@ -115,7 +115,7 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: numeric(undefined, 1) }, DEFAULT_TEMPO)
+    const voices = instrument.trigger({ velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO)
     assert.strictEqual(voices.length, 1)
     assert.strictEqual(voices[0].source.type, 'sample')
     assert.strictEqual(voices[0].source.assetId, asset.id)
@@ -129,7 +129,7 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.track.tempo, numeric('bpm', 123))
+    assert.deepStrictEqual(result.track.tempo, runtimeNumeric('bpm', 123))
   })
 
   it('should allow parts and buses to shadow top-level variables', () => {
@@ -150,7 +150,7 @@ describe('compiler/generator/generator.ts', () => {
 
   it('should clamp negative part lengths to 0', () => {
     const result = generateSource('track { part intro (-4.bars) {} }')
-    assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 0))
+    assert.deepStrictEqual(result.track.parts[0].length, runtimeNumeric('beats', 0))
   })
 
   it('should support part lengths from variables', () => {
@@ -167,9 +167,9 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 42))
-    assert.deepStrictEqual(result.track.parts[1].length, numeric('beats', 43))
-    assert.deepStrictEqual(result.track.parts[2].length, numeric('beats', 200))
+    assert.deepStrictEqual(result.track.parts[0].length, runtimeNumeric('beats', 42))
+    assert.deepStrictEqual(result.track.parts[1].length, runtimeNumeric('beats', 43))
+    assert.deepStrictEqual(result.track.parts[2].length, runtimeNumeric('beats', 200))
   })
 
   it('should support units: beat, beats, bar, bars', () => {
@@ -183,10 +183,10 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 1))
-    assert.deepStrictEqual(result.track.parts[1].length, numeric('beats', 2))
-    assert.deepStrictEqual(result.track.parts[2].length, numeric('beats', 4))
-    assert.deepStrictEqual(result.track.parts[3].length, numeric('beats', 8))
+    assert.deepStrictEqual(result.track.parts[0].length, runtimeNumeric('beats', 1))
+    assert.deepStrictEqual(result.track.parts[1].length, runtimeNumeric('beats', 2))
+    assert.deepStrictEqual(result.track.parts[2].length, runtimeNumeric('beats', 4))
+    assert.deepStrictEqual(result.track.parts[3].length, runtimeNumeric('beats', 8))
   })
 
   it('should resolve variables in track scope', () => {
@@ -203,9 +203,9 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.track.parts[0].length, numeric('beats', 8))
-    assert.deepStrictEqual(result.track.parts[1].length, numeric('beats', 9))
-    assert.deepStrictEqual(result.track.parts[2].length, numeric('beats', 200))
+    assert.deepStrictEqual(result.track.parts[0].length, runtimeNumeric('beats', 8))
+    assert.deepStrictEqual(result.track.parts[1].length, runtimeNumeric('beats', 9))
+    assert.deepStrictEqual(result.track.parts[2].length, runtimeNumeric('beats', 200))
   })
 
   it('should resolve variables in mixer scope', () => {
@@ -222,9 +222,9 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.mixer.buses[0].gain.initial, numeric('db', -42))
-    assert.deepStrictEqual(result.mixer.buses[1].gain.initial, numeric('db', -41))
-    assert.deepStrictEqual(result.mixer.buses[2].gain.initial, numeric('db', -200))
+    assert.deepStrictEqual(result.mixer.buses[0].gain.initial, runtimeNumeric('db', -42))
+    assert.deepStrictEqual(result.mixer.buses[1].gain.initial, runtimeNumeric('db', -41))
+    assert.deepStrictEqual(result.mixer.buses[2].gain.initial, runtimeNumeric('db', -200))
   })
 
   it('should resolve variables in part scope', () => {
@@ -243,8 +243,8 @@ describe('compiler/generator/generator.ts', () => {
     const routing = result.track.parts[0].routings[0]
     assert.strictEqual(routing.source.type, 'pattern')
     assert.deepStrictEqual([...routing.source.value.evaluate()], [
-      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 1), velocity: numeric(undefined, 1) },
-      { time: numeric('beats', 1), pitch: 'D4', gate: numeric('beats', 1), velocity: numeric(undefined, 1) }
+      { time: runtimeNumeric('beats', 0), pitch: 'C4', gate: runtimeNumeric('beats', 1), velocity: runtimeNumeric(undefined, 1) },
+      { time: runtimeNumeric('beats', 1), pitch: 'D4', gate: runtimeNumeric('beats', 1), velocity: runtimeNumeric(undefined, 1) }
     ])
   })
 
@@ -262,7 +262,7 @@ describe('compiler/generator/generator.ts', () => {
     const result = generateSource(source)
     const effect = result.mixer.buses[0].effects[0]
     assert.strictEqual(effect.type, 'gain')
-    assert.deepStrictEqual(effect.gain.initial, numeric('db', -20))
+    assert.deepStrictEqual(effect.gain.initial, runtimeNumeric('db', -20))
   })
 
   it('should generate instrument routings for patterns', () => {
@@ -281,8 +281,8 @@ describe('compiler/generator/generator.ts', () => {
     const routing = result.track.parts[0].routings[0]
     assert.strictEqual(routing.source.type, 'pattern')
     assert.deepStrictEqual([...routing.source.value.evaluate()], [
-      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 0.5), velocity: numeric(undefined, 1) },
-      { time: numeric('beats', 2), pitch: 'D4', gate: numeric('beats', 1), velocity: numeric(undefined, 0.75) }
+      { time: runtimeNumeric('beats', 0), pitch: 'C4', gate: runtimeNumeric('beats', 0.5), velocity: runtimeNumeric(undefined, 1) },
+      { time: runtimeNumeric('beats', 2), pitch: 'D4', gate: runtimeNumeric('beats', 1), velocity: runtimeNumeric(undefined, 0.75) }
     ])
   })
 
@@ -302,8 +302,8 @@ describe('compiler/generator/generator.ts', () => {
     const routing = result.track.parts[0].routings[0]
     assert.strictEqual(routing.source.type, 'pattern')
     assert.deepStrictEqual([...routing.source.value.evaluate()], [
-      { time: numeric('beats', 0), pitch: 'C4', gate: numeric('beats', 2), velocity: numeric(undefined, 1) },
-      { time: numeric('beats', 2), pitch: 'D4', gate: numeric('beats', 1), velocity: numeric(undefined, 0) }
+      { time: runtimeNumeric('beats', 0), pitch: 'C4', gate: runtimeNumeric('beats', 2), velocity: runtimeNumeric(undefined, 1) },
+      { time: runtimeNumeric('beats', 2), pitch: 'D4', gate: runtimeNumeric('beats', 1), velocity: runtimeNumeric(undefined, 0) }
     ])
   })
 
@@ -324,8 +324,8 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 4), value: numeric('db', 0), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 4), value: runtimeNumeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -346,9 +346,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 4), value: numeric('db', -30), shape: 'linear' },
-      { time: numeric('s', 6), value: numeric('db', 0), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 4), value: runtimeNumeric('db', -30), shape: 'linear' },
+      { time: runtimeNumeric('s', 6), value: runtimeNumeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -369,9 +369,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 10), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 16), value: numeric('db', -30), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 10), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 16), value: runtimeNumeric('db', -30), shape: 'linear' }
     ])
   })
 
@@ -392,9 +392,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 12), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 16), value: numeric('db', 0), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 12), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 16), value: runtimeNumeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -415,9 +415,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 12), value: numeric('db', -30), shape: 'linear' },
-      { time: numeric('s', 16), value: numeric('db', -30), shape: 'step' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 12), value: runtimeNumeric('db', -30), shape: 'linear' },
+      { time: runtimeNumeric('s', 16), value: runtimeNumeric('db', -30), shape: 'step' }
     ])
   })
 
@@ -438,8 +438,8 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -30), shape: 'step' },
-      { time: numeric('s', 8), value: numeric('db', 0), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -30), shape: 'step' },
+      { time: runtimeNumeric('s', 8), value: runtimeNumeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -463,10 +463,10 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -60), shape: 'step' },
-      { time: numeric('s', 4), value: numeric('db', 0), shape: 'linear' },
-      { time: numeric('s', 4), value: numeric('db', -15), shape: 'step' },
-      { time: numeric('s', 8), value: numeric('db', -30), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -60), shape: 'step' },
+      { time: runtimeNumeric('s', 4), value: runtimeNumeric('db', 0), shape: 'linear' },
+      { time: runtimeNumeric('s', 4), value: runtimeNumeric('db', -15), shape: 'step' },
+      { time: runtimeNumeric('s', 8), value: runtimeNumeric('db', -30), shape: 'linear' }
     ])
   })
 
@@ -488,8 +488,8 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -15), shape: 'step' },
-      { time: numeric('s', 4), value: numeric('db', -15), shape: 'step' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -15), shape: 'step' },
+      { time: runtimeNumeric('s', 4), value: runtimeNumeric('db', -15), shape: 'step' }
     ])
   })
 
@@ -511,9 +511,9 @@ describe('compiler/generator/generator.ts', () => {
     const [automation] = result.automations.values()
 
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -15), shape: 'step' },
-      { time: numeric('s', 2), value: numeric('db', -30), shape: 'step' },
-      { time: numeric('s', 4), value: numeric('db', 0), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -15), shape: 'step' },
+      { time: runtimeNumeric('s', 2), value: runtimeNumeric('db', -30), shape: 'step' },
+      { time: runtimeNumeric('s', 4), value: runtimeNumeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -534,8 +534,8 @@ describe('compiler/generator/generator.ts', () => {
     const automation = result.automations.get(result.mixer.buses[0].gain.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('db', -20), shape: 'step' },
-      { time: numeric('s', 8), value: numeric('db', 0), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', -20), shape: 'step' },
+      { time: runtimeNumeric('s', 8), value: runtimeNumeric('db', 0), shape: 'linear' }
     ])
   })
 
@@ -558,13 +558,13 @@ describe('compiler/generator/generator.ts', () => {
 
     const effect = result.mixer.buses[0].effects[0]
     assert.strictEqual(effect.type, 'lowpass')
-    assert.deepStrictEqual(effect.frequency.initial, numeric('hz', 123))
+    assert.deepStrictEqual(effect.frequency.initial, runtimeNumeric('hz', 123))
 
     const automation = result.automations.get(effect.frequency.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('hz', 100), shape: 'step' },
-      { time: numeric('s', 8), value: numeric('hz', 4000), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('hz', 100), shape: 'step' },
+      { time: runtimeNumeric('s', 8), value: runtimeNumeric('hz', 4000), shape: 'linear' }
     ])
   })
 
@@ -588,13 +588,13 @@ describe('compiler/generator/generator.ts', () => {
 
     const effect = result.mixer.buses[0].effects[0]
     assert.strictEqual(effect.type, 'lowpass')
-    assert.deepStrictEqual(effect.frequency.initial, numeric('hz', 200))
+    assert.deepStrictEqual(effect.frequency.initial, runtimeNumeric('hz', 200))
 
     const automation = result.automations.get(effect.frequency.id)
     assert.ok(automation != null)
     assert.deepStrictEqual(automation.points, [
-      { time: numeric('s', 0), value: numeric('hz', 500), shape: 'step' },
-      { time: numeric('s', 8), value: numeric('hz', 1000), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('hz', 500), shape: 'step' },
+      { time: runtimeNumeric('s', 8), value: runtimeNumeric('hz', 1000), shape: 'linear' }
     ])
   })
 
@@ -685,13 +685,13 @@ describe('compiler/generator/generator.ts', () => {
 
     assert.deepStrictEqual(effect, {
       type: 'delay',
-      mix: numeric(undefined, 0.25),
-      time: numeric('s', 1.5),
+      mix: runtimeNumeric(undefined, 0.25),
+      time: runtimeNumeric('s', 1.5),
       feedback: {
         id: effect.feedback.id,
-        initial: numeric(undefined, 0.4)
+        initial: runtimeNumeric(undefined, 0.4)
       },
-      wet: numeric('db', 0)
+      wet: runtimeNumeric('db', 0)
     })
   })
 
@@ -708,9 +708,9 @@ describe('compiler/generator/generator.ts', () => {
     const result = generateSource(source)
     assert.deepStrictEqual(result.mixer.buses[0].effects[0], {
       type: 'reverb',
-      mix: numeric(undefined, 0.25),
-      decay: numeric('beats', 2),
-      wet: numeric('db', 0)
+      mix: runtimeNumeric(undefined, 0.25),
+      decay: runtimeNumeric('beats', 2),
+      wet: runtimeNumeric('db', 0)
     })
   })
 
@@ -734,7 +734,7 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.instruments.size, 1)
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: numeric(undefined, 1) }, DEFAULT_TEMPO)
+    const voices = instrument.trigger({ velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO)
     assert.strictEqual(voices.length, 0)
   })
 
@@ -760,24 +760,24 @@ describe('compiler/generator/generator.ts', () => {
     const pitchFrequency = getMidiFrequency(convertPitchToMidi(pitch))
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: numeric(undefined, 1), pitch }, DEFAULT_TEMPO)
+    const voices = instrument.trigger({ velocity: runtimeNumeric(undefined, 1), pitch }, DEFAULT_TEMPO)
     assert.strictEqual(voices.length, 2)
 
     const [voice0, voice1] = voices
     assert.deepStrictEqual(voice0.envelope.points, [
-      { time: numeric('s', 0), value: numeric('db', 0), shape: 'step' },
-      { time: numeric('s', 0.5), value: numeric('db', -60), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', 0), shape: 'step' },
+      { time: runtimeNumeric('s', 0.5), value: runtimeNumeric('db', -60), shape: 'linear' }
     ])
     assert.strictEqual(voice0.source.type, 'oscillator')
     assert.strictEqual(voice0.source.shape, 'sine')
-    assert.deepStrictEqual(voice0.source.frequency, numeric('hz', 440))
+    assert.deepStrictEqual(voice0.source.frequency, runtimeNumeric('hz', 440))
 
     assert.deepStrictEqual(voice1.envelope.points, [
-      { time: numeric('s', 0), value: numeric('db', 0), shape: 'step' },
-      { time: numeric('s', 0.5), value: numeric('db', -60), shape: 'linear' }
+      { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', 0), shape: 'step' },
+      { time: runtimeNumeric('s', 0.5), value: runtimeNumeric('db', -60), shape: 'linear' }
     ])
     assert.strictEqual(voice1.source.type, 'oscillator')
     assert.strictEqual(voice1.source.shape, 'sine')
-    assert.deepStrictEqual(voice1.source.frequency, numeric('hz', pitchFrequency))
+    assert.deepStrictEqual(voice1.source.frequency, runtimeNumeric('hz', pitchFrequency))
   })
 })

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -1,5 +1,5 @@
 import type { Instrument } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GenerateOptions } from '../../../src/compiler/generator/options.js'
@@ -18,7 +18,7 @@ const options: GenerateOptions = {
 describe('compiler/generator/scopes.ts', () => {
   describe('createGlobalScope()', () => {
     it('should create a global scope with the provided options and initial resolutions', () => {
-      const foo = Numbers.of(numeric('db', 12))
+      const foo = Numbers.of(runtimeNumeric('db', 12))
 
       const result = createGlobalScope(options, new Map([['foo', foo]]))
 
@@ -39,15 +39,15 @@ describe('compiler/generator/scopes.ts', () => {
 
       const bus0 = {
         name: 'bus0',
-        gain: scope.allocateParameter(numeric('db', 0)),
-        pan: scope.allocateParameter(numeric(undefined, 0)),
+        gain: scope.allocateParameter(runtimeNumeric('db', 0)),
+        pan: scope.allocateParameter(runtimeNumeric(undefined, 0)),
         effects: []
       } as const
 
       const bus1 = {
         name: 'bus1',
-        gain: scope.allocateParameter(numeric('db', -3)),
-        pan: scope.allocateParameter(numeric(undefined, -0.5)),
+        gain: scope.allocateParameter(runtimeNumeric('db', -3)),
+        pan: scope.allocateParameter(runtimeNumeric(undefined, -0.5)),
         effects: []
       } as const
 
@@ -66,15 +66,15 @@ describe('compiler/generator/scopes.ts', () => {
     it('should allocate parameters with unique IDs', () => {
       const scope = createGlobalScope(options, new Map())
 
-      const parameter0 = scope.allocateParameter(numeric('db', 12))
-      const parameter1 = scope.allocateParameter(numeric('db', 6))
+      const parameter0 = scope.allocateParameter(runtimeNumeric('db', 12))
+      const parameter1 = scope.allocateParameter(runtimeNumeric('db', 6))
 
       assert.strictEqual(parameter0.id, 0)
       assert.strictEqual(parameter1.id, 1)
 
       assert.deepStrictEqual([...scope.automations], [
-        [0, { initial: numeric('db', 12), points: [] }],
-        [1, { initial: numeric('db', 6), points: [] }]
+        [0, { initial: runtimeNumeric('db', 12), points: [] }],
+        [1, { initial: runtimeNumeric('db', 6), points: [] }]
       ])
     })
 
@@ -82,12 +82,12 @@ describe('compiler/generator/scopes.ts', () => {
       const scope = createGlobalScope(options, new Map())
 
       const instrument0 = {
-        gain: scope.allocateParameter(numeric('db', -6)),
+        gain: scope.allocateParameter(runtimeNumeric('db', -6)),
         trigger: () => []
       } satisfies Omit<Instrument, 'id'>
 
       const instrument1 = {
-        gain: scope.allocateParameter(numeric('db', -3)),
+        gain: scope.allocateParameter(runtimeNumeric('db', -3)),
         trigger: () => []
       } satisfies Omit<Instrument, 'id'>
 
@@ -130,7 +130,7 @@ describe('compiler/generator/scopes.ts', () => {
   describe('createLocalScope()', () => {
     it('should create a local scope with the provided parent and empty resolutions', () => {
       const globalScope = createGlobalScope(options, new Map([
-        ['foo', Numbers.of(numeric('db', 12))]
+        ['foo', Numbers.of(runtimeNumeric('db', 12))]
       ]))
 
       const localScope = createLocalScope(globalScope)
@@ -139,7 +139,7 @@ describe('compiler/generator/scopes.ts', () => {
       assert.strictEqual(localScope.parent, globalScope)
       assert.strictEqual(localScope.resolutions.get('foo'), undefined)
 
-      const bar = Numbers.of(numeric('db', 6))
+      const bar = Numbers.of(runtimeNumeric('db', 6))
       localScope.resolutions.set('bar', bar)
       assert.strictEqual(localScope.resolutions.get('bar'), bar)
       assert.strictEqual(globalScope.resolutions.get('bar'), undefined)
@@ -155,11 +155,11 @@ describe('compiler/generator/scopes.ts', () => {
   describe('cloneScope()', () => {
     it('should create a new scope with the same top and parent, and a copy of the resolutions', () => {
       const globalScope = createGlobalScope(options, new Map([
-        ['foo', Numbers.of(numeric('db', 12))]
+        ['foo', Numbers.of(runtimeNumeric('db', 12))]
       ]))
 
       const localScope = createLocalScope(globalScope)
-      localScope.resolutions.set('bar', Numbers.of(numeric('db', 6)))
+      localScope.resolutions.set('bar', Numbers.of(runtimeNumeric('db', 6)))
 
       const clonedScope = cloneScope(localScope)
 
@@ -171,15 +171,15 @@ describe('compiler/generator/scopes.ts', () => {
 
     it('should not be affected by changes to the original scope after cloning', () => {
       const globalScope = createGlobalScope(options, new Map([
-        ['foo', Numbers.of(numeric('db', 12))]
+        ['foo', Numbers.of(runtimeNumeric('db', 12))]
       ]))
 
       const localScope = createLocalScope(globalScope)
-      localScope.resolutions.set('bar', Numbers.of(numeric('db', 6)))
+      localScope.resolutions.set('bar', Numbers.of(runtimeNumeric('db', 6)))
 
       const clonedScope = cloneScope(localScope)
 
-      localScope.resolutions.set('baz', Numbers.of(numeric('db', 3)))
+      localScope.resolutions.set('baz', Numbers.of(runtimeNumeric('db', 3)))
 
       assert.strictEqual(clonedScope.resolutions.get('baz'), undefined)
     })

--- a/packages/language/test/library/envelope.test.ts
+++ b/packages/language/test/library/envelope.test.ts
@@ -1,6 +1,6 @@
 import type { Curve } from '@core'
 import { gainToDb } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric, RuntimeNumeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
@@ -120,7 +120,7 @@ describe('envelope.ts', () => {
         velocity: runtimeNumeric(undefined, 0.75)
       })
 
-      const velocityLevel = gainToDb(runtimeNumeric(undefined, 0.75))
+      const velocityLevel = runtimeNumeric('db', gainToDb(0.75 as Numeric<undefined>))
 
       const startLevel = runtimeNumeric('db', velocityLevel.value + RELATIVE_SILENCE.value)
       const sustainLevel = runtimeNumeric('db', velocityLevel.value - 6)

--- a/packages/language/test/library/envelope.test.ts
+++ b/packages/language/test/library/envelope.test.ts
@@ -1,26 +1,26 @@
 import type { Curve } from '@core'
 import { gainToDb } from '@core'
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { Envelope } from '../../src/library/envelope.js'
 import { applyEnvelope } from '../../src/library/envelope.js'
 
-const COMPLETE_SILENCE = numeric('db', -Infinity)
-const RELATIVE_SILENCE = numeric('db', -60)
+const COMPLETE_SILENCE = runtimeNumeric('db', -Infinity)
+const RELATIVE_SILENCE = runtimeNumeric('db', -60)
 
-function interpolateDb (start: number, end: number, duration: number, elapsed: number): Numeric<'db'> {
+function interpolateDb (start: number, end: number, duration: number, elapsed: number): RuntimeNumeric<'db'> {
   const t = elapsed / duration
-  return numeric('db', start + t * (end - start))
+  return runtimeNumeric('db', start + t * (end - start))
 }
 
 function createEnvelope (values: { attack: number, decay: number, sustain: number, release: number }): Envelope {
   return {
-    attack: numeric('s', values.attack),
-    decay: numeric('s', values.decay),
-    sustain: numeric('db', values.sustain),
-    release: numeric('s', values.release)
+    attack: runtimeNumeric('s', values.attack),
+    decay: runtimeNumeric('s', values.decay),
+    sustain: runtimeNumeric('db', values.sustain),
+    release: runtimeNumeric('s', values.release)
   }
 }
 
@@ -29,15 +29,15 @@ describe('envelope.ts', () => {
     it('emits attack and decay without release when hold duration is absent', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: -6, release: 3 }), {
         gate: undefined,
-        velocity: numeric(undefined, 1)
+        velocity: runtimeNumeric(undefined, 1)
       })
 
       assert.deepStrictEqual(result, {
         initial: COMPLETE_SILENCE,
         points: [
-          { time: numeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
-          { time: numeric('s', 1), value: numeric('db', 0), shape: 'linear' },
-          { time: numeric('s', 3), value: numeric('db', -6), shape: 'linear' }
+          { time: runtimeNumeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
+          { time: runtimeNumeric('s', 1), value: runtimeNumeric('db', 0), shape: 'linear' },
+          { time: runtimeNumeric('s', 3), value: runtimeNumeric('db', -6), shape: 'linear' }
         ]
       } satisfies Curve<'s', 'db'>)
     })
@@ -45,14 +45,14 @@ describe('envelope.ts', () => {
     it('handles zero-length attack by setting the peak immediately before decay', () => {
       const result = applyEnvelope(createEnvelope({ attack: 0, decay: 2, sustain: -6, release: 3 }), {
         gate: undefined,
-        velocity: numeric(undefined, 1)
+        velocity: runtimeNumeric(undefined, 1)
       })
 
       assert.deepStrictEqual(result, {
         initial: COMPLETE_SILENCE,
         points: [
-          { time: numeric('s', 0), value: numeric('db', 0), shape: 'step' },
-          { time: numeric('s', 2), value: numeric('db', -6), shape: 'linear' }
+          { time: runtimeNumeric('s', 0), value: runtimeNumeric('db', 0), shape: 'step' },
+          { time: runtimeNumeric('s', 2), value: runtimeNumeric('db', -6), shape: 'linear' }
         ]
       } satisfies Curve<'s', 'db'>)
     })
@@ -60,98 +60,98 @@ describe('envelope.ts', () => {
     it('handles zero-length decay by setting the sustain level immediately after attack', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 0, sustain: -6, release: 3 }), {
         gate: undefined,
-        velocity: numeric(undefined, 1)
+        velocity: runtimeNumeric(undefined, 1)
       })
 
       assert.deepStrictEqual(result, {
         initial: COMPLETE_SILENCE,
         points: [
-          { time: numeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
-          { time: numeric('s', 1), value: numeric('db', 0), shape: 'linear' },
-          { time: numeric('s', 1), value: numeric('db', -6), shape: 'step' }
+          { time: runtimeNumeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
+          { time: runtimeNumeric('s', 1), value: runtimeNumeric('db', 0), shape: 'linear' },
+          { time: runtimeNumeric('s', 1), value: runtimeNumeric('db', -6), shape: 'step' }
         ]
       } satisfies Curve<'s', 'db'>)
     })
 
     it('starts release from the current attack level when the note ends during attack', () => {
       const result = applyEnvelope(createEnvelope({ attack: 4, decay: 2, sustain: -6, release: 1 }), {
-        gate: numeric('s', 1),
-        velocity: numeric(undefined, 1)
+        gate: runtimeNumeric('s', 1),
+        velocity: runtimeNumeric(undefined, 1)
       })
 
       const attackLevel = interpolateDb(RELATIVE_SILENCE.value, 0, 4, 1)
-      const releaseEndValue = numeric('db', attackLevel.value + RELATIVE_SILENCE.value)
+      const releaseEndValue = runtimeNumeric('db', attackLevel.value + RELATIVE_SILENCE.value)
 
       assert.deepStrictEqual(result, {
         initial: COMPLETE_SILENCE,
         points: [
-          { time: numeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
-          { time: numeric('s', 1), value: attackLevel, shape: 'linear' },
-          { time: numeric('s', 2), value: releaseEndValue, shape: 'linear' },
-          { time: numeric('s', 2), value: COMPLETE_SILENCE, shape: 'step' }
+          { time: runtimeNumeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
+          { time: runtimeNumeric('s', 1), value: attackLevel, shape: 'linear' },
+          { time: runtimeNumeric('s', 2), value: releaseEndValue, shape: 'linear' },
+          { time: runtimeNumeric('s', 2), value: COMPLETE_SILENCE, shape: 'step' }
         ]
       } satisfies Curve<'s', 'db'>)
     })
 
     it('starts release from the current decay level when the note ends during decay', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: -6, release: 1 }), {
-        gate: numeric('s', 2),
-        velocity: numeric(undefined, 1)
+        gate: runtimeNumeric('s', 2),
+        velocity: runtimeNumeric(undefined, 1)
       })
 
       const decayLevel = interpolateDb(0, -6, 2, 1)
-      const releaseEndValue = numeric('db', decayLevel.value + RELATIVE_SILENCE.value)
+      const releaseEndValue = runtimeNumeric('db', decayLevel.value + RELATIVE_SILENCE.value)
 
       assert.deepStrictEqual(result, {
         initial: COMPLETE_SILENCE,
         points: [
-          { time: numeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
-          { time: numeric('s', 1), value: numeric('db', 0), shape: 'linear' },
-          { time: numeric('s', 2), value: decayLevel, shape: 'linear' },
-          { time: numeric('s', 3), value: releaseEndValue, shape: 'linear' },
-          { time: numeric('s', 3), value: COMPLETE_SILENCE, shape: 'step' }
+          { time: runtimeNumeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
+          { time: runtimeNumeric('s', 1), value: runtimeNumeric('db', 0), shape: 'linear' },
+          { time: runtimeNumeric('s', 2), value: decayLevel, shape: 'linear' },
+          { time: runtimeNumeric('s', 3), value: releaseEndValue, shape: 'linear' },
+          { time: runtimeNumeric('s', 3), value: COMPLETE_SILENCE, shape: 'step' }
         ]
       } satisfies Curve<'s', 'db'>)
     })
 
     it('starts release from sustain when the note ends after decay', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: -6, release: 4 }), {
-        gate: numeric('s', 5),
-        velocity: numeric(undefined, 0.75)
+        gate: runtimeNumeric('s', 5),
+        velocity: runtimeNumeric(undefined, 0.75)
       })
 
-      const velocityLevel = gainToDb(numeric(undefined, 0.75))
+      const velocityLevel = gainToDb(runtimeNumeric(undefined, 0.75))
 
-      const startLevel = numeric('db', velocityLevel.value + RELATIVE_SILENCE.value)
-      const sustainLevel = numeric('db', velocityLevel.value - 6)
-      const releaseEndValue = numeric('db', sustainLevel.value + RELATIVE_SILENCE.value)
+      const startLevel = runtimeNumeric('db', velocityLevel.value + RELATIVE_SILENCE.value)
+      const sustainLevel = runtimeNumeric('db', velocityLevel.value - 6)
+      const releaseEndValue = runtimeNumeric('db', sustainLevel.value + RELATIVE_SILENCE.value)
 
       assert.deepStrictEqual(result, {
         initial: COMPLETE_SILENCE,
         points: [
-          { time: numeric('s', 0), value: startLevel, shape: 'step' },
-          { time: numeric('s', 1), value: velocityLevel, shape: 'linear' },
-          { time: numeric('s', 3), value: sustainLevel, shape: 'linear' },
-          { time: numeric('s', 5), value: sustainLevel, shape: 'step' },
-          { time: numeric('s', 9), value: releaseEndValue, shape: 'linear' },
-          { time: numeric('s', 9), value: COMPLETE_SILENCE, shape: 'step' }
+          { time: runtimeNumeric('s', 0), value: startLevel, shape: 'step' },
+          { time: runtimeNumeric('s', 1), value: velocityLevel, shape: 'linear' },
+          { time: runtimeNumeric('s', 3), value: sustainLevel, shape: 'linear' },
+          { time: runtimeNumeric('s', 5), value: sustainLevel, shape: 'step' },
+          { time: runtimeNumeric('s', 9), value: releaseEndValue, shape: 'linear' },
+          { time: runtimeNumeric('s', 9), value: COMPLETE_SILENCE, shape: 'step' }
         ]
       } satisfies Curve<'s', 'db'>)
     })
 
     it('handles zero-length release by setting the value to 0 immediately after hold duration', () => {
       const result = applyEnvelope(createEnvelope({ attack: 1, decay: 2, sustain: -6, release: 0 }), {
-        gate: numeric('s', 5),
-        velocity: numeric(undefined, 1)
+        gate: runtimeNumeric('s', 5),
+        velocity: runtimeNumeric(undefined, 1)
       })
 
       assert.deepStrictEqual(result, {
         initial: COMPLETE_SILENCE,
         points: [
-          { time: numeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
-          { time: numeric('s', 1), value: numeric('db', 0), shape: 'linear' },
-          { time: numeric('s', 3), value: numeric('db', -6), shape: 'linear' },
-          { time: numeric('s', 5), value: COMPLETE_SILENCE, shape: 'step' }
+          { time: runtimeNumeric('s', 0), value: RELATIVE_SILENCE, shape: 'step' },
+          { time: runtimeNumeric('s', 1), value: runtimeNumeric('db', 0), shape: 'linear' },
+          { time: runtimeNumeric('s', 3), value: runtimeNumeric('db', -6), shape: 'linear' },
+          { time: runtimeNumeric('s', 5), value: COMPLETE_SILENCE, shape: 'step' }
         ]
       } satisfies Curve<'s', 'db'>)
     })

--- a/packages/language/test/library/modules/effects.test.ts
+++ b/packages/language/test/library/modules/effects.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GlobalScope } from '../../../src/compiler/generator/scopes.js'
@@ -21,9 +21,9 @@ function createFunctionContext (): GlobalScope {
 }
 
 describe('library/modules/effects.ts', () => {
-  // helper to create Numeric<'beats'>
-  const beats = (value: number) => numeric('beats', value)
-  const seconds = (value: number) => numeric('s', value)
+  // helper to create RuntimeNumeric<'beats'>
+  const beats = (value: number) => runtimeNumeric('beats', value)
+  const seconds = (value: number) => runtimeNumeric('s', value)
 
   describe('gain', () => {
     const gain = getFunctionExport(effectsModule, 'gain')
@@ -32,7 +32,7 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = gain.invoke(context, {
-        gain: Numbers.of(numeric('db', -6))
+        gain: Numbers.of(runtimeNumeric('db', -6))
       })
 
       const [gainId] = context.automations.keys()
@@ -41,7 +41,7 @@ describe('library/modules/effects.ts', () => {
         type: 'gain',
         gain: {
           id: gainId,
-          initial: numeric('db', -6)
+          initial: runtimeNumeric('db', -6)
         }
       })
 
@@ -56,7 +56,7 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = pan.invoke(context, {
-        pan: Numbers.of(numeric(undefined, 0.5))
+        pan: Numbers.of(runtimeNumeric(undefined, 0.5))
       })
 
       const [panId] = context.automations.keys()
@@ -65,7 +65,7 @@ describe('library/modules/effects.ts', () => {
         type: 'pan',
         pan: {
           id: panId,
-          initial: numeric(undefined, 0.5)
+          initial: runtimeNumeric(undefined, 0.5)
         }
       })
 
@@ -80,7 +80,7 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = lowpass.invoke(context, {
-        frequency: Numbers.of(numeric('hz', 1000))
+        frequency: Numbers.of(runtimeNumeric('hz', 1000))
       })
 
       const [frequencyId] = context.automations.keys()
@@ -89,7 +89,7 @@ describe('library/modules/effects.ts', () => {
         type: 'lowpass',
         frequency: {
           id: frequencyId,
-          initial: numeric('hz', 1000)
+          initial: runtimeNumeric('hz', 1000)
         }
       })
 
@@ -104,7 +104,7 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = highpass.invoke(context, {
-        frequency: Numbers.of(numeric('hz', 200))
+        frequency: Numbers.of(runtimeNumeric('hz', 200))
       })
 
       const [frequencyId] = context.automations.keys()
@@ -113,7 +113,7 @@ describe('library/modules/effects.ts', () => {
         type: 'highpass',
         frequency: {
           id: frequencyId,
-          initial: numeric('hz', 200)
+          initial: runtimeNumeric('hz', 200)
         }
       })
 
@@ -128,12 +128,12 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = width.invoke(context, {
-        width: Numbers.of(numeric(undefined, 0.8))
+        width: Numbers.of(runtimeNumeric(undefined, 0.8))
       })
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'width',
-        width: numeric(undefined, 0.8)
+        width: runtimeNumeric(undefined, 0.8)
       })
 
       assert.strictEqual(RecordFacet.has(result), false)
@@ -147,22 +147,22 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = delay.invoke(context, {
-        mix: Numbers.of(numeric(undefined, 0.5)),
+        mix: Numbers.of(runtimeNumeric(undefined, 0.5)),
         time: Numbers.of(beats(0.5)),
-        feedback: Numbers.of(numeric(undefined, 0.3))
+        feedback: Numbers.of(runtimeNumeric(undefined, 0.3))
       })
 
       const [feedbackId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'delay',
-        mix: numeric(undefined, 0.5),
+        mix: runtimeNumeric(undefined, 0.5),
         time: beats(0.5),
         feedback: {
           id: feedbackId,
-          initial: numeric(undefined, 0.3)
+          initial: runtimeNumeric(undefined, 0.3)
         },
-        wet: numeric('db', 0)
+        wet: runtimeNumeric('db', 0)
       })
 
       assert.deepStrictEqual(Object.keys(RecordFacet.get(result)), ['feedback'])
@@ -172,22 +172,22 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = delay.invoke(context, {
-        mix: Numbers.of(numeric(undefined, 0.5)),
+        mix: Numbers.of(runtimeNumeric(undefined, 0.5)),
         time: Numbers.of(seconds(1.5)),
-        feedback: Numbers.of(numeric(undefined, 0.3))
+        feedback: Numbers.of(runtimeNumeric(undefined, 0.3))
       })
 
       const [feedbackId] = context.automations.keys()
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'delay',
-        mix: numeric(undefined, 0.5),
+        mix: runtimeNumeric(undefined, 0.5),
         time: seconds(1.5),
         feedback: {
           id: feedbackId,
-          initial: numeric(undefined, 0.3)
+          initial: runtimeNumeric(undefined, 0.3)
         },
-        wet: numeric('db', 0)
+        wet: runtimeNumeric('db', 0)
       })
 
       assert.deepStrictEqual(Object.keys(RecordFacet.get(result)), ['feedback'])
@@ -197,15 +197,15 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = delay.invoke(context, {
-        mix: Numbers.of(numeric(undefined, 0.5)),
+        mix: Numbers.of(runtimeNumeric(undefined, 0.5)),
         time: Numbers.of(beats(0.5)),
-        feedback: Numbers.of(numeric(undefined, 0.3)),
-        wet: Numbers.of(numeric('db', 3))
+        feedback: Numbers.of(runtimeNumeric(undefined, 0.3)),
+        wet: Numbers.of(runtimeNumeric('db', 3))
       })
 
       const effect = EffectFacet.get(result)
       assert.strictEqual(effect.type, 'delay')
-      assert.deepStrictEqual(effect.wet, numeric('db', 3))
+      assert.deepStrictEqual(effect.wet, runtimeNumeric('db', 3))
     })
   })
 
@@ -216,15 +216,15 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = reverb.invoke(context, {
-        decay: Numbers.of(numeric('s', 2.0)),
-        mix: Numbers.of(numeric(undefined, 0.4))
+        decay: Numbers.of(runtimeNumeric('s', 2.0)),
+        mix: Numbers.of(runtimeNumeric(undefined, 0.4))
       })
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'reverb',
-        decay: numeric('s', 2.0),
-        mix: numeric(undefined, 0.4),
-        wet: numeric('db', 0)
+        decay: runtimeNumeric('s', 2.0),
+        mix: runtimeNumeric(undefined, 0.4),
+        wet: runtimeNumeric('db', 0)
       })
 
       assert.strictEqual(RecordFacet.has(result), false)
@@ -235,14 +235,14 @@ describe('library/modules/effects.ts', () => {
 
       const result = reverb.invoke(context, {
         decay: Numbers.of(beats(2)),
-        mix: Numbers.of(numeric(undefined, 0.4))
+        mix: Numbers.of(runtimeNumeric(undefined, 0.4))
       })
 
       assert.deepStrictEqual(EffectFacet.get(result), {
         type: 'reverb',
         decay: beats(2),
-        mix: numeric(undefined, 0.4),
-        wet: numeric('db', 0)
+        mix: runtimeNumeric(undefined, 0.4),
+        wet: runtimeNumeric('db', 0)
       })
 
       assert.strictEqual(RecordFacet.has(result), false)
@@ -252,14 +252,14 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = reverb.invoke(context, {
-        decay: Numbers.of(numeric('s', 2.0)),
-        mix: Numbers.of(numeric(undefined, 0.4)),
-        wet: Numbers.of(numeric('db', -3))
+        decay: Numbers.of(runtimeNumeric('s', 2.0)),
+        mix: Numbers.of(runtimeNumeric(undefined, 0.4)),
+        wet: Numbers.of(runtimeNumeric('db', -3))
       })
 
       const effect = EffectFacet.get(result)
       assert.strictEqual(effect.type, 'reverb')
-      assert.deepStrictEqual(effect.wet, numeric('db', -3))
+      assert.deepStrictEqual(effect.wet, runtimeNumeric('db', -3))
     })
   })
 
@@ -270,7 +270,7 @@ describe('library/modules/effects.ts', () => {
       const context = createFunctionContext()
 
       const result = clip.invoke(context, {
-        threshold: Numbers.of(numeric(undefined, 0.8))
+        threshold: Numbers.of(runtimeNumeric(undefined, 0.8))
       })
 
       const [thresholdId] = context.automations.keys()
@@ -279,7 +279,7 @@ describe('library/modules/effects.ts', () => {
         type: 'clip',
         threshold: {
           id: thresholdId,
-          initial: numeric(undefined, 0.8)
+          initial: runtimeNumeric(undefined, 0.8)
         }
       })
 

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -1,5 +1,5 @@
 import type { Instrument } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GlobalScope } from '../../../src/compiler/generator/scopes.js'
@@ -11,7 +11,7 @@ import { InstrumentFacet } from '../../../src/type-system/domain/instrument.js'
 import { Numbers } from '../../../src/type-system/helpers.js'
 import { getFunctionExport } from './test-utils.js'
 
-const DEFAULT_TEMPO = numeric('bpm', 120)
+const DEFAULT_TEMPO = runtimeNumeric('bpm', 120)
 
 function createFunctionContext (): GlobalScope {
   return createGlobalScope({
@@ -26,13 +26,13 @@ function createFunctionContext (): GlobalScope {
 
 describe('library/modules/instruments.ts', () => {
   const declickEnvelope = () => applyEnvelope({
-    attack: numeric('s', 0.003),
-    decay: numeric('s', 0),
-    sustain: numeric('db', 0),
-    release: numeric('s', 0.003)
+    attack: runtimeNumeric('s', 0.003),
+    decay: runtimeNumeric('s', 0),
+    sustain: runtimeNumeric('db', 0),
+    release: runtimeNumeric('s', 0.003)
   }, {
-    velocity: numeric(undefined, 1),
-    gate: numeric('s', 1.5)
+    velocity: runtimeNumeric(undefined, 1),
+    gate: runtimeNumeric('s', 1.5)
   })
 
   describe('sample', () => {
@@ -43,9 +43,9 @@ describe('library/modules/instruments.ts', () => {
 
       const result = sample.invoke(context, {
         url: StringFacet.type().of('https://example.com/kick.wav'),
-        gain: Numbers.of(numeric('db', -3)),
+        gain: Numbers.of(runtimeNumeric('db', -3)),
         root_note: StringFacet.type().of('C4'),
-        length: Numbers.of(numeric('s', 1.5))
+        length: Numbers.of(runtimeNumeric('s', 1.5))
       })
 
       const [asset] = context.assets.values()
@@ -55,19 +55,19 @@ describe('library/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(instrument, {
         id: instrument.id,
-        gain: { id: instrument.gain.id, initial: numeric('db', -3) },
+        gain: { id: instrument.gain.id, initial: runtimeNumeric('db', -3) },
         trigger: instrument.trigger
       } satisfies Instrument)
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }, DEFAULT_TEMPO), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO), [
         {
           envelope: declickEnvelope(),
-          duration: numeric('s', 1.503),
+          duration: runtimeNumeric('s', 1.503),
           source: {
             type: 'sample',
             assetId: asset.id,
-            length: numeric('s', 1.5),
-            playbackRate: numeric(undefined, 1)
+            length: runtimeNumeric('s', 1.5),
+            playbackRate: runtimeNumeric(undefined, 1)
           }
         }
       ])
@@ -94,27 +94,27 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
-        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
+        gain: { id: instrument.gain.id, initial: runtimeNumeric('db', 0) },
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: numeric(undefined, 1) }, DEFAULT_TEMPO), [
+      assert.deepStrictEqual(instrument.trigger({ velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO), [
         {
           envelope: applyEnvelope({
-            attack: numeric('s', 0.003),
-            decay: numeric('s', 0),
-            sustain: numeric('db', 0),
-            release: numeric('s', 0.003)
+            attack: runtimeNumeric('s', 0.003),
+            decay: runtimeNumeric('s', 0),
+            sustain: runtimeNumeric('db', 0),
+            release: runtimeNumeric('s', 0.003)
           }, {
             gate: undefined,
-            velocity: numeric(undefined, 1)
+            velocity: runtimeNumeric(undefined, 1)
           }),
           duration: undefined,
           source: {
             type: 'sample',
             assetId: asset.id,
             length: undefined,
-            playbackRate: numeric(undefined, 1)
+            playbackRate: runtimeNumeric(undefined, 1)
           }
         }
       ])
@@ -132,11 +132,11 @@ describe('library/modules/instruments.ts', () => {
 
         const result = sample.invoke(context, {
           url: StringFacet.type().of('https://example.com/kick.wav'),
-          length: Numbers.of(numeric('s', length))
+          length: Numbers.of(runtimeNumeric('s', length))
         })
 
         const instrument = InstrumentFacet.get(result)
-        const voices = instrument.trigger({ velocity: numeric(undefined, 1) }, DEFAULT_TEMPO)
+        const voices = instrument.trigger({ velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO)
 
         assert.strictEqual(voices.length, 0)
       }
@@ -153,26 +153,26 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
-        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
+        gain: { id: instrument.gain.id, initial: runtimeNumeric('db', 0) },
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }, DEFAULT_TEMPO), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO), [
         {
           envelope: applyEnvelope({
-            attack: numeric('s', 0.003),
-            decay: numeric('s', 0),
-            sustain: numeric('db', 0),
-            release: numeric('s', 0.003)
+            attack: runtimeNumeric('s', 0.003),
+            decay: runtimeNumeric('s', 0),
+            sustain: runtimeNumeric('db', 0),
+            release: runtimeNumeric('s', 0.003)
           }, {
             gate: undefined,
-            velocity: numeric(undefined, 1)
+            velocity: runtimeNumeric(undefined, 1)
           }),
           duration: undefined,
           source: {
             type: 'oscillator',
             shape: 'sine',
-            frequency: numeric('hz', 440)
+            frequency: runtimeNumeric('hz', 440)
           }
         }
       ])
@@ -195,26 +195,26 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
-        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
+        gain: { id: instrument.gain.id, initial: runtimeNumeric('db', 0) },
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }, DEFAULT_TEMPO), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO), [
         {
           envelope: applyEnvelope({
-            attack: numeric('s', 0.003),
-            decay: numeric('s', 0),
-            sustain: numeric('db', 0),
-            release: numeric('s', 0.003)
+            attack: runtimeNumeric('s', 0.003),
+            decay: runtimeNumeric('s', 0),
+            sustain: runtimeNumeric('db', 0),
+            release: runtimeNumeric('s', 0.003)
           }, {
             gate: undefined,
-            velocity: numeric(undefined, 1)
+            velocity: runtimeNumeric(undefined, 1)
           }),
           duration: undefined,
           source: {
             type: 'oscillator',
             shape: 'square',
-            frequency: numeric('hz', 440)
+            frequency: runtimeNumeric('hz', 440)
           }
         }
       ])
@@ -237,26 +237,26 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
-        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
+        gain: { id: instrument.gain.id, initial: runtimeNumeric('db', 0) },
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }, DEFAULT_TEMPO), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO), [
         {
           envelope: applyEnvelope({
-            attack: numeric('s', 0.003),
-            decay: numeric('s', 0),
-            sustain: numeric('db', 0),
-            release: numeric('s', 0.003)
+            attack: runtimeNumeric('s', 0.003),
+            decay: runtimeNumeric('s', 0),
+            sustain: runtimeNumeric('db', 0),
+            release: runtimeNumeric('s', 0.003)
           }, {
             gate: undefined,
-            velocity: numeric(undefined, 1)
+            velocity: runtimeNumeric(undefined, 1)
           }),
           duration: undefined,
           source: {
             type: 'oscillator',
             shape: 'saw',
-            frequency: numeric('hz', 440)
+            frequency: runtimeNumeric('hz', 440)
           }
         }
       ])
@@ -279,26 +279,26 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
-        gain: { id: instrument.gain.id, initial: numeric('db', 0) },
+        gain: { id: instrument.gain.id, initial: runtimeNumeric('db', 0) },
         trigger: instrument.trigger
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: numeric(undefined, 1) }, DEFAULT_TEMPO), [
+      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: runtimeNumeric(undefined, 1) }, DEFAULT_TEMPO), [
         {
           envelope: applyEnvelope({
-            attack: numeric('s', 0.003),
-            decay: numeric('s', 0),
-            sustain: numeric('db', 0),
-            release: numeric('s', 0.003)
+            attack: runtimeNumeric('s', 0.003),
+            decay: runtimeNumeric('s', 0),
+            sustain: runtimeNumeric('db', 0),
+            release: runtimeNumeric('s', 0.003)
           }, {
             gate: undefined,
-            velocity: numeric(undefined, 1)
+            velocity: runtimeNumeric(undefined, 1)
           }),
           duration: undefined,
           source: {
             type: 'oscillator',
             shape: 'triangle',
-            frequency: numeric('hz', 440)
+            frequency: runtimeNumeric('hz', 440)
           }
         }
       ])

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -1,5 +1,5 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { Function } from '../../src/type-system/base/function.js'
@@ -26,13 +26,13 @@ describe('type-system/base', () => {
 
   describe('NumberFacet', () => {
     it('should support unit-specific facets and detail()', () => {
-      const genericValue = NumberFacet.type().of(numeric('db', -3))
+      const genericValue = NumberFacet.type().of(runtimeNumeric('db', -3))
       const decibelFacet = NumberFacet.with('db')
       const decibelType = decibelFacet.type()
-      const decibelValue = decibelType.of(numeric('db', -3))
+      const decibelValue = decibelType.of(runtimeNumeric('db', -3))
       const specificData = decibelFacet.get(decibelValue)
 
-      expectTypeEquals<Numeric<'db'>, typeof specificData>()
+      expectTypeEquals<RuntimeNumeric<'db'>, typeof specificData>()
       assert.strictEqual(NumberFacet.format(), 'number')
       assert.strictEqual(NumberFacet.with(undefined).format(), 'number')
       assert.strictEqual(decibelFacet.format(), 'number(db)')
@@ -69,7 +69,7 @@ describe('type-system/base', () => {
       const value = typedType.of(func)
       const loadedFunction = typedFacet.get(value)
       const result = loadedFunction.invoke(undefined as never, {
-        amount: amountType.of(numeric('db', -6))
+        amount: amountType.of(runtimeNumeric('db', -6))
       })
 
       expectTypeEquals<Function<typeof schema, typeof returnType>, typeof loadedFunction>()
@@ -118,7 +118,7 @@ describe('type-system/base', () => {
       const recordFacet = RecordFacet.with({ gain: gainType, label: labelType })
       const recordType = recordFacet.type()
       const recordValue = recordType.of({
-        gain: gainType.of(numeric('db', -9)),
+        gain: gainType.of(runtimeNumeric('db', -9)),
         label: labelType.of('lead')
       })
       const recordData = recordFacet.get(recordValue)
@@ -146,7 +146,7 @@ describe('type-system/base', () => {
     it('should not expose object prototype properties', () => {
       const recordFacet = RecordFacet.with({ gain: NumberFacet.type() })
       const recordType = recordFacet.type()
-      const recordValue = recordType.of({ gain: NumberFacet.with('db').type().of(numeric('db', -9)) })
+      const recordValue = recordType.of({ gain: NumberFacet.with('db').type().of(runtimeNumeric('db', -9)) })
       const recordData = recordFacet.get(recordValue)
 
       assert.strictEqual(Object.getPrototypeOf(RecordFacet.detail(recordType)), null)
@@ -156,7 +156,7 @@ describe('type-system/base', () => {
       assert.strictEqual((recordData as Record<string, unknown>).constructor, undefined)
 
       const genericRecordType = RecordFacet.type()
-      const genericRecordValue = genericRecordType.of({ gain: NumberFacet.with('db').type().of(numeric('db', -9)) })
+      const genericRecordValue = genericRecordType.of({ gain: NumberFacet.with('db').type().of(runtimeNumeric('db', -9)) })
       const genericRecordData = RecordFacet.get(genericRecordValue)
 
       assert.strictEqual(Object.getPrototypeOf(RecordFacet.detail(genericRecordType)), null)

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -1,6 +1,6 @@
 import type { Bus, BusId, Effect, Instrument, InstrumentId, Parameter, ParameterId, Part, Pattern } from '@core'
 import { createSerialPattern } from '@core'
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { BusFacet } from '../../src/type-system/domain/bus.js'
@@ -15,18 +15,18 @@ import { expectTypeEquals } from '../test-utils.js'
 
 const gainParameter: Parameter<'db'> = {
   id: 1 as ParameterId,
-  initial: numeric('db', -6)
+  initial: runtimeNumeric('db', -6)
 }
 
 const panParameter: Parameter<undefined> = {
   id: 2 as ParameterId,
-  initial: numeric(undefined, 0.25)
+  initial: runtimeNumeric(undefined, 0.25)
 }
 
 const pattern: Pattern = createSerialPattern([
   { value: 'C4' },
-  { value: '-', length: numeric(undefined, 1) },
-  { value: 'E4', gate: numeric(undefined, 0.5) }
+  { value: '-', length: runtimeNumeric(undefined, 1) },
+  { value: 'E4', gate: runtimeNumeric(undefined, 0.5) }
 ])
 
 const effect: Effect = {
@@ -42,7 +42,7 @@ const instrument: Instrument = {
 
 const part: Part = {
   name: 'intro',
-  length: numeric('beats', 4),
+  length: runtimeNumeric('beats', 4),
   routings: [{
     source: {
       type: 'pattern',
@@ -92,16 +92,16 @@ describe('type-system/domain', () => {
         segments: [
           {
             type: 'hold',
-            length: numeric('beats', 1),
+            length: runtimeNumeric('beats', 1),
             unit: 'db',
-            value: numeric('db', -6)
+            value: runtimeNumeric('db', -6)
           },
           {
             type: 'lin',
-            length: numeric('beats', 2),
+            length: runtimeNumeric('beats', 2),
             unit: 'db',
-            start: numeric('db', -6),
-            end: numeric('db', 0)
+            start: runtimeNumeric('db', -6),
+            end: runtimeNumeric('db', 0)
           }
         ]
       }

--- a/packages/language/test/type-system/type-system.test.ts
+++ b/packages/language/test/type-system/type-system.test.ts
@@ -1,5 +1,5 @@
-import type { Numeric, Unit } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric, Unit } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { makeFacet, makeType, makeUnion } from '../../src/type-system/factory.js'
@@ -8,11 +8,11 @@ import { expectTypeEquals } from '../test-utils.js'
 
 const stringFacet = makeFacet<'string', string>('string', {})
 const numberFacet = makeFacet<'number', number>('number', {})
-const numericFacet = makeFacet<'numeric', Numeric<Unit>>('numeric', {})
-const decibelFacet = makeFacet<'numeric', Numeric<'db'>>('numeric', { unit: 'db' }, {
+const numericFacet = makeFacet<'numeric', RuntimeNumeric<Unit>>('numeric', {})
+const decibelFacet = makeFacet<'numeric', RuntimeNumeric<'db'>>('numeric', { unit: 'db' }, {
   format: () => 'numeric(db)'
 })
-const hertzFacet = makeFacet<'numeric', Numeric<'hz'>>('numeric', { unit: 'hz' }, {
+const hertzFacet = makeFacet<'numeric', RuntimeNumeric<'hz'>>('numeric', { unit: 'hz' }, {
   format: () => 'numeric(hz)'
 })
 
@@ -29,7 +29,7 @@ describe('type-system', () => {
   describe('DataForFacet', () => {
     it('should infer facet data', () => {
       expectTypeEquals<string, DataForFacet<typeof stringFacet>>()
-      expectTypeEquals<Numeric<Unit>, DataForFacet<typeof numericFacet>>()
+      expectTypeEquals<RuntimeNumeric<Unit>, DataForFacet<typeof numericFacet>>()
     })
   })
 
@@ -49,16 +49,16 @@ describe('type-system', () => {
 
   describe('get()', () => {
     it('should infer a more specific data type from the value if available', () => {
-      const specificValue = decibelType.of(numeric('db', 42))
+      const specificValue = decibelType.of(runtimeNumeric('db', 42))
       const specificData = numericFacet.get(specificValue)
-      expectTypeEquals<Numeric<Unit> & Numeric<'db'>, typeof specificData>()
+      expectTypeEquals<RuntimeNumeric<Unit> & RuntimeNumeric<'db'>, typeof specificData>()
       expectTypeEquals<'db', typeof specificData.unit>()
       assert.strictEqual(specificData.unit, 'db')
       assert.strictEqual(specificData.value, 42)
 
       const widenedValue: Value = specificValue
       const widenedData = numericFacet.get(widenedValue)
-      expectTypeEquals<Numeric<Unit>, typeof widenedData>()
+      expectTypeEquals<RuntimeNumeric<Unit>, typeof widenedData>()
       expectTypeEquals<Unit, typeof widenedData.unit>()
       assert.strictEqual(widenedData.unit, 'db')
       assert.strictEqual(widenedData.value, 42)
@@ -120,31 +120,31 @@ describe('type-system', () => {
 
     it('should check values', () => {
       const pairValue = stringAndNumberType.of('hello', 42)
-      const broadNumericValue = numericType.of(numeric(undefined, 5))
-      const decibelValue = decibelType.of(numeric('db', 42))
+      const broadRuntimeNumericValue = numericType.of(runtimeNumeric(undefined, 5))
+      const decibelValue = decibelType.of(runtimeNumeric('db', 42))
 
       assert.strictEqual(stringFacet.has(pairValue), true)
       assert.strictEqual(numberFacet.has(pairValue), true)
       assert.strictEqual(decibelFacet.has(decibelValue), true)
       assert.strictEqual(numericFacet.has(decibelValue), true)
-      assert.strictEqual(decibelFacet.has(broadNumericValue), false)
+      assert.strictEqual(decibelFacet.has(broadRuntimeNumericValue), false)
     })
 
     it('should retrieve facet data', () => {
       const pairValue = stringAndNumberType.of('hello', 42)
-      const broadNumericValue = numericType.of(numeric(undefined, 5))
-      const decibelValue = decibelType.of(numeric('db', 42))
+      const broadRuntimeNumericValue = numericType.of(runtimeNumeric(undefined, 5))
+      const decibelValue = decibelType.of(runtimeNumeric('db', 42))
 
       assert.strictEqual(stringFacet.get(pairValue), 'hello')
       assert.strictEqual(numberFacet.get(pairValue), 42)
-      assert.deepStrictEqual(decibelFacet.get(decibelValue), numeric('db', 42))
+      assert.deepStrictEqual(decibelFacet.get(decibelValue), runtimeNumeric('db', 42))
 
       assert.throws(() => stringFacet.get(decibelValue), /Value is not assignable to facet: string/)
-      assert.throws(() => decibelFacet.get(broadNumericValue), /Value is not assignable to facet: numeric/)
+      assert.throws(() => decibelFacet.get(broadRuntimeNumericValue), /Value is not assignable to facet: numeric/)
     })
 
     it('should narrow values through has()', () => {
-      const maybeFacetValue: Value = decibelType.of(numeric('db', 42))
+      const maybeFacetValue: Value = decibelType.of(runtimeNumeric('db', 42))
       if (!numericFacet.has(maybeFacetValue)) {
         assert.fail('Expected numericFacet.has() to narrow a decibel value')
       }
@@ -228,7 +228,7 @@ describe('type-system', () => {
     })
 
     it('should narrow values through has()', () => {
-      const maybeTypeValue: Value = decibelType.of(numeric('db', 42))
+      const maybeTypeValue: Value = decibelType.of(runtimeNumeric('db', 42))
       if (!decibelType.has(maybeTypeValue)) {
         assert.fail('Expected decibelType.has() to narrow a decibel value')
       }
@@ -272,19 +272,19 @@ describe('type-system', () => {
       const primitiveUnion = makeUnion(stringType, numberType)
       const stringValue = stringType.of('hello')
       const pairValue = stringAndNumberType.of('hello', 42)
-      const decibelValue = decibelType.of(numeric('db', 42))
-      const broadNumericValue = numericType.of(numeric(undefined, 5))
+      const decibelValue = decibelType.of(runtimeNumeric('db', 42))
+      const broadRuntimeNumericValue = numericType.of(runtimeNumeric(undefined, 5))
 
       assert.strictEqual(primitiveUnion.has(stringValue), true)
       assert.strictEqual(primitiveUnion.has(pairValue), true)
       assert.strictEqual(primitiveUnion.has(decibelValue), false)
 
       assert.strictEqual(numericUnion.has(decibelValue), true)
-      assert.strictEqual(numericUnion.has(broadNumericValue), false)
+      assert.strictEqual(numericUnion.has(broadRuntimeNumericValue), false)
     })
 
     it('should narrow values through has()', () => {
-      const maybeUnionValue: Value = hertzType.of(numeric('hz', 1000))
+      const maybeUnionValue: Value = hertzType.of(runtimeNumeric('hz', 1000))
       if (!numericUnion.has(maybeUnionValue)) {
         assert.fail('Expected numericUnion.has() to narrow a member value')
       }

--- a/packages/utility/src/numeric/numeric.ts
+++ b/packages/utility/src/numeric/numeric.ts
@@ -5,11 +5,13 @@ export type Unit = string | undefined
 type LiteralString<S extends string> = string extends S ? never : S
 type LiteralUnit<U extends Unit> = U extends string ? LiteralString<U> : U
 
-export interface Numeric<U extends Unit> {
+export type Numeric<U extends Unit> = number & { readonly __unit: U }
+
+export interface RuntimeNumeric<U extends Unit> {
   readonly unit: U
-  readonly value: number
+  readonly value: Numeric<U>
 }
 
-export function numeric<const U extends Unit> (unit: LiteralUnit<U>, value: number): Numeric<U> {
-  return { unit, value }
+export function runtimeNumeric<const U extends Unit> (unit: LiteralUnit<U>, value: number): RuntimeNumeric<U> {
+  return { unit, value: value as Numeric<U> }
 }

--- a/packages/utility/test/numeric/numeric.test.ts
+++ b/packages/utility/test/numeric/numeric.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { numeric } from '../../src/numeric/numeric.js'
+import { runtimeNumeric } from '../../src/numeric/numeric.js'
 
 describe('numeric/numeric.ts', () => {
-  describe('numeric()', () => {
-    it('should create a numeric value with the specified unit and value', () => {
-      const num = numeric('s', 2.5)
+  describe('runtimeNumeric()', () => {
+    it('should create a runtimeNumeric value with the specified unit and value', () => {
+      const num = runtimeNumeric('s', 2.5)
       assert.deepStrictEqual(num, { unit: 's', value: 2.5 })
     })
   })

--- a/packages/webaudio/src/assets/cache.ts
+++ b/packages/webaudio/src/assets/cache.ts
@@ -1,8 +1,8 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 
 export interface AssetCacheOptions<T> {
-  readonly maxSize: RuntimeNumeric<'bytes'>
-  readonly getSize: (value: T) => number
+  readonly maxSize: Numeric<'bytes'>
+  readonly getSize: (value: T) => Numeric<'bytes'>
 }
 
 export interface AssetCache<T> {
@@ -13,7 +13,7 @@ export interface AssetCache<T> {
 
 interface CacheEntry<T> {
   readonly value: T
-  readonly size: number
+  readonly size: Numeric<'bytes'>
 }
 
 export function createAssetCache<T> (options: AssetCacheOptions<T>): AssetCache<T> {
@@ -29,7 +29,7 @@ export function createAssetCache<T> (options: AssetCacheOptions<T>): AssetCache<
   }
 
   const evictIfNeeded = (requiredSize: number): void => {
-    while (totalSize + requiredSize > options.maxSize.value) {
+    while (totalSize + requiredSize > options.maxSize) {
       const oldestKey = cache.keys().next().value
       if (oldestKey == null) {
         break
@@ -54,7 +54,7 @@ export function createAssetCache<T> (options: AssetCacheOptions<T>): AssetCache<
       deleteKey(key)
 
       const size = options.getSize(value)
-      if (size > options.maxSize.value) {
+      if (size > options.maxSize) {
         return // too large to store
       }
 

--- a/packages/webaudio/src/assets/cache.ts
+++ b/packages/webaudio/src/assets/cache.ts
@@ -1,7 +1,7 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 
 export interface AssetCacheOptions<T> {
-  readonly maxSize: Numeric<'bytes'>
+  readonly maxSize: RuntimeNumeric<'bytes'>
   readonly getSize: (value: T) => number
 }
 

--- a/packages/webaudio/src/assets/fetcher.ts
+++ b/packages/webaudio/src/assets/fetcher.ts
@@ -1,14 +1,14 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { AssetCache } from './cache.js'
 import { createAssetCache } from './cache.js'
 
 export interface CacheLimits {
-  readonly arrayBuffer: RuntimeNumeric<'bytes'>
-  readonly audioBuffer: RuntimeNumeric<'bytes'>
+  readonly arrayBuffer: Numeric<'bytes'>
+  readonly audioBuffer: Numeric<'bytes'>
 }
 
 export interface AudioFetcherOptions {
-  readonly timeout: RuntimeNumeric<'s'>
+  readonly timeout: Numeric<'s'>
   readonly cacheLimits: CacheLimits
 }
 
@@ -20,23 +20,23 @@ export function createAudioFetcher (options: AudioFetcherOptions): AudioFetcher 
   // This uses two levels of caching as the decoded audio is typically much larger
   // than the raw data fetched from the network.
 
-  const arrayBufferCache = options.cacheLimits.arrayBuffer.value > 0
+  const arrayBufferCache = options.cacheLimits.arrayBuffer > 0
     ? createAssetCache<ArrayBuffer>({
         maxSize: options.cacheLimits.arrayBuffer,
-        getSize: (value) => value.byteLength
+        getSize: (value) => value.byteLength as Numeric<'bytes'>
       })
     : undefined
 
-  const audioBufferCache = options.cacheLimits.audioBuffer.value > 0
+  const audioBufferCache = options.cacheLimits.audioBuffer > 0
     ? createAssetCache<AudioBuffer>({
         maxSize: options.cacheLimits.audioBuffer,
-        getSize: (value) => value.length * value.numberOfChannels * 4 // 32-bit float
+        getSize: (value) => (value.length * value.numberOfChannels * 4) as Numeric<'bytes'> // 32-bit float
       })
     : undefined
 
   return {
     fetch: async (ctx: BaseAudioContext, url: string | URL) => {
-      const signal = AbortSignal.timeout(options.timeout.value * 1000)
+      const signal = AbortSignal.timeout(options.timeout * 1000)
 
       try {
         return await fetchAudioBuffer(ctx, url, signal, {

--- a/packages/webaudio/src/assets/fetcher.ts
+++ b/packages/webaudio/src/assets/fetcher.ts
@@ -1,14 +1,14 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import type { AssetCache } from './cache.js'
 import { createAssetCache } from './cache.js'
 
 export interface CacheLimits {
-  readonly arrayBuffer: Numeric<'bytes'>
-  readonly audioBuffer: Numeric<'bytes'>
+  readonly arrayBuffer: RuntimeNumeric<'bytes'>
+  readonly audioBuffer: RuntimeNumeric<'bytes'>
 }
 
 export interface AudioFetcherOptions {
-  readonly timeout: Numeric<'s'>
+  readonly timeout: RuntimeNumeric<'s'>
   readonly cacheLimits: CacheLimits
 }
 

--- a/packages/webaudio/src/engine/engine.ts
+++ b/packages/webaudio/src/engine/engine.ts
@@ -1,6 +1,6 @@
 import type { AudioGraph, EntityKey, Node } from '@audiograph'
-import type { RuntimeNumeric, Observable, Observer, UnsubscribeFn } from '@utility'
-import { DisposeStack, MutableObservable, runtimeNumeric } from '@utility'
+import type { Numeric, Observable, Observer, UnsubscribeFn } from '@utility'
+import { DisposeStack, MutableObservable } from '@utility'
 import type { CacheLimits } from '../assets/fetcher.js'
 import { createAudioFetcher } from '../assets/fetcher.js'
 import type { MeterCallbacks } from '../graph/factory.js'
@@ -10,20 +10,20 @@ import { createAudioSession } from './session.js'
 import type { BeatRange } from './types.js'
 
 export interface AudioEngineOptions {
-  readonly outputGain: RuntimeNumeric<'db'>
-  readonly assetLoadTimeout: RuntimeNumeric<'s'>
+  readonly outputGain: Numeric<'db'>
+  readonly assetLoadTimeout: Numeric<'s'>
   readonly cacheLimits: CacheLimits
 }
 
 export interface AudioEngine {
-  readonly outputGain: MutableObservable<RuntimeNumeric<'db'>>
+  readonly outputGain: MutableObservable<Numeric<'db'>>
 
   readonly playing: Observable<boolean>
   readonly play: (graph: AudioGraph<Node>) => void
   readonly stop: () => void
 
   readonly range: MutableObservable<BeatRange>
-  readonly position: Observable<RuntimeNumeric<'beats'>>
+  readonly position: Observable<Numeric<'beats'>>
   readonly errors: Observable<readonly Error[]>
 
   readonly meters: {
@@ -41,7 +41,7 @@ export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
   })
 
   const playing = new MutableObservable(false)
-  const range = new MutableObservable({ start: runtimeNumeric('beats', 0) })
+  const range = new MutableObservable<BeatRange>({ start: 0 as Numeric<'beats'> })
   const position = new MutableObservable(range.get().start)
   const errors = new MutableObservable<readonly Error[]>([])
 

--- a/packages/webaudio/src/engine/engine.ts
+++ b/packages/webaudio/src/engine/engine.ts
@@ -1,6 +1,6 @@
 import type { AudioGraph, EntityKey, Node } from '@audiograph'
-import type { Numeric, Observable, Observer, UnsubscribeFn } from '@utility'
-import { DisposeStack, MutableObservable, numeric } from '@utility'
+import type { RuntimeNumeric, Observable, Observer, UnsubscribeFn } from '@utility'
+import { DisposeStack, MutableObservable, runtimeNumeric } from '@utility'
 import type { CacheLimits } from '../assets/fetcher.js'
 import { createAudioFetcher } from '../assets/fetcher.js'
 import type { MeterCallbacks } from '../graph/factory.js'
@@ -10,20 +10,20 @@ import { createAudioSession } from './session.js'
 import type { BeatRange } from './types.js'
 
 export interface AudioEngineOptions {
-  readonly outputGain: Numeric<'db'>
-  readonly assetLoadTimeout: Numeric<'s'>
+  readonly outputGain: RuntimeNumeric<'db'>
+  readonly assetLoadTimeout: RuntimeNumeric<'s'>
   readonly cacheLimits: CacheLimits
 }
 
 export interface AudioEngine {
-  readonly outputGain: MutableObservable<Numeric<'db'>>
+  readonly outputGain: MutableObservable<RuntimeNumeric<'db'>>
 
   readonly playing: Observable<boolean>
   readonly play: (graph: AudioGraph<Node>) => void
   readonly stop: () => void
 
   readonly range: MutableObservable<BeatRange>
-  readonly position: Observable<Numeric<'beats'>>
+  readonly position: Observable<RuntimeNumeric<'beats'>>
   readonly errors: Observable<readonly Error[]>
 
   readonly meters: {
@@ -41,7 +41,7 @@ export function createAudioEngine (options: AudioEngineOptions): AudioEngine {
   })
 
   const playing = new MutableObservable(false)
-  const range = new MutableObservable({ start: numeric('beats', 0) })
+  const range = new MutableObservable({ start: runtimeNumeric('beats', 0) })
   const position = new MutableObservable(range.get().start)
   const errors = new MutableObservable<readonly Error[]>([])
 

--- a/packages/webaudio/src/engine/session.ts
+++ b/packages/webaudio/src/engine/session.ts
@@ -25,9 +25,9 @@ export function createAudioSession (
 ): AudioSession {
   const disposeStack = new DisposeStack()
 
-  const endPosition = range.end ?? graph.length.value
-  const startTime = beatsToSeconds(range.start, graph.tempo.value)
-  const endTime = beatsToSeconds(endPosition, graph.tempo.value)
+  const endPosition = range.end ?? graph.length
+  const startTime = beatsToSeconds(range.start, graph.tempo)
+  const endTime = beatsToSeconds(endPosition, graph.tempo)
 
   // Whether nothing should be played at all because the start is after the end
   const endImmediately = endPosition <= 0 || range.start >= endPosition
@@ -86,7 +86,7 @@ export function createAudioSession (
       disposeStack.push(transport.time.subscribe((time) => {
         if (!disposed) {
           const clamped = Math.max(startTime, time)
-          position.set((clamped * graph.tempo.value / 60) as Numeric<'beats'>)
+          position.set((clamped * graph.tempo / 60) as Numeric<'beats'>)
         }
       }))
     }).catch((err: unknown) => {

--- a/packages/webaudio/src/engine/session.ts
+++ b/packages/webaudio/src/engine/session.ts
@@ -1,7 +1,7 @@
 import type { AudioGraph, Node } from '@audiograph'
 import { beatsToSeconds, dbToGain } from '@core'
-import type { Numeric, Observable } from '@utility'
-import { DisposeStack, MutableObservable, numeric } from '@utility'
+import type { RuntimeNumeric, Observable } from '@utility'
+import { DisposeStack, MutableObservable, runtimeNumeric } from '@utility'
 import type { AudioFetcher } from '../assets/fetcher.js'
 import type { MeterCallbacks } from '../graph/factory.js'
 import { createWebAudioGraph } from '../graph/graph.js'
@@ -10,7 +10,7 @@ import type { BeatRange } from './types.js'
 
 export interface AudioSession {
   readonly ended: Observable<boolean>
-  readonly position: Observable<Numeric<'beats'>>
+  readonly position: Observable<RuntimeNumeric<'beats'>>
   readonly errors: Observable<readonly Error[]>
   readonly start: () => void
   readonly dispose: () => void
@@ -19,7 +19,7 @@ export interface AudioSession {
 export function createAudioSession (
   graph: AudioGraph<Node>,
   range: BeatRange,
-  outputGain: Observable<Numeric<'db'>>,
+  outputGain: Observable<RuntimeNumeric<'db'>>,
   fetcher: AudioFetcher,
   meterCallbacks: MeterCallbacks
 ): AudioSession {
@@ -86,7 +86,7 @@ export function createAudioSession (
       disposeStack.push(transport.time.subscribe((time) => {
         if (!disposed) {
           const clamped = Math.max(startTime.value, time.value)
-          position.set(numeric('beats', clamped * graph.tempo.value / 60))
+          position.set(runtimeNumeric('beats', clamped * graph.tempo.value / 60))
         }
       }))
     }).catch((err: unknown) => {

--- a/packages/webaudio/src/engine/session.ts
+++ b/packages/webaudio/src/engine/session.ts
@@ -1,7 +1,7 @@
 import type { AudioGraph, Node } from '@audiograph'
 import { beatsToSeconds, dbToGain } from '@core'
-import type { RuntimeNumeric, Observable } from '@utility'
-import { DisposeStack, MutableObservable, runtimeNumeric } from '@utility'
+import type { Numeric, Observable } from '@utility'
+import { DisposeStack, MutableObservable } from '@utility'
 import type { AudioFetcher } from '../assets/fetcher.js'
 import type { MeterCallbacks } from '../graph/factory.js'
 import { createWebAudioGraph } from '../graph/graph.js'
@@ -10,7 +10,7 @@ import type { BeatRange } from './types.js'
 
 export interface AudioSession {
   readonly ended: Observable<boolean>
-  readonly position: Observable<RuntimeNumeric<'beats'>>
+  readonly position: Observable<Numeric<'beats'>>
   readonly errors: Observable<readonly Error[]>
   readonly start: () => void
   readonly dispose: () => void
@@ -19,29 +19,29 @@ export interface AudioSession {
 export function createAudioSession (
   graph: AudioGraph<Node>,
   range: BeatRange,
-  outputGain: Observable<RuntimeNumeric<'db'>>,
+  outputGain: Observable<Numeric<'db'>>,
   fetcher: AudioFetcher,
   meterCallbacks: MeterCallbacks
 ): AudioSession {
   const disposeStack = new DisposeStack()
 
-  const endPosition = range.end ?? graph.length
-  const startTime = beatsToSeconds(range.start, graph.tempo)
-  const endTime = beatsToSeconds(endPosition, graph.tempo)
+  const endPosition = range.end ?? graph.length.value
+  const startTime = beatsToSeconds(range.start, graph.tempo.value)
+  const endTime = beatsToSeconds(endPosition, graph.tempo.value)
 
   // Whether nothing should be played at all because the start is after the end
-  const endImmediately = endPosition.value <= 0 || range.start.value >= endPosition.value
+  const endImmediately = endPosition <= 0 || range.start >= endPosition
 
   const transport = createOnlineTransport()
   disposeStack.pushDisposable(transport)
 
-  transport.output.gain.value = dbToGain(outputGain.get()).value
+  transport.output.gain.value = dbToGain(outputGain.get())
 
   disposeStack.push(outputGain.subscribe((value) => {
     const gain = transport.output.gain
     const currentTime = transport.ctx.currentTime
     gain.setValueAtTime(gain.value, currentTime)
-    gain.linearRampToValueAtTime(dbToGain(value).value, currentTime + 0.05)
+    gain.linearRampToValueAtTime(dbToGain(value), currentTime + 0.05)
   }))
 
   const ended = new MutableObservable(false)
@@ -78,15 +78,15 @@ export function createAudioSession (
         if (!disposed) {
           ended.set(true)
         }
-      }, (endTime.value - startTime.value) * 1000)
+      }, (endTime - startTime) * 1000)
 
       disposeStack.push(() => clearTimeout(endTimeout))
 
       // Track position based on render-thread time updates.
       disposeStack.push(transport.time.subscribe((time) => {
         if (!disposed) {
-          const clamped = Math.max(startTime.value, time.value)
-          position.set(runtimeNumeric('beats', clamped * graph.tempo.value / 60))
+          const clamped = Math.max(startTime, time)
+          position.set((clamped * graph.tempo.value / 60) as Numeric<'beats'>)
         }
       }))
     }).catch((err: unknown) => {

--- a/packages/webaudio/src/engine/types.ts
+++ b/packages/webaudio/src/engine/types.ts
@@ -1,6 +1,6 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 
 export interface BeatRange {
-  readonly start: Numeric<'beats'>
-  readonly end?: Numeric<'beats'>
+  readonly start: RuntimeNumeric<'beats'>
+  readonly end?: RuntimeNumeric<'beats'>
 }

--- a/packages/webaudio/src/engine/types.ts
+++ b/packages/webaudio/src/engine/types.ts
@@ -1,6 +1,6 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 
 export interface BeatRange {
-  readonly start: RuntimeNumeric<'beats'>
-  readonly end?: RuntimeNumeric<'beats'>
+  readonly start: Numeric<'beats'>
+  readonly end?: Numeric<'beats'>
 }

--- a/packages/webaudio/src/graph/automation.ts
+++ b/packages/webaudio/src/graph/automation.ts
@@ -1,5 +1,5 @@
 import type { Curve, CurveShape } from '@core'
-import type { Unit } from '@utility'
+import type { Numeric, Unit } from '@utility'
 import type { Transport } from '../transport/transport.js'
 
 export function automate<U extends Unit> (transport: Transport, param: AudioParam, source: Curve<'s', U>): void {
@@ -110,7 +110,7 @@ export function applyAutomationPoints<U extends Unit> (time: number, transport: 
   }
 }
 
-function evaluateCurve (shape: CurveShape, t: number, startValue: number, endValue: number): number {
+function evaluateCurve<const U extends Unit> (shape: CurveShape, t: number, startValue: Numeric<U>, endValue: Numeric<U>): Numeric<U> {
   if (t <= 0) {
     return startValue
   }
@@ -124,7 +124,7 @@ function evaluateCurve (shape: CurveShape, t: number, startValue: number, endVal
       return startValue
 
     case 'linear':
-      return (1 - t) * startValue + t * endValue
+      return ((1 - t) * startValue + t * endValue) as Numeric<U>
 
     case 'exponential': {
       // Exponential interpolation is multiplicative / log-linear:
@@ -140,7 +140,7 @@ function evaluateCurve (shape: CurveShape, t: number, startValue: number, endVal
       const safeStart = startValue > 0 ? startValue : Number.EPSILON
       const safeEnd = endValue > 0 ? endValue : Number.EPSILON
 
-      return Math.exp((1 - t) * Math.log(safeStart) + t * Math.log(safeEnd))
+      return (Math.exp((1 - t) * Math.log(safeStart) + t * Math.log(safeEnd))) as Numeric<U>
     }
   }
 }

--- a/packages/webaudio/src/graph/automation.ts
+++ b/packages/webaudio/src/graph/automation.ts
@@ -10,7 +10,7 @@ export function automate<U extends Unit> (transport: Transport, param: AudioPara
     return
   }
 
-  transport.schedule(0, (time) => {
+  transport.schedule(0 as Numeric<'s'>, (time) => {
     param.setValueAtTime(source.initial.value, 0)
 
     // Precompute point times

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -99,7 +99,7 @@ export function createReverbInstance (node: ReverbNode, transport: Transport): I
     createBuffer: (options) => new AudioBuffer(options),
     numberOfChannels: ctx.destination.channelCount,
     sampleRate: ctx.sampleRate,
-    decay: node.decay
+    decay: node.decay.value
   })
 
   return toInstance(audioNode)

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -25,7 +25,7 @@ export function createBiquadInstance (node: BiquadNode, transport: Transport): I
   const audioNode = transport.ctx.createBiquadFilter()
   audioNode.type = node.filterType
   automate(transport, audioNode.frequency, node.frequency)
-  audioNode.Q.value = -node.rolloffPerOctave.value
+  audioNode.Q.value = -(node.rolloffPerOctave.value as number)
   return toInstance(audioNode)
 }
 

--- a/packages/webaudio/src/graph/effect.ts
+++ b/packages/webaudio/src/graph/effect.ts
@@ -25,7 +25,7 @@ export function createBiquadInstance (node: BiquadNode, transport: Transport): I
   const audioNode = transport.ctx.createBiquadFilter()
   audioNode.type = node.filterType
   automate(transport, audioNode.frequency, node.frequency)
-  audioNode.Q.value = -(node.rolloffPerOctave.value as number)
+  audioNode.Q.value = -(node.rolloffPerOctave as number)
   return toInstance(audioNode)
 }
 
@@ -42,8 +42,8 @@ export function createWidthInstance (node: WidthNode, transport: Transport): Ins
 
   const merger = ctx.createChannelMerger(2)
 
-  const directGain = (1 + node.width.value) / 2
-  const crossGain = (1 - node.width.value) / 2
+  const directGain = (1 + node.width) / 2
+  const crossGain = (1 - node.width) / 2
 
   const leftDirect = ctx.createGain()
   leftDirect.gain.value = directGain
@@ -85,8 +85,8 @@ export function createWidthInstance (node: WidthNode, transport: Transport): Ins
 }
 
 export function createDelayInstance (node: DelayNode, transport: Transport): Instance {
-  const audioNode = transport.ctx.createDelay(Math.max(1, node.time.value))
-  audioNode.delayTime.value = node.time.value
+  const audioNode = transport.ctx.createDelay(Math.max(1, node.time))
+  audioNode.delayTime.value = node.time
   return toInstance(audioNode)
 }
 
@@ -99,7 +99,7 @@ export function createReverbInstance (node: ReverbNode, transport: Transport): I
     createBuffer: (options) => new AudioBuffer(options),
     numberOfChannels: ctx.destination.channelCount,
     sampleRate: ctx.sampleRate,
-    decay: node.decay.value
+    decay: node.decay
   })
 
   return toInstance(audioNode)

--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -104,7 +104,7 @@ function scheduleNoteEvents (graph: AudioGraph<Node>, instances: Map<NodeId, Ins
   for (const [nodeId, options] of graph.noteEvents) {
     const instance = instances.get(nodeId)
     for (const event of options) {
-      instance?.triggerNote?.(event, graph.tempo.value)
+      instance?.triggerNote?.(event, graph.tempo)
     }
   }
 }

--- a/packages/webaudio/src/graph/graph.ts
+++ b/packages/webaudio/src/graph/graph.ts
@@ -104,7 +104,7 @@ function scheduleNoteEvents (graph: AudioGraph<Node>, instances: Map<NodeId, Ins
   for (const [nodeId, options] of graph.noteEvents) {
     const instance = instances.get(nodeId)
     for (const event of options) {
-      instance?.triggerNote?.(event, graph.tempo)
+      instance?.triggerNote?.(event, graph.tempo.value)
     }
   }
 }

--- a/packages/webaudio/src/graph/instance.ts
+++ b/packages/webaudio/src/graph/instance.ts
@@ -1,5 +1,5 @@
 import type { NoteEvent } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 
 export interface Instance {
   readonly dispose: () => void
@@ -7,5 +7,5 @@ export interface Instance {
   readonly input?: AudioNode
   readonly output?: AudioNode
 
-  readonly triggerNote?: (note: NoteEvent, tempo: RuntimeNumeric<'bpm'>) => void
+  readonly triggerNote?: (note: NoteEvent, tempo: Numeric<'bpm'>) => void
 }

--- a/packages/webaudio/src/graph/instance.ts
+++ b/packages/webaudio/src/graph/instance.ts
@@ -1,5 +1,5 @@
 import type { NoteEvent } from '@core'
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 
 export interface Instance {
   readonly dispose: () => void
@@ -7,5 +7,5 @@ export interface Instance {
   readonly input?: AudioNode
   readonly output?: AudioNode
 
-  readonly triggerNote?: (note: NoteEvent, tempo: Numeric<'bpm'>) => void
+  readonly triggerNote?: (note: NoteEvent, tempo: RuntimeNumeric<'bpm'>) => void
 }

--- a/packages/webaudio/src/graph/instruments/instrument.ts
+++ b/packages/webaudio/src/graph/instruments/instrument.ts
@@ -1,7 +1,7 @@
 import type { InstrumentNode, SourceNode } from '@audiograph'
 import type { NoteEvent } from '@core'
 import { timeToSeconds } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import type { Transport } from '../../transport/transport.js'
 import { applyAutomationPoints } from '../automation.js'
 import type { Assets } from '../factory.js'
@@ -26,7 +26,7 @@ export function createInstrumentInstance (
     }
   }
 
-  const scheduleAtNote = (note: NoteEvent, tempo: RuntimeNumeric<'bpm'>, callback: (time: number) => void) => {
+  const scheduleAtNote = (note: NoteEvent, tempo: Numeric<'bpm'>, callback: (time: number) => void) => {
     const time = timeToSeconds(note.time, tempo).value
     transport.schedule(time, callback)
   }

--- a/packages/webaudio/src/graph/instruments/instrument.ts
+++ b/packages/webaudio/src/graph/instruments/instrument.ts
@@ -27,7 +27,7 @@ export function createInstrumentInstance (
   }
 
   const scheduleAtNote = (note: NoteEvent, tempo: Numeric<'bpm'>, callback: (time: number) => void) => {
-    const time = timeToSeconds(note.time, tempo).value
+    const time = timeToSeconds(note.time, tempo)
     transport.schedule(time, callback)
   }
 

--- a/packages/webaudio/src/graph/instruments/instrument.ts
+++ b/packages/webaudio/src/graph/instruments/instrument.ts
@@ -1,7 +1,7 @@
 import type { InstrumentNode, SourceNode } from '@audiograph'
 import type { NoteEvent } from '@core'
 import { timeToSeconds } from '@core'
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import type { Transport } from '../../transport/transport.js'
 import { applyAutomationPoints } from '../automation.js'
 import type { Assets } from '../factory.js'
@@ -26,7 +26,7 @@ export function createInstrumentInstance (
     }
   }
 
-  const scheduleAtNote = (note: NoteEvent, tempo: Numeric<'bpm'>, callback: (time: number) => void) => {
+  const scheduleAtNote = (note: NoteEvent, tempo: RuntimeNumeric<'bpm'>, callback: (time: number) => void) => {
     const time = timeToSeconds(note.time, tempo).value
     transport.schedule(time, callback)
   }

--- a/packages/webaudio/src/graph/instruments/instrument.ts
+++ b/packages/webaudio/src/graph/instruments/instrument.ts
@@ -54,7 +54,7 @@ export function createInstrumentInstance (
       sourceNode.start(time)
 
       if (source.duration != null) {
-        sourceNode.stop(time + source.duration.value)
+        sourceNode.stop(time + source.duration)
       }
 
       sourceNode.addEventListener('ended', () => {

--- a/packages/webaudio/src/graph/instruments/oscillator.ts
+++ b/packages/webaudio/src/graph/instruments/oscillator.ts
@@ -27,7 +27,7 @@ export function createOscillatorSource (
 ): AudioScheduledSourceNode {
   const oscillator = transport.ctx.createOscillator()
   oscillator.type = oscillatorTypeMap[node.shape]
-  oscillator.frequency.value = node.frequency.value
+  oscillator.frequency.value = node.frequency
 
   return oscillator
 }

--- a/packages/webaudio/src/graph/instruments/sample.ts
+++ b/packages/webaudio/src/graph/instruments/sample.ts
@@ -27,7 +27,7 @@ export function createSampleSource (
 
   const sourceNode = transport.ctx.createBufferSource()
   sourceNode.buffer = sampleBuffer
-  sourceNode.playbackRate.value = node.playbackRate.value
+  sourceNode.playbackRate.value = node.playbackRate
 
   return sourceNode
 }

--- a/packages/webaudio/src/graph/metering.ts
+++ b/packages/webaudio/src/graph/metering.ts
@@ -12,7 +12,7 @@ export async function createGainMeterInstance (
   meterCallbacks?: MeterCallbacks
 ): Promise<Instance> {
   const instance = await createGainMeter(transport.ctx, {
-    interval: node.interval.value * transport.ctx.sampleRate
+    interval: node.interval * transport.ctx.sampleRate
   })
 
   let unsubscribe: UnsubscribeFn | undefined

--- a/packages/webaudio/src/graph/noise.ts
+++ b/packages/webaudio/src/graph/noise.ts
@@ -1,4 +1,4 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { mulberry32, xmur3 } from '@utility'
 
 type CreateAudioBuffer = (options: AudioBufferOptions) => AudioBuffer
@@ -11,12 +11,12 @@ export function generateReverbImpulseResponse (options: {
   readonly createBuffer: CreateAudioBuffer
   readonly numberOfChannels: number
   readonly sampleRate: number
-  readonly decay: RuntimeNumeric<'s'>
+  readonly decay: Numeric<'s'>
 }): AudioBuffer {
   const { sampleRate, numberOfChannels, decay, createBuffer } = options
 
   // buffer length must be non-zero
-  const length = Math.max(1, Math.floor(sampleRate * decay.value))
+  const length = Math.max(1, Math.floor(sampleRate * decay))
 
   const noise = createNoiseBuffer({ numberOfChannels, sampleRate, createBuffer })
   const ir = createBuffer({ length, numberOfChannels, sampleRate })

--- a/packages/webaudio/src/graph/noise.ts
+++ b/packages/webaudio/src/graph/noise.ts
@@ -1,4 +1,4 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import { mulberry32, xmur3 } from '@utility'
 
 type CreateAudioBuffer = (options: AudioBufferOptions) => AudioBuffer
@@ -11,7 +11,7 @@ export function generateReverbImpulseResponse (options: {
   readonly createBuffer: CreateAudioBuffer
   readonly numberOfChannels: number
   readonly sampleRate: number
-  readonly decay: Numeric<'s'>
+  readonly decay: RuntimeNumeric<'s'>
 }): AudioBuffer {
   const { sampleRate, numberOfChannels, decay, createBuffer } = options
 

--- a/packages/webaudio/src/renderer/renderer.ts
+++ b/packages/webaudio/src/renderer/renderer.ts
@@ -1,6 +1,6 @@
 import type { AudioGraph, Node } from '@audiograph'
 import { beatsToSeconds } from '@core'
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import { DisposeStack } from '@utility'
 import type { CacheLimits } from '../assets/fetcher.js'
 import { createAudioFetcher } from '../assets/fetcher.js'
@@ -8,7 +8,7 @@ import { createWebAudioGraph } from '../graph/graph.js'
 import { createOfflineTransport } from '../transport/transport.js'
 
 export interface AudioRendererOptions {
-  readonly assetLoadTimeout: Numeric<'s'>
+  readonly assetLoadTimeout: RuntimeNumeric<'s'>
   readonly cacheLimits: CacheLimits
 }
 

--- a/packages/webaudio/src/renderer/renderer.ts
+++ b/packages/webaudio/src/renderer/renderer.ts
@@ -1,6 +1,6 @@
 import type { AudioGraph, Node } from '@audiograph'
 import { beatsToSeconds } from '@core'
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { DisposeStack } from '@utility'
 import type { CacheLimits } from '../assets/fetcher.js'
 import { createAudioFetcher } from '../assets/fetcher.js'
@@ -8,7 +8,7 @@ import { createWebAudioGraph } from '../graph/graph.js'
 import { createOfflineTransport } from '../transport/transport.js'
 
 export interface AudioRendererOptions {
-  readonly assetLoadTimeout: RuntimeNumeric<'s'>
+  readonly assetLoadTimeout: Numeric<'s'>
   readonly cacheLimits: CacheLimits
 }
 
@@ -37,8 +37,8 @@ export function createAudioRenderer (options: AudioRendererOptions): AudioRender
     render: async (graph, options) => {
       const disposeStack = new DisposeStack()
 
-      const duration = beatsToSeconds(graph.length, graph.tempo)
-      const safeDuration = Math.max(0.001, duration.value)
+      const duration = beatsToSeconds(graph.length.value, graph.tempo.value)
+      const safeDuration = Math.max(0.001, duration)
 
       const transport = createOfflineTransport({
         channels: options.channels,
@@ -51,7 +51,7 @@ export function createAudioRenderer (options: AudioRendererOptions): AudioRender
           if (time == null) {
             return
           }
-          options.onProgress?.(Math.max(0, Math.min(1, time.value / safeDuration)))
+          options.onProgress?.(Math.max(0, Math.min(1, time / safeDuration)))
         }))
       }
 

--- a/packages/webaudio/src/renderer/renderer.ts
+++ b/packages/webaudio/src/renderer/renderer.ts
@@ -37,7 +37,7 @@ export function createAudioRenderer (options: AudioRendererOptions): AudioRender
     render: async (graph, options) => {
       const disposeStack = new DisposeStack()
 
-      const duration = beatsToSeconds(graph.length.value, graph.tempo.value)
+      const duration = beatsToSeconds(graph.length, graph.tempo)
       const safeDuration = Math.max(0.001, duration)
 
       const transport = createOfflineTransport({

--- a/packages/webaudio/src/time-tracker/common.ts
+++ b/packages/webaudio/src/time-tracker/common.ts
@@ -1,11 +1,11 @@
-import type { RuntimeNumeric, Observable } from '@utility'
+import type { Numeric, Observable } from '@utility'
 
 export interface TimeTrackerOptions {
-  readonly updateInterval: RuntimeNumeric<'s'>
-  readonly offsetTime: RuntimeNumeric<'s'>
+  readonly updateInterval: Numeric<'s'>
+  readonly offsetTime: Numeric<'s'>
 }
 
 export interface TimeTracker {
   readonly dispose: () => void
-  readonly time: Observable<RuntimeNumeric<'s'>>
+  readonly time: Observable<Numeric<'s'>>
 }

--- a/packages/webaudio/src/time-tracker/common.ts
+++ b/packages/webaudio/src/time-tracker/common.ts
@@ -1,11 +1,11 @@
-import type { Numeric, Observable } from '@utility'
+import type { RuntimeNumeric, Observable } from '@utility'
 
 export interface TimeTrackerOptions {
-  readonly updateInterval: Numeric<'s'>
-  readonly offsetTime: Numeric<'s'>
+  readonly updateInterval: RuntimeNumeric<'s'>
+  readonly offsetTime: RuntimeNumeric<'s'>
 }
 
 export interface TimeTracker {
   readonly dispose: () => void
-  readonly time: Observable<Numeric<'s'>>
+  readonly time: Observable<RuntimeNumeric<'s'>>
 }

--- a/packages/webaudio/src/time-tracker/interval.ts
+++ b/packages/webaudio/src/time-tracker/interval.ts
@@ -1,14 +1,15 @@
-import { MutableObservable, runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
+import { MutableObservable } from '@utility'
 import type { TimeTracker, TimeTrackerOptions } from './common.js'
 
 export function createIntervalTimeTracker (ctx: BaseAudioContext, options: TimeTrackerOptions): TimeTracker {
   const { updateInterval, offsetTime } = options
 
-  const time = new MutableObservable(runtimeNumeric('s', 0))
+  const time = new MutableObservable(0 as Numeric<'s'>)
 
   const interval = setInterval(() => {
-    time.set(runtimeNumeric('s', ctx.currentTime - offsetTime.value))
-  }, updateInterval.value * 1000)
+    time.set((ctx.currentTime - offsetTime) as Numeric<'s'>)
+  }, updateInterval * 1000)
 
   const dispose = () => {
     clearInterval(interval)

--- a/packages/webaudio/src/time-tracker/interval.ts
+++ b/packages/webaudio/src/time-tracker/interval.ts
@@ -1,13 +1,13 @@
-import { MutableObservable, numeric } from '@utility'
+import { MutableObservable, runtimeNumeric } from '@utility'
 import type { TimeTracker, TimeTrackerOptions } from './common.js'
 
 export function createIntervalTimeTracker (ctx: BaseAudioContext, options: TimeTrackerOptions): TimeTracker {
   const { updateInterval, offsetTime } = options
 
-  const time = new MutableObservable(numeric('s', 0))
+  const time = new MutableObservable(runtimeNumeric('s', 0))
 
   const interval = setInterval(() => {
-    time.set(numeric('s', ctx.currentTime - offsetTime.value))
+    time.set(runtimeNumeric('s', ctx.currentTime - offsetTime.value))
   }, updateInterval.value * 1000)
 
   const dispose = () => {

--- a/packages/webaudio/src/time-tracker/worklet.ts
+++ b/packages/webaudio/src/time-tracker/worklet.ts
@@ -1,4 +1,4 @@
-import { MutableObservable, numeric } from '@utility'
+import { MutableObservable, runtimeNumeric } from '@utility'
 import { createTimeMeter } from '../worklets/metering/factory.js'
 import type { TimeTracker, TimeTrackerOptions } from './common.js'
 
@@ -14,10 +14,10 @@ export async function createWorkletTimeTracker (
 
   input.connect(instance.node)
 
-  const time = new MutableObservable(numeric('s', 0))
+  const time = new MutableObservable(runtimeNumeric('s', 0))
   const unsubscribe = instance.measurements.subscribe((measurement) => {
     if (measurement != null) {
-      time.set(numeric('s', measurement.time - offsetTime.value))
+      time.set(runtimeNumeric('s', measurement.time - offsetTime.value))
     }
   })
 

--- a/packages/webaudio/src/time-tracker/worklet.ts
+++ b/packages/webaudio/src/time-tracker/worklet.ts
@@ -1,4 +1,5 @@
-import { MutableObservable, runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
+import { MutableObservable } from '@utility'
 import { createTimeMeter } from '../worklets/metering/factory.js'
 import type { TimeTracker, TimeTrackerOptions } from './common.js'
 
@@ -9,15 +10,15 @@ export async function createWorkletTimeTracker (
 ): Promise<TimeTracker> {
   const { updateInterval, offsetTime } = options
 
-  const interval = Math.max(1, Math.floor(updateInterval.value * ctx.sampleRate))
+  const interval = Math.max(1, Math.floor(updateInterval * ctx.sampleRate))
   const instance = await createTimeMeter(ctx, { interval })
 
   input.connect(instance.node)
 
-  const time = new MutableObservable(runtimeNumeric('s', 0))
+  const time = new MutableObservable(0 as Numeric<'s'>)
   const unsubscribe = instance.measurements.subscribe((measurement) => {
     if (measurement != null) {
-      time.set(runtimeNumeric('s', measurement.time - offsetTime.value))
+      time.set((measurement.time - offsetTime) as Numeric<'s'>)
     }
   })
 

--- a/packages/webaudio/src/transport/scheduler.ts
+++ b/packages/webaudio/src/transport/scheduler.ts
@@ -1,4 +1,4 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { insertSorted } from '@utility'
 
 export interface Scheduler {
@@ -7,7 +7,7 @@ export interface Scheduler {
    *
    * @param offsetTime AudioContext time when transport time is 0.
    */
-  readonly start: (offsetTime: number) => void
+  readonly start: (offsetTime: Numeric<'s'>) => void
 
   /**
    * Stop periodic flushing of events.
@@ -19,7 +19,7 @@ export interface Scheduler {
    *
    * The callback receives an absolute AudioContext time.
    */
-  readonly schedule: (time: number, callback: (time: number) => void) => void
+  readonly schedule: (time: Numeric<'s'>, callback: (time: Numeric<'s'>) => void) => void
 
   /**
    * Flush any currently-due events (useful after scheduling near-term events).
@@ -31,17 +31,17 @@ export interface RealtimeSchedulerOptions {
   /**
    * Time source for the scheduler (e.g. AudioContext.currentTime).
    */
-  readonly now: () => number
+  readonly now: () => Numeric<'s'>
 
   /**
    * Scheduler tick frequency.
    */
-  readonly tickInterval: RuntimeNumeric<'s'>
+  readonly tickInterval: Numeric<'s'>
 
   /**
    * How far ahead (from transport time) callbacks may run.
    */
-  readonly scheduleAheadTime: RuntimeNumeric<'s'>
+  readonly scheduleAheadTime: Numeric<'s'>
 
   readonly timers?: {
     readonly setInterval: typeof globalThis.setInterval
@@ -60,21 +60,21 @@ export function createRealtimeScheduler (options: RealtimeSchedulerOptions): Sch
   const queue = createScheduledEventQueue()
 
   let interval: ReturnType<typeof globalThis.setInterval> | undefined
-  let offsetTime = 0
+  let offsetTime = 0 as Numeric<'s'>
   let started = false
 
   const flush = () => {
     if (started) {
-      queue.flushBefore(now() - offsetTime + scheduleAheadTime.value, offsetTime)
+      queue.flushBefore(now() - offsetTime + scheduleAheadTime, offsetTime)
     }
   }
 
-  const start = (newOffsetTime: number) => {
+  const start = (newOffsetTime: Numeric<'s'>) => {
     if (!started) {
       started = true
       offsetTime = newOffsetTime
       flush()
-      interval = timers.setInterval(flush, tickInterval.value * 1000)
+      interval = timers.setInterval(flush, tickInterval * 1000)
     }
   }
 
@@ -87,10 +87,10 @@ export function createRealtimeScheduler (options: RealtimeSchedulerOptions): Sch
     started = false
   }
 
-  const schedule = (time: number, callback: (time: number) => void) => {
+  const schedule = (time: Numeric<'s'>, callback: (time: Numeric<'s'>) => void) => {
     queue.schedule({ time, callback })
     // If the event is near, try scheduling it without waiting for the next tick.
-    if (started && time <= now() - offsetTime + scheduleAheadTime.value) {
+    if (started && time <= now() - offsetTime + scheduleAheadTime) {
       flush()
     }
   }
@@ -101,7 +101,7 @@ export function createRealtimeScheduler (options: RealtimeSchedulerOptions): Sch
 export function createImmediateScheduler (): Scheduler {
   const queue = createScheduledEventQueue()
 
-  let offsetTime = 0
+  let offsetTime = 0 as Numeric<'s'>
   let started = false
 
   const flush = () => {
@@ -110,7 +110,7 @@ export function createImmediateScheduler (): Scheduler {
     }
   }
 
-  const start = (newOffsetTime: number) => {
+  const start = (newOffsetTime: Numeric<'s'>) => {
     if (!started) {
       started = true
       offsetTime = newOffsetTime
@@ -122,7 +122,7 @@ export function createImmediateScheduler (): Scheduler {
     started = false
   }
 
-  const schedule = (time: number, callback: (time: number) => void) => {
+  const schedule = (time: Numeric<'s'>, callback: (time: Numeric<'s'>) => void) => {
     queue.schedule({ time, callback })
     if (started) {
       flush()
@@ -139,8 +139,8 @@ interface ScheduledEventQueue {
 }
 
 interface ScheduledEvent {
-  readonly time: number
-  readonly callback: (time: number) => void
+  readonly time: Numeric<'s'>
+  readonly callback: (time: Numeric<'s'>) => void
 }
 
 const compareByTime = (a: ScheduledEvent, b: ScheduledEvent): number => a.time - b.time
@@ -169,7 +169,7 @@ function createScheduledEventQueue (): ScheduledEventQueue {
     ensureSorted()
 
     for (const event of scheduled) {
-      event.callback(event.time + offsetTime)
+      event.callback((event.time + offsetTime) as Numeric<'s'>)
     }
 
     scheduled.splice(0, scheduled.length)
@@ -185,7 +185,7 @@ function createScheduledEventQueue (): ScheduledEventQueue {
         break
       }
 
-      event.callback(event.time + offsetTime)
+      event.callback((event.time + offsetTime) as Numeric<'s'>)
       ++flushed
     }
 

--- a/packages/webaudio/src/transport/scheduler.ts
+++ b/packages/webaudio/src/transport/scheduler.ts
@@ -1,4 +1,4 @@
-import type { Numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
 import { insertSorted } from '@utility'
 
 export interface Scheduler {
@@ -36,12 +36,12 @@ export interface RealtimeSchedulerOptions {
   /**
    * Scheduler tick frequency.
    */
-  readonly tickInterval: Numeric<'s'>
+  readonly tickInterval: RuntimeNumeric<'s'>
 
   /**
    * How far ahead (from transport time) callbacks may run.
    */
-  readonly scheduleAheadTime: Numeric<'s'>
+  readonly scheduleAheadTime: RuntimeNumeric<'s'>
 
   readonly timers?: {
     readonly setInterval: typeof globalThis.setInterval

--- a/packages/webaudio/src/transport/transport.ts
+++ b/packages/webaudio/src/transport/transport.ts
@@ -1,11 +1,11 @@
-import type { RuntimeNumeric, Observable } from '@utility'
-import { DisposeStack, MutableObservable, runtimeNumeric } from '@utility'
+import type { Numeric, Observable } from '@utility'
+import { DisposeStack, MutableObservable } from '@utility'
 import { createIntervalTimeTracker } from '../time-tracker/interval.js'
 import { createWorkletTimeTracker } from '../time-tracker/worklet.js'
 import { createImmediateScheduler, createRealtimeScheduler } from './scheduler.js'
 
 export interface OfflineTransportOptions {
-  readonly duration: RuntimeNumeric<'s'>
+  readonly duration: Numeric<'s'>
   readonly channels: number
   readonly sampleRate: number
 }
@@ -15,27 +15,27 @@ export interface Transport {
   readonly input: AudioNode
   readonly output: GainNode
 
-  readonly schedule: (time: number, callback: (time: number) => void) => void
+  readonly schedule: (time: Numeric<'s'>, callback: (time: Numeric<'s'>) => void) => void
 }
 
 export interface OnlineTransport extends Transport {
-  readonly start: (position: RuntimeNumeric<'s'>) => Promise<void>
-  readonly time: Observable<RuntimeNumeric<'s'>>
+  readonly start: (position: Numeric<'s'>) => Promise<void>
+  readonly time: Observable<Numeric<'s'>>
 
   readonly dispose: () => void
 }
 
 export interface OfflineTransport extends Transport {
   readonly render: () => Promise<AudioBuffer>
-  readonly time: Observable<RuntimeNumeric<'s'> | undefined>
+  readonly time: Observable<Numeric<'s'> | undefined>
 }
 
-const TICK_INTERVAL = runtimeNumeric('s', 0.025)
-const SCHEDULE_AHEAD_TIME = runtimeNumeric('s', 0.05)
+const TICK_INTERVAL = 0.025 as Numeric<'s'>
+const SCHEDULE_AHEAD_TIME = 0.05 as Numeric<'s'>
 
 // Assuming faster than real-time rendering, so less frequent updates should be sufficient for offline
-const TIME_UPDATE_INTERVAL_ONLINE = runtimeNumeric('s', 0.050)
-const TIME_UPDATE_INTERVAL_OFFLINE = runtimeNumeric('s', 0.100)
+const TIME_UPDATE_INTERVAL_ONLINE = 0.050 as Numeric<'s'>
+const TIME_UPDATE_INTERVAL_OFFLINE = 0.100 as Numeric<'s'>
 
 export function createOnlineTransport (): OnlineTransport {
   const disposeStack = new DisposeStack()
@@ -60,13 +60,13 @@ export function createOnlineTransport (): OnlineTransport {
   output.connect(ctx.destination)
   disposeStack.push(() => output.disconnect())
 
-  let offsetTime = ctx.currentTime
+  let offsetTime = ctx.currentTime as Numeric<'s'>
   let started = false
 
-  const time = new MutableObservable(runtimeNumeric('s', 0))
+  const time = new MutableObservable(0 as Numeric<'s'>)
 
   const scheduler = createRealtimeScheduler({
-    now: () => ctx.currentTime,
+    now: () => ctx.currentTime as Numeric<'s'>,
     tickInterval: TICK_INTERVAL,
     scheduleAheadTime: SCHEDULE_AHEAD_TIME
   })
@@ -80,14 +80,14 @@ export function createOnlineTransport (): OnlineTransport {
     started = true
 
     await ctx.resume()
-    offsetTime = ctx.currentTime - position.value
+    offsetTime = (ctx.currentTime - position) as Numeric<'s'>
 
     scheduler.start(offsetTime)
 
     const tracker = await (async () => {
       const options = {
         updateInterval: TIME_UPDATE_INTERVAL_ONLINE,
-        offsetTime: runtimeNumeric('s', offsetTime)
+        offsetTime
       }
 
       try {
@@ -118,7 +118,7 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
   const ctx = new OfflineAudioContext({
     numberOfChannels: options.channels,
     // buffer must be non-zero length as required by the spec
-    length: Math.max(1, Math.ceil(options.duration.value * options.sampleRate)),
+    length: Math.max(1, Math.ceil(options.duration * options.sampleRate)),
     sampleRate: options.sampleRate
   })
 
@@ -127,18 +127,18 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
   output.connect(ctx.destination)
   disposeStack.push(() => output.disconnect())
 
-  const time = new MutableObservable<RuntimeNumeric<'s'> | undefined>(undefined)
+  const time = new MutableObservable<Numeric<'s'> | undefined>(undefined)
 
   const scheduler = createImmediateScheduler()
   disposeStack.push(() => scheduler.stop())
 
   const render: OfflineTransport['render'] = async () => {
-    scheduler.start(0)
+    scheduler.start(0 as Numeric<'s'>)
 
     try {
       const tracker = await createWorkletTimeTracker(ctx, input, {
         updateInterval: TIME_UPDATE_INTERVAL_OFFLINE,
-        offsetTime: runtimeNumeric('s', 0)
+        offsetTime: 0 as Numeric<'s'>
       })
 
       disposeStack.pushDisposable(tracker)
@@ -151,7 +151,7 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
 
     // Offline rendering knows its exact end time even if the worklet meter's
     // final postMessage is delayed or never observed on the main thread.
-    time.set(runtimeNumeric('s', buffer.length / buffer.sampleRate))
+    time.set((buffer.length / buffer.sampleRate) as Numeric<'s'>)
 
     disposeStack.dispose()
 

--- a/packages/webaudio/src/transport/transport.ts
+++ b/packages/webaudio/src/transport/transport.ts
@@ -1,11 +1,11 @@
-import type { Numeric, Observable } from '@utility'
-import { DisposeStack, MutableObservable, numeric } from '@utility'
+import type { RuntimeNumeric, Observable } from '@utility'
+import { DisposeStack, MutableObservable, runtimeNumeric } from '@utility'
 import { createIntervalTimeTracker } from '../time-tracker/interval.js'
 import { createWorkletTimeTracker } from '../time-tracker/worklet.js'
 import { createImmediateScheduler, createRealtimeScheduler } from './scheduler.js'
 
 export interface OfflineTransportOptions {
-  readonly duration: Numeric<'s'>
+  readonly duration: RuntimeNumeric<'s'>
   readonly channels: number
   readonly sampleRate: number
 }
@@ -19,23 +19,23 @@ export interface Transport {
 }
 
 export interface OnlineTransport extends Transport {
-  readonly start: (position: Numeric<'s'>) => Promise<void>
-  readonly time: Observable<Numeric<'s'>>
+  readonly start: (position: RuntimeNumeric<'s'>) => Promise<void>
+  readonly time: Observable<RuntimeNumeric<'s'>>
 
   readonly dispose: () => void
 }
 
 export interface OfflineTransport extends Transport {
   readonly render: () => Promise<AudioBuffer>
-  readonly time: Observable<Numeric<'s'> | undefined>
+  readonly time: Observable<RuntimeNumeric<'s'> | undefined>
 }
 
-const TICK_INTERVAL = numeric('s', 0.025)
-const SCHEDULE_AHEAD_TIME = numeric('s', 0.05)
+const TICK_INTERVAL = runtimeNumeric('s', 0.025)
+const SCHEDULE_AHEAD_TIME = runtimeNumeric('s', 0.05)
 
 // Assuming faster than real-time rendering, so less frequent updates should be sufficient for offline
-const TIME_UPDATE_INTERVAL_ONLINE = numeric('s', 0.050)
-const TIME_UPDATE_INTERVAL_OFFLINE = numeric('s', 0.100)
+const TIME_UPDATE_INTERVAL_ONLINE = runtimeNumeric('s', 0.050)
+const TIME_UPDATE_INTERVAL_OFFLINE = runtimeNumeric('s', 0.100)
 
 export function createOnlineTransport (): OnlineTransport {
   const disposeStack = new DisposeStack()
@@ -63,7 +63,7 @@ export function createOnlineTransport (): OnlineTransport {
   let offsetTime = ctx.currentTime
   let started = false
 
-  const time = new MutableObservable(numeric('s', 0))
+  const time = new MutableObservable(runtimeNumeric('s', 0))
 
   const scheduler = createRealtimeScheduler({
     now: () => ctx.currentTime,
@@ -87,7 +87,7 @@ export function createOnlineTransport (): OnlineTransport {
     const tracker = await (async () => {
       const options = {
         updateInterval: TIME_UPDATE_INTERVAL_ONLINE,
-        offsetTime: numeric('s', offsetTime)
+        offsetTime: runtimeNumeric('s', offsetTime)
       }
 
       try {
@@ -127,7 +127,7 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
   output.connect(ctx.destination)
   disposeStack.push(() => output.disconnect())
 
-  const time = new MutableObservable<Numeric<'s'> | undefined>(undefined)
+  const time = new MutableObservable<RuntimeNumeric<'s'> | undefined>(undefined)
 
   const scheduler = createImmediateScheduler()
   disposeStack.push(() => scheduler.stop())
@@ -138,7 +138,7 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
     try {
       const tracker = await createWorkletTimeTracker(ctx, input, {
         updateInterval: TIME_UPDATE_INTERVAL_OFFLINE,
-        offsetTime: numeric('s', 0)
+        offsetTime: runtimeNumeric('s', 0)
       })
 
       disposeStack.pushDisposable(tracker)
@@ -151,7 +151,7 @@ export function createOfflineTransport (options: OfflineTransportOptions): Offli
 
     // Offline rendering knows its exact end time even if the worklet meter's
     // final postMessage is delayed or never observed on the main thread.
-    time.set(numeric('s', buffer.length / buffer.sampleRate))
+    time.set(runtimeNumeric('s', buffer.length / buffer.sampleRate))
 
     disposeStack.dispose()
 

--- a/packages/webaudio/src/worklets/loader.ts
+++ b/packages/webaudio/src/worklets/loader.ts
@@ -1,10 +1,10 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 
 interface AudioContextWithWorklet extends BaseAudioContext {
   readonly audioWorklet: AudioWorklet
 }
 
-const LOAD_TIMEOUT = runtimeNumeric('s', 30)
+const LOAD_TIMEOUT = 30 as Numeric<'s'>
 
 const workletCache = new WeakMap<BaseAudioContext, Map<string, Promise<void>>>()
 
@@ -20,7 +20,7 @@ export async function addWorkletModule (ctx: BaseAudioContext, moduleUrl: string
     }
   }
 
-  const promise = add(ctx, moduleUrl, AbortSignal.timeout(LOAD_TIMEOUT.value * 1000))
+  const promise = add(ctx, moduleUrl, AbortSignal.timeout(LOAD_TIMEOUT * 1000))
 
   let ctxCache = workletCache.get(ctx)
   if (ctxCache == null) {

--- a/packages/webaudio/src/worklets/loader.ts
+++ b/packages/webaudio/src/worklets/loader.ts
@@ -1,10 +1,10 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 
 interface AudioContextWithWorklet extends BaseAudioContext {
   readonly audioWorklet: AudioWorklet
 }
 
-const LOAD_TIMEOUT = numeric('s', 30)
+const LOAD_TIMEOUT = runtimeNumeric('s', 30)
 
 const workletCache = new WeakMap<BaseAudioContext, Map<string, Promise<void>>>()
 

--- a/packages/webaudio/test-browser/graph/effect.test.ts
+++ b/packages/webaudio/test-browser/graph/effect.test.ts
@@ -1,5 +1,4 @@
 import type { Numeric } from '@utility'
-import { runtimeNumeric } from '@utility'
 import { describe, expect, it } from 'vitest'
 import { createDelayInstance, createWidthInstance } from '../../src/graph/effect.js'
 import type { Transport } from '../../src/transport/transport.js'
@@ -31,7 +30,7 @@ async function renderWidth (options: {
 }> {
   const { width, inputChannels, fill } = options
   const { ctx, transport } = createTestTransport()
-  const instance = createWidthInstance({ type: 'width', width: runtimeNumeric(undefined, width) }, transport)
+  const instance = createWidthInstance({ type: 'width', width }, transport)
 
   try {
     const input = ctx.createBuffer(inputChannels, length, sampleRate)
@@ -73,7 +72,7 @@ async function renderDelay (options: {
     schedule: (_time, onSchedule) => onSchedule(0 as Numeric<'s'>)
   }
 
-  const instance = createDelayInstance({ type: 'delay', time: runtimeNumeric('s', time) }, transport)
+  const instance = createDelayInstance({ type: 'delay', time }, transport)
 
   try {
     const source = ctx.createBufferSource()

--- a/packages/webaudio/test-browser/graph/effect.test.ts
+++ b/packages/webaudio/test-browser/graph/effect.test.ts
@@ -1,4 +1,4 @@
-import type { RuntimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { runtimeNumeric } from '@utility'
 import { describe, expect, it } from 'vitest'
 import { createDelayInstance, createWidthInstance } from '../../src/graph/effect.js'
@@ -15,14 +15,14 @@ function createTestTransport () {
     ctx,
     input: output,
     output,
-    schedule: (_time, onSchedule) => onSchedule(0)
+    schedule: (_time, onSchedule) => onSchedule(0 as Numeric<'s'>)
   }
 
   return { ctx, transport }
 }
 
 async function renderWidth (options: {
-  readonly width: RuntimeNumeric<undefined>
+  readonly width: Numeric<undefined>
   readonly inputChannels: number
   readonly fill: (buffer: AudioBuffer) => void
 }): Promise<{
@@ -31,7 +31,7 @@ async function renderWidth (options: {
 }> {
   const { width, inputChannels, fill } = options
   const { ctx, transport } = createTestTransport()
-  const instance = createWidthInstance({ type: 'width', width }, transport)
+  const instance = createWidthInstance({ type: 'width', width: runtimeNumeric(undefined, width) }, transport)
 
   try {
     const input = ctx.createBuffer(inputChannels, length, sampleRate)
@@ -54,13 +54,13 @@ async function renderWidth (options: {
 }
 
 async function renderDelay (options: {
-  readonly time: RuntimeNumeric<'s'>
+  readonly time: Numeric<'s'>
 }): Promise<{
   readonly output: AudioBuffer
 }> {
   const { time } = options
 
-  const delaySeconds = Math.max(1.25, time.value + 0.25)
+  const delaySeconds = Math.max(1.25, time + 0.25)
   const delaySamples = Math.ceil(delaySeconds * sampleRate)
   const renderLength = delaySamples + 256
 
@@ -70,10 +70,10 @@ async function renderDelay (options: {
     ctx,
     input: output,
     output,
-    schedule: (_time, onSchedule) => onSchedule(0)
+    schedule: (_time, onSchedule) => onSchedule(0 as Numeric<'s'>)
   }
 
-  const instance = createDelayInstance({ type: 'delay', time }, transport)
+  const instance = createDelayInstance({ type: 'delay', time: runtimeNumeric('s', time) }, transport)
 
   try {
     const source = ctx.createBufferSource()
@@ -97,7 +97,7 @@ describe('graph/effect.ts', () => {
   describe('createWidthInstance', () => {
     it('renders mono-compatible output when width = 0', async () => {
       const { output } = await renderWidth({
-        width: runtimeNumeric(undefined, 0),
+        width: 0 as Numeric<undefined>,
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -111,7 +111,7 @@ describe('graph/effect.ts', () => {
 
     it('swaps stereo channels when width = -1', async () => {
       const { output } = await renderWidth({
-        width: runtimeNumeric(undefined, -1),
+        width: -1 as Numeric<undefined>,
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -125,7 +125,7 @@ describe('graph/effect.ts', () => {
 
     it('applies weighted stereo mix when width = 0.5', async () => {
       const { output } = await renderWidth({
-        width: runtimeNumeric(undefined, 0.5),
+        width: 0.5 as Numeric<undefined>,
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -139,7 +139,7 @@ describe('graph/effect.ts', () => {
 
     it('passes through unmodified stereo signal when width = 1', async () => {
       const { input, output } = await renderWidth({
-        width: runtimeNumeric(undefined, 1),
+        width: 1 as Numeric<undefined>,
         inputChannels: 2,
         fill: (input) => {
           fillSignal(input.getChannelData(0), { sampleRate, frequency: 440 })
@@ -154,7 +154,7 @@ describe('graph/effect.ts', () => {
     it('keeps mono the same for any width', async () => {
       for (const widthValue of [-1, -0.5, 0, 0.5, 1]) {
         const { input, output } = await renderWidth({
-          width: runtimeNumeric(undefined, widthValue),
+          width: widthValue as Numeric<undefined>,
           inputChannels: 2,
           fill: (input) => {
             const mono = fillSignal(input.getChannelData(0), { sampleRate, frequency: 440 })
@@ -172,7 +172,7 @@ describe('graph/effect.ts', () => {
       // With upmixing, the output should be the same in both channels.
 
       const { input, output } = await renderWidth({
-        width: runtimeNumeric(undefined, 1),
+        width: 1 as Numeric<undefined>,
         inputChannels: 1,
         fill: (input) => {
           fillSignal(input.getChannelData(0), { sampleRate, frequency: 440 })
@@ -185,7 +185,7 @@ describe('graph/effect.ts', () => {
 
     it('does not clamp out-of-range width values', async () => {
       const expanded = await renderWidth({
-        width: runtimeNumeric(undefined, 1.5),
+        width: 1.5 as Numeric<undefined>,
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -197,7 +197,7 @@ describe('graph/effect.ts', () => {
       expect(average(expanded.output.getChannelData(1))).toBeCloseTo(-0.25, 3)
 
       const inverted = await renderWidth({
-        width: runtimeNumeric(undefined, -1.5),
+        width: -1.5 as Numeric<undefined>,
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -212,7 +212,7 @@ describe('graph/effect.ts', () => {
 
   describe('createDelayInstance', () => {
     it('supports delay times longer than one second', async () => {
-      const time = runtimeNumeric('s', 1.5)
+      const time = 1.5 as Numeric<'s'>
       const { output } = await renderDelay({ time })
 
       const channel = output.getChannelData(0)
@@ -220,7 +220,7 @@ describe('graph/effect.ts', () => {
         return Math.abs(value) > Math.abs(data[bestIndex]) ? index : bestIndex
       }, 0)
 
-      expect(peakIndex / sampleRate).toBeCloseTo(time.value, 2)
+      expect(peakIndex / sampleRate).toBeCloseTo(time, 2)
     })
   })
 })

--- a/packages/webaudio/test-browser/graph/effect.test.ts
+++ b/packages/webaudio/test-browser/graph/effect.test.ts
@@ -1,5 +1,5 @@
-import type { Numeric } from '@utility'
-import { numeric } from '@utility'
+import type { RuntimeNumeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { describe, expect, it } from 'vitest'
 import { createDelayInstance, createWidthInstance } from '../../src/graph/effect.js'
 import type { Transport } from '../../src/transport/transport.js'
@@ -22,7 +22,7 @@ function createTestTransport () {
 }
 
 async function renderWidth (options: {
-  readonly width: Numeric<undefined>
+  readonly width: RuntimeNumeric<undefined>
   readonly inputChannels: number
   readonly fill: (buffer: AudioBuffer) => void
 }): Promise<{
@@ -54,7 +54,7 @@ async function renderWidth (options: {
 }
 
 async function renderDelay (options: {
-  readonly time: Numeric<'s'>
+  readonly time: RuntimeNumeric<'s'>
 }): Promise<{
   readonly output: AudioBuffer
 }> {
@@ -97,7 +97,7 @@ describe('graph/effect.ts', () => {
   describe('createWidthInstance', () => {
     it('renders mono-compatible output when width = 0', async () => {
       const { output } = await renderWidth({
-        width: numeric(undefined, 0),
+        width: runtimeNumeric(undefined, 0),
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -111,7 +111,7 @@ describe('graph/effect.ts', () => {
 
     it('swaps stereo channels when width = -1', async () => {
       const { output } = await renderWidth({
-        width: numeric(undefined, -1),
+        width: runtimeNumeric(undefined, -1),
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -125,7 +125,7 @@ describe('graph/effect.ts', () => {
 
     it('applies weighted stereo mix when width = 0.5', async () => {
       const { output } = await renderWidth({
-        width: numeric(undefined, 0.5),
+        width: runtimeNumeric(undefined, 0.5),
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -139,7 +139,7 @@ describe('graph/effect.ts', () => {
 
     it('passes through unmodified stereo signal when width = 1', async () => {
       const { input, output } = await renderWidth({
-        width: numeric(undefined, 1),
+        width: runtimeNumeric(undefined, 1),
         inputChannels: 2,
         fill: (input) => {
           fillSignal(input.getChannelData(0), { sampleRate, frequency: 440 })
@@ -154,7 +154,7 @@ describe('graph/effect.ts', () => {
     it('keeps mono the same for any width', async () => {
       for (const widthValue of [-1, -0.5, 0, 0.5, 1]) {
         const { input, output } = await renderWidth({
-          width: numeric(undefined, widthValue),
+          width: runtimeNumeric(undefined, widthValue),
           inputChannels: 2,
           fill: (input) => {
             const mono = fillSignal(input.getChannelData(0), { sampleRate, frequency: 440 })
@@ -172,7 +172,7 @@ describe('graph/effect.ts', () => {
       // With upmixing, the output should be the same in both channels.
 
       const { input, output } = await renderWidth({
-        width: numeric(undefined, 1),
+        width: runtimeNumeric(undefined, 1),
         inputChannels: 1,
         fill: (input) => {
           fillSignal(input.getChannelData(0), { sampleRate, frequency: 440 })
@@ -185,7 +185,7 @@ describe('graph/effect.ts', () => {
 
     it('does not clamp out-of-range width values', async () => {
       const expanded = await renderWidth({
-        width: numeric(undefined, 1.5),
+        width: runtimeNumeric(undefined, 1.5),
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -197,7 +197,7 @@ describe('graph/effect.ts', () => {
       expect(average(expanded.output.getChannelData(1))).toBeCloseTo(-0.25, 3)
 
       const inverted = await renderWidth({
-        width: numeric(undefined, -1.5),
+        width: runtimeNumeric(undefined, -1.5),
         inputChannels: 2,
         fill: (input) => {
           input.getChannelData(0).fill(1)
@@ -212,7 +212,7 @@ describe('graph/effect.ts', () => {
 
   describe('createDelayInstance', () => {
     it('supports delay times longer than one second', async () => {
-      const time = numeric('s', 1.5)
+      const time = runtimeNumeric('s', 1.5)
       const { output } = await renderDelay({ time })
 
       const channel = output.getChannelData(0)

--- a/packages/webaudio/test-browser/transport/transport.test.ts
+++ b/packages/webaudio/test-browser/transport/transport.test.ts
@@ -1,4 +1,4 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import { describe, expect, it } from 'vitest'
 import { createOfflineTransport } from '../../src/transport/transport.js'
 
@@ -6,14 +6,14 @@ describe('transport/transport.ts', () => {
   describe('createOfflineTransport', () => {
     it('uses the immediate scheduler during offline rendering', async () => {
       const transport = createOfflineTransport({
-        duration: runtimeNumeric('s', 3),
+        duration: 3 as Numeric<'s'>,
         channels: 2,
         sampleRate: 44_100
       })
 
       const calls: number[] = []
-      transport.schedule(2, (time) => calls.push(time))
-      transport.schedule(1, (time) => calls.push(time))
+      transport.schedule(2 as Numeric<'s'>, (time) => calls.push(time))
+      transport.schedule(1 as Numeric<'s'>, (time) => calls.push(time))
 
       const buffer = await transport.render()
 
@@ -25,7 +25,7 @@ describe('transport/transport.ts', () => {
 
     it('tracks time during offline rendering', async () => {
       const transport = createOfflineTransport({
-        duration: runtimeNumeric('s', 3),
+        duration: 3 as Numeric<'s'>,
         channels: 2,
         sampleRate: 44_100
       })
@@ -34,10 +34,9 @@ describe('transport/transport.ts', () => {
       const trackedTime = transport.time.get()
 
       expect(trackedTime).toBeDefined()
-      expect(trackedTime?.unit).toBe('s')
 
       // 2 significant digits: 128 frames (one quantum) at 44.1kHz is approximately 2.9ms
-      expect(trackedTime?.value).toBeCloseTo(3, 2)
+      expect(trackedTime).toBeCloseTo(3, 2)
     })
   })
 })

--- a/packages/webaudio/test-browser/transport/transport.test.ts
+++ b/packages/webaudio/test-browser/transport/transport.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { describe, expect, it } from 'vitest'
 import { createOfflineTransport } from '../../src/transport/transport.js'
 
@@ -6,7 +6,7 @@ describe('transport/transport.ts', () => {
   describe('createOfflineTransport', () => {
     it('uses the immediate scheduler during offline rendering', async () => {
       const transport = createOfflineTransport({
-        duration: numeric('s', 3),
+        duration: runtimeNumeric('s', 3),
         channels: 2,
         sampleRate: 44_100
       })
@@ -25,7 +25,7 @@ describe('transport/transport.ts', () => {
 
     it('tracks time during offline rendering', async () => {
       const transport = createOfflineTransport({
-        duration: numeric('s', 3),
+        duration: runtimeNumeric('s', 3),
         channels: 2,
         sampleRate: 44_100
       })

--- a/packages/webaudio/test/assets/cache.test.ts
+++ b/packages/webaudio/test/assets/cache.test.ts
@@ -1,4 +1,4 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { createAssetCache } from '../../src/assets/cache.js'
@@ -6,16 +6,16 @@ import { createAssetCache } from '../../src/assets/cache.js'
 describe('assets/cache.ts', () => {
   it('returns nothing for missing keys', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 100),
-      getSize: (v) => v
+      maxSize: 100 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
     assert.strictEqual(cache.get('missing'), undefined)
   })
 
   it('stores and retrieves values', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 100),
-      getSize: (v) => v
+      maxSize: 100 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
     cache.set('a', 10)
     cache.set('b', 20)
@@ -25,8 +25,8 @@ describe('assets/cache.ts', () => {
 
   it('evicts least recently used items when exceeding max size', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 30),
-      getSize: (v) => v
+      maxSize: 30 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
     cache.set('a', 10)
     cache.set('b', 15)
@@ -48,8 +48,8 @@ describe('assets/cache.ts', () => {
 
   it('does not store items larger than max size', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 20),
-      getSize: (v) => v
+      maxSize: 20 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
     cache.set('a', 25) // Too large to store
     assert.strictEqual(cache.get('a'), undefined)
@@ -60,8 +60,8 @@ describe('assets/cache.ts', () => {
 
   it('deletes existing value when updated with an oversize item', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 20),
-      getSize: (v) => v
+      maxSize: 20 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
     cache.set('a', 10)
     assert.strictEqual(cache.get('a'), 10)
@@ -72,8 +72,8 @@ describe('assets/cache.ts', () => {
 
   it('replaces existing values without double-counting size', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 20),
-      getSize: (v) => v
+      maxSize: 20 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
 
     cache.set('a', 10)
@@ -89,8 +89,8 @@ describe('assets/cache.ts', () => {
 
   it('frees space for new entries when existing entries are shrunk', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 20),
-      getSize: (v) => v
+      maxSize: 20 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
 
     cache.set('a', 15)
@@ -107,8 +107,8 @@ describe('assets/cache.ts', () => {
 
   it('deletes keys', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 20),
-      getSize: (v) => v
+      maxSize: 20 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
     cache.set('a', 10)
     cache.set('b', 5)
@@ -120,8 +120,8 @@ describe('assets/cache.ts', () => {
 
   it('frees space when deleting keys', () => {
     const cache = createAssetCache<number>({
-      maxSize: runtimeNumeric('bytes', 20),
-      getSize: (v) => v
+      maxSize: 20 as Numeric<'bytes'>,
+      getSize: (v) => v as Numeric<'bytes'>
     })
     cache.set('a', 15)
     cache.set('b', 5)

--- a/packages/webaudio/test/assets/cache.test.ts
+++ b/packages/webaudio/test/assets/cache.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { createAssetCache } from '../../src/assets/cache.js'
@@ -6,7 +6,7 @@ import { createAssetCache } from '../../src/assets/cache.js'
 describe('assets/cache.ts', () => {
   it('returns nothing for missing keys', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 100),
+      maxSize: runtimeNumeric('bytes', 100),
       getSize: (v) => v
     })
     assert.strictEqual(cache.get('missing'), undefined)
@@ -14,7 +14,7 @@ describe('assets/cache.ts', () => {
 
   it('stores and retrieves values', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 100),
+      maxSize: runtimeNumeric('bytes', 100),
       getSize: (v) => v
     })
     cache.set('a', 10)
@@ -25,7 +25,7 @@ describe('assets/cache.ts', () => {
 
   it('evicts least recently used items when exceeding max size', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 30),
+      maxSize: runtimeNumeric('bytes', 30),
       getSize: (v) => v
     })
     cache.set('a', 10)
@@ -48,7 +48,7 @@ describe('assets/cache.ts', () => {
 
   it('does not store items larger than max size', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 20),
+      maxSize: runtimeNumeric('bytes', 20),
       getSize: (v) => v
     })
     cache.set('a', 25) // Too large to store
@@ -60,7 +60,7 @@ describe('assets/cache.ts', () => {
 
   it('deletes existing value when updated with an oversize item', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 20),
+      maxSize: runtimeNumeric('bytes', 20),
       getSize: (v) => v
     })
     cache.set('a', 10)
@@ -72,7 +72,7 @@ describe('assets/cache.ts', () => {
 
   it('replaces existing values without double-counting size', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 20),
+      maxSize: runtimeNumeric('bytes', 20),
       getSize: (v) => v
     })
 
@@ -89,7 +89,7 @@ describe('assets/cache.ts', () => {
 
   it('frees space for new entries when existing entries are shrunk', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 20),
+      maxSize: runtimeNumeric('bytes', 20),
       getSize: (v) => v
     })
 
@@ -107,7 +107,7 @@ describe('assets/cache.ts', () => {
 
   it('deletes keys', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 20),
+      maxSize: runtimeNumeric('bytes', 20),
       getSize: (v) => v
     })
     cache.set('a', 10)
@@ -120,7 +120,7 @@ describe('assets/cache.ts', () => {
 
   it('frees space when deleting keys', () => {
     const cache = createAssetCache<number>({
-      maxSize: numeric('bytes', 20),
+      maxSize: runtimeNumeric('bytes', 20),
       getSize: (v) => v
     })
     cache.set('a', 15)

--- a/packages/webaudio/test/graph/noise.test.ts
+++ b/packages/webaudio/test/graph/noise.test.ts
@@ -1,7 +1,7 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
+import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { generateReverbImpulseResponse } from '../../src/graph/noise.js'
-import assert from 'node:assert'
 
 class MockAudioBuffer {
   readonly length: number
@@ -39,7 +39,7 @@ describe('graph/noise.ts', () => {
   describe('generateReverbImpulseResponse', () => {
     it('generates an impulse response with the expected properties', () => {
       const sampleRate = 44_100
-      const decay = runtimeNumeric('s', 1.5)
+      const decay = 1.5 as Numeric<'s'>
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
@@ -48,7 +48,7 @@ describe('graph/noise.ts', () => {
         decay
       })
 
-      const expectedLength = Math.max(1, Math.floor(sampleRate * decay.value))
+      const expectedLength = Math.max(1, Math.floor(sampleRate * decay))
       assert.strictEqual(ir.length, expectedLength, `Expected impulse response length to be ${expectedLength}, but got ${ir.length}`)
 
       assert.strictEqual(ir.numberOfChannels, 4)
@@ -57,7 +57,7 @@ describe('graph/noise.ts', () => {
 
     it('generates an impulse response with a decaying envelope', () => {
       const sampleRate = 44_100
-      const decay = runtimeNumeric('s', 2)
+      const decay = 2 as Numeric<'s'>
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
@@ -78,7 +78,7 @@ describe('graph/noise.ts', () => {
 
     it('generates different noise for different channels', () => {
       const sampleRate = 44_100
-      const decay = runtimeNumeric('s', 1)
+      const decay = 1 as Numeric<'s'>
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
@@ -96,7 +96,7 @@ describe('graph/noise.ts', () => {
 
     it('handles long decay times without errors', () => {
       const sampleRate = 44_100
-      const decay = runtimeNumeric('s', 30)
+      const decay = 30 as Numeric<'s'>
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
@@ -105,7 +105,7 @@ describe('graph/noise.ts', () => {
         decay
       })
 
-      assert.strictEqual(ir.length, Math.max(1, Math.floor(sampleRate * decay.value)))
+      assert.strictEqual(ir.length, Math.max(1, Math.floor(sampleRate * decay)))
     })
   })
 })

--- a/packages/webaudio/test/graph/noise.test.ts
+++ b/packages/webaudio/test/graph/noise.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import { describe, it } from 'node:test'
 import { generateReverbImpulseResponse } from '../../src/graph/noise.js'
 import assert from 'node:assert'
@@ -39,7 +39,7 @@ describe('graph/noise.ts', () => {
   describe('generateReverbImpulseResponse', () => {
     it('generates an impulse response with the expected properties', () => {
       const sampleRate = 44_100
-      const decay = numeric('s', 1.5)
+      const decay = runtimeNumeric('s', 1.5)
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
@@ -57,7 +57,7 @@ describe('graph/noise.ts', () => {
 
     it('generates an impulse response with a decaying envelope', () => {
       const sampleRate = 44_100
-      const decay = numeric('s', 2)
+      const decay = runtimeNumeric('s', 2)
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
@@ -78,7 +78,7 @@ describe('graph/noise.ts', () => {
 
     it('generates different noise for different channels', () => {
       const sampleRate = 44_100
-      const decay = numeric('s', 1)
+      const decay = runtimeNumeric('s', 1)
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,
@@ -96,7 +96,7 @@ describe('graph/noise.ts', () => {
 
     it('handles long decay times without errors', () => {
       const sampleRate = 44_100
-      const decay = numeric('s', 30)
+      const decay = runtimeNumeric('s', 30)
 
       const ir = generateReverbImpulseResponse({
         createBuffer: (options) => new MockAudioBuffer(options) as any as AudioBuffer,

--- a/packages/webaudio/test/transport/scheduler.test.ts
+++ b/packages/webaudio/test/transport/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { numeric } from '@utility'
+import { runtimeNumeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { createImmediateScheduler, createRealtimeScheduler } from '../../src/transport/scheduler.js'
@@ -15,8 +15,8 @@ describe('transport/scheduler.ts', () => {
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: numeric('s', 0.01),
-        scheduleAheadTime: numeric('s', 0.05),
+        tickInterval: runtimeNumeric('s', 0.01),
+        scheduleAheadTime: runtimeNumeric('s', 0.05),
 
         timers: {
           setInterval: ((handler: unknown) => {
@@ -61,8 +61,8 @@ describe('transport/scheduler.ts', () => {
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: numeric('s', 0.01),
-        scheduleAheadTime: numeric('s', 0.05),
+        tickInterval: runtimeNumeric('s', 0.01),
+        scheduleAheadTime: runtimeNumeric('s', 0.05),
 
         timers: {
           setInterval: (() => 1) as unknown as SetInterval,
@@ -91,8 +91,8 @@ describe('transport/scheduler.ts', () => {
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: numeric('s', 0.01),
-        scheduleAheadTime: numeric('s', 0.05),
+        tickInterval: runtimeNumeric('s', 0.01),
+        scheduleAheadTime: runtimeNumeric('s', 0.05),
 
         timers: {
           setInterval: ((handler: unknown) => {
@@ -127,8 +127,8 @@ describe('transport/scheduler.ts', () => {
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: numeric('s', 0.01),
-        scheduleAheadTime: numeric('s', 0.05),
+        tickInterval: runtimeNumeric('s', 0.01),
+        scheduleAheadTime: runtimeNumeric('s', 0.05),
 
         timers: {
           setInterval: ((handler: unknown) => {
@@ -161,8 +161,8 @@ describe('transport/scheduler.ts', () => {
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: numeric('s', 0.01),
-        scheduleAheadTime: numeric('s', 0.05),
+        tickInterval: runtimeNumeric('s', 0.01),
+        scheduleAheadTime: runtimeNumeric('s', 0.05),
 
         timers: {
           setInterval: ((handler: unknown) => {

--- a/packages/webaudio/test/transport/scheduler.test.ts
+++ b/packages/webaudio/test/transport/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { runtimeNumeric } from '@utility'
+import type { Numeric } from '@utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { createImmediateScheduler, createRealtimeScheduler } from '../../src/transport/scheduler.js'
@@ -9,14 +9,14 @@ type ClearInterval = typeof globalThis.clearInterval
 describe('transport/scheduler.ts', () => {
   describe('createRealtimeScheduler', () => {
     it('runs callbacks shortly before their target time', () => {
-      let nowSeconds = 10
+      let nowSeconds = 10 as Numeric<'s'>
 
       let intervalCallback: (() => void) | undefined
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: runtimeNumeric('s', 0.01),
-        scheduleAheadTime: runtimeNumeric('s', 0.05),
+        tickInterval: 0.01 as Numeric<'s'>,
+        scheduleAheadTime: 0.05 as Numeric<'s'>,
 
         timers: {
           setInterval: ((handler: unknown) => {
@@ -30,25 +30,25 @@ describe('transport/scheduler.ts', () => {
         }
       })
 
-      scheduler.start(10)
+      scheduler.start(10 as Numeric<'s'>)
 
       let called = false
       let callNow: number | undefined
       let targetTime: number | undefined
 
-      scheduler.schedule(1, (time) => {
+      scheduler.schedule(1 as Numeric<'s'>, (time) => {
         called = true
         callNow = nowSeconds
         targetTime = time
       })
 
       // Not yet within the schedule-ahead window
-      nowSeconds = 10.9
+      nowSeconds = 10.9 as Numeric<'s'>
       intervalCallback?.()
       assert.strictEqual(called, false)
 
       // Enter the window: transportNow=0.96, threshold=1.01 -> event time 1 runs
-      nowSeconds = 10.96
+      nowSeconds = 10.96 as Numeric<'s'>
       intervalCallback?.()
 
       assert.strictEqual(called, true)
@@ -57,12 +57,12 @@ describe('transport/scheduler.ts', () => {
     })
 
     it('executes past events immediately on start', () => {
-      const nowSeconds = 10
+      const nowSeconds = 10 as Numeric<'s'>
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: runtimeNumeric('s', 0.01),
-        scheduleAheadTime: runtimeNumeric('s', 0.05),
+        tickInterval: 0.01 as Numeric<'s'>,
+        scheduleAheadTime: 0.05 as Numeric<'s'>,
 
         timers: {
           setInterval: (() => 1) as unknown as SetInterval,
@@ -73,26 +73,26 @@ describe('transport/scheduler.ts', () => {
       let called = false
       let targetTime = undefined
 
-      scheduler.schedule(-0.5, (time) => {
+      scheduler.schedule(-0.5 as Numeric<'s'>, (time) => {
         called = true
         targetTime = time
       })
 
-      scheduler.start(10)
+      scheduler.start(10 as Numeric<'s'>)
 
       assert.strictEqual(called, true)
       assert.strictEqual(targetTime, 9.5)
     })
 
     it('preserves chronological callback order', () => {
-      let nowSeconds = 10
+      let nowSeconds = 10 as Numeric<'s'>
 
       let intervalCallback: (() => void) | undefined
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: runtimeNumeric('s', 0.01),
-        scheduleAheadTime: runtimeNumeric('s', 0.05),
+        tickInterval: 0.01 as Numeric<'s'>,
+        scheduleAheadTime: 0.05 as Numeric<'s'>,
 
         timers: {
           setInterval: ((handler: unknown) => {
@@ -108,27 +108,27 @@ describe('transport/scheduler.ts', () => {
 
       // Schedule out of order before start
       const calls: number[] = []
-      scheduler.schedule(2, (time) => calls.push(time))
-      scheduler.schedule(1, (time) => calls.push(time))
+      scheduler.schedule(2 as Numeric<'s'>, (time) => calls.push(time))
+      scheduler.schedule(1 as Numeric<'s'>, (time) => calls.push(time))
 
-      scheduler.start(10)
+      scheduler.start(10 as Numeric<'s'>)
 
       // Move time until both are within the window
-      nowSeconds = 11.96 // transportNow=1.96 -> threshold=2.01
+      nowSeconds = 11.96 as Numeric<'s'> // transportNow=1.96 -> threshold=2.01
       intervalCallback?.()
 
       assert.deepStrictEqual(calls, [11, 12])
     })
 
     it('preserves chronological callback order for events scheduled after start', () => {
-      let nowSeconds = 10
+      let nowSeconds = 10 as Numeric<'s'>
 
       let intervalCallback: (() => void) | undefined
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: runtimeNumeric('s', 0.01),
-        scheduleAheadTime: runtimeNumeric('s', 0.05),
+        tickInterval: 0.01 as Numeric<'s'>,
+        scheduleAheadTime: 0.05 as Numeric<'s'>,
 
         timers: {
           setInterval: ((handler: unknown) => {
@@ -144,25 +144,25 @@ describe('transport/scheduler.ts', () => {
 
       const calls: number[] = []
 
-      scheduler.start(10)
-      scheduler.schedule(2, (time) => calls.push(time))
-      scheduler.schedule(1, (time) => calls.push(time))
+      scheduler.start(10 as Numeric<'s'>)
+      scheduler.schedule(2 as Numeric<'s'>, (time) => calls.push(time))
+      scheduler.schedule(1 as Numeric<'s'>, (time) => calls.push(time))
 
-      nowSeconds = 11.96
+      nowSeconds = 11.96 as Numeric<'s'>
       intervalCallback?.()
 
       assert.deepStrictEqual(calls, [11, 12])
     })
 
     it('does not run callbacks after stop', () => {
-      let nowSeconds = 10
+      let nowSeconds = 10 as Numeric<'s'>
 
       let intervalCallback: (() => void) | undefined
 
       const scheduler = createRealtimeScheduler({
         now: () => nowSeconds,
-        tickInterval: runtimeNumeric('s', 0.01),
-        scheduleAheadTime: runtimeNumeric('s', 0.05),
+        tickInterval: 0.01 as Numeric<'s'>,
+        scheduleAheadTime: 0.05 as Numeric<'s'>,
 
         timers: {
           setInterval: ((handler: unknown) => {
@@ -178,11 +178,11 @@ describe('transport/scheduler.ts', () => {
 
       const calls: number[] = []
 
-      scheduler.start(10)
+      scheduler.start(10 as Numeric<'s'>)
       scheduler.stop()
 
-      nowSeconds = 10.96
-      scheduler.schedule(1, (time) => calls.push(time))
+      nowSeconds = 10.96 as Numeric<'s'>
+      scheduler.schedule(1 as Numeric<'s'>, (time) => calls.push(time))
       scheduler.flush()
       intervalCallback?.()
 
@@ -195,10 +195,10 @@ describe('transport/scheduler.ts', () => {
       const scheduler = createImmediateScheduler()
 
       const calls: number[] = []
-      scheduler.schedule(2, (time) => calls.push(time))
-      scheduler.schedule(1, (time) => calls.push(time))
+      scheduler.schedule(2 as Numeric<'s'>, (time) => calls.push(time))
+      scheduler.schedule(1 as Numeric<'s'>, (time) => calls.push(time))
 
-      scheduler.start(10)
+      scheduler.start(10 as Numeric<'s'>)
 
       assert.deepStrictEqual(calls, [11, 12])
     })
@@ -207,10 +207,10 @@ describe('transport/scheduler.ts', () => {
       const scheduler = createImmediateScheduler()
 
       const calls: number[] = []
-      scheduler.start(10)
+      scheduler.start(10 as Numeric<'s'>)
 
-      scheduler.schedule(2, (time) => calls.push(time))
-      scheduler.schedule(1, (time) => calls.push(time))
+      scheduler.schedule(2 as Numeric<'s'>, (time) => calls.push(time))
+      scheduler.schedule(1 as Numeric<'s'>, (time) => calls.push(time))
 
       assert.deepStrictEqual(calls, [12, 11])
     })
@@ -219,10 +219,10 @@ describe('transport/scheduler.ts', () => {
       const scheduler = createImmediateScheduler()
 
       const calls: number[] = []
-      scheduler.start(10)
+      scheduler.start(10 as Numeric<'s'>)
       scheduler.stop()
 
-      scheduler.schedule(1, (time) => calls.push(time))
+      scheduler.schedule(1 as Numeric<'s'>, (time) => calls.push(time))
       scheduler.flush()
 
       assert.deepStrictEqual(calls, [])


### PR DESCRIPTION
RuntimeNumeric has overhead due to the object construction. Most callees
do not need dynamic unit information and can hence use a simpler branded
type. This also improves the ergonomics as the branded type can be used
directly in calculations instead of having to access its value property.

This PR introduces the type split and migrates many usages of
RuntimeNumeric, though many remain for future migration.