### PR TITLE
feat: Add open-source license information

### DIFF
--- a/container/nginx-server.conf
+++ b/container/nginx-server.conf
@@ -2,6 +2,7 @@ map $sent_http_content_type $expires {
     default                     off;
 
     ~*^text/html                epoch;
+    ~*^text/markdown            epoch;
     ~*^text/css                 max;
     ~*^application/javascript   max;
     ~*^text/javascript          max;
@@ -20,6 +21,10 @@ map $sent_http_content_type $expires {
     ~*^application/vnd\.ms-fontobject max;
 }
 
+types {
+    text/markdown md;
+}
+
 server {
     listen       80;
     server_name  localhost;
@@ -28,6 +33,7 @@ server {
 
     charset_types
         text/html
+        text/markdown
         text/css
         text/plain
         application/javascript

--- a/packages/app/src/modules/settings/SettingsPanel.tsx
+++ b/packages/app/src/modules/settings/SettingsPanel.tsx
@@ -30,6 +30,11 @@ export const SettingsPanel: FunctionComponent<PanelProps> = () => {
             <GitHub className='mr-2' />
             github.com/meyfa/cadence
           </a>
+
+          <p>
+            This app uses open-source libraries.
+            Please see: <a href='/license.md' target='_blank' rel='noreferrer' className='outline-none hocus:underline text-content-200 hocus:text-content-300'>licenses</a>
+          </p>
         </Card>
       </div>
     </div>

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -29,6 +29,10 @@ const config = defineConfig({
   build: {
     outDir: 'dist',
 
+    license: {
+      fileName: 'license.md'
+    },
+
     rolldownOptions: {
       output: {
         codeSplitting: {


### PR DESCRIPTION
Vite is configured to generate a license.md file during the build, which can be viewed in the app's settings panel. It contains the license texts of all bundled dependencies.