### PR TITLE
feat!: Require envelope and output in voices

### DIFF
--- a/packages/audiograph/src/lowering.ts
+++ b/packages/audiograph/src/lowering.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Oscillator, Program, Sample, Track, Voice } from '@meyfa/cadence-core'
+import type { Bus, BusId, Effect, Instrument, InstrumentId, MixerRouting, Oscillator, Program, Sample, Track, VoiceInstance } from '@meyfa/cadence-core'
 import { calculateTotalLength, dbToGain, renderPatternEvents, timeToSeconds } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
 import { computeParameterCurve, feedbackTransform, frequencyTransform, gainTransform, panTransform, transformCurve } from './automation.ts'
@@ -119,10 +119,13 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
     trigger: (note) => {
       const result: SourceNode[] = []
 
-      for (const voice of instrument.trigger(note, program.track.tempo)) {
-        if (voice.duration == null || voice.duration > 0) {
-          result.push(createSourceNode(voice))
+      for (const voice of instrument.voices) {
+        const instance = voice.invoke(note, program.track.tempo)
+        if (instance.duration != null && instance.duration <= 0) {
+          continue
         }
+
+        result.push(createSourceNode(instance))
       }
 
       return result
@@ -142,17 +145,17 @@ function createInstrument (program: Program, instrument: Instrument, builder: Bu
   }
 }
 
-function createSourceNode (voice: Voice): SourceNode {
+function createSourceNode (voice: VoiceInstance): SourceNode {
   switch (voice.source.type) {
     case 'sample':
-      return createSampleSourceNode(voice as Voice<Sample>)
+      return createSampleSourceNode(voice as VoiceInstance<Sample>)
 
     case 'oscillator':
-      return createOscillatorSourceNode(voice as Voice<Oscillator>)
+      return createOscillatorSourceNode(voice as VoiceInstance<Oscillator>)
   }
 }
 
-function createSampleSourceNode (voice: Voice<Sample>): SourceNode {
+function createSampleSourceNode (voice: VoiceInstance<Sample>): SourceNode {
   const { assetId, playbackRate } = voice.source
 
   if (playbackRate <= 0 || !Number.isFinite(playbackRate)) {
@@ -168,7 +171,7 @@ function createSampleSourceNode (voice: Voice<Sample>): SourceNode {
   }
 }
 
-function createOscillatorSourceNode (voice: Voice<Oscillator>): SourceNode {
+function createOscillatorSourceNode (voice: VoiceInstance<Oscillator>): SourceNode {
   const { shape, frequency } = voice.source
 
   if (frequency <= 0 || !Number.isFinite(frequency)) {

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -199,15 +199,17 @@ describe('lowering.ts', () => {
               unit: 'db',
               initial: db(-6)
             },
-            trigger: () => [
+            voices: [
               {
-                envelope: SIMPLE_CURVE,
-                source: {
-                  type: 'oscillator',
-                  shape: 'sine',
-                  frequency: hz(440)
-                },
-                duration: seconds(1)
+                invoke: () => ({
+                  envelope: SIMPLE_CURVE,
+                  source: {
+                    type: 'oscillator',
+                    shape: 'sine',
+                    frequency: hz(440)
+                  },
+                  duration: seconds(1)
+                })
               }
             ]
           } satisfies Instrument
@@ -351,7 +353,7 @@ describe('lowering.ts', () => {
               unit: 'db',
               initial: db(-6)
             },
-            trigger: () => []
+            voices: []
           } satisfies Instrument
         ]
       ]),
@@ -440,7 +442,7 @@ describe('lowering.ts', () => {
               unit: 'db',
               initial: db(-6)
             },
-            trigger: () => []
+            voices: []
           } satisfies Instrument
         ]
       ]),
@@ -521,7 +523,7 @@ describe('lowering.ts', () => {
         unit: 'db',
         initial: db(-Infinity)
       },
-      trigger: () => []
+      voices: []
     })
 
     assert.doesNotThrow(() => createAudioGraph(program))
@@ -536,7 +538,7 @@ describe('lowering.ts', () => {
           unit: 'db',
           initial: db(gain)
         },
-        trigger: () => []
+        voices: []
       })
 
       assert.throws(() => createAudioGraph(program), /Invalid gain/, `should throw for gain: ${gain}`)
@@ -575,14 +577,16 @@ describe('lowering.ts', () => {
           unit: 'db',
           initial: db(-6)
         },
-        trigger: () => [
+        voices: [
           {
-            envelope: curve,
-            source: {
-              type: 'oscillator',
-              shape: 'sine',
-              frequency: hz(440)
-            }
+            invoke: () => ({
+              envelope: curve,
+              source: {
+                type: 'oscillator',
+                shape: 'sine',
+                frequency: hz(440)
+              }
+            })
           }
         ]
       })
@@ -601,14 +605,16 @@ describe('lowering.ts', () => {
 
   it('should skip voices with negative or zero duration', () => {
     const makeVoice = (frequency: Numeric<'hz'>, duration: Numeric<'s'> | undefined) => ({
-      envelope: SIMPLE_CURVE,
-      source: {
-        type: 'oscillator',
-        shape: 'sine',
-        frequency
-      },
-      duration
-    } as const)
+      invoke: () => ({
+        envelope: SIMPLE_CURVE,
+        source: {
+          type: 'oscillator',
+          shape: 'sine',
+          frequency
+        },
+        duration
+      } as const)
+    })
 
     const program = createProgramWithInstrument({
       id: 100 as InstrumentId,
@@ -617,7 +623,7 @@ describe('lowering.ts', () => {
         unit: 'db',
         initial: db(-6)
       },
-      trigger: () => [
+      voices: [
         makeVoice(hz(100), seconds(-1)),
         makeVoice(hz(200), seconds(0)),
         makeVoice(hz(300), seconds(1)),
@@ -649,15 +655,17 @@ describe('lowering.ts', () => {
           unit: 'db',
           initial: db(-6)
         },
-        trigger: () => [
+        voices: [
           {
-            envelope: SIMPLE_CURVE,
-            source: {
-              type: 'sample',
-              assetId: 300 as AssetId,
-              length: seconds(-1),
-              playbackRate: scalar(playbackRate)
-            }
+            invoke: () => ({
+              envelope: SIMPLE_CURVE,
+              source: {
+                type: 'sample',
+                assetId: 300 as AssetId,
+                length: seconds(-1),
+                playbackRate: scalar(playbackRate)
+              }
+            })
           }
         ]
       }, {
@@ -687,14 +695,16 @@ describe('lowering.ts', () => {
           unit: 'db',
           initial: db(-6)
         },
-        trigger: () => [
+        voices: [
           {
-            envelope: SIMPLE_CURVE,
-            source: {
-              type: 'oscillator',
-              shape: 'sine',
-              frequency: hz(frequency)
-            }
+            invoke: () => ({
+              envelope: SIMPLE_CURVE,
+              source: {
+                type: 'oscillator',
+                shape: 'sine',
+                frequency: hz(frequency)
+              }
+            })
           }
         ]
       })
@@ -1586,7 +1596,7 @@ describe('lowering.ts', () => {
           unit: 'db',
           initial: db(-6)
         },
-        trigger: () => []
+        voices: []
       }))
 
       assert.strictEqual(graph.meters.size, 0)
@@ -1608,7 +1618,7 @@ describe('lowering.ts', () => {
                 unit: 'db',
                 initial: db(-6)
               },
-              trigger: () => []
+              voices: []
             } satisfies Instrument
           ]
         ]),
@@ -1705,7 +1715,7 @@ describe('lowering.ts', () => {
         unit: 'db',
         initial: db(-6)
       },
-      trigger: () => []
+      voices: []
     })
 
     for (const interval of [Infinity, -Infinity, Number.NaN, 0, -1]) {

--- a/packages/core/src/program/instruments.ts
+++ b/packages/core/src/program/instruments.ts
@@ -10,10 +10,14 @@ export interface Instrument {
   readonly id: InstrumentId
   readonly label?: string
   readonly gain: Parameter<'db'>
-  readonly trigger: (note: NoteData, tempo: Numeric<'bpm'>) => readonly Voice[]
+  readonly voices: readonly Voice[]
 }
 
-export interface Voice<S extends Source = Source> {
+export interface Voice {
+  readonly invoke: (note: NoteData, tempo: Numeric<'bpm'>) => VoiceInstance
+}
+
+export interface VoiceInstance<S extends Source = Source> {
   readonly source: S
   readonly envelope: Curve<'s', 'db'>
   readonly duration?: Numeric<'s'>

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -722,6 +722,14 @@ function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileE
     }
   }
 
+  if (!hasEnvelope) {
+    errors.push(new CompileError('Voice is missing an envelope', voice.range))
+  }
+
+  if (!hasOutput) {
+    errors.push(new CompileError('Voice is missing an output', voice.range))
+  }
+
   return errors
 }
 

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -1,5 +1,5 @@
 import { ast } from '@meyfa/cadence-ast'
-import type { Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, Part, Pattern, Program, Source, Step, Track, Voice } from '@meyfa/cadence-core'
+import type { Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, NoteData, Part, Pattern, Program, Source, Step, Track, Voice, VoiceInstance } from '@meyfa/cadence-core'
 import { beatsToSeconds, concatPatterns, convertPitchToMidi, createParallelPattern, createSerialPattern, getMidiFrequency, mergePatterns } from '@meyfa/cadence-core'
 import type { Numeric, RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
@@ -537,7 +537,7 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   const instrumentScope = createLocalScope(scope)
 
-  const voiceConstructors: Array<(note: NoteValue, tempo: Numeric<'bpm'>) => readonly Voice[]> = []
+  const voices: Voice[] = []
 
   for (const child of expression.children) {
     switch (child.type) {
@@ -546,8 +546,7 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
         break
 
       case 'VoiceStatement': {
-        const frozenScope = cloneScope(instrumentScope)
-        voiceConstructors.push((note, tempo) => generateVoice(frozenScope, child, note, tempo))
+        voices.push(generateVoice(instrumentScope, child))
         break
       }
 
@@ -557,54 +556,68 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   }
 
   const gainParameter = scope.top.allocateParameter('db', 0 as Numeric<'db'>)
-
-  const instrument = scope.top.allocateInstrument({
-    gain: gainParameter,
-    trigger: (note, tempo) => {
-      if (voiceConstructors.length === 0) {
-        return []
-      }
-
-      const gate = Numbers.of(runtimeNumeric('beats', note.gate ?? 0 as Numeric<'beats'>))
-      const frequency = Numbers.of(
-        runtimeNumeric('hz', getMidiFrequency(note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE))
-      )
-      const velocity = Numbers.of(runtimeNumeric(undefined, note.velocity))
-
-      const noteBinding = noteType.of({ gate, frequency, velocity })
-
-      return voiceConstructors.flatMap((create) => create(noteBinding, tempo))
-    }
-  })
+  const instrument = scope.top.allocateInstrument({ gain: gainParameter, voices })
 
   return InstrumentFacet.type().of(instrument)
 }
 
-function generateVoice (scope: Scope, voice: ast.VoiceStatement, note: NoteValue, tempo: Numeric<'bpm'>): readonly Voice[] {
-  const voiceScope = createLocalScope(scope)
+function generateVoice (scope: Scope, voice: ast.VoiceStatement): Voice {
+  const frozenScope: Scope = cloneScope(scope)
 
-  if (voice.bindings.note != null) {
-    assert(!voiceScope.resolutions.has(voice.bindings.note.name))
-    voiceScope.resolutions.set(voice.bindings.note.name, note)
+  const invoke: Voice['invoke'] = (note, tempo) => {
+    const instanceScope = createLocalScope(frozenScope)
+
+    if (voice.bindings.note != null) {
+      const noteBinding = createNoteBinding(note)
+
+      assert(!instanceScope.resolutions.has(voice.bindings.note.name))
+      instanceScope.resolutions.set(voice.bindings.note.name, noteBinding)
+    }
+
+    return createVoiceInstance(voice, instanceScope, tempo)
   }
 
+  return { invoke }
+}
+
+const noteBindingCache = new WeakMap<NoteData, NoteValue>()
+
+function createNoteBinding (note: NoteData): NoteValue {
+  const cached = noteBindingCache.get(note)
+  if (cached != null) {
+    return cached
+  }
+
+  const gate = Numbers.of(runtimeNumeric('beats', note.gate ?? 0 as Numeric<'beats'>))
+  const frequency = Numbers.of(
+    runtimeNumeric('hz', getMidiFrequency(note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE))
+  )
+  const velocity = Numbers.of(runtimeNumeric(undefined, note.velocity))
+
+  const binding = noteType.of({ gate, frequency, velocity })
+  noteBindingCache.set(note, binding)
+
+  return binding
+}
+
+function createVoiceInstance (voice: ast.VoiceStatement, scope: MutableScope, tempo: Numeric<'bpm'>): VoiceInstance {
   let envelopeValue: Curve<'db'> | undefined
   let outputValue: Source | undefined
 
   for (const child of voice.children) {
     switch (child.type) {
       case 'Assignment':
-        processAssignment(voiceScope, child)
+        processAssignment(scope, child)
         break
 
       case 'EnvelopeStatement':
         assert(envelopeValue == null)
-        envelopeValue = CurveFacet.with('db').get(resolve(voiceScope, child.expression))
+        envelopeValue = CurveFacet.with('db').get(resolve(scope, child.expression))
         break
 
       case 'OutputStatement':
         assert(outputValue == null)
-        outputValue = SourceFacet.get(resolve(voiceScope, child.expression))
+        outputValue = SourceFacet.get(resolve(scope, child.expression))
         break
 
       default:
@@ -612,9 +625,8 @@ function generateVoice (scope: Scope, voice: ast.VoiceStatement, note: NoteValue
     }
   }
 
-  if (outputValue == null || envelopeValue == null) {
-    return []
-  }
+  assert(envelopeValue != null)
+  assert(outputValue != null)
 
   const envelope = {
     initial: -Infinity as Numeric<'db'>,
@@ -624,13 +636,11 @@ function generateVoice (scope: Scope, voice: ast.VoiceStatement, note: NoteValue
     })
   }
 
-  return [
-    {
-      envelope,
-      source: outputValue,
-      duration: envelope.points.at(-1)?.time
-    }
-  ]
+  return {
+    envelope,
+    source: outputValue,
+    duration: envelope.points.at(-1)?.time
+  }
 }
 
 function computeUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Value {

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -1,4 +1,4 @@
-import type { Oscillator } from '@meyfa/cadence-core'
+import type { AssetId, MidiNote, Oscillator, Voice } from '@meyfa/cadence-core'
 import { beatsToSeconds, convertPitchToMidi, getMidiFrequency, isPitch } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
 import type { AssetContext, InstrumentContext, ParameterContext } from '../../compiler/generator/scopes.ts'
@@ -39,6 +39,60 @@ function getSampleInstrumentLabel (url: string): string {
   return `sample(${filename})`
 }
 
+function createSampleVoice (assetId: AssetId, rootNote: MidiNote, length: Numeric<'s'> | undefined): Voice {
+  const invoke: Voice['invoke'] = (note, tempo) => {
+    const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNote
+    const playbackRate = Math.pow(2, (midiNote - rootNote) / 12) as Numeric<undefined>
+
+    const gate: Numeric<'s'> | undefined = (() => {
+      if (note.gate == null) {
+        return length
+      }
+      const gateSeconds = beatsToSeconds(note.gate, tempo)
+      return length == null ? gateSeconds : Math.min(gateSeconds, length) as Numeric<'s'>
+    })()
+
+    const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
+    const duration = gate != null ? envelope.points.at(-1)?.time : undefined
+
+    return {
+      envelope,
+      source: {
+        type: 'sample',
+        assetId,
+        length,
+        playbackRate
+      },
+      duration
+    }
+  }
+
+  return { invoke }
+}
+
+function createOscillatorVoice (shape: Oscillator['shape']): Voice {
+  const invoke: Voice['invoke'] = (note, tempo) => {
+    const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE
+    const frequency = getMidiFrequency(midiNote)
+
+    const gate = note.gate != null ? beatsToSeconds(note.gate, tempo) : undefined
+    const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
+    const duration = gate != null ? envelope.points.at(-1)?.time : undefined
+
+    return {
+      envelope,
+      source: {
+        type: 'oscillator',
+        shape,
+        frequency
+      },
+      duration
+    }
+  }
+
+  return { invoke }
+}
+
 const sample = Functions.of({
   summary: 'Creates a sample-backed instrument from a URL.',
 
@@ -61,54 +115,18 @@ const sample = Functions.of({
       return string != null && isPitch(string) ? string : undefined
     })()
     const lengthValue = length != null ? NumberFacet.get(length).value : undefined
-
     const gainParameter = context.allocateParameter('db', gainValue)
-
-    const asset = context.allocateAsset({
-      url: urlValue
-    })
-
+    const asset = context.allocateAsset({ url: urlValue })
     const rootNoteMidi = rootNote != null ? convertPitchToMidi(rootNote) : DEFAULT_ROOT_NOTE
 
-    const invalidLength = lengthValue != null && (!Number.isFinite(lengthValue) || lengthValue <= 0)
+    const voices = lengthValue == null || (Number.isFinite(lengthValue) && lengthValue > 0)
+      ? [createSampleVoice(asset.id, rootNoteMidi, lengthValue)]
+      : []
 
     const instrument = context.allocateInstrument({
       label: getSampleInstrumentLabel(urlValue),
-
       gain: gainParameter,
-
-      trigger: (note, tempo) => {
-        if (invalidLength) {
-          return []
-        }
-
-        const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : rootNoteMidi
-        const playbackRate = Math.pow(2, (midiNote - rootNoteMidi) / 12) as Numeric<undefined>
-
-        const gate: Numeric<'s'> | undefined = (() => {
-          if (note.gate == null) {
-            return lengthValue
-          }
-          const gateSeconds = beatsToSeconds(note.gate, tempo)
-          return lengthValue == null ? gateSeconds : Math.min(gateSeconds, lengthValue) as Numeric<'s'>
-        })()
-
-        const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
-        const duration = gate != null ? envelope.points.at(-1)?.time : undefined
-
-        return [
-          {
-            envelope,
-            source: {
-              type: 'sample',
-              assetId: asset.id,
-              length: lengthValue,
-              playbackRate
-            },
-            duration
-          }
-        ]
-      }
+      voices
     })
 
     return SampleInstrumentType.of(instrument, {
@@ -131,31 +149,12 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
       const gainValue = gain != null ? NumberFacet.get(gain).value : UNITY_GAIN
       const gainParameter = context.allocateParameter('db', gainValue)
 
+      const voices = [createOscillatorVoice(shape)]
+
       const instrument = context.allocateInstrument({
         label: shape,
-
         gain: gainParameter,
-
-        trigger: (note, tempo) => {
-          const midiNote = note.pitch != null ? convertPitchToMidi(note.pitch) : DEFAULT_ROOT_NOTE
-          const frequency = getMidiFrequency(midiNote)
-
-          const gate = note.gate != null ? beatsToSeconds(note.gate, tempo) : undefined
-          const envelope = applyEnvelope(ENVELOPE_DECLICK, { velocity: note.velocity, gate })
-          const duration = gate != null ? envelope.points.at(-1)?.time : undefined
-
-          return [
-            {
-              envelope,
-              source: {
-                type: 'oscillator',
-                shape,
-                frequency
-              },
-              duration
-            }
-          ]
-        }
+        voices
       })
 
       return OscillatorInstrumentType.of(instrument, {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -309,6 +309,18 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should allow instrument definitions without voices', () => {
+      const source = [
+        'use "sources" as src',
+        '',
+        'my_instrument = instrument {',
+        '  foo = -6.db',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should allow valid instrument definitions', () => {
       const source = [
         'use "sources" as src',
@@ -320,7 +332,6 @@ describe('compiler/checker/checker.ts', () => {
         '    envelope ~[lin(0.db, -60.db):100.ms]',
         '    output src.sine(bar)',
         '  }',
-        '  voice note {}',
         '  voice note {',
         '    baz = note',
         '    note_frequency = note.frequency',
@@ -788,6 +799,7 @@ describe('compiler/checker/checker.ts', () => {
         '  voice {',
         '    bar = 440.hz',
         '    bar = 880.hz',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
         '    output src.sine(440)',
         '  }',
         '}'
@@ -796,6 +808,21 @@ describe('compiler/checker/checker.ts', () => {
       assertErrorMessages(source, [
         'Identifier "bar" is already defined',
         'Expected type number(hz), got number'
+      ])
+    })
+
+    it('should reject empty voice', () => {
+      const source = [
+        'use "sources" as src',
+        '',
+        'my_instrument = instrument {',
+        '  voice {}',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Voice is missing an envelope',
+        'Voice is missing an output'
       ])
     })
 
@@ -819,10 +846,17 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject accessing note from another voice', () => {
       const source = [
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
-        '  voice note {}',
+        '  voice note {',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    output src.sine(440.hz)',
+        '  }',
         '  voice {',
         '    baz = note',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    output src.sine(440.hz)',
         '  }',
         '}'
       ].join('\n')
@@ -834,15 +868,20 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject reassignment of the note binding', () => {
       const source = [
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
         '  voice note {',
         '    note = 440.hz',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    output src.sine(note)',
         '  }',
         '}'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Identifier "note" is already defined'
+        'Identifier "note" is already defined',
+        'Expected type number(hz), got record(frequency, gate, velocity)'
       ])
     })
 
@@ -859,16 +898,20 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Multiple output statements in a voice'
+        'Multiple output statements in a voice',
+        'Voice is missing an envelope'
       ])
     })
 
     it('should reject multiple envelopes in a voice', () => {
       const source = [
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
         '  voice {',
         '    envelope ~[lin(0.db, -60.db):100.ms]',
         '    envelope ~[lin(-60.db, 0.db):100.ms]',
+        '    output src.sine(440.hz)',
         '  }',
         '}'
       ].join('\n')
@@ -881,9 +924,13 @@ describe('compiler/checker/checker.ts', () => {
     it('should reject blocking effects in non-blocking contexts', () => {
       const source = [
         'use "instruments" as *',
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
         '  voice {',
         '    foo = sample("piano.wav")',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    output src.sine(440.hz)',
         '  }',
         '}'
       ].join('\n')
@@ -895,9 +942,13 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject instrument expressions in non-blocking contexts', () => {
       const source = [
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
         '  voice {',
         '    foo = instrument {}',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    output src.sine(440.hz)',
         '  }',
         '}'
       ].join('\n')
@@ -953,9 +1004,13 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should enforce ordering within instrument definitions', () => {
       const source = [
+        'use "sources" as src',
+        '',
         'my_instrument = instrument {',
         '  voice {',
         '    bar = foo',
+        '    envelope ~[lin(0.db, -60.db):100.ms]',
+        '    output src.sine(440.hz)',
         '  }',
         '  foo = -6.db',
         '}'

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -103,10 +103,11 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: scalar(1) }, DEFAULT_TEMPO)
-    assert.strictEqual(voices.length, 1)
-    assert.strictEqual(voices[0].source.type, 'sample')
-    assert.strictEqual(voices[0].source.assetId, asset.id)
+    assert.strictEqual(instrument.voices.length, 1)
+
+    const voice = instrument.voices[0].invoke({ velocity: scalar(1) }, DEFAULT_TEMPO)
+    assert.strictEqual(voice.source.type, 'sample')
+    assert.strictEqual(voice.source.assetId, asset.id)
   })
 
   it('should support import aliases', () => {
@@ -122,10 +123,10 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(asset.url, 'kick.wav')
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: scalar(1) }, DEFAULT_TEMPO)
-    assert.strictEqual(voices.length, 1)
-    assert.strictEqual(voices[0].source.type, 'sample')
-    assert.strictEqual(voices[0].source.assetId, asset.id)
+    assert.strictEqual(instrument.voices.length, 1)
+
+    const voice = instrument.voices[0].invoke({ velocity: scalar(1) }, DEFAULT_TEMPO)
+    assert.strictEqual(voice.source.type, 'sample')
   })
 
   it('should support shadowing of imported names', () => {
@@ -722,19 +723,10 @@ describe('compiler/generator/generator.ts', () => {
     })
   })
 
-  it('should generate silent instruments', () => {
+  it('should generate instrument without voices', () => {
     const source = [
       'my_instrument = instrument {',
       '  foo = -6.db',
-      '  voice {',
-      '    bar = 440.hz',
-      '  }',
-      '  voice note {',
-      '    baz = note',
-      '    note_frequency = note.frequency',
-      '    note_gate = note.gate',
-      '    note_velocity = note.velocity',
-      '  }',
       '}'
     ].join('\n')
 
@@ -742,8 +734,7 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.instruments.size, 1)
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: scalar(1) }, DEFAULT_TEMPO)
-    assert.strictEqual(voices.length, 0)
+    assert.deepStrictEqual(instrument.voices, [])
   })
 
   it('should generate instruments with voices', () => {
@@ -755,8 +746,10 @@ describe('compiler/generator/generator.ts', () => {
       '    output src.sine(440.hz)',
       '  }',
       '  voice note {',
+      '    n = note',
+      '    f = n.frequency',
       '    envelope ~[lin(0.db, -60.db):1.beat]',
-      '    output src.sine(note.frequency)',
+      '    output src.sine(f)',
       '  }',
       '}'
     ].join('\n')
@@ -768,10 +761,11 @@ describe('compiler/generator/generator.ts', () => {
     const pitchFrequency = getMidiFrequency(convertPitchToMidi(pitch))
 
     const [instrument] = result.instruments.values()
-    const voices = instrument.trigger({ velocity: scalar(1), pitch }, DEFAULT_TEMPO)
-    assert.strictEqual(voices.length, 2)
+    assert.strictEqual(instrument.voices.length, 2)
 
-    const [voice0, voice1] = voices
+    const voice0 = instrument.voices[0].invoke({ velocity: scalar(1), pitch }, DEFAULT_TEMPO)
+    const voice1 = instrument.voices[1].invoke({ velocity: scalar(1), pitch }, DEFAULT_TEMPO)
+
     assert.deepStrictEqual(voice0.envelope.points, [
       { time: seconds(0), value: db(0), shape: 'step' },
       { time: seconds(0.5), value: db(-60), shape: 'linear' }

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -87,12 +87,12 @@ describe('compiler/generator/scopes.ts', () => {
 
       const instrument0 = {
         gain: scope.allocateParameter('db', db(-6)),
-        trigger: () => []
+        voices: []
       } satisfies Omit<Instrument, 'id'>
 
       const instrument1 = {
         gain: scope.allocateParameter('db', db(-3)),
-        trigger: () => []
+        voices: []
       } satisfies Omit<Instrument, 'id'>
 
       const allocated0 = scope.allocateInstrument(instrument0)

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -67,21 +67,23 @@ describe('library/modules/instruments.ts', () => {
           unit: 'db',
           initial: db(-3)
         },
-        trigger: instrument.trigger
+        voices: [
+          {
+            invoke: instrument.voices[0].invoke
+          }
+        ]
       } satisfies Instrument)
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: scalar(1) }, DEFAULT_TEMPO), [
-        {
-          envelope: declickEnvelope(),
-          duration: seconds(1.503),
-          source: {
-            type: 'sample',
-            assetId: asset.id,
-            length: seconds(1.5),
-            playbackRate: scalar(1)
-          }
+      assert.deepStrictEqual(instrument.voices[0].invoke({ velocity: scalar(1) }, DEFAULT_TEMPO), {
+        envelope: declickEnvelope(),
+        duration: seconds(1.503),
+        source: {
+          type: 'sample',
+          assetId: asset.id,
+          length: seconds(1.5),
+          playbackRate: scalar(1)
         }
-      ])
+      })
 
       assert.deepStrictEqual([...context.instruments], [
         [instrument.id, InstrumentFacet.get(result)]
@@ -111,29 +113,31 @@ describe('library/modules/instruments.ts', () => {
           unit: 'db',
           initial: db(0)
         },
-        trigger: instrument.trigger
+        voices: [
+          {
+            invoke: instrument.voices[0].invoke
+          }
+        ]
       })
 
-      assert.deepStrictEqual(instrument.trigger({ velocity: scalar(1) }, DEFAULT_TEMPO), [
-        {
-          envelope: applyEnvelope({
-            attack: seconds(0.003),
-            decay: seconds(0),
-            sustain: db(0),
-            release: seconds(0.003)
-          }, {
-            gate: undefined,
-            velocity: scalar(1)
-          }),
-          duration: undefined,
-          source: {
-            type: 'sample',
-            assetId: asset.id,
-            length: undefined,
-            playbackRate: scalar(1)
-          }
+      assert.deepStrictEqual(instrument.voices[0].invoke({ velocity: scalar(1) }, DEFAULT_TEMPO), {
+        envelope: applyEnvelope({
+          attack: seconds(0.003),
+          decay: seconds(0),
+          sustain: db(0),
+          release: seconds(0.003)
+        }, {
+          gate: undefined,
+          velocity: scalar(1)
+        }),
+        duration: undefined,
+        source: {
+          type: 'sample',
+          assetId: asset.id,
+          length: undefined,
+          playbackRate: scalar(1)
         }
-      ])
+      })
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -152,9 +156,7 @@ describe('library/modules/instruments.ts', () => {
         })
 
         const instrument = InstrumentFacet.get(result)
-        const voices = instrument.trigger({ velocity: scalar(1) }, DEFAULT_TEMPO)
-
-        assert.strictEqual(voices.length, 0)
+        assert.strictEqual(instrument.voices.length, 0)
       }
     })
   })
@@ -175,28 +177,30 @@ describe('library/modules/instruments.ts', () => {
           unit: 'db',
           initial: db(0)
         },
-        trigger: instrument.trigger
+        voices: [
+          {
+            invoke: instrument.voices[0].invoke
+          }
+        ]
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), [
-        {
-          envelope: applyEnvelope({
-            attack: seconds(0.003),
-            decay: seconds(0),
-            sustain: db(0),
-            release: seconds(0.003)
-          }, {
-            gate: undefined,
-            velocity: scalar(1)
-          }),
-          duration: undefined,
-          source: {
-            type: 'oscillator',
-            shape: 'sine',
-            frequency: hz(440)
-          }
+      assert.deepStrictEqual(instrument.voices[0].invoke({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), {
+        envelope: applyEnvelope({
+          attack: seconds(0.003),
+          decay: seconds(0),
+          sustain: db(0),
+          release: seconds(0.003)
+        }, {
+          gate: undefined,
+          velocity: scalar(1)
+        }),
+        duration: undefined,
+        source: {
+          type: 'oscillator',
+          shape: 'sine',
+          frequency: hz(440)
         }
-      ])
+      })
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -222,28 +226,30 @@ describe('library/modules/instruments.ts', () => {
           unit: 'db',
           initial: db(0)
         },
-        trigger: instrument.trigger
+        voices: [
+          {
+            invoke: instrument.voices[0].invoke
+          }
+        ]
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), [
-        {
-          envelope: applyEnvelope({
-            attack: seconds(0.003),
-            decay: seconds(0),
-            sustain: db(0),
-            release: seconds(0.003)
-          }, {
-            gate: undefined,
-            velocity: scalar(1)
-          }),
-          duration: undefined,
-          source: {
-            type: 'oscillator',
-            shape: 'square',
-            frequency: hz(440)
-          }
+      assert.deepStrictEqual(instrument.voices[0].invoke({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), {
+        envelope: applyEnvelope({
+          attack: seconds(0.003),
+          decay: seconds(0),
+          sustain: db(0),
+          release: seconds(0.003)
+        }, {
+          gate: undefined,
+          velocity: scalar(1)
+        }),
+        duration: undefined,
+        source: {
+          type: 'oscillator',
+          shape: 'square',
+          frequency: hz(440)
         }
-      ])
+      })
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -269,28 +275,30 @@ describe('library/modules/instruments.ts', () => {
           unit: 'db',
           initial: db(0)
         },
-        trigger: instrument.trigger
+        voices: [
+          {
+            invoke: instrument.voices[0].invoke
+          }
+        ]
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), [
-        {
-          envelope: applyEnvelope({
-            attack: seconds(0.003),
-            decay: seconds(0),
-            sustain: db(0),
-            release: seconds(0.003)
-          }, {
-            gate: undefined,
-            velocity: scalar(1)
-          }),
-          duration: undefined,
-          source: {
-            type: 'oscillator',
-            shape: 'saw',
-            frequency: hz(440)
-          }
+      assert.deepStrictEqual(instrument.voices[0].invoke({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), {
+        envelope: applyEnvelope({
+          attack: seconds(0.003),
+          decay: seconds(0),
+          sustain: db(0),
+          release: seconds(0.003)
+        }, {
+          gate: undefined,
+          velocity: scalar(1)
+        }),
+        duration: undefined,
+        source: {
+          type: 'oscillator',
+          shape: 'saw',
+          frequency: hz(440)
         }
-      ])
+      })
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]
@@ -316,28 +324,30 @@ describe('library/modules/instruments.ts', () => {
           unit: 'db',
           initial: db(0)
         },
-        trigger: instrument.trigger
+        voices: [
+          {
+            invoke: instrument.voices[0].invoke
+          }
+        ]
       })
 
-      assert.deepStrictEqual(instrument.trigger({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), [
-        {
-          envelope: applyEnvelope({
-            attack: seconds(0.003),
-            decay: seconds(0),
-            sustain: db(0),
-            release: seconds(0.003)
-          }, {
-            gate: undefined,
-            velocity: scalar(1)
-          }),
-          duration: undefined,
-          source: {
-            type: 'oscillator',
-            shape: 'triangle',
-            frequency: hz(440)
-          }
+      assert.deepStrictEqual(instrument.voices[0].invoke({ pitch: 'A4', velocity: scalar(1) }, DEFAULT_TEMPO), {
+        envelope: applyEnvelope({
+          attack: seconds(0.003),
+          decay: seconds(0),
+          sustain: db(0),
+          release: seconds(0.003)
+        }, {
+          gate: undefined,
+          velocity: scalar(1)
+        }),
+        duration: undefined,
+        source: {
+          type: 'oscillator',
+          shape: 'triangle',
+          frequency: hz(440)
         }
-      ])
+      })
 
       assert.deepStrictEqual([...context.instruments], [
         [id, InstrumentFacet.get(result)]

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -40,7 +40,7 @@ const effect: Effect = {
 const instrument: Instrument = {
   id: 1 as InstrumentId,
   gain: gainParameter,
-  trigger: () => []
+  voices: []
 }
 
 const part: Part = {


### PR DESCRIPTION
Before this change, voices without `envelope` and/or `output` would stay silent without providing feedback to the user. Now, such voices will fail to compile such that the user is informed of the issue.