### PR TITLE
feat: Add label property to Instrument

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -61,7 +61,7 @@ function getNodeLabel ({ data }: MixerFlowNode): string | undefined {
       return data.object.name
 
     case 'instrument':
-      return undefined // TODO: Find a way to describe the instrument
+      return data.object.label
   }
 }
 
@@ -268,10 +268,11 @@ const BusNodeInfo: FunctionComponent<{
 const InstrumentNodeInfo: FunctionComponent<{
   object: Instrument
   program: Program
-}> = () => {
+}> = ({ object }) => {
   return (
     <>
       <div className='font-bold'>(Instrument)</div>
+      <div>{object.label}</div>
     </>
   )
 }

--- a/packages/core/src/program/instruments.ts
+++ b/packages/core/src/program/instruments.ts
@@ -8,6 +8,7 @@ export type InstrumentId = Brand<number, 'core.InstrumentId'>
 
 export interface Instrument {
   readonly id: InstrumentId
+  readonly label?: string
   readonly gain: Parameter<'db'>
   readonly trigger: (note: NoteData, tempo: Numeric<'bpm'>) => readonly Voice[]
 }

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -33,6 +33,12 @@ const OscillatorInstrumentType = makeType(InstrumentFacet, RecordFacet.with({
   gain: ParameterFacet.with('db').type()
 }))
 
+function getSampleInstrumentLabel (url: string): string {
+  const lastSlashIndex = url.lastIndexOf('/')
+  const filename = lastSlashIndex !== -1 ? url.slice(lastSlashIndex + 1) : url
+  return `sample(${filename})`
+}
+
 const sample = Functions.of({
   summary: 'Creates a sample-backed instrument from a URL.',
 
@@ -67,6 +73,8 @@ const sample = Functions.of({
     const invalidLength = lengthValue != null && (!Number.isFinite(lengthValue) || lengthValue <= 0)
 
     const instrument = context.allocateInstrument({
+      label: getSampleInstrumentLabel(urlValue),
+
       gain: gainParameter,
 
       trigger: (note, tempo) => {
@@ -124,6 +132,8 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
       const gainParameter = context.allocateParameter('db', gainValue)
 
       const instrument = context.allocateInstrument({
+        label: shape,
+
         gain: gainParameter,
 
         trigger: (note, tempo) => {

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -61,6 +61,7 @@ describe('library/modules/instruments.ts', () => {
 
       assert.deepStrictEqual(instrument, {
         id: instrument.id,
+        label: 'sample(kick.wav)',
         gain: {
           id: instrument.gain.id,
           unit: 'db',
@@ -104,6 +105,7 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
+        label: 'sample(snare.wav)',
         gain: {
           id: instrument.gain.id,
           unit: 'db',
@@ -167,6 +169,7 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
+        label: 'sine',
         gain: {
           id: instrument.gain.id,
           unit: 'db',
@@ -213,6 +216,7 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
+        label: 'square',
         gain: {
           id: instrument.gain.id,
           unit: 'db',
@@ -259,6 +263,7 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
+        label: 'saw',
         gain: {
           id: instrument.gain.id,
           unit: 'db',
@@ -305,6 +310,7 @@ describe('library/modules/instruments.ts', () => {
       const { id, ...instrument } = InstrumentFacet.get(result)
 
       assert.deepStrictEqual(instrument, {
+        label: 'triangle',
         gain: {
           id: instrument.gain.id,
           unit: 'db',


### PR DESCRIPTION
This is intended to provide a minimum amount of context until a more robust solution can be found for making instruments identifiable in the mixer panel.