### PR TITLE
fix: Prevent tab title capturing global shortcuts

### DIFF
--- a/packages/editor/src/layout/components/TabTitle.tsx
+++ b/packages/editor/src/layout/components/TabTitle.tsx
@@ -137,12 +137,20 @@ export const TabTitle: FunctionComponent<{
     }
   }, [disabled, resolvedOnClose])
 
+  const onKeyDownCapture = useCallback((event: React.KeyboardEvent) => {
+    // Let modified Space combinations bubble to global shortcut handlers.
+    if (event.code === 'Space' && (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey)) {
+      event.preventDefault()
+    }
+  }, [])
+
   return (
     <HUITab
       as='div'
       ref={setElementRef}
       {...attributes}
       {...listeners}
+      onKeyDownCapture={onKeyDownCapture}
       onFocusCapture={disabled ? undefined : onTabFocus}
       style={{ position: 'relative', flex: 'none', outline: 'none', pointerEvents: disabled ? 'none' : undefined }}
     >


### PR DESCRIPTION
The tab title has default behavior for the Space key. However, it should not capture Space key events with modifier keys also held, as this would prevent shortcuts such as "Playback: Toggle" (Ctrl+Shift+Space) from working when the tab title is focused.