### PR TITLE
feat: Add routing type to compiler

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -95,7 +95,7 @@ export interface Call extends ASTNode {
   readonly arguments: ReadonlyArray<Expression | Property>
 }
 
-export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Bus | Track | Part | Automation
+export type Value = Identifier | Number | String | Pattern | Curve | Instrument | Voice | Mixer | Bus | Track | Part | Routing | Automation
 export type Expression = Value | UnaryExpression | BinaryExpression | PropertyAccess | Call
 
 // Composite Types
@@ -228,13 +228,13 @@ export interface NodeByType {
   Property: Property
   Call: Call
   Assignment: Assignment
-  Routing: Routing
 
   Mixer: Mixer
   Bus: Bus
   EffectStatement: EffectStatement
   Track: Track
   Part: Part
+  Routing: Routing
   Automation: Automation
 
   Instrument: Instrument

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -142,7 +142,7 @@ AccessOrCall {
 }
 
 expression {
-  Automation | AccessOrCall | UnaryExpression | BinaryExpression
+  Automation | Routing | AccessOrCall | UnaryExpression | BinaryExpression
 }
 
 UnaryExpression {
@@ -176,7 +176,6 @@ Assignment {
 Routing {
   VariableName
   "<<"
-  (VariableName "<<")*
   expression
 }
 

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -18,6 +18,7 @@ import { MixerFacet } from '../../type-system/domain/mixer.ts'
 import { ParameterFacet } from '../../type-system/domain/parameter.ts'
 import { PartFacet } from '../../type-system/domain/part.ts'
 import { PatternFacet } from '../../type-system/domain/pattern.ts'
+import { RoutingFacet } from '../../type-system/domain/routing.ts'
 import { SourceFacet } from '../../type-system/domain/source.ts'
 import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
@@ -237,6 +238,9 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
 
     case 'Part':
       return checkPart(scope, expression)
+
+    case 'Routing':
+      return checkRouting(scope, expression)
 
     case 'Automation':
       return checkAutomation(scope, expression)
@@ -718,9 +722,11 @@ function checkPart (scope: Scope, part: ast.Part): Checked<FacetType> {
         errors.push(...checkAssignment(partScope, child))
         break
 
-      case 'Routing':
-        errors.push(...checkInstrumentRouting(partScope, child))
+      case 'Routing': {
+        const routingCheck = checkRouting(partScope, child)
+        errors.push(...routingCheck.errors)
         break
+      }
 
       case 'Automation': {
         const automationCheck = checkAutomation(partScope, child)
@@ -736,7 +742,7 @@ function checkPart (scope: Scope, part: ast.Part): Checked<FacetType> {
   return { errors, result: PartFacet.type() }
 }
 
-function checkInstrumentRouting (scope: Scope, routing: ast.Routing): readonly CompileError[] {
+function checkRouting (scope: Scope, routing: ast.Routing): Checked<FacetType> {
   const errors: CompileError[] = []
 
   const destination = resolveInScope(scope, routing.destination.name)
@@ -752,7 +758,7 @@ function checkInstrumentRouting (scope: Scope, routing: ast.Routing): readonly C
     errors.push(...checkType(PatternFacet.type(), sourceCheck.result, routing.source.range))
   }
 
-  return errors
+  return { errors, result: RoutingFacet.type() }
 }
 
 function checkAutomation (scope: Scope, expression: ast.Automation): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -19,6 +19,7 @@ import { MixerFacet } from '../../type-system/domain/mixer.ts'
 import { ParameterFacet } from '../../type-system/domain/parameter.ts'
 import { PartFacet } from '../../type-system/domain/part.ts'
 import { PatternFacet } from '../../type-system/domain/pattern.ts'
+import { RoutingFacet } from '../../type-system/domain/routing.ts'
 import { SourceFacet } from '../../type-system/domain/source.ts'
 import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
@@ -181,6 +182,9 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
 
     case 'Part':
       return generatePart(scope, expression)
+
+    case 'Routing':
+      return generateRouting(scope, expression)
 
     case 'Automation':
       return generateAutomation(scope, expression)
@@ -632,17 +636,7 @@ function generatePart (scope: Scope, part: ast.Part): Value {
         break
 
       case 'Routing':
-        routings.push({
-          source: {
-            type: 'pattern',
-            value: PatternFacet.get(resolve(partScope, child.source))
-          },
-
-          destination: {
-            type: 'instrument',
-            id: InstrumentFacet.get(resolve(partScope, child.destination)).id
-          }
-        })
+        routings.push(RoutingFacet.get(resolve(partScope, child)))
         break
 
       case 'Automation':
@@ -655,6 +649,16 @@ function generatePart (scope: Scope, part: ast.Part): Value {
   }
 
   return PartFacet.type().of({ name, length: length.value, routings, automations })
+}
+
+function generateRouting (scope: Scope, routing: ast.Routing): Value {
+  const destination = InstrumentFacet.get(resolve(scope, routing.destination))
+  const source = PatternFacet.get(resolve(scope, routing.source))
+
+  return RoutingFacet.type().of({
+    destination: { type: 'instrument', id: destination.id },
+    source: { type: 'pattern', value: source }
+  })
 }
 
 function generateAutomation (scope: Scope, statement: ast.Automation): Value {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -349,6 +349,7 @@ const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast
   p.recursive(() => bus_),
   p.recursive(() => track_),
   p.recursive(() => part_),
+  p.recursive(() => routing_),
   p.recursive(() => automation_)
 )
 

--- a/packages/language/src/type-system/domain/routing.ts
+++ b/packages/language/src/type-system/domain/routing.ts
@@ -1,0 +1,6 @@
+import type { InstrumentRouting } from '@meyfa/cadence-core'
+import { makeFacet } from '../factory.ts'
+
+const FACET_NAME = 'routing'
+
+export const RoutingFacet = makeFacet<typeof FACET_NAME, InstrumentRouting>(FACET_NAME, {})

--- a/packages/language/test/type-system/domain.test.ts
+++ b/packages/language/test/type-system/domain.test.ts
@@ -1,4 +1,4 @@
-import type { Automation, Bus, BusId, Effect, Instrument, InstrumentId, Mixer, Parameter, ParameterId, Part, Pattern, RelativeCurve, Source, Track, Voice } from '@meyfa/cadence-core'
+import type { Automation, Bus, BusId, Effect, Instrument, InstrumentId, InstrumentRouting, Mixer, Parameter, ParameterId, Part, Pattern, RelativeCurve, Source, Track, Voice } from '@meyfa/cadence-core'
 import { createSerialPattern } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
@@ -13,6 +13,7 @@ import { MixerFacet } from '../../src/type-system/domain/mixer.ts'
 import { ParameterFacet } from '../../src/type-system/domain/parameter.ts'
 import { PartFacet } from '../../src/type-system/domain/part.ts'
 import { PatternFacet } from '../../src/type-system/domain/pattern.ts'
+import { RoutingFacet } from '../../src/type-system/domain/routing.ts'
 import { SourceFacet } from '../../src/type-system/domain/source.ts'
 import { TrackFacet } from '../../src/type-system/domain/track.ts'
 import { VoiceFacet } from '../../src/type-system/domain/voice.ts'
@@ -123,6 +124,17 @@ const track: Track = {
 const mixer: Mixer = {
   buses: [bus],
   routings: []
+}
+
+const routing: InstrumentRouting = {
+  source: {
+    type: 'pattern',
+    value: pattern
+  },
+  destination: {
+    type: 'instrument',
+    id: instrument.id
+  }
 }
 
 const automation: Automation = {
@@ -255,6 +267,18 @@ describe('type-system/domain', () => {
       assert.strictEqual(PatternFacet.has(value), true)
       assert.strictEqual(patternData, pattern)
       assert.deepStrictEqual(Array.from(patternData.evaluate()), Array.from(pattern.evaluate()))
+    })
+  })
+
+  describe('RoutingFacet', () => {
+    it('should format and round-trip routing values', () => {
+      const value = RoutingFacet.type().of(routing)
+      const routingData = RoutingFacet.get(value)
+
+      expectTypeEquals<InstrumentRouting, typeof routingData>()
+      assert.strictEqual(RoutingFacet.format(), 'routing')
+      assert.strictEqual(RoutingFacet.has(value), true)
+      assert.strictEqual(routingData, routing)
     })
   })
 


### PR DESCRIPTION
See PR #625 where the same was done for automations.

With this patch, a routing (pattern to instrument) is now a first-class type in the compiler and can be used in an expression.