### PR TITLE
feat: Treat parts as expressions, not statements

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -95,7 +95,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Track
+export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Track | Part
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -125,11 +125,11 @@ export type ArgumentList = ReadonlyArray<Expression | Property>
 export interface Track extends ASTNode {
   readonly type: 'Track'
   readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Assignment | PartStatement>
+  readonly children: ReadonlyArray<Assignment | Part>
 }
 
-export interface PartStatement extends ASTNode {
-  readonly type: 'PartStatement'
+export interface Part extends ASTNode {
+  readonly type: 'Part'
   readonly name?: Identifier
   readonly properties: ArgumentList
   readonly children: ReadonlyArray<Assignment | Routing | AutomateStatement>
@@ -231,7 +231,7 @@ export interface NodeByType {
   Routing: Routing
 
   Track: Track
-  PartStatement: PartStatement
+  Part: Part
   Mixer: Mixer
   BusStatement: BusStatement
   EffectStatement: EffectStatement

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -470,7 +470,8 @@ describe('lowering.ts', () => {
                   id: instrumentId
                 }
               } satisfies InstrumentRouting
-            ]
+            ],
+            automations: []
           },
           {
             name: 'Part 2',
@@ -489,7 +490,8 @@ describe('lowering.ts', () => {
                   id: instrumentId
                 }
               } satisfies InstrumentRouting
-            ]
+            ],
+            automations: []
           }
         ]
       },

