### PR TITLE
feat: Add automation type to compiler

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -95,7 +95,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Bus | Track | Part
+export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Bus | Track | Part | Automation
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -145,7 +145,7 @@ export interface Part extends ASTNode {
   readonly type: 'Part'
   readonly name?: Identifier
   readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Assignment | Routing | AutomateStatement>
+  readonly children: ReadonlyArray<Assignment | Routing | Automation>
 }
 
 export interface EffectStatement extends ASTNode {
@@ -154,8 +154,8 @@ export interface EffectStatement extends ASTNode {
   readonly expression: Expression
 }
 
-export interface AutomateStatement extends ASTNode {
-  readonly type: 'AutomateStatement'
+export interface Automation extends ASTNode {
+  readonly type: 'Automation'
   readonly target: Expression
   readonly curve: Expression
 }
@@ -232,10 +232,10 @@ export interface NodeByType {
 
   Mixer: Mixer
   Bus: Bus
+  EffectStatement: EffectStatement
   Track: Track
   Part: Part
-  EffectStatement: EffectStatement
-  AutomateStatement: AutomateStatement
+  Automation: Automation
 
   Instrument: Instrument
   Voice: Voice

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -142,7 +142,7 @@ AccessOrCall {
 }
 
 expression {
-  AccessOrCall | UnaryExpression | BinaryExpression
+  Automation | AccessOrCall | UnaryExpression | BinaryExpression
 }
 
 UnaryExpression {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -9,6 +9,7 @@ import { ModuleFacet } from '../../type-system/base/module.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
 import { RecordFacet } from '../../type-system/base/record.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
+import { AutomationFacet } from '../../type-system/domain/automation.ts'
 import { BusFacet } from '../../type-system/domain/bus.ts'
 import { CurveFacet } from '../../type-system/domain/curve.ts'
 import { EffectFacet } from '../../type-system/domain/effect.ts'
@@ -236,6 +237,9 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
 
     case 'Part':
       return checkPart(scope, expression)
+
+    case 'Automation':
+      return checkAutomation(scope, expression)
 
     case 'UnaryExpression':
       return checkUnaryExpression(scope, expression)
@@ -718,9 +722,11 @@ function checkPart (scope: Scope, part: ast.Part): Checked<FacetType> {
         errors.push(...checkInstrumentRouting(partScope, child))
         break
 
-      case 'AutomateStatement':
-        errors.push(...checkAutomation(partScope, child))
+      case 'Automation': {
+        const automationCheck = checkAutomation(partScope, child)
+        errors.push(...automationCheck.errors)
         break
+      }
 
       default:
         assertNever(child)
@@ -749,20 +755,20 @@ function checkInstrumentRouting (scope: Scope, routing: ast.Routing): readonly C
   return errors
 }
 
-function checkAutomation (scope: Scope, automation: ast.AutomateStatement): readonly CompileError[] {
+function checkAutomation (scope: Scope, expression: ast.Automation): Checked<FacetType> {
   const errors: CompileError[] = []
 
-  const targetCheck = checkExpression(scope, automation.target)
+  const targetCheck = checkExpression(scope, expression.target)
   errors.push(...targetCheck.errors)
   if (targetCheck.result != null) {
-    errors.push(...checkType(ParameterFacet.type(), targetCheck.result, automation.target.range))
+    errors.push(...checkType(ParameterFacet.type(), targetCheck.result, expression.target.range))
   }
 
-  const curveCheck = checkExpression(scope, automation.curve)
+  const curveCheck = checkExpression(scope, expression.curve)
   errors.push(...curveCheck.errors)
 
   if (curveCheck.result == null) {
-    return errors
+    return { errors, result: AutomationFacet.type() }
   }
 
   let curveType = CurveFacet.type()
@@ -772,9 +778,9 @@ function checkAutomation (scope: Scope, automation: ast.AutomateStatement): read
     curveType = CurveFacet.with(parameterType).type()
   }
 
-  errors.push(...checkType(curveType, curveCheck.result, automation.curve.range))
+  errors.push(...checkType(curveType, curveCheck.result, expression.curve.range))
 
-  return errors
+  return { errors, result: AutomationFacet.type() }
 }
 
 function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -10,6 +10,7 @@ import { ModuleFacet } from '../../type-system/base/module.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
 import { RecordFacet } from '../../type-system/base/record.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
+import { AutomationFacet } from '../../type-system/domain/automation.ts'
 import { BusFacet } from '../../type-system/domain/bus.ts'
 import { CurveFacet } from '../../type-system/domain/curve.ts'
 import { EffectFacet } from '../../type-system/domain/effect.ts'
@@ -180,6 +181,9 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
 
     case 'Part':
       return generatePart(scope, expression)
+
+    case 'Automation':
+      return generateAutomation(scope, expression)
 
     case 'UnaryExpression':
       return computeUnaryExpression(scope, expression)
@@ -641,8 +645,8 @@ function generatePart (scope: Scope, part: ast.Part): Value {
         })
         break
 
-      case 'AutomateStatement':
-        automations.push(generateAutomation(partScope, child))
+      case 'Automation':
+        automations.push(AutomationFacet.get(resolve(partScope, child)))
         break
 
       default:
@@ -653,14 +657,11 @@ function generatePart (scope: Scope, part: ast.Part): Value {
   return PartFacet.type().of({ name, length: length.value, routings, automations })
 }
 
-function generateAutomation (scope: Scope, statement: ast.AutomateStatement): Automation {
+function generateAutomation (scope: Scope, statement: ast.Automation): Value {
   const target = ParameterFacet.get(resolve(scope, statement.target))
   const curve = CurveFacet.get(resolve(scope, statement.curve))
 
-  return {
-    parameterId: target.id,
-    curve
-  }
+  return AutomationFacet.type().of({ parameterId: target.id, curve })
 }
 
 function applyAutomation (top: GlobalScope, automation: Automation, options: RenderCurveOptions): void {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -348,7 +348,8 @@ const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast
   p.recursive(() => mixer_),
   p.recursive(() => bus_),
   p.recursive(() => track_),
-  p.recursive(() => part_)
+  p.recursive(() => part_),
+  p.recursive(() => automation_)
 )
 
 const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
@@ -516,7 +517,7 @@ const routing_: p.Parser<Token, unknown, ast.Routing> = p.abc(
   }
 )
 
-const automateStatement_: p.Parser<Token, unknown, ast.AutomateStatement> = p.ab(
+const automation_: p.Parser<Token, unknown, ast.Automation> = p.ab(
   combine2(
     keyword('automate'),
     expression_
@@ -526,7 +527,7 @@ const automateStatement_: p.Parser<Token, unknown, ast.AutomateStatement> = p.ab
     expression_
   ),
   ([_automate, target], [_as, curve]) => {
-    return ast.make('AutomateStatement', combineSourceRanges(_automate, curve), { target, curve })
+    return ast.make('Automation', combineSourceRanges(_automate, curve), { target, curve })
   }
 )
 
@@ -548,7 +549,7 @@ const part_: p.Parser<Token, unknown, ast.Part> = p.abc(
     p.many(
       p.eitherOr(
         assignment_,
-        p.eitherOr(routing_, automateStatement_)
+        p.eitherOr(routing_, automation_)
       )
     ),
     expectLiteral('}')

--- a/packages/language/src/type-system/domain/automation.ts
+++ b/packages/language/src/type-system/domain/automation.ts
@@ -1,0 +1,6 @@
+import type { Automation } from '@meyfa/cadence-core'
+import { makeFacet } from '../factory.ts'
+
+const FACET_NAME = 'automation'
+
+export const AutomationFacet = makeFacet<typeof FACET_NAME, Automation>(FACET_NAME, {})

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -1,9 +1,10 @@
-import type { Bus, BusId, Effect, Instrument, InstrumentId, Mixer, Parameter, ParameterId, Part, Pattern, RelativeCurve, Source, Track, Voice } from '@meyfa/cadence-core'
+import type { Automation, Bus, BusId, Effect, Instrument, InstrumentId, Mixer, Parameter, ParameterId, Part, Pattern, RelativeCurve, Source, Track, Voice } from '@meyfa/cadence-core'
 import { createSerialPattern } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
+import { AutomationFacet } from '../../src/type-system/domain/automation.ts'
 import { BusFacet } from '../../src/type-system/domain/bus.ts'
 import { CurveFacet } from '../../src/type-system/domain/curve.ts'
 import { EffectFacet } from '../../src/type-system/domain/effect.ts'
@@ -124,7 +125,24 @@ const mixer: Mixer = {
   routings: []
 }
 
+const automation: Automation = {
+  parameterId: gainParameter.id,
+  curve
+}
+
 describe('type-system/domain', () => {
+  describe('AutomationFacet', () => {
+    it('should format and round-trip automation values', () => {
+      const value = AutomationFacet.type().of(automation)
+      const automationData = AutomationFacet.get(value)
+
+      expectTypeEquals<Automation, typeof automationData>()
+      assert.strictEqual(AutomationFacet.format(), 'automation')
+      assert.strictEqual(AutomationFacet.has(value), true)
+      assert.strictEqual(automationData, automation)
+    })
+  })
+
   describe('BusFacet', () => {
     it('should format and round-trip bus values', () => {
       const value = BusFacet.type().of(bus)


### PR DESCRIPTION
With this patch, automations (the application of a curve on a parameter) are no longer statements, but rather expressions with a dedicated type.