### PR TITLE
feat: Add Voice type to compiler

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -95,7 +95,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Identifier | Number | String | Pattern | Curve | Instrument
+export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -162,11 +162,11 @@ export interface AutomateStatement extends ASTNode {
 
 export interface Instrument extends ASTNode {
   readonly type: 'Instrument'
-  readonly children: ReadonlyArray<Assignment | VoiceStatement>
+  readonly children: ReadonlyArray<Assignment | Voice>
 }
 
-export interface VoiceStatement extends ASTNode {
-  readonly type: 'VoiceStatement'
+export interface Voice extends ASTNode {
+  readonly type: 'Voice'
   readonly children: ReadonlyArray<Assignment | EnvelopeStatement | OutputStatement>
   readonly bindings: {
     readonly note?: Identifier
@@ -238,7 +238,7 @@ export interface NodeByType {
   AutomateStatement: AutomateStatement
 
   Instrument: Instrument
-  VoiceStatement: VoiceStatement
+  Voice: Voice
   EnvelopeStatement: EnvelopeStatement
   OutputStatement: OutputStatement
 

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -113,7 +113,7 @@ argumentList {
 }
 
 primary {
-  "(" expression ")" | Number | String | Pattern | Curve | Instrument | Call | VariableName | BusNamespace
+  "(" expression ")" | Number | String | Pattern | Curve | Instrument | Voice | Call | VariableName | BusNamespace
 }
 
 Call {
@@ -217,11 +217,11 @@ EffectStatement {
 Instrument {
   kw<"instrument">
   InstrumentBlock[group=Block] {
-    "{" (Assignment | VoiceStatement)* "}"
+    "{" (Assignment | Voice)* "}"
   }
 }
 
-VoiceStatement {
+Voice {
   kw<"voice">
   VariableDefinition?
   VoiceBlock[group=Block] {

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -123,7 +123,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
-      case 'VoiceStatement': {
+      case 'Voice': {
         const scope = addScope({ kind: 'voice', range, parentId: scopeId })
         nextScopeId = scope.id
         break
@@ -180,7 +180,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
             break
           }
 
-          case 'VoiceStatement': {
+          case 'Voice': {
             addBinding({ kind: 'regular', scopeId, name, range: nameRange })
             break
           }

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -32,6 +32,7 @@ import { isSyntaxUnit, toBaseUnit } from '../units.ts'
 import { checkCyclicRoutings } from './routings.ts'
 import type { MutableNamespace, MutableScope, Scope } from './scopes.ts'
 import { createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
+import { VoiceFacet } from '../../type-system/domain/voice.ts'
 
 export type CheckedProgram = Brand<ast.Program, 'language.CheckedProgram'>
 export type CheckResult = Result<CheckedProgram, CompoundError<CompileError>>
@@ -441,6 +442,9 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
 
 function checkExpression (scope: Scope, expression: ast.Expression): Checked<FacetType> {
   switch (expression.type) {
+    case 'Identifier':
+      return checkIdentifier(scope, expression)
+
     case 'Number':
       return checkNumber(scope, expression)
 
@@ -456,8 +460,8 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
     case 'Instrument':
       return checkInstrument(scope, expression)
 
-    case 'Identifier':
-      return checkIdentifier(scope, expression)
+    case 'Voice':
+      return checkVoice(scope, expression)
 
     case 'UnaryExpression':
       return checkUnaryExpression(scope, expression)
@@ -471,6 +475,15 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
     case 'Call':
       return checkCall(scope, expression)
   }
+}
+
+function checkIdentifier (scope: Scope, identifier: ast.Identifier): Checked<FacetType> {
+  const valueType = resolveInScope(scope, identifier.name)
+  if (valueType == null) {
+    return { errors: [new CompileError(`Unknown identifier "${identifier.name}"`, identifier.range)] }
+  }
+
+  return { errors: [], result: valueType }
 }
 
 function checkNumber (scope: Scope, number: ast.Number): Checked<FacetType> {
@@ -654,9 +667,11 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
         errors.push(...checkAssignment(instrumentScope, child))
         break
 
-      case 'VoiceStatement':
-        errors.push(...checkVoice(instrumentScope, child))
+      case 'Voice': {
+        const voiceCheck = checkVoice(instrumentScope, child)
+        errors.push(...voiceCheck.errors)
         break
+      }
 
       default:
         assertNever(child)
@@ -666,7 +681,7 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
   return { errors, result: InstrumentFacet.type() }
 }
 
-function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileError[] {
+function checkVoice (scope: Scope, voice: ast.Voice): Checked<FacetType> {
   const voiceScope = createLocalScope(scope, { blocking: false })
   const errors: CompileError[] = []
 
@@ -730,16 +745,7 @@ function checkVoice (scope: Scope, voice: ast.VoiceStatement): readonly CompileE
     errors.push(new CompileError('Voice is missing an output', voice.range))
   }
 
-  return errors
-}
-
-function checkIdentifier (scope: Scope, identifier: ast.Identifier): Checked<FacetType> {
-  const valueType = resolveInScope(scope, identifier.name)
-  if (valueType == null) {
-    return { errors: [new CompileError(`Unknown identifier "${identifier.name}"`, identifier.range)] }
-  }
-
-  return { errors: [], result: valueType }
+  return { errors, result: VoiceFacet.type() }
 }
 
 function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -19,6 +19,7 @@ import { ParameterFacet } from '../../type-system/domain/parameter.ts'
 import { PartFacet } from '../../type-system/domain/part.ts'
 import { PatternFacet } from '../../type-system/domain/pattern.ts'
 import { SourceFacet } from '../../type-system/domain/source.ts'
+import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeType } from '../../type-system/factory.ts'
 import { Curves, Numbers, Parameters } from '../../type-system/helpers.ts'
 import type { InferSchema, Schema } from '../../type-system/schema.ts'
@@ -392,6 +393,9 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
  */
 function resolve (scope: Scope, expression: ast.Expression): Value {
   switch (expression.type) {
+    case 'Identifier':
+      return resolveIdentifier(scope, expression)
+
     case 'Number':
       return toNumberValue(scope.top.options, undefined, expression.value)
 
@@ -407,8 +411,8 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
     case 'Instrument':
       return generateInstrument(scope, expression)
 
-    case 'Identifier':
-      return resolveIdentifier(scope, expression)
+    case 'Voice':
+      return generateVoice(scope, expression)
 
     case 'UnaryExpression':
       return computeUnaryExpression(scope, expression)
@@ -545,8 +549,8 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
         processAssignment(instrumentScope, child)
         break
 
-      case 'VoiceStatement': {
-        voices.push(generateVoice(instrumentScope, child))
+      case 'Voice': {
+        voices.push(VoiceFacet.get(resolve(instrumentScope, child)))
         break
       }
 
@@ -561,7 +565,7 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   return InstrumentFacet.type().of(instrument)
 }
 
-function generateVoice (scope: Scope, voice: ast.VoiceStatement): Voice {
+function generateVoice (scope: Scope, voice: ast.Voice): Value {
   const frozenScope: Scope = cloneScope(scope)
 
   const invoke: Voice['invoke'] = (note, tempo) => {
@@ -577,7 +581,7 @@ function generateVoice (scope: Scope, voice: ast.VoiceStatement): Voice {
     return createVoiceInstance(voice, instanceScope, tempo)
   }
 
-  return { invoke }
+  return VoiceFacet.type().of({ invoke })
 }
 
 const noteBindingCache = new WeakMap<NoteData, NoteValue>()
@@ -600,7 +604,7 @@ function createNoteBinding (note: NoteData): NoteValue {
   return binding
 }
 
-function createVoiceInstance (voice: ast.VoiceStatement, scope: MutableScope, tempo: Numeric<'bpm'>): VoiceInstance {
+function createVoiceInstance (voice: ast.Voice, scope: MutableScope, tempo: Numeric<'bpm'>): VoiceInstance {
   let envelopeValue: Curve<'db'> | undefined
   let outputValue: Source | undefined
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -343,7 +343,8 @@ const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast
   string_,
   serialPattern_,
   curve_,
-  p.recursive(() => instrument_)
+  p.recursive(() => instrument_),
+  p.recursive(() => voice_)
 )
 
 const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
@@ -683,7 +684,7 @@ const envelopeStatement_: p.Parser<Token, unknown, ast.EnvelopeStatement> = p.ab
   }
 )
 
-const voiceStatement_: p.Parser<Token, unknown, ast.VoiceStatement> = p.abc(
+const voice_: p.Parser<Token, unknown, ast.Voice> = p.abc(
   keyword('voice'),
   p.option(identifier_, undefined),
   combine3(
@@ -694,7 +695,7 @@ const voiceStatement_: p.Parser<Token, unknown, ast.VoiceStatement> = p.abc(
     expectLiteral('}')
   ),
   (_voice, note, [_lp, children, _rp]) => {
-    return ast.make('VoiceStatement', combineSourceRanges(_voice, _rp), {
+    return ast.make('Voice', combineSourceRanges(_voice, _rp), {
       children,
       bindings: {
         note
@@ -708,7 +709,7 @@ const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.ab(
   combine3(
     expectLiteral('{'),
     p.many(
-      p.eitherOr(assignment_, voiceStatement_)
+      p.eitherOr(assignment_, voice_)
     ),
     expectLiteral('}')
   ),

--- a/packages/language/src/type-system/domain/voice.ts
+++ b/packages/language/src/type-system/domain/voice.ts
@@ -1,0 +1,6 @@
+import type { Voice } from '@meyfa/cadence-core'
+import { makeFacet } from '../factory.ts'
+
+const FACET_NAME = 'voice'
+
+export const VoiceFacet = makeFacet<typeof FACET_NAME, Voice>(FACET_NAME, {})

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -816,7 +816,7 @@ describe('parser/parser.ts', () => {
               }
             },
             {
-              type: 'VoiceStatement',
+              type: 'Voice',
               bindings: {
                 note: undefined
               },
@@ -833,7 +833,7 @@ describe('parser/parser.ts', () => {
               ]
             },
             {
-              type: 'VoiceStatement',
+              type: 'Voice',
               bindings: {
                 note: { type: 'Identifier', name: 'note' }
               },

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, Parameter, ParameterId, Part, Pattern } from '@meyfa/cadence-core'
+import type { Bus, BusId, Effect, Instrument, InstrumentId, Parameter, ParameterId, Part, Pattern, Source, Voice } from '@meyfa/cadence-core'
 import { createSerialPattern } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
@@ -12,6 +12,8 @@ import { InstrumentFacet } from '../../src/type-system/domain/instrument.ts'
 import { ParameterFacet } from '../../src/type-system/domain/parameter.ts'
 import { PartFacet } from '../../src/type-system/domain/part.ts'
 import { PatternFacet } from '../../src/type-system/domain/pattern.ts'
+import { SourceFacet } from '../../src/type-system/domain/source.ts'
+import { VoiceFacet } from '../../src/type-system/domain/voice.ts'
 import { expectTypeEquals } from '../test-utils.ts'
 
 const gainParameter: Parameter<'db'> = {
@@ -66,48 +68,62 @@ const bus: Bus = {
   effects: [effect]
 }
 
-describe('type-system/domain', () => {
-  describe('ParameterFacet', () => {
-    it('should support unit-specific parameters and detail()', () => {
-      const genericValue = ParameterFacet.type().of(gainParameter)
-      const decibelFacet = ParameterFacet.with('db')
-      const decibelType = decibelFacet.type()
-      const decibelValue = decibelType.of(gainParameter)
-      const parameterData = decibelFacet.get(decibelValue)
+const curve: Curve<'db'> = {
+  unit: 'db',
+  segments: [
+    {
+      type: 'hold',
+      length: runtimeNumeric('beats', 1),
+      unit: 'db',
+      value: runtimeNumeric('db', -6)
+    },
+    {
+      type: 'lin',
+      length: runtimeNumeric('beats', 2),
+      unit: 'db',
+      start: runtimeNumeric('db', -6),
+      end: runtimeNumeric('db', 0)
+    }
+  ]
+}
 
-      expectTypeEquals<Parameter<'db'>, typeof parameterData>()
-      assert.strictEqual(ParameterFacet.format(), 'parameter')
-      assert.strictEqual(ParameterFacet.with(undefined).format(), 'parameter')
-      assert.strictEqual(decibelFacet.format(), 'parameter(db)')
-      assert.strictEqual(ParameterFacet.has(decibelValue), true)
-      assert.strictEqual(decibelFacet.has(genericValue), false)
-      assert.strictEqual(ParameterFacet.detail(decibelType), 'db')
-      assert.strictEqual(parameterData.initial, -6)
-      assert.throws(() => ParameterFacet.detail(ParameterFacet.type()), /Invalid generics for parameter facet/)
+const source: Source = {
+  type: 'oscillator',
+  shape: 'sine',
+  frequency: 440 as Numeric<'hz'>
+}
+
+const voice: Voice = {
+  invoke: () => ({
+    source,
+    envelope: {
+      initial: 0 as Numeric<'db'>,
+      points: [
+        {
+          time: 0 as Numeric<'s'>,
+          value: 0 as Numeric<'db'>,
+          shape: 'step'
+        }
+      ]
+    }
+  })
+}
+
+describe('type-system/domain', () => {
+  describe('BusFacet', () => {
+    it('should format and round-trip bus values', () => {
+      const value = BusFacet.type().of(bus)
+      const busData = BusFacet.get(value)
+
+      expectTypeEquals<Bus, typeof busData>()
+      assert.strictEqual(BusFacet.format(), 'bus')
+      assert.strictEqual(BusFacet.has(value), true)
+      assert.strictEqual(busData, bus)
     })
   })
 
   describe('CurveFacet', () => {
     it('should support unit-specific curves and detail()', () => {
-      const curve: Curve<'db'> = {
-        unit: 'db',
-        segments: [
-          {
-            type: 'hold',
-            length: runtimeNumeric('beats', 1),
-            unit: 'db',
-            value: runtimeNumeric('db', -6)
-          },
-          {
-            type: 'lin',
-            length: runtimeNumeric('beats', 2),
-            unit: 'db',
-            start: runtimeNumeric('db', -6),
-            end: runtimeNumeric('db', 0)
-          }
-        ]
-      }
-
       const genericValue = CurveFacet.type().of(curve)
       const decibelFacet = CurveFacet.with('db')
       const decibelType = decibelFacet.type()
@@ -124,18 +140,6 @@ describe('type-system/domain', () => {
       assert.strictEqual(curveData.segments[0]?.unit, 'db')
       assert.strictEqual(curveData.segments[1]?.type, 'lin')
       assert.throws(() => CurveFacet.detail(CurveFacet.type()), /Invalid generics for curve facet/)
-    })
-  })
-
-  describe('BusFacet', () => {
-    it('should format and round-trip bus values', () => {
-      const value = BusFacet.type().of(bus)
-      const busData = BusFacet.get(value)
-
-      expectTypeEquals<Bus, typeof busData>()
-      assert.strictEqual(BusFacet.format(), 'bus')
-      assert.strictEqual(BusFacet.has(value), true)
-      assert.strictEqual(busData, bus)
     })
   })
 
@@ -164,6 +168,26 @@ describe('type-system/domain', () => {
     })
   })
 
+  describe('ParameterFacet', () => {
+    it('should support unit-specific parameters and detail()', () => {
+      const genericValue = ParameterFacet.type().of(gainParameter)
+      const decibelFacet = ParameterFacet.with('db')
+      const decibelType = decibelFacet.type()
+      const decibelValue = decibelType.of(gainParameter)
+      const parameterData = decibelFacet.get(decibelValue)
+
+      expectTypeEquals<Parameter<'db'>, typeof parameterData>()
+      assert.strictEqual(ParameterFacet.format(), 'parameter')
+      assert.strictEqual(ParameterFacet.with(undefined).format(), 'parameter')
+      assert.strictEqual(decibelFacet.format(), 'parameter(db)')
+      assert.strictEqual(ParameterFacet.has(decibelValue), true)
+      assert.strictEqual(decibelFacet.has(genericValue), false)
+      assert.strictEqual(ParameterFacet.detail(decibelType), 'db')
+      assert.strictEqual(parameterData.initial, -6)
+      assert.throws(() => ParameterFacet.detail(ParameterFacet.type()), /Invalid generics for parameter facet/)
+    })
+  })
+
   describe('PartFacet', () => {
     it('should format and round-trip part values', () => {
       const value = PartFacet.type().of(part)
@@ -186,6 +210,30 @@ describe('type-system/domain', () => {
       assert.strictEqual(PatternFacet.has(value), true)
       assert.strictEqual(patternData, pattern)
       assert.deepStrictEqual(Array.from(patternData.evaluate()), Array.from(pattern.evaluate()))
+    })
+  })
+
+  describe('SourceFacet', () => {
+    it('should format and round-trip source values', () => {
+      const value = SourceFacet.type().of(source)
+      const sourceData = SourceFacet.get(value)
+
+      expectTypeEquals<Source, typeof sourceData>()
+      assert.strictEqual(SourceFacet.format(), 'source')
+      assert.strictEqual(SourceFacet.has(value), true)
+      assert.strictEqual(sourceData, source)
+    })
+  })
+
+  describe('VoiceFacet', () => {
+    it('should format and round-trip voice values', () => {
+      const value = VoiceFacet.type().of(voice)
+      const voiceData = VoiceFacet.get(value)
+
+      expectTypeEquals<Voice, typeof voiceData>()
+      assert.strictEqual(VoiceFacet.format(), 'voice')
+      assert.strictEqual(VoiceFacet.has(value), true)
+      assert.strictEqual(voiceData, voice)
     })
   })
 })


### PR DESCRIPTION
Voices inside an instrument block are no longer treated as statements, but are instead a value type and resolved as such in the compiler.