### PR TITLE
feat: Treat buses as expressions, not statements

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -95,7 +95,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Track | Part
+export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Bus | Track | Part
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -122,6 +122,19 @@ export type ArgumentList = ReadonlyArray<Expression | Property>
 
 // Domain Types
 
+export interface Mixer extends ASTNode {
+  readonly type: 'Mixer'
+  readonly properties: ArgumentList
+  readonly children: ReadonlyArray<Assignment | Bus>
+}
+
+export interface Bus extends ASTNode {
+  readonly type: 'Bus'
+  readonly name: Identifier
+  readonly properties: ArgumentList
+  readonly children: ReadonlyArray<Assignment | Identifier | EffectStatement>
+}
+
 export interface Track extends ASTNode {
   readonly type: 'Track'
   readonly properties: ArgumentList
@@ -133,19 +146,6 @@ export interface Part extends ASTNode {
   readonly name?: Identifier
   readonly properties: ArgumentList
   readonly children: ReadonlyArray<Assignment | Routing | AutomateStatement>
-}
-
-export interface Mixer extends ASTNode {
-  readonly type: 'Mixer'
-  readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Assignment | BusStatement>
-}
-
-export interface BusStatement extends ASTNode {
-  readonly type: 'BusStatement'
-  readonly name: Identifier
-  readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Assignment | Identifier | EffectStatement>
 }
 
 export interface EffectStatement extends ASTNode {
@@ -230,10 +230,10 @@ export interface NodeByType {
   Assignment: Assignment
   Routing: Routing
 
+  Mixer: Mixer
+  Bus: Bus
   Track: Track
   Part: Part
-  Mixer: Mixer
-  BusStatement: BusStatement
   EffectStatement: EffectStatement
   AutomateStatement: AutomateStatement
 

--- a/packages/audiograph/test/lowering.test.ts
+++ b/packages/audiograph/test/lowering.test.ts
@@ -82,6 +82,7 @@ function createProgramWithEffect (effect: Effect): Program {
         {
           id: 100 as BusId,
           name: 'Bus 1',
+          sources: [],
           gain: {
             id: 400 as ParameterId,
             unit: 'db',
@@ -229,6 +230,7 @@ describe('lowering.ts', () => {
           {
             id: busId,
             name: 'Bus 1',
+            sources: [],
             gain: {
               id: busGainId,
               unit: 'db',
@@ -1635,6 +1637,7 @@ describe('lowering.ts', () => {
             {
               id: busId,
               name: 'Bus 1',
+              sources: [],
               gain: {
                 id: 201 as ParameterId,
                 unit: 'db',

--- a/packages/core/src/program/mixer.ts
+++ b/packages/core/src/program/mixer.ts
@@ -13,6 +13,7 @@ export type BusId = Brand<number, 'core.BusId'>
 export interface Bus {
   readonly id: BusId
   readonly name: string
+  readonly sources: readonly MixerSource[]
   readonly pan: Parameter<undefined>
   readonly gain: Parameter<'db'>
   readonly effects: readonly Effect[]
@@ -20,19 +21,21 @@ export interface Bus {
 
 export interface MixerRouting {
   readonly implicit: boolean
+  readonly source: MixerSource
+  readonly destination: MixerDestination
+}
 
-  readonly source: {
-    readonly type: 'instrument'
-    readonly id: InstrumentId
-  } | {
-    readonly type: 'bus'
-    readonly id: BusId
-  }
+export type MixerSource = {
+  readonly type: 'instrument'
+  readonly id: InstrumentId
+} | {
+  readonly type: 'bus'
+  readonly id: BusId
+}
 
-  readonly destination: {
-    readonly type: 'output'
-  } | {
-    readonly type: 'bus'
-    readonly id: BusId
-  }
+export type MixerDestination = {
+  readonly type: 'output'
+} | {
+  readonly type: 'bus'
+  readonly id: BusId
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -116,9 +116,9 @@ primary {
   "(" expression ")" |
   Call |
   VariableName |
-  BusNamespace |
   Number |
   String |
+  Bus |
   Curve |
   Instrument |
   Mixer |
@@ -134,7 +134,7 @@ Call {
 }
 
 AccessOrCall {
-  primary
+  (primary | BusNamespace "." Member { Unit | word })
   (
     "." Call |
     "." Member { Unit | word }
@@ -208,11 +208,11 @@ Mixer {
   kw<"mixer">
   ("(" argumentList? ")")?
   MixerBlock[group=Block] {
-    "{" (Assignment | BusStatement)* "}"
+    "{" (Assignment | Bus)* "}"
   }
 }
 
-BusStatement {
+Bus {
   kw<"bus"> VariableDefinition
   ("(" argumentList? ")")?
   BusBlock[group=Block] {

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -100,7 +100,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
-      case 'BusStatement': {
+      case 'Bus': {
         const block = cursor.node.getChild('BusBlock')
         if (block != null) {
           const blockRange = toSourceRange(document, block.from, block.to)
@@ -163,7 +163,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
             break
           }
 
-          case 'BusStatement': {
+          case 'Bus': {
             if (pendingScope?.kind === 'bus') {
               addBinding({ kind: 'bus', scopeId, name, range: nameRange, declaredScopeId: pendingScope.id })
             }

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -228,6 +228,9 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
     case 'Mixer':
       return checkMixer(scope, expression)
 
+    case 'Bus':
+      return checkBus(scope, expression)
+
     case 'Track':
       return checkTrack(scope, expression)
 
@@ -529,9 +532,7 @@ function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
 
   errors.push(...checkArgumentList(mixerScope, expression.properties, mixerSchema, expression.range, 'property'))
 
-  const busNamespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
-
-  const buses: ast.BusStatement[] = []
+  const buses: ast.Bus[] = []
 
   for (const child of expression.children) {
     switch (child.type) {
@@ -539,23 +540,19 @@ function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
         errors.push(...checkAssignment(mixerScope, child))
         break
 
-      case 'BusStatement': {
+      case 'Bus': {
         const bus = child
         buses.push(bus)
-
-        if (busNamespace.resolutions.has(bus.name.name)) {
-          errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
-        } else if (mixerScope.resolutions.has(bus.name.name)) {
-          errors.push(new CompileError(`Bus name "${bus.name.name}" conflicts with existing identifier`, bus.name.range))
-        }
 
         const busCheck = checkBus(mixerScope, bus)
         errors.push(...busCheck.errors)
 
-        const type = busCheck.result ?? BusFacet.type()
-        mixerScope.resolutions.set(bus.name.name, type)
-        mixerScope.top.buses.set(bus.name.name, type)
-        busNamespace.resolutions.set(bus.name.name, type)
+        if (mixerScope.resolutions.has(bus.name.name)) {
+          errors.push(new CompileError(`Bus name "${bus.name.name}" conflicts with existing identifier`, bus.name.range))
+        } else {
+          const type = busCheck.result ?? BusFacet.type()
+          mixerScope.resolutions.set(bus.name.name, type)
+        }
 
         break
       }
@@ -574,7 +571,7 @@ function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
   return { errors, result: MixerFacet.type() }
 }
 
-function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
+function checkBus (scope: Scope, bus: ast.Bus): Checked<FacetType> {
   const busScope = createLocalScope(scope)
   const errors: CompileError[] = []
 
@@ -648,6 +645,13 @@ function checkBus (scope: Scope, bus: ast.BusStatement): Checked<FacetType> {
   }
 
   const type = makeType(BusFacet, RecordFacet.with(record))
+
+  const namespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
+  if (namespace.resolutions.has(bus.name.name)) {
+    errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
+  } else {
+    namespace.resolutions.set(bus.name.name, type)
+  }
 
   return { errors, result: type }
 }

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -11,7 +11,6 @@ export interface Scope {
 }
 
 export interface GlobalScope extends Scope {
-  readonly buses: Map<string, FacetType>
   readonly namespaces: Map<string, MutableNamespace>
 }
 

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -1,5 +1,5 @@
 import { ast } from '@meyfa/cadence-ast'
-import type { Automation, Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, NoteData, Part, Pattern, Program, RelativeCurve, RelativeCurveSegment, Source, Step, Track, Voice, VoiceInstance } from '@meyfa/cadence-core'
+import type { Automation, Bus, BusId, Effect, InstrumentId, InstrumentRouting, Mixer, MixerRouting, MixerSource, NoteData, Part, Pattern, Program, RelativeCurve, RelativeCurveSegment, Source, Step, Track, Voice, VoiceInstance } from '@meyfa/cadence-core'
 import { beatsToSeconds, concatPatterns, convertPitchToMidi, createParallelPattern, createSerialPattern, getMidiFrequency, mergePatterns } from '@meyfa/cadence-core'
 import type { Numeric, RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
@@ -37,7 +37,7 @@ import { unaryOperations } from '../operators/unary.ts'
 import { resolveInScope } from '../resolution.ts'
 import { isSyntaxUnit, toNumberValue } from '../units.ts'
 import type { GenerateOptions } from './options.ts'
-import type { GlobalScope, MutableNamespace, MutableScope, Scope } from './scopes.ts'
+import type { GlobalScope, MutableScope, Scope } from './scopes.ts'
 import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
 
 /**
@@ -171,6 +171,9 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
 
     case 'Mixer':
       return generateMixer(scope, expression)
+
+    case 'Bus':
+      return generateBus(scope, expression)
 
     case 'Track':
       return generateTrack(scope, expression)
@@ -414,9 +417,6 @@ function createVoiceInstance (voice: ast.Voice, scope: MutableScope, tempo: Nume
 function generateMixer (scope: Scope, mixer: ast.Mixer): Value {
   const mixerScope = createLocalScope(scope)
 
-  const busNamespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
-
-  const busStatements: ast.BusStatement[] = []
   const buses: Bus[] = []
   const routings: MixerRouting[] = []
 
@@ -426,11 +426,21 @@ function generateMixer (scope: Scope, mixer: ast.Mixer): Value {
         processAssignment(mixerScope, child)
         break
 
-      case 'BusStatement': {
-        busStatements.push(child)
-        const generated = generateBus(mixerScope, child, busNamespace)
-        buses.push(generated.bus)
-        routings.push(...generated.routings)
+      case 'Bus': {
+        const busValue = resolve(mixerScope, child)
+        const bus = BusFacet.get(busValue)
+        buses.push(bus)
+
+        assert(!mixerScope.resolutions.has(child.name.name))
+        mixerScope.resolutions.set(child.name.name, busValue)
+
+        const destination = { type: 'bus', id: bus.id } as const
+        routings.push(...bus.sources.map((source) => ({
+          implicit: false,
+          source,
+          destination
+        })))
+
         break
       }
 
@@ -461,7 +471,7 @@ function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRo
     }
   }
 
-  const createImplicitRouting = (source: MixerRouting['source']) => {
+  const createImplicitRouting = (source: MixerSource) => {
     routings.push({ implicit: true, source, destination: { type: 'output' } })
   }
 
@@ -476,13 +486,10 @@ function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRo
   return routings
 }
 
-interface BusGenerationResult {
-  readonly bus: Bus
-  readonly routings: readonly MixerRouting[]
-}
-
-function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: MutableNamespace): BusGenerationResult {
+function generateBus (scope: Scope, bus: ast.Bus): Value {
   const busScope = createLocalScope(scope)
+
+  const namespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
 
   const name = bus.name.name
   const properties = resolveArgumentList(scope, bus.properties, busSchema)
@@ -490,7 +497,7 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
   const valueRecord: Record<string, Value> = Object.create(null)
   const typeRecord: Record<string, FacetType> = Object.create(null)
 
-  const sources: Array<MixerRouting['source']> = []
+  const sources: MixerSource[] = []
   const effects: Effect[] = []
 
   for (const child of bus.children) {
@@ -544,23 +551,13 @@ function generateBus (scope: MutableScope, bus: ast.BusStatement, namespace: Mut
   valueRecord.pan = Parameters.of(pan)
   typeRecord.pan = valueRecord.pan.type
 
-  const data = scope.top.allocateBus({ name, gain, pan, effects })
+  const data = scope.top.allocateBus({ name, sources, gain, pan, effects })
   const value = makeType(BusFacet, RecordFacet.with(typeRecord)).of(data, valueRecord)
-
-  assert(!scope.resolutions.has(name))
-  scope.resolutions.set(name, value)
 
   assert(!namespace.resolutions.has(name))
   namespace.resolutions.set(name, value)
 
-  const destination = { type: 'bus', id: data.id } as const
-  const routings = sources.map((source) => ({
-    implicit: false,
-    source,
-    destination
-  }))
-
-  return { bus: data, routings }
+  return value
 }
 
 function generateTrack (scope: Scope, track: ast.Track): Value {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -346,6 +346,7 @@ const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast
   p.recursive(() => instrument_),
   p.recursive(() => voice_),
   p.recursive(() => mixer_),
+  p.recursive(() => bus_),
   p.recursive(() => track_),
   p.recursive(() => part_)
 )
@@ -610,10 +611,10 @@ const effectStatement_: p.Parser<Token, unknown, ast.EffectStatement> = p.abc(
   }
 )
 
-const busStatement_: p.Parser<Token, unknown, ast.BusStatement> = p.abc(
+const bus_: p.Parser<Token, unknown, ast.Bus> = p.abc(
   combine2(
     keyword('bus'),
-    expect(identifier_, 'bus name')
+    identifier_
   ),
   p.option(
     combine3(
@@ -636,7 +637,7 @@ const busStatement_: p.Parser<Token, unknown, ast.BusStatement> = p.abc(
   ([_bus, name], callChain, [_lp, children, _rp]) => {
     const args = callChain == null ? [] : callChain[1]
 
-    return ast.make('BusStatement', combineSourceRanges(_bus, _rp), {
+    return ast.make('Bus', combineSourceRanges(_bus, _rp), {
       name,
       properties: args,
       children
@@ -657,7 +658,7 @@ const mixer_: p.Parser<Token, unknown, ast.Mixer> = p.abc(
   combine3(
     expectLiteral('{'),
     p.many(
-      p.eitherOr(assignment_, busStatement_)
+      p.eitherOr(assignment_, bus_)
     ),
     expectLiteral('}')
   ),

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -618,7 +618,8 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Duplicate bus named "foo"'
+        'Duplicate bus named "foo"',
+        'Bus name "foo" conflicts with existing identifier'
       ])
     })
 

--- a/packages/language/test/compiler/checker/scopes.test.ts
+++ b/packages/language/test/compiler/checker/scopes.test.ts
@@ -15,7 +15,6 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(result.resolutions.get('foo'), foo)
       assert.deepStrictEqual(result.allowedEffects, { blocking: true })
 
-      assert.strictEqual(result.buses.size, 0)
       assert.strictEqual(result.namespaces.size, 0)
     })
   })

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -43,6 +43,7 @@ describe('compiler/generator/scopes.ts', () => {
 
       const bus0 = {
         name: 'bus0',
+        sources: [],
         gain: scope.allocateParameter('db', db(0)),
         pan: scope.allocateParameter(undefined, scalar(0)),
         effects: []
@@ -50,6 +51,7 @@ describe('compiler/generator/scopes.ts', () => {
 
       const bus1 = {
         name: 'bus1',
+        sources: [],
         gain: scope.allocateParameter('db', db(-3)),
         pan: scope.allocateParameter(undefined, scalar(-0.5)),
         effects: []

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -633,7 +633,7 @@ describe('parser/parser.ts', () => {
         properties: [],
         children: [
           {
-            type: 'BusStatement',
+            type: 'Bus',
             name: { type: 'Identifier', name: 'mybus' },
             properties: [
               {
@@ -739,7 +739,7 @@ describe('parser/parser.ts', () => {
   it('should reject unnamed buses', () => {
     const result = parse(lexSource('mixer { bus {} }'))
     assert.strictEqual(result.complete, false)
-    assert.strictEqual(result.error.message, 'Unexpected "{"; expected bus name')
+    assert.strictEqual(result.error.message, 'Unexpected "bus"; expected "}"')
   })
 
   it('should allow assignments in track and mixer bodies', () => {

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -67,6 +67,7 @@ const part: Part = {
 const bus: Bus = {
   id: 1 as BusId,
   name: 'main',
+  sources: [],
   pan: panParameter,
   gain: gainParameter,
   effects: [effect]


### PR DESCRIPTION
There is already a `Bus` value type. This patch makes it so that buses are valid wherever expressions are valid, resolving to the `Bus` type, which is consumed by the mixer.

See PR #623 where the same was done for parts.