--- a/packages/core/src/curve/types.ts
+++ b/packages/core/src/curve/types.ts
@@ -1,4 +1,32 @@
-import type { Numeric, Unit } from '@meyfa/cadence-utility'
+import type { Numeric, RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
+
+// relative (as specified in the program)
+
+export type CurveDuration = RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>
+
+export interface RelativeCurve<U extends Unit> {
+  readonly unit: U
+  readonly segments: ReadonlyArray<RelativeCurveSegment<U>>
+}
+
+export type RelativeCurveSegment<U extends Unit> = HoldSegment<U> | LinearSegment<U>
+
+export interface HoldSegment<U extends Unit> {
+  readonly type: 'hold'
+  readonly length: CurveDuration
+  readonly unit: U
+  readonly value: RuntimeNumeric<U>
+}
+
+export interface LinearSegment<U extends Unit> {
+  readonly type: 'lin'
+  readonly length: CurveDuration
+  readonly unit: U
+  readonly start: RuntimeNumeric<U>
+  readonly end: RuntimeNumeric<U>
+}
+
+// absolute (rendered)
 
 export type CurveShape = 'step' | 'linear' | 'exponential'
 

--- a/packages/core/src/program/track.ts
+++ b/packages/core/src/program/track.ts
@@ -1,5 +1,7 @@
-import type { Numeric } from '@meyfa/cadence-utility'
+import type { Numeric, Unit } from '@meyfa/cadence-utility'
+import type { RelativeCurve } from '../curve/types.ts'
 import type { Pattern } from '../pattern/types.ts'
+import type { ParameterId } from './automations.ts'
 import type { InstrumentId } from './instruments.ts'
 
 export interface Track {
@@ -11,6 +13,7 @@ export interface Part {
   readonly name?: string
   readonly length: Numeric<'beats'>
   readonly routings: readonly InstrumentRouting[]
+  readonly automations: readonly Automation[]
 }
 
 export interface InstrumentRouting {
@@ -23,4 +26,9 @@ export interface InstrumentRouting {
     readonly type: 'instrument'
     readonly id: InstrumentId
   }
+}
+
+export interface Automation {
+  readonly parameterId: ParameterId
+  readonly curve: RelativeCurve<Unit>
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -122,6 +122,7 @@ primary {
   Curve |
   Instrument |
   Mixer |
+  Part |
   Pattern |
   Track |
   Voice
@@ -190,11 +191,11 @@ Track {
   kw<"track">
   ("(" argumentList? ")")?
   TrackBlock[group=Block] {
-    "{" (Assignment | PartStatement)* "}"
+    "{" (Assignment | Part)* "}"
   }
 }
 
-PartStatement {
+Part {
   kw<"part">
   VariableDefinition?
   ("(" argumentList? ")")?

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -158,7 +158,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
             break
           }
 
-          case 'PartStatement': {
+          case 'Part': {
             addBinding({ kind: 'part', scopeId, name, range: nameRange })
             break
           }

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -231,6 +231,9 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
     case 'Track':
       return checkTrack(scope, expression)
 
+    case 'Part':
+      return checkPart(scope, expression)
+
     case 'UnaryExpression':
       return checkUnaryExpression(scope, expression)
 
@@ -667,7 +670,7 @@ function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
         errors.push(...checkAssignment(trackScope, child))
         break
 
-      case 'PartStatement': {
+      case 'Part': {
         if (child.name != null) {
           if (seenParts.has(child.name.name)) {
             errors.push(new CompileError(`Duplicate part named "${child.name.name}"`, child.range))
@@ -681,7 +684,9 @@ function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
           trackScope.resolutions.set(child.name.name, PartFacet.type())
         }
 
-        errors.push(...checkPart(trackScope, child))
+        const partCheck = checkPart(trackScope, child)
+        errors.push(...partCheck.errors)
+
         break
       }
 
@@ -693,7 +698,7 @@ function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
   return { errors, result: TrackFacet.type() }
 }
 
-function checkPart (scope: Scope, part: ast.PartStatement): readonly CompileError[] {
+function checkPart (scope: Scope, part: ast.Part): Checked<FacetType> {
   const partScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
@@ -718,7 +723,7 @@ function checkPart (scope: Scope, part: ast.PartStatement): readonly CompileErro
     }
   }
 
-  return errors
+  return { errors, result: PartFacet.type() }
 }
 
 function checkInstrumentRouting (scope: Scope, routing: ast.Routing): readonly CompileError[] {

--- a/packages/language/src/compiler/curves.ts
+++ b/packages/language/src/compiler/curves.ts
@@ -1,7 +1,6 @@
-import type { CurvePoint, CurveShape } from '@meyfa/cadence-core'
+import type { CurveDuration, CurvePoint, CurveShape, HoldSegment, LinearSegment, RelativeCurve, RelativeCurveSegment } from '@meyfa/cadence-core'
 import { timeToSeconds } from '@meyfa/cadence-core'
 import type { Numeric, RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
-import type { Curve, CurveDuration, CurveSegment, HoldCurveSegment, LinearCurveSegment } from '../type-system/domain/curve.ts'
 import { assert, nonNull } from './assert.ts'
 
 const SEGMENT_TYPE_HOLD = 'hold'
@@ -10,11 +9,11 @@ const SEGMENT_TYPE_LINEAR = 'lin'
 const TIME_EPSILON = 1e-6 // 1 microsecond, which is less than 1 sample at 96 kHz
 
 export interface CurveSegmentType {
-  readonly type: CurveSegment<any>['type']
+  readonly type: RelativeCurveSegment<any>['type']
   readonly parameterCount: number
-  readonly create: <U extends Unit>(parameters: ReadonlyArray<RuntimeNumeric<U>>, length: CurveDuration) => CurveSegment<U>
-  readonly start: <U extends Unit>(segment: CurveSegment<U>) => RuntimeNumeric<U>
-  readonly end: <U extends Unit>(segment: CurveSegment<U>) => RuntimeNumeric<U>
+  readonly create: <U extends Unit>(parameters: ReadonlyArray<RuntimeNumeric<U>>, length: CurveDuration) => RelativeCurveSegment<U>
+  readonly start: <U extends Unit>(segment: RelativeCurveSegment<U>) => RuntimeNumeric<U>
+  readonly end: <U extends Unit>(segment: RelativeCurveSegment<U>) => RuntimeNumeric<U>
   readonly endShape: CurveShape
 }
 
@@ -26,8 +25,8 @@ const curveSegmentTypes: ReadonlyMap<string, CurveSegmentType> = new Map([
       const [value] = parameters
       return { type: SEGMENT_TYPE_HOLD, length, unit: value.unit, value }
     },
-    start: <U extends Unit>(segment: CurveSegment<U>) => (segment as HoldCurveSegment<U>).value,
-    end: <U extends Unit>(segment: CurveSegment<U>) => (segment as HoldCurveSegment<U>).value,
+    start: <U extends Unit>(segment: RelativeCurveSegment<U>) => (segment as HoldSegment<U>).value,
+    end: <U extends Unit>(segment: RelativeCurveSegment<U>) => (segment as HoldSegment<U>).value,
     endShape: 'step'
   }],
 
@@ -38,8 +37,8 @@ const curveSegmentTypes: ReadonlyMap<string, CurveSegmentType> = new Map([
       const [start, end] = parameters
       return { type: SEGMENT_TYPE_LINEAR, length, unit: start.unit, start, end }
     },
-    start: <U extends Unit>(segment: CurveSegment<U>) => (segment as LinearCurveSegment<U>).start,
-    end: <U extends Unit>(segment: CurveSegment<U>) => (segment as LinearCurveSegment<U>).end,
+    start: <U extends Unit>(segment: RelativeCurveSegment<U>) => (segment as LinearSegment<U>).start,
+    end: <U extends Unit>(segment: RelativeCurveSegment<U>) => (segment as LinearSegment<U>).end,
     endShape: 'linear'
   }]
 ])
@@ -48,7 +47,7 @@ export function getCurveSegmentType (type: string): CurveSegmentType | undefined
   return curveSegmentTypes.get(type)
 }
 
-export function createCurve<U extends Unit> (segments: ReadonlyArray<CurveSegment<U>>): Curve<U> {
+export function createCurve<U extends Unit> (segments: ReadonlyArray<RelativeCurveSegment<U>>): RelativeCurve<U> {
   const unit = segments.at(0)?.unit as U
   return { unit, segments }
 }
@@ -57,7 +56,7 @@ export function createCurveSegment<U extends Unit> (
   type: string,
   parameters: ReadonlyArray<RuntimeNumeric<U>>,
   length: CurveDuration
-): CurveSegment<U> {
+): RelativeCurveSegment<U> {
   const definition = nonNull(curveSegmentTypes.get(type), `Unknown curve segment type: ${type}`)
   assert(definition.parameterCount === parameters.length, 'Invalid curve parameters')
 
@@ -70,7 +69,7 @@ export interface RenderCurveOptions {
   readonly tempo: Numeric<'bpm'>
 }
 
-export function renderCurvePoints<U extends Unit> (curve: Curve<U>, options: RenderCurveOptions): ReadonlyArray<CurvePoint<'s', U>> {
+export function renderCurvePoints<U extends Unit> (curve: RelativeCurve<U>, options: RenderCurveOptions): ReadonlyArray<CurvePoint<'s', U>> {
   const segments = curve.segments
   if (segments.length === 0 || (options.limit != null && options.limit <= 0)) {
     return []

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -1,5 +1,5 @@
 import { ast } from '@meyfa/cadence-ast'
-import type { Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, NoteData, Part, Pattern, Program, Source, Step, Track, Voice, VoiceInstance } from '@meyfa/cadence-core'
+import type { Automation, Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, NoteData, Part, Pattern, Program, RelativeCurve, RelativeCurveSegment, Source, Step, Track, Voice, VoiceInstance } from '@meyfa/cadence-core'
 import { beatsToSeconds, concatPatterns, convertPitchToMidi, createParallelPattern, createSerialPattern, getMidiFrequency, mergePatterns } from '@meyfa/cadence-core'
 import type { Numeric, RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
@@ -11,7 +11,6 @@ import { NumberFacet } from '../../type-system/base/number.ts'
 import { RecordFacet } from '../../type-system/base/record.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
 import { BusFacet } from '../../type-system/domain/bus.ts'
-import type { Curve, CurveSegment } from '../../type-system/domain/curve.ts'
 import { CurveFacet } from '../../type-system/domain/curve.ts'
 import { EffectFacet } from '../../type-system/domain/effect.ts'
 import { InstrumentFacet } from '../../type-system/domain/instrument.ts'
@@ -176,6 +175,9 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
     case 'Track':
       return generateTrack(scope, expression)
 
+    case 'Part':
+      return generatePart(scope, expression)
+
     case 'UnaryExpression':
       return computeUnaryExpression(scope, expression)
 
@@ -270,7 +272,7 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
   assert(segments.length > 0)
   assert(otherChildren.length === 0)
 
-  const generatedSegments: Array<CurveSegment<Unit>> = []
+  const generatedSegments: Array<RelativeCurveSegment<Unit>> = []
 
   const getPreviousSegmentEnd = (): RuntimeNumeric<Unit> => {
     const previous = nonNull(generatedSegments.at(-1))
@@ -367,7 +369,7 @@ function createNoteBinding (note: NoteData): NoteValue {
 }
 
 function createVoiceInstance (voice: ast.Voice, scope: MutableScope, tempo: Numeric<'bpm'>): VoiceInstance {
-  let envelopeValue: Curve<'db'> | undefined
+  let envelopeValue: RelativeCurve<'db'> | undefined
   let outputValue: Source | undefined
 
   for (const child of voice.children) {
@@ -581,13 +583,23 @@ function generateTrack (scope: Scope, track: ast.Track): Value {
         processAssignment(trackScope, child)
         break
 
-      case 'PartStatement': {
-        const part = generatePart(trackScope, child, currentTime, tempo)
+      case 'Part': {
+        const part = PartFacet.get(resolve(trackScope, child))
         parts.push(part)
 
         if (part.name != null) {
           assert(!trackScope.resolutions.has(part.name))
           trackScope.resolutions.set(part.name, PartFacet.type().of(part))
+        }
+
+        const automationRenderOptions: RenderCurveOptions = {
+          offset: beatsToSeconds(currentTime, tempo),
+          limit: beatsToSeconds(part.length, tempo),
+          tempo
+        }
+
+        for (const automation of part.automations) {
+          applyAutomation(scope.top, automation, automationRenderOptions)
         }
 
         currentTime = currentTime + part.length as Numeric<'beats'>
@@ -602,17 +614,15 @@ function generateTrack (scope: Scope, track: ast.Track): Value {
   return TrackFacet.type().of({ tempo, parts })
 }
 
-function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric<'beats'>, tempo: Numeric<'bpm'>): Part {
+function generatePart (scope: Scope, part: ast.Part): Value {
   const partScope = createLocalScope(scope)
 
   const name = part.name?.name
   const properties = resolveArgumentList(scope, part.properties, partSchema)
   const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)
 
-  const startTimeSeconds = beatsToSeconds(startTime, tempo)
-  const lengthSeconds = beatsToSeconds(length.value, tempo)
-
   const routings: InstrumentRouting[] = []
+  const automations: Automation[] = []
 
   for (const child of part.children) {
     switch (child.type) {
@@ -635,7 +645,7 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
         break
 
       case 'AutomateStatement':
-        generateAutomation(partScope, child, { offset: startTimeSeconds, limit: lengthSeconds, tempo })
+        automations.push(generateAutomation(partScope, child))
         break
 
       default:
@@ -643,18 +653,27 @@ function generatePart (scope: Scope, part: ast.PartStatement, startTime: Numeric
     }
   }
 
-  return { name, length: length.value, routings }
+  return PartFacet.type().of({ name, length: length.value, routings, automations })
 }
 
-function generateAutomation (scope: Scope, statement: ast.AutomateStatement, options: RenderCurveOptions): void {
+function generateAutomation (scope: Scope, statement: ast.AutomateStatement): Automation {
   const target = ParameterFacet.get(resolve(scope, statement.target))
   const curve = CurveFacet.get(resolve(scope, statement.curve))
 
+  return {
+    parameterId: target.id,
+    curve
+  }
+}
+
+function applyAutomation (top: GlobalScope, automation: Automation, options: RenderCurveOptions): void {
+  const { parameterId, curve } = automation
+
   const rendered = renderCurvePoints(curve, options)
-  const existing = nonNull(scope.top.automations.get(target.id), 'Parameter allocated incorrectly')
+  const existing = nonNull(top.automations.get(parameterId), 'Parameter allocated incorrectly')
 
   const points = mergeCurvePoints(existing.points, rendered)
-  scope.top.automations.set(target.id, { ...existing, points })
+  top.automations.set(parameterId, { ...existing, points })
 }
 
 function computeUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Value {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -346,7 +346,8 @@ const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast
   p.recursive(() => instrument_),
   p.recursive(() => voice_),
   p.recursive(() => mixer_),
-  p.recursive(() => track_)
+  p.recursive(() => track_),
+  p.recursive(() => part_)
 )
 
 const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
@@ -528,7 +529,7 @@ const automateStatement_: p.Parser<Token, unknown, ast.AutomateStatement> = p.ab
   }
 )
 
-const partStatement_: p.Parser<Token, unknown, ast.PartStatement> = p.abc(
+const part_: p.Parser<Token, unknown, ast.Part> = p.abc(
   combine2(
     keyword('part'),
     p.option(identifier_, undefined)
@@ -554,7 +555,7 @@ const partStatement_: p.Parser<Token, unknown, ast.PartStatement> = p.abc(
   ([_part, name], callChain, [_lp, children, _rp]) => {
     const args = callChain == null ? [] : callChain[1]
 
-    return ast.make('PartStatement', combineSourceRanges(_part, _rp), {
+    return ast.make('Part', combineSourceRanges(_part, _rp), {
       name,
       properties: args,
       children
@@ -575,7 +576,7 @@ const track_: p.Parser<Token, unknown, ast.Track> = p.abc(
   combine3(
     expectLiteral('{'),
     p.many(
-      p.eitherOr(assignment_, partStatement_)
+      p.eitherOr(assignment_, part_)
     ),
     expectLiteral('}')
   ),

--- a/packages/language/src/type-system/domain/curve.ts
+++ b/packages/language/src/type-system/domain/curve.ts
@@ -1,43 +1,20 @@
-import type { RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
+import type { RelativeCurve } from '@meyfa/cadence-core'
+import type { Unit } from '@meyfa/cadence-utility'
 import { makeFacet } from '../factory.ts'
 import type { Facet, FacetType } from '../types.ts'
 
-export type CurveDuration = RuntimeNumeric<'beats'> | RuntimeNumeric<'s'>
-
-export interface Curve<U extends Unit> {
-  readonly unit: U
-  readonly segments: ReadonlyArray<CurveSegment<U>>
-}
-
-export type CurveSegment<U extends Unit> = HoldCurveSegment<U> | LinearCurveSegment<U>
-
-export interface HoldCurveSegment<U extends Unit> {
-  readonly type: 'hold'
-  readonly length: CurveDuration
-  readonly unit: U
-  readonly value: RuntimeNumeric<U>
-}
-
-export interface LinearCurveSegment<U extends Unit> {
-  readonly type: 'lin'
-  readonly length: CurveDuration
-  readonly unit: U
-  readonly start: RuntimeNumeric<U>
-  readonly end: RuntimeNumeric<U>
-}
-
 const FACET_NAME = 'curve'
 
-const cache = new Map<Unit, Facet<typeof FACET_NAME, Curve<Unit>>>()
+const cache = new Map<Unit, Facet<typeof FACET_NAME, RelativeCurve<Unit>>>()
 
 export const CurveFacet = {
-  ...makeFacet<typeof FACET_NAME, Curve<Unit>>(FACET_NAME, {}),
+  ...makeFacet<typeof FACET_NAME, RelativeCurve<Unit>>(FACET_NAME, {}),
 
   with: <const U extends Unit> (unit: U) => {
-    let cached = cache.get(unit) as Facet<typeof FACET_NAME, Curve<U>> | undefined
+    let cached = cache.get(unit) as Facet<typeof FACET_NAME, RelativeCurve<U>> | undefined
 
     if (cached == null) {
-      cached = makeFacet<typeof FACET_NAME, Curve<U>>(FACET_NAME, { unit }, {
+      cached = makeFacet<typeof FACET_NAME, RelativeCurve<U>>(FACET_NAME, { unit }, {
         format: () => unit == null ? FACET_NAME : `${FACET_NAME}(${unit})`
       })
       cache.set(unit, cached)

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -1,4 +1,4 @@
-import type { Parameter } from '@meyfa/cadence-core'
+import type { Parameter, RelativeCurve } from '@meyfa/cadence-core'
 import type { RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
 import type { Function } from './base/function.ts'
 import { FunctionFacet } from './base/function.ts'
@@ -6,12 +6,11 @@ import type { Module } from './base/module.ts'
 import { ModuleFacet } from './base/module.ts'
 import { NumberFacet } from './base/number.ts'
 import { RecordFacet } from './base/record.ts'
+import { CurveFacet } from './domain/curve.ts'
 import { ParameterFacet } from './domain/parameter.ts'
 import { makeType } from './factory.ts'
 import type { Schema } from './schema.ts'
 import type { Facet, FacetType, Value } from './types.ts'
-import type { Curve } from './domain/curve.ts'
-import { CurveFacet } from './domain/curve.ts'
 
 export const Functions = {
   of: <const S extends Schema, const R extends FacetType, const Context> (value: Function<S, R, Context>): Value => {
@@ -58,7 +57,7 @@ export const Parameters = {
 }
 
 export const Curves = {
-  of: <const U extends Unit> (value: Curve<U>): Value<Facet<'curve', Curve<U>>> => {
+  of: <const U extends Unit> (value: RelativeCurve<U>): Value<Facet<'curve', RelativeCurve<U>>> => {
     return CurveFacet.with(value.unit).type().of(value)
   }
 }

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -708,7 +708,7 @@ describe('parser/parser.ts', () => {
         properties: [],
         children: [
           {
-            type: 'PartStatement',
+            type: 'Part',
             name: undefined,
             properties: [
               {
@@ -720,7 +720,7 @@ describe('parser/parser.ts', () => {
             children: []
           },
           {
-            type: 'PartStatement',
+            type: 'Part',
             name: { type: 'Identifier', name: 'my_part' },
             properties: [
               {

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -1,11 +1,10 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, Mixer, Parameter, ParameterId, Part, Pattern, Source, Track, Voice } from '@meyfa/cadence-core'
+import type { Bus, BusId, Effect, Instrument, InstrumentId, Mixer, Parameter, ParameterId, Part, Pattern, RelativeCurve, Source, Track, Voice } from '@meyfa/cadence-core'
 import { createSerialPattern } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { BusFacet } from '../../src/type-system/domain/bus.ts'
-import type { Curve } from '../../src/type-system/domain/curve.ts'
 import { CurveFacet } from '../../src/type-system/domain/curve.ts'
 import { EffectFacet } from '../../src/type-system/domain/effect.ts'
 import { InstrumentFacet } from '../../src/type-system/domain/instrument.ts'
@@ -50,16 +49,19 @@ const instrument: Instrument = {
 const part: Part = {
   name: 'intro',
   length: 4 as Numeric<'beats'>,
-  routings: [{
-    source: {
-      type: 'pattern',
-      value: pattern
-    },
-    destination: {
-      type: 'instrument',
-      id: instrument.id
+  routings: [
+    {
+      source: {
+        type: 'pattern',
+        value: pattern
+      },
+      destination: {
+        type: 'instrument',
+        id: instrument.id
+      }
     }
-  }]
+  ],
+  automations: []
 }
 
 const bus: Bus = {
@@ -70,7 +72,7 @@ const bus: Bus = {
   effects: [effect]
 }
 
-const curve: Curve<'db'> = {
+const curve: RelativeCurve<'db'> = {
   unit: 'db',
   segments: [
     {
@@ -142,7 +144,7 @@ describe('type-system/domain', () => {
       const decibelValue = decibelType.of(curve)
       const curveData = decibelFacet.get(decibelValue)
 
-      expectTypeEquals<Curve<'db'>, typeof curveData>()
+      expectTypeEquals<RelativeCurve<'db'>, typeof curveData>()
       assert.strictEqual(CurveFacet.format(), 'curve')
       assert.strictEqual(CurveFacet.with(undefined).format(), 'curve')
       assert.strictEqual(decibelFacet.format(), 'curve(db)')


### PR DESCRIPTION
There is already a `Part` value type. This patch makes it so that parts are valid wherever expressions are valid, resolving to the `Part` type, which is consumed by the track.

As parts may now appear outside the track, we cannot use track context such as the part's relative position during its construction. Therefore, automations are stored on the part, and only rendered when the track is built.