### PR TITLE
feat: Add Track and Mixer types to compiler

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -95,7 +95,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice
+export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Track
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -122,8 +122,8 @@ export type ArgumentList = ReadonlyArray<Expression | Property>
 
 // Domain Types
 
-export interface TrackStatement extends ASTNode {
-  readonly type: 'TrackStatement'
+export interface Track extends ASTNode {
+  readonly type: 'Track'
   readonly properties: ArgumentList
   readonly children: ReadonlyArray<Assignment | PartStatement>
 }
@@ -135,8 +135,8 @@ export interface PartStatement extends ASTNode {
   readonly children: ReadonlyArray<Assignment | Routing | AutomateStatement>
 }
 
-export interface MixerStatement extends ASTNode {
-  readonly type: 'MixerStatement'
+export interface Mixer extends ASTNode {
+  readonly type: 'Mixer'
   readonly properties: ArgumentList
   readonly children: ReadonlyArray<Assignment | BusStatement>
 }
@@ -188,7 +188,7 @@ export interface OutputStatement extends ASTNode {
 export interface Program extends ASTNode {
   readonly type: 'Program'
   readonly imports: readonly UseStatement[]
-  readonly children: ReadonlyArray<Assignment | TrackStatement | MixerStatement>
+  readonly children: ReadonlyArray<Assignment | Track | Mixer>
 }
 
 // Factory
@@ -230,9 +230,9 @@ export interface NodeByType {
   Assignment: Assignment
   Routing: Routing
 
-  TrackStatement: TrackStatement
+  Track: Track
   PartStatement: PartStatement
-  MixerStatement: MixerStatement
+  Mixer: Mixer
   BusStatement: BusStatement
   EffectStatement: EffectStatement
   AutomateStatement: AutomateStatement

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -56,7 +56,7 @@ Unit[@dynamicPrecedence=1] {
 }
 
 @top Program {
-  (UseStatement | Assignment | TrackStatement | MixerStatement)*
+  (UseStatement | Assignment | Track | Mixer)*
 }
 
 interpolationExpression {
@@ -113,7 +113,18 @@ argumentList {
 }
 
 primary {
-  "(" expression ")" | Number | String | Pattern | Curve | Instrument | Voice | Call | VariableName | BusNamespace
+  "(" expression ")" |
+  Call |
+  VariableName |
+  BusNamespace |
+  Number |
+  String |
+  Curve |
+  Instrument |
+  Mixer |
+  Pattern |
+  Track |
+  Voice
 }
 
 Call {
@@ -175,7 +186,7 @@ Automation {
   expression
 }
 
-TrackStatement {
+Track {
   kw<"track">
   ("(" argumentList? ")")?
   TrackBlock[group=Block] {
@@ -192,7 +203,7 @@ PartStatement {
   }
 }
 
-MixerStatement {
+Mixer {
   kw<"mixer">
   ("(" argumentList? ")")?
   MixerBlock[group=Block] {

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -144,12 +144,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       }
 
       case 'VariableDefinition': {
-        // The parser can produce VariableDefinition nodes with trailing whitespace (possibly a bug).
-        // Example (emits "kick " with a trailing space):
-        //     track { part { kick } }
-        const rawName = document.sliceString(from, to)
-        const name = rawName.trimEnd()
-        const nameRange = toSourceRange(document, from, from + name.length)
+        const { name, range: nameRange } = getVariableName(document, from, to)
 
         switch (parentType) {
           case 'Assignment': {
@@ -198,8 +193,8 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       case 'Callee':
       case 'Member':
       case 'BusNamespace': {
-        const name = document.sliceString(from, to)
-        accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range, previousSibling })
+        const { name, range: nameRange } = getVariableName(document, from, to)
+        accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range: nameRange, previousSibling })
         break
       }
     }
@@ -257,6 +252,17 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
   sortByOffset(imports)
 
   return { rootScopeId, scopes, identifiers, bindings, imports }
+}
+
+function getVariableName (document: TextLike, from: number, to: number): Readonly<{ name: string, range: SourceRange }> {
+  // The parser can produce nodes with trailing whitespace (possibly a bug).
+  // Example (emits "kick " with a trailing space):
+  //     track { part { kick } }
+  const rawName = document.sliceString(from, to)
+  const name = rawName.trimEnd()
+  const range = toSourceRange(document, from, from + name.length)
+
+  return { name, range }
 }
 
 function sortByOffset (items: Array<{ readonly range: SourceRange }>): void {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -13,14 +13,17 @@ import { BusFacet } from '../../type-system/domain/bus.ts'
 import { CurveFacet } from '../../type-system/domain/curve.ts'
 import { EffectFacet } from '../../type-system/domain/effect.ts'
 import { InstrumentFacet } from '../../type-system/domain/instrument.ts'
+import { MixerFacet } from '../../type-system/domain/mixer.ts'
 import { ParameterFacet } from '../../type-system/domain/parameter.ts'
 import { PartFacet } from '../../type-system/domain/part.ts'
 import { PatternFacet } from '../../type-system/domain/pattern.ts'
 import { SourceFacet } from '../../type-system/domain/source.ts'
+import { TrackFacet } from '../../type-system/domain/track.ts'
+import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeType, makeUnion } from '../../type-system/factory.ts'
 import type { Schema, SchemaItem } from '../../type-system/schema.ts'
 import type { FacetType, Type, Value } from '../../type-system/types.ts'
-import { assertNever } from '../assert.ts'
+import { assertNever, nonNull } from '../assert.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
 import { BUS_NAMESPACE, busSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
 import { getCurveSegmentType } from '../curves.ts'
@@ -30,9 +33,8 @@ import { unaryOperations } from '../operators/unary.ts'
 import { resolveInScope } from '../resolution.ts'
 import { isSyntaxUnit, toBaseUnit } from '../units.ts'
 import { checkCyclicRoutings } from './routings.ts'
-import type { MutableNamespace, MutableScope, Scope } from './scopes.ts'
+import type { MutableScope, Scope } from './scopes.ts'
 import { createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
-import { VoiceFacet } from '../../type-system/domain/voice.ts'
 
 export type CheckedProgram = Brand<ast.Program, 'language.CheckedProgram'>
 export type CheckResult = Result<CheckedProgram, CompoundError<CompileError>>
@@ -70,21 +72,25 @@ export function check (program: ast.Program): CheckResult {
         errors.push(...checkAssignment(scope, child))
         break
 
-      case 'TrackStatement':
+      case 'Track': {
         if (hasTrack) {
           errors.push(new CompileError('Multiple track definitions', child.range))
         }
         hasTrack = true
-        errors.push(...checkTrack(scope, child))
+        const trackCheck = checkExpression(scope, child)
+        errors.push(...trackCheck.errors)
         break
+      }
 
-      case 'MixerStatement':
+      case 'Mixer': {
         if (hasMixer) {
           errors.push(new CompileError('Multiple mixer definitions', child.range))
         }
         hasMixer = true
-        errors.push(...checkMixer(scope, child, busNamespace))
+        const mixerCheck = checkExpression(scope, child)
+        errors.push(...mixerCheck.errors)
         break
+      }
 
       default:
         assertNever(child)
@@ -196,250 +202,6 @@ function checkAssignment (scope: MutableScope, assignment: ast.Assignment): read
   return errors
 }
 
-function checkTrack (scope: MutableScope, track: ast.TrackStatement): readonly CompileError[] {
-  const trackScope = createLocalScope(scope)
-  const errors: CompileError[] = []
-
-  errors.push(...checkArgumentList(trackScope, track.properties, trackSchema, track.range, 'property'))
-
-  const seenParts = new Set<string>()
-
-  for (const child of track.children) {
-    switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(trackScope, child))
-        break
-
-      case 'PartStatement': {
-        if (child.name != null) {
-          if (seenParts.has(child.name.name)) {
-            errors.push(new CompileError(`Duplicate part named "${child.name.name}"`, child.range))
-          } else if (trackScope.resolutions.has(child.name.name)) {
-            errors.push(new CompileError(`Part name "${child.name.name}" conflicts with existing identifier`, child.name.range))
-          }
-
-          seenParts.add(child.name.name)
-
-          // Reserve the name in the local scope
-          trackScope.resolutions.set(child.name.name, PartFacet.type())
-        }
-
-        errors.push(...checkPart(trackScope, child))
-        break
-      }
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  return errors
-}
-
-function checkPart (scope: Scope, part: ast.PartStatement): readonly CompileError[] {
-  const partScope = createLocalScope(scope)
-  const errors: CompileError[] = []
-
-  errors.push(...checkArgumentList(scope, part.properties, partSchema, part.range, 'property'))
-
-  for (const child of part.children) {
-    switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(partScope, child))
-        break
-
-      case 'Routing':
-        errors.push(...checkInstrumentRouting(partScope, child))
-        break
-
-      case 'AutomateStatement':
-        errors.push(...checkAutomation(partScope, child))
-        break
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  return errors
-}
-
-function checkInstrumentRouting (scope: Scope, routing: ast.Routing): readonly CompileError[] {
-  const errors: CompileError[] = []
-
-  const destination = resolveInScope(scope, routing.destination.name)
-  if (destination == null) {
-    errors.push(new CompileError(`Unknown identifier "${routing.destination.name}"`, routing.destination.range))
-  } else {
-    errors.push(...checkType(InstrumentFacet.type(), destination, routing.destination.range))
-  }
-
-  const sourceCheck = checkExpression(scope, routing.source)
-  errors.push(...sourceCheck.errors)
-  if (sourceCheck.result != null) {
-    errors.push(...checkType(PatternFacet.type(), sourceCheck.result, routing.source.range))
-  }
-
-  return errors
-}
-
-function checkAutomation (scope: Scope, automation: ast.AutomateStatement): readonly CompileError[] {
-  const errors: CompileError[] = []
-
-  const targetCheck = checkExpression(scope, automation.target)
-  errors.push(...targetCheck.errors)
-  if (targetCheck.result != null) {
-    errors.push(...checkType(ParameterFacet.type(), targetCheck.result, automation.target.range))
-  }
-
-  const curveCheck = checkExpression(scope, automation.curve)
-  errors.push(...curveCheck.errors)
-
-  if (curveCheck.result == null) {
-    return errors
-  }
-
-  let curveType = CurveFacet.type()
-
-  if (targetCheck.result != null && ParameterFacet.is(targetCheck.result)) {
-    const parameterType = ParameterFacet.detail(targetCheck.result)
-    curveType = CurveFacet.with(parameterType).type()
-  }
-
-  errors.push(...checkType(curveType, curveCheck.result, automation.curve.range))
-
-  return errors
-}
-
-function checkMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: MutableNamespace): readonly CompileError[] {
-  const mixerScope = createLocalScope(scope)
-  const errors: CompileError[] = []
-
-  errors.push(...checkArgumentList(mixerScope, mixer.properties, mixerSchema, mixer.range, 'property'))
-
-  const buses: ast.BusStatement[] = []
-  const seenBuses = new Map<string, FacetType>()
-
-  for (const child of mixer.children) {
-    switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(mixerScope, child))
-        break
-
-      case 'BusStatement': {
-        const bus = child
-        buses.push(bus)
-
-        if (seenBuses.has(bus.name.name)) {
-          errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
-        } else if (mixerScope.resolutions.has(bus.name.name)) {
-          errors.push(new CompileError(`Bus name "${bus.name.name}" conflicts with existing identifier`, bus.name.range))
-        }
-
-        const busCheck = checkBus(mixerScope, bus)
-        errors.push(...busCheck.errors)
-
-        const type = busCheck.result ?? BusFacet.type()
-        seenBuses.set(bus.name.name, type)
-        mixerScope.resolutions.set(bus.name.name, type)
-        mixerScope.top.buses.set(bus.name.name, type)
-        busNamespace.resolutions.set(bus.name.name, type)
-
-        break
-      }
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  errors.push(...checkCyclicRoutings(buses.map((bus) => ({
-    name: bus.name.name,
-    sources: bus.children.filter((child) => child.type === 'Identifier').map((source) => source.name),
-    range: bus.name.range
-  }))))
-
-  return errors
-}
-
-function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
-  const busScope = createLocalScope(scope)
-  const errors: CompileError[] = []
-
-  errors.push(...checkArgumentList(scope, bus.properties, busSchema, bus.range, 'property'))
-
-  const properties = {
-    gain: ParameterFacet.with('db').type(),
-    pan: ParameterFacet.with(undefined).type()
-  }
-
-  const record: Record<string, FacetType> = Object.create(null)
-  Object.assign(record, properties)
-
-  for (const child of bus.children) {
-    switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(busScope, child))
-        break
-
-      case 'Identifier': {
-        const sourceCheck = checkExpression(busScope, child)
-        errors.push(...sourceCheck.errors)
-
-        if (sourceCheck.result != null) {
-          const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
-          errors.push(...checkType(options, sourceCheck.result, child.range))
-        }
-
-        break
-      }
-
-      case 'EffectStatement': {
-        const effectCheck = checkExpression(busScope, child.expression)
-        errors.push(...effectCheck.errors)
-
-        let effectType: FacetType | undefined
-
-        if (effectCheck.result != null) {
-          const typeErrors = checkType(EffectFacet.type(), effectCheck.result, child.expression.range)
-          errors.push(...typeErrors)
-
-          if (typeErrors.length === 0) {
-            effectType = effectCheck.result
-          }
-        }
-
-        if (child.name == null) {
-          continue
-        }
-
-        if (Object.hasOwn(properties, child.name.name)) {
-          errors.push(new CompileError(`Effect name "${child.name.name}" conflicts with bus property of the same name`, child.name.range))
-          continue
-        }
-
-        if (Object.hasOwn(record, child.name.name)) {
-          errors.push(new CompileError(`Duplicate effect name "${child.name.name}"`, child.name.range))
-          continue
-        }
-
-        if (effectType != null) {
-          record[child.name.name] = effectType
-        }
-
-        break
-      }
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  const type = makeType(BusFacet, RecordFacet.with(record))
-
-  return { errors, result: type }
-}
-
 function checkExpression (scope: Scope, expression: ast.Expression): Checked<FacetType> {
   switch (expression.type) {
     case 'Identifier':
@@ -462,6 +224,12 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
 
     case 'Voice':
       return checkVoice(scope, expression)
+
+    case 'Mixer':
+      return checkMixer(scope, expression)
+
+    case 'Track':
+      return checkTrack(scope, expression)
 
     case 'UnaryExpression':
       return checkUnaryExpression(scope, expression)
@@ -746,6 +514,258 @@ function checkVoice (scope: Scope, voice: ast.Voice): Checked<FacetType> {
   }
 
   return { errors, result: VoiceFacet.type() }
+}
+
+function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
+  const mixerScope = createLocalScope(scope)
+  const errors: CompileError[] = []
+
+  if (!scope.allowedEffects.blocking) {
+    errors.push(new CompileError('Cannot construct a mixer in a realtime context', expression.range))
+  }
+
+  errors.push(...checkArgumentList(mixerScope, expression.properties, mixerSchema, expression.range, 'property'))
+
+  const busNamespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
+
+  const buses: ast.BusStatement[] = []
+
+  for (const child of expression.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(mixerScope, child))
+        break
+
+      case 'BusStatement': {
+        const bus = child
+        buses.push(bus)
+
+        if (busNamespace.resolutions.has(bus.name.name)) {
+          errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
+        } else if (mixerScope.resolutions.has(bus.name.name)) {
+          errors.push(new CompileError(`Bus name "${bus.name.name}" conflicts with existing identifier`, bus.name.range))
+        }
+
+        const busCheck = checkBus(mixerScope, bus)
+        errors.push(...busCheck.errors)
+
+        const type = busCheck.result ?? BusFacet.type()
+        mixerScope.resolutions.set(bus.name.name, type)
+        mixerScope.top.buses.set(bus.name.name, type)
+        busNamespace.resolutions.set(bus.name.name, type)
+
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  errors.push(...checkCyclicRoutings(buses.map((bus) => ({
+    name: bus.name.name,
+    sources: bus.children.filter((child) => child.type === 'Identifier').map((source) => source.name),
+    range: bus.name.range
+  }))))
+
+  return { errors, result: MixerFacet.type() }
+}
+
+function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
+  const busScope = createLocalScope(scope)
+  const errors: CompileError[] = []
+
+  errors.push(...checkArgumentList(scope, bus.properties, busSchema, bus.range, 'property'))
+
+  const properties = {
+    gain: ParameterFacet.with('db').type(),
+    pan: ParameterFacet.with(undefined).type()
+  }
+
+  const record: Record<string, FacetType> = Object.create(null)
+  Object.assign(record, properties)
+
+  for (const child of bus.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(busScope, child))
+        break
+
+      case 'Identifier': {
+        const sourceCheck = checkExpression(busScope, child)
+        errors.push(...sourceCheck.errors)
+
+        if (sourceCheck.result != null) {
+          const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
+          errors.push(...checkType(options, sourceCheck.result, child.range))
+        }
+
+        break
+      }
+
+      case 'EffectStatement': {
+        const effectCheck = checkExpression(busScope, child.expression)
+        errors.push(...effectCheck.errors)
+
+        let effectType: FacetType | undefined
+
+        if (effectCheck.result != null) {
+          const typeErrors = checkType(EffectFacet.type(), effectCheck.result, child.expression.range)
+          errors.push(...typeErrors)
+
+          if (typeErrors.length === 0) {
+            effectType = effectCheck.result
+          }
+        }
+
+        if (child.name == null) {
+          continue
+        }
+
+        if (Object.hasOwn(properties, child.name.name)) {
+          errors.push(new CompileError(`Effect name "${child.name.name}" conflicts with bus property of the same name`, child.name.range))
+          continue
+        }
+
+        if (Object.hasOwn(record, child.name.name)) {
+          errors.push(new CompileError(`Duplicate effect name "${child.name.name}"`, child.name.range))
+          continue
+        }
+
+        if (effectType != null) {
+          record[child.name.name] = effectType
+        }
+
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  const type = makeType(BusFacet, RecordFacet.with(record))
+
+  return { errors, result: type }
+}
+
+function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
+  const trackScope = createLocalScope(scope)
+  const errors: CompileError[] = []
+
+  if (!scope.allowedEffects.blocking) {
+    errors.push(new CompileError('Cannot construct a track in a realtime context', expression.range))
+  }
+
+  errors.push(...checkArgumentList(trackScope, expression.properties, trackSchema, expression.range, 'property'))
+
+  const seenParts = new Set<string>()
+
+  for (const child of expression.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(trackScope, child))
+        break
+
+      case 'PartStatement': {
+        if (child.name != null) {
+          if (seenParts.has(child.name.name)) {
+            errors.push(new CompileError(`Duplicate part named "${child.name.name}"`, child.range))
+          } else if (trackScope.resolutions.has(child.name.name)) {
+            errors.push(new CompileError(`Part name "${child.name.name}" conflicts with existing identifier`, child.name.range))
+          }
+
+          seenParts.add(child.name.name)
+
+          // Reserve the name in the local scope
+          trackScope.resolutions.set(child.name.name, PartFacet.type())
+        }
+
+        errors.push(...checkPart(trackScope, child))
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  return { errors, result: TrackFacet.type() }
+}
+
+function checkPart (scope: Scope, part: ast.PartStatement): readonly CompileError[] {
+  const partScope = createLocalScope(scope)
+  const errors: CompileError[] = []
+
+  errors.push(...checkArgumentList(scope, part.properties, partSchema, part.range, 'property'))
+
+  for (const child of part.children) {
+    switch (child.type) {
+      case 'Assignment':
+        errors.push(...checkAssignment(partScope, child))
+        break
+
+      case 'Routing':
+        errors.push(...checkInstrumentRouting(partScope, child))
+        break
+
+      case 'AutomateStatement':
+        errors.push(...checkAutomation(partScope, child))
+        break
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  return errors
+}
+
+function checkInstrumentRouting (scope: Scope, routing: ast.Routing): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  const destination = resolveInScope(scope, routing.destination.name)
+  if (destination == null) {
+    errors.push(new CompileError(`Unknown identifier "${routing.destination.name}"`, routing.destination.range))
+  } else {
+    errors.push(...checkType(InstrumentFacet.type(), destination, routing.destination.range))
+  }
+
+  const sourceCheck = checkExpression(scope, routing.source)
+  errors.push(...sourceCheck.errors)
+  if (sourceCheck.result != null) {
+    errors.push(...checkType(PatternFacet.type(), sourceCheck.result, routing.source.range))
+  }
+
+  return errors
+}
+
+function checkAutomation (scope: Scope, automation: ast.AutomateStatement): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  const targetCheck = checkExpression(scope, automation.target)
+  errors.push(...targetCheck.errors)
+  if (targetCheck.result != null) {
+    errors.push(...checkType(ParameterFacet.type(), targetCheck.result, automation.target.range))
+  }
+
+  const curveCheck = checkExpression(scope, automation.curve)
+  errors.push(...curveCheck.errors)
+
+  if (curveCheck.result == null) {
+    return errors
+  }
+
+  let curveType = CurveFacet.type()
+
+  if (targetCheck.result != null && ParameterFacet.is(targetCheck.result)) {
+    const parameterType = ParameterFacet.detail(targetCheck.result)
+    curveType = CurveFacet.with(parameterType).type()
+  }
+
+  errors.push(...checkType(curveType, curveCheck.result, automation.curve.range))
+
+  return errors
 }
 
 function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Checked<FacetType> {

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -12,7 +12,7 @@ export interface Scope {
 
 export interface GlobalScope extends Scope {
   readonly buses: Map<string, FacetType>
-  readonly namespaces: Map<string, Namespace>
+  readonly namespaces: Map<string, MutableNamespace>
 }
 
 export interface MutableScope extends Scope {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -15,10 +15,12 @@ import type { Curve, CurveSegment } from '../../type-system/domain/curve.ts'
 import { CurveFacet } from '../../type-system/domain/curve.ts'
 import { EffectFacet } from '../../type-system/domain/effect.ts'
 import { InstrumentFacet } from '../../type-system/domain/instrument.ts'
+import { MixerFacet } from '../../type-system/domain/mixer.ts'
 import { ParameterFacet } from '../../type-system/domain/parameter.ts'
 import { PartFacet } from '../../type-system/domain/part.ts'
 import { PatternFacet } from '../../type-system/domain/pattern.ts'
 import { SourceFacet } from '../../type-system/domain/source.ts'
+import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeType } from '../../type-system/factory.ts'
 import { Curves, Numbers, Parameters } from '../../type-system/helpers.ts'
@@ -60,14 +62,14 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
         processAssignment(scope, child)
         break
 
-      case 'MixerStatement':
+      case 'Mixer':
         assert(mixer == null)
-        mixer = generateMixer(scope, child, busNamespace)
+        mixer = MixerFacet.get(resolve(scope, child))
         break
 
-      case 'TrackStatement':
+      case 'Track':
         assert(track == null)
-        track = generateTrack(scope, child)
+        track = TrackFacet.get(resolve(scope, child))
         break
 
       default:
@@ -141,252 +143,6 @@ function processAssignment (scope: MutableScope, assignment: ast.Assignment): vo
   scope.resolutions.set(assignment.key.name, resolve(scope, assignment.value))
 }
 
-function generateTrack (scope: Scope, track: ast.TrackStatement): Track {
-  const { options } = scope.top
-
-  const properties = resolveArgumentList(scope, track.properties, trackSchema)
-
-  const tempo = properties.tempo != null
-    ? clamped(NumberFacet.get(properties.tempo), options.tempo.minimum, options.tempo.maximum).value
-    : options.tempo.default
-
-  const trackScope = createLocalScope(scope)
-  const parts: Part[] = []
-
-  let currentTime = 0 as Numeric<'beats'>
-
-  for (const child of track.children) {
-    switch (child.type) {
-      case 'Assignment':
-        processAssignment(trackScope, child)
-        break
-
-      case 'PartStatement': {
-        const part = generatePart(trackScope, child, currentTime, tempo)
-        parts.push(part)
-
-        if (part.name != null) {
-          assert(!trackScope.resolutions.has(part.name))
-          trackScope.resolutions.set(part.name, PartFacet.type().of(part))
-        }
-
-        currentTime = currentTime + part.length as Numeric<'beats'>
-        break
-      }
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  return { tempo, parts }
-}
-
-function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric<'beats'>, tempo: Numeric<'bpm'>): Part {
-  const partScope = createLocalScope(scope)
-
-  const name = part.name?.name
-  const properties = resolveArgumentList(scope, part.properties, partSchema)
-  const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)
-
-  const startTimeSeconds = beatsToSeconds(startTime, tempo)
-  const lengthSeconds = beatsToSeconds(length.value, tempo)
-
-  const routings: InstrumentRouting[] = []
-
-  for (const child of part.children) {
-    switch (child.type) {
-      case 'Assignment':
-        processAssignment(partScope, child)
-        break
-
-      case 'Routing':
-        routings.push({
-          source: {
-            type: 'pattern',
-            value: PatternFacet.get(resolve(partScope, child.source))
-          },
-
-          destination: {
-            type: 'instrument',
-            id: InstrumentFacet.get(resolve(partScope, child.destination)).id
-          }
-        })
-        break
-
-      case 'AutomateStatement':
-        generateAutomation(partScope, child, { offset: startTimeSeconds, limit: lengthSeconds, tempo })
-        break
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  return { name, length: length.value, routings }
-}
-
-function generateAutomation (scope: Scope, statement: ast.AutomateStatement, options: RenderCurveOptions): void {
-  const target = ParameterFacet.get(resolve(scope, statement.target))
-  const curve = CurveFacet.get(resolve(scope, statement.curve))
-
-  const rendered = renderCurvePoints(curve, options)
-  const existing = nonNull(scope.top.automations.get(target.id), 'Parameter allocated incorrectly')
-
-  const points = mergeCurvePoints(existing.points, rendered)
-  scope.top.automations.set(target.id, { ...existing, points })
-}
-
-function generateMixer (scope: Scope, mixer: ast.MixerStatement, busNamespace: MutableNamespace): Mixer {
-  const mixerScope = createLocalScope(scope)
-
-  const busStatements: ast.BusStatement[] = []
-  const buses: Bus[] = []
-  const routings: MixerRouting[] = []
-
-  for (const child of mixer.children) {
-    switch (child.type) {
-      case 'Assignment':
-        processAssignment(mixerScope, child)
-        break
-
-      case 'BusStatement': {
-        busStatements.push(child)
-        const generated = generateBus(mixerScope, child, busNamespace)
-        buses.push(generated.bus)
-        routings.push(...generated.routings)
-        break
-      }
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  return { buses, routings }
-}
-
-function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRouting[] {
-  const routings: MixerRouting[] = []
-
-  const unroutedBuses = new Set<BusId>(mixer.buses.map((b) => b.id))
-  const unroutedInstruments = new Set<InstrumentId>(scope.top.instruments.keys())
-
-  for (const routing of mixer.routings) {
-    switch (routing.source.type) {
-      case 'bus':
-        unroutedBuses.delete(routing.source.id)
-        break
-      case 'instrument':
-        unroutedInstruments.delete(routing.source.id)
-        break
-      default:
-        assertNever(routing.source)
-    }
-  }
-
-  const createImplicitRouting = (source: MixerRouting['source']) => {
-    routings.push({ implicit: true, source, destination: { type: 'output' } })
-  }
-
-  for (const busId of unroutedBuses) {
-    createImplicitRouting({ type: 'bus', id: busId })
-  }
-
-  for (const instrumentId of unroutedInstruments) {
-    createImplicitRouting({ type: 'instrument', id: instrumentId })
-  }
-
-  return routings
-}
-
-interface BusGenerationResult {
-  readonly bus: Bus
-  readonly routings: readonly MixerRouting[]
-}
-
-function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: MutableNamespace): BusGenerationResult {
-  const busScope = createLocalScope(scope)
-
-  const name = bus.name.name
-  const properties = resolveArgumentList(scope, bus.properties, busSchema)
-
-  const valueRecord: Record<string, Value> = Object.create(null)
-  const typeRecord: Record<string, FacetType> = Object.create(null)
-
-  const sources: Array<MixerRouting['source']> = []
-  const effects: Effect[] = []
-
-  for (const child of bus.children) {
-    switch (child.type) {
-      case 'Assignment':
-        processAssignment(busScope, child)
-        break
-
-      case 'Identifier': {
-        const source = resolve(busScope, child)
-
-        if (InstrumentFacet.has(source)) {
-          sources.push({ type: 'instrument', id: InstrumentFacet.get(source).id })
-        } else if (BusFacet.has(source)) {
-          sources.push({ type: 'bus', id: BusFacet.get(source).id })
-        } else {
-          fail()
-        }
-
-        break
-      }
-
-      case 'EffectStatement': {
-        const effectValue = resolve(busScope, child.expression)
-        effects.push(EffectFacet.get(effectValue))
-
-        const effectName = child.name?.name
-        if (effectName != null) {
-          valueRecord[effectName] = effectValue
-          typeRecord[effectName] = effectValue.type
-        }
-
-        break
-      }
-
-      default:
-        assertNever(child)
-    }
-  }
-
-  // These must always be allocated even if not explicitly set,
-  // as they could still be automated.
-  const gainData = properties.gain != null ? NumberFacet.get(properties.gain).value : 0 as Numeric<'db'>
-  const panData = properties.pan != null ? NumberFacet.get(properties.pan).value : 0 as Numeric<undefined>
-
-  const gain = scope.top.allocateParameter('db', gainData)
-  valueRecord.gain = Parameters.of(gain)
-  typeRecord.gain = valueRecord.gain.type
-
-  const pan = scope.top.allocateParameter(undefined, panData)
-  valueRecord.pan = Parameters.of(pan)
-  typeRecord.pan = valueRecord.pan.type
-
-  const data = scope.top.allocateBus({ name, gain, pan, effects })
-  const value = makeType(BusFacet, RecordFacet.with(typeRecord)).of(data, valueRecord)
-
-  assert(!scope.resolutions.has(name))
-  scope.resolutions.set(name, value)
-
-  assert(!namespace.resolutions.has(name))
-  namespace.resolutions.set(name, value)
-
-  const destination = { type: 'bus', id: data.id } as const
-  const routings = sources.map((source) => ({
-    implicit: false,
-    source,
-    destination
-  }))
-
-  return { bus: data, routings }
-}
-
 /**
  * Resolve an expression to a value within the given scope. Since this expression (or sub-expressions) may call
  * functions, the scope may be updated.
@@ -413,6 +169,12 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
 
     case 'Voice':
       return generateVoice(scope, expression)
+
+    case 'Mixer':
+      return generateMixer(scope, expression)
+
+    case 'Track':
+      return generateTrack(scope, expression)
 
     case 'UnaryExpression':
       return computeUnaryExpression(scope, expression)
@@ -645,6 +407,254 @@ function createVoiceInstance (voice: ast.Voice, scope: MutableScope, tempo: Nume
     source: outputValue,
     duration: envelope.points.at(-1)?.time
   }
+}
+
+function generateMixer (scope: Scope, mixer: ast.Mixer): Value {
+  const mixerScope = createLocalScope(scope)
+
+  const busNamespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
+
+  const busStatements: ast.BusStatement[] = []
+  const buses: Bus[] = []
+  const routings: MixerRouting[] = []
+
+  for (const child of mixer.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(mixerScope, child)
+        break
+
+      case 'BusStatement': {
+        busStatements.push(child)
+        const generated = generateBus(mixerScope, child, busNamespace)
+        buses.push(generated.bus)
+        routings.push(...generated.routings)
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  return MixerFacet.type().of({ buses, routings })
+}
+
+function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRouting[] {
+  const routings: MixerRouting[] = []
+
+  const unroutedBuses = new Set<BusId>(mixer.buses.map((b) => b.id))
+  const unroutedInstruments = new Set<InstrumentId>(scope.top.instruments.keys())
+
+  for (const routing of mixer.routings) {
+    switch (routing.source.type) {
+      case 'bus':
+        unroutedBuses.delete(routing.source.id)
+        break
+      case 'instrument':
+        unroutedInstruments.delete(routing.source.id)
+        break
+      default:
+        assertNever(routing.source)
+    }
+  }
+
+  const createImplicitRouting = (source: MixerRouting['source']) => {
+    routings.push({ implicit: true, source, destination: { type: 'output' } })
+  }
+
+  for (const busId of unroutedBuses) {
+    createImplicitRouting({ type: 'bus', id: busId })
+  }
+
+  for (const instrumentId of unroutedInstruments) {
+    createImplicitRouting({ type: 'instrument', id: instrumentId })
+  }
+
+  return routings
+}
+
+interface BusGenerationResult {
+  readonly bus: Bus
+  readonly routings: readonly MixerRouting[]
+}
+
+function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: MutableNamespace): BusGenerationResult {
+  const busScope = createLocalScope(scope)
+
+  const name = bus.name.name
+  const properties = resolveArgumentList(scope, bus.properties, busSchema)
+
+  const valueRecord: Record<string, Value> = Object.create(null)
+  const typeRecord: Record<string, FacetType> = Object.create(null)
+
+  const sources: Array<MixerRouting['source']> = []
+  const effects: Effect[] = []
+
+  for (const child of bus.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(busScope, child)
+        break
+
+      case 'Identifier': {
+        const source = resolve(busScope, child)
+
+        if (InstrumentFacet.has(source)) {
+          sources.push({ type: 'instrument', id: InstrumentFacet.get(source).id })
+        } else if (BusFacet.has(source)) {
+          sources.push({ type: 'bus', id: BusFacet.get(source).id })
+        } else {
+          fail()
+        }
+
+        break
+      }
+
+      case 'EffectStatement': {
+        const effectValue = resolve(busScope, child.expression)
+        effects.push(EffectFacet.get(effectValue))
+
+        const effectName = child.name?.name
+        if (effectName != null) {
+          valueRecord[effectName] = effectValue
+          typeRecord[effectName] = effectValue.type
+        }
+
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  // These must always be allocated even if not explicitly set,
+  // as they could still be automated.
+  const gainData = properties.gain != null ? NumberFacet.get(properties.gain).value : 0 as Numeric<'db'>
+  const panData = properties.pan != null ? NumberFacet.get(properties.pan).value : 0 as Numeric<undefined>
+
+  const gain = scope.top.allocateParameter('db', gainData)
+  valueRecord.gain = Parameters.of(gain)
+  typeRecord.gain = valueRecord.gain.type
+
+  const pan = scope.top.allocateParameter(undefined, panData)
+  valueRecord.pan = Parameters.of(pan)
+  typeRecord.pan = valueRecord.pan.type
+
+  const data = scope.top.allocateBus({ name, gain, pan, effects })
+  const value = makeType(BusFacet, RecordFacet.with(typeRecord)).of(data, valueRecord)
+
+  assert(!scope.resolutions.has(name))
+  scope.resolutions.set(name, value)
+
+  assert(!namespace.resolutions.has(name))
+  namespace.resolutions.set(name, value)
+
+  const destination = { type: 'bus', id: data.id } as const
+  const routings = sources.map((source) => ({
+    implicit: false,
+    source,
+    destination
+  }))
+
+  return { bus: data, routings }
+}
+
+function generateTrack (scope: Scope, track: ast.Track): Value {
+  const { options } = scope.top
+
+  const properties = resolveArgumentList(scope, track.properties, trackSchema)
+
+  const tempo = properties.tempo != null
+    ? clamped(NumberFacet.get(properties.tempo), options.tempo.minimum, options.tempo.maximum).value
+    : options.tempo.default
+
+  const trackScope = createLocalScope(scope)
+  const parts: Part[] = []
+
+  let currentTime = 0 as Numeric<'beats'>
+
+  for (const child of track.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(trackScope, child)
+        break
+
+      case 'PartStatement': {
+        const part = generatePart(trackScope, child, currentTime, tempo)
+        parts.push(part)
+
+        if (part.name != null) {
+          assert(!trackScope.resolutions.has(part.name))
+          trackScope.resolutions.set(part.name, PartFacet.type().of(part))
+        }
+
+        currentTime = currentTime + part.length as Numeric<'beats'>
+        break
+      }
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  return TrackFacet.type().of({ tempo, parts })
+}
+
+function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric<'beats'>, tempo: Numeric<'bpm'>): Part {
+  const partScope = createLocalScope(scope)
+
+  const name = part.name?.name
+  const properties = resolveArgumentList(scope, part.properties, partSchema)
+  const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)
+
+  const startTimeSeconds = beatsToSeconds(startTime, tempo)
+  const lengthSeconds = beatsToSeconds(length.value, tempo)
+
+  const routings: InstrumentRouting[] = []
+
+  for (const child of part.children) {
+    switch (child.type) {
+      case 'Assignment':
+        processAssignment(partScope, child)
+        break
+
+      case 'Routing':
+        routings.push({
+          source: {
+            type: 'pattern',
+            value: PatternFacet.get(resolve(partScope, child.source))
+          },
+
+          destination: {
+            type: 'instrument',
+            id: InstrumentFacet.get(resolve(partScope, child.destination)).id
+          }
+        })
+        break
+
+      case 'AutomateStatement':
+        generateAutomation(partScope, child, { offset: startTimeSeconds, limit: lengthSeconds, tempo })
+        break
+
+      default:
+        assertNever(child)
+    }
+  }
+
+  return { name, length: length.value, routings }
+}
+
+function generateAutomation (scope: Scope, statement: ast.AutomateStatement, options: RenderCurveOptions): void {
+  const target = ParameterFacet.get(resolve(scope, statement.target))
+  const curve = CurveFacet.get(resolve(scope, statement.curve))
+
+  const rendered = renderCurvePoints(curve, options)
+  const existing = nonNull(scope.top.automations.get(target.id), 'Parameter allocated incorrectly')
+
+  const points = mergeCurvePoints(existing.points, rendered)
+  scope.top.automations.set(target.id, { ...existing, points })
 }
 
 function computeUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Value {

--- a/packages/language/src/compiler/generator/scopes.ts
+++ b/packages/language/src/compiler/generator/scopes.ts
@@ -35,7 +35,7 @@ export interface Scope {
 export interface GlobalScope extends Scope, Context {
   readonly options: GenerateOptions
 
-  readonly namespaces: Map<string, Namespace>
+  readonly namespaces: Map<string, MutableNamespace>
 
   readonly buses: Map<BusId, Bus>
   readonly instruments: Map<InstrumentId, Instrument>

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -344,7 +344,9 @@ const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast
   serialPattern_,
   curve_,
   p.recursive(() => instrument_),
-  p.recursive(() => voice_)
+  p.recursive(() => voice_),
+  p.recursive(() => mixer_),
+  p.recursive(() => track_)
 )
 
 const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
@@ -560,7 +562,7 @@ const partStatement_: p.Parser<Token, unknown, ast.PartStatement> = p.abc(
   }
 )
 
-const trackStatement_: p.Parser<Token, unknown, ast.TrackStatement> = p.abc(
+const track_: p.Parser<Token, unknown, ast.Track> = p.abc(
   keyword('track'),
   p.option(
     combine3(
@@ -580,7 +582,7 @@ const trackStatement_: p.Parser<Token, unknown, ast.TrackStatement> = p.abc(
   (_track, callChain, [_lp, children, _rp]) => {
     const args = callChain == null ? [] : callChain[1]
 
-    return ast.make('TrackStatement', combineSourceRanges(_track, _rp), {
+    return ast.make('Track', combineSourceRanges(_track, _rp), {
       properties: args,
       children
     })
@@ -641,7 +643,7 @@ const busStatement_: p.Parser<Token, unknown, ast.BusStatement> = p.abc(
   }
 )
 
-const mixerStatement_: p.Parser<Token, unknown, ast.MixerStatement> = p.abc(
+const mixer_: p.Parser<Token, unknown, ast.Mixer> = p.abc(
   keyword('mixer'),
   p.option(
     combine3(
@@ -661,7 +663,7 @@ const mixerStatement_: p.Parser<Token, unknown, ast.MixerStatement> = p.abc(
   (_mixer, callChain, [_lp, children, _rp]) => {
     const args = callChain == null ? [] : callChain[1]
 
-    return ast.make('MixerStatement', combineSourceRanges(_mixer, _rp), {
+    return ast.make('Mixer', combineSourceRanges(_mixer, _rp), {
       properties: args,
       children
     })
@@ -724,7 +726,7 @@ const program_: p.Parser<Token, unknown, ast.Program> = p.abc(
   p.many(useStatement_),
   p.many(
     p.eitherOr(
-      p.eitherOr(assignment_, p.eitherOr(trackStatement_, mixerStatement_)),
+      p.eitherOr(assignment_, p.eitherOr(track_, mixer_)),
       p.map(p.any, (token) => {
         const context = truncateString(token.text, ERROR_CONTEXT_LIMIT)
         throw new ParseError(`Unexpected statement beginning with "${context}"`, getSourceRange(token))

--- a/packages/language/src/type-system/domain/mixer.ts
+++ b/packages/language/src/type-system/domain/mixer.ts
@@ -1,0 +1,6 @@
+import type { Mixer } from '@meyfa/cadence-core'
+import { makeFacet } from '../factory.ts'
+
+const FACET_NAME = 'mixer'
+
+export const MixerFacet = makeFacet<typeof FACET_NAME, Mixer>(FACET_NAME, {})

--- a/packages/language/src/type-system/domain/track.ts
+++ b/packages/language/src/type-system/domain/track.ts
@@ -1,0 +1,6 @@
+import type { Track } from '@meyfa/cadence-core'
+import { makeFacet } from '../factory.ts'
+
+const FACET_NAME = 'track'
+
+export const TrackFacet = makeFacet<typeof FACET_NAME, Track>(FACET_NAME, {})

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -622,6 +622,17 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
+    it('should reject duplicate bus names across different mixers', () => {
+      const source = [
+        'm1 = mixer { bus foo {} }',
+        'm2 = mixer { bus foo {} }'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Duplicate bus named "foo"'
+      ])
+    })
+
     it('should reject conflicting bus name and local variable name', () => {
       const source = [
         'mixer {',
@@ -940,13 +951,16 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
-    it('should reject instrument expressions in non-blocking contexts', () => {
+    it('should reject blocking expressions in non-blocking contexts', () => {
       const source = [
         'use "sources" as src',
         '',
         'my_instrument = instrument {',
         '  voice {',
-        '    foo = instrument {}',
+        '    inv_instrument = instrument {}',
+        '    inv_mixer = mixer {}',
+        '    inv_track = track {}',
+        '',
         '    envelope ~[lin(0.db, -60.db):100.ms]',
         '    output src.sine(440.hz)',
         '  }',
@@ -954,7 +968,9 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Cannot construct an instrument in a realtime context'
+        'Cannot construct an instrument in a realtime context',
+        'Cannot construct a mixer in a realtime context',
+        'Cannot construct a track in a realtime context'
       ])
     })
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -629,7 +629,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'MixerStatement',
+        type: 'Mixer',
         properties: [],
         children: [
           {
@@ -704,7 +704,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'TrackStatement',
+        type: 'Track',
         properties: [],
         children: [
           {
@@ -757,7 +757,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'TrackStatement',
+        type: 'Track',
         properties: [],
         children: [
           {
@@ -768,7 +768,7 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'MixerStatement',
+        type: 'Mixer',
         properties: [],
         children: [
           {

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -1,4 +1,4 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, Parameter, ParameterId, Part, Pattern, Source, Voice } from '@meyfa/cadence-core'
+import type { Bus, BusId, Effect, Instrument, InstrumentId, Mixer, Parameter, ParameterId, Part, Pattern, Source, Track, Voice } from '@meyfa/cadence-core'
 import { createSerialPattern } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
@@ -9,10 +9,12 @@ import type { Curve } from '../../src/type-system/domain/curve.ts'
 import { CurveFacet } from '../../src/type-system/domain/curve.ts'
 import { EffectFacet } from '../../src/type-system/domain/effect.ts'
 import { InstrumentFacet } from '../../src/type-system/domain/instrument.ts'
+import { MixerFacet } from '../../src/type-system/domain/mixer.ts'
 import { ParameterFacet } from '../../src/type-system/domain/parameter.ts'
 import { PartFacet } from '../../src/type-system/domain/part.ts'
 import { PatternFacet } from '../../src/type-system/domain/pattern.ts'
 import { SourceFacet } from '../../src/type-system/domain/source.ts'
+import { TrackFacet } from '../../src/type-system/domain/track.ts'
 import { VoiceFacet } from '../../src/type-system/domain/voice.ts'
 import { expectTypeEquals } from '../test-utils.ts'
 
@@ -109,6 +111,16 @@ const voice: Voice = {
   })
 }
 
+const track: Track = {
+  tempo: 120 as Numeric<'bpm'>,
+  parts: [part]
+}
+
+const mixer: Mixer = {
+  buses: [bus],
+  routings: []
+}
+
 describe('type-system/domain', () => {
   describe('BusFacet', () => {
     it('should format and round-trip bus values', () => {
@@ -168,6 +180,18 @@ describe('type-system/domain', () => {
     })
   })
 
+  describe('MixerFacet', () => {
+    it('should format and round-trip mixer values', () => {
+      const value = MixerFacet.type().of(mixer)
+      const mixerData = MixerFacet.get(value)
+
+      expectTypeEquals<Mixer, typeof mixerData>()
+      assert.strictEqual(MixerFacet.format(), 'mixer')
+      assert.strictEqual(MixerFacet.has(value), true)
+      assert.strictEqual(mixerData, mixer)
+    })
+  })
+
   describe('ParameterFacet', () => {
     it('should support unit-specific parameters and detail()', () => {
       const genericValue = ParameterFacet.type().of(gainParameter)
@@ -222,6 +246,18 @@ describe('type-system/domain', () => {
       assert.strictEqual(SourceFacet.format(), 'source')
       assert.strictEqual(SourceFacet.has(value), true)
       assert.strictEqual(sourceData, source)
+    })
+  })
+
+  describe('TrackFacet', () => {
+    it('should format and round-trip track values', () => {
+      const value = TrackFacet.type().of(track)
+      const trackData = TrackFacet.get(value)
+
+      expectTypeEquals<Track, typeof trackData>()
+      assert.strictEqual(TrackFacet.format(), 'track')
+      assert.strictEqual(TrackFacet.has(value), true)
+      assert.strictEqual(trackData, track)
     })
   })
 


### PR DESCRIPTION
`track {}` and `mixer {}` are now expressions that produce `Track` and `Mixer` values, respectively. This is one step towards an expression- oriented language design.