### PR TITLE
feat!: Remove multiline string literal support

### DIFF
--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -9,7 +9,7 @@
 
   stringDelimiter { "\"" }
   stringEscape { "\\" $[.] }
-  stringContent { !["\\{] }
+  stringContent { !["\\{\r\n] }
 
   "~["
   "[" "]"

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -163,4 +163,26 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, 'db', source.indexOf('0.5.db') + '0.5.'.length, 'number')
     assertHighlightAt(spans, source, 'ms', source.indexOf('250.ms') + '250.'.length, 'number')
   })
+
+  it('terminates strings at newlines', () => {
+    const source = 'foo = "Hello,\nWorld"'
+
+    const spans = getHighlightSpans(source)
+
+    const stringSpans = spans.filter((span) => span.classes.includes('string'))
+    assert.strictEqual(stringSpans.length, 1)
+
+    assert.strictEqual(stringSpans[0].text, '"Hello,')
+  })
+
+  it('terminates strings at carriage returns', () => {
+    const source = 'foo = "Hello,\rWorld"'
+
+    const spans = getHighlightSpans(source)
+
+    const stringSpans = spans.filter((span) => span.classes.includes('string'))
+    assert.strictEqual(stringSpans.length, 1)
+
+    assert.strictEqual(stringSpans[0].text, '"Hello,')
+  })
 })

--- a/packages/language/src/lexer/lexer.ts
+++ b/packages/language/src/lexer/lexer.ts
@@ -22,7 +22,8 @@ function lazy (fn: () => Lexer): Lexer {
 const stringLexer = createLexer([
   { name: '"', pop: true },
   { name: 'stringEscape', regex: /\\./ },
-  { name: 'stringContent', regex: /[^"\\{]+/ },
+  { name: 'stringNewline', regex: /\r\n|\r|\n/ },
+  { name: 'stringContent', regex: /[^"\\{\r\n]+/ },
   { name: '{', push: lazy(() => interpolationLexer) }
 ], undefined, options)
 
@@ -82,6 +83,20 @@ export function lex (input: string, filePath?: string): LexResult {
   }
 
   const lexerResult = mainLexer(input)
+
+  const stringNewline = lexerResult.tokens.find((token) => token.name === 'stringNewline')
+  if (stringNewline != null) {
+    return {
+      complete: false,
+      error: new LexError('Unexpected newline in string', {
+        offset: stringNewline.offset,
+        length: 1,
+        filePath,
+        ...getLineAndColumn(stringNewline.offset)
+      })
+    }
+  }
+
   if (!lexerResult.complete) {
     const context = truncateString(input.slice(lexerResult.offset), ERROR_CONTEXT_LIMIT)
 

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -109,6 +109,20 @@ describe('lexer/lexer.ts', () => {
     })
   })
 
+  it('should fail to lex strings with newlines', () => {
+    const result = lex('"hello\nworld"')
+    assert.strictEqual(result.complete, false)
+    assert.strictEqual(result.error.name, 'LexError')
+    assert.strictEqual(result.error.message, 'Unexpected newline in string')
+  })
+
+  it('should fail to lex strings with carriage returns', () => {
+    const result = lex('"hello\rworld"')
+    assert.strictEqual(result.complete, false)
+    assert.strictEqual(result.error.name, 'LexError')
+    assert.strictEqual(result.error.message, 'Unexpected newline in string')
+  })
+
   it('should lex string literals with interpolations', () => {
     const result = lex('"value is {x + 1}" "multiple {a} and {b * 2} interpolations"')
     assert.deepStrictEqual(stripTokenMeta(result), {

--- a/packages/language/test/parser/string.test.ts
+++ b/packages/language/test/parser/string.test.ts
@@ -7,8 +7,6 @@ describe('parser/string.ts', () => {
     it('should parse plain string literals', () => {
       assert.strictEqual(parseStringLiteral('""'), '')
       assert.strictEqual(parseStringLiteral('"hello world"'), 'hello world')
-      assert.strictEqual(parseStringLiteral('"Newline\nin string"'), 'Newline\nin string')
-      assert.strictEqual(parseStringLiteral('"Tab\tseparated"'), 'Tab\tseparated')
     })
 
     it('should parse string literals with escapes', () => {
@@ -26,6 +24,10 @@ describe('parser/string.ts', () => {
       assert.strictEqual(parseStringLiteral('hello'), undefined)
       assert.strictEqual(parseStringLiteral('"Unclosed string'), undefined)
       assert.strictEqual(parseStringLiteral('Unopened string"'), undefined)
+      assert.strictEqual(parseStringLiteral('"Newline\nin string"'), undefined)
+      assert.strictEqual(parseStringLiteral('"Newline in string\n"'), undefined)
+      assert.strictEqual(parseStringLiteral('"Carriage return\rin string"'), undefined)
+      assert.strictEqual(parseStringLiteral('"Carriage return in string\r"'), undefined)
     })
 
     it('should return undefined when the input contains interpolation syntax', () => {
@@ -45,7 +47,7 @@ describe('parser/string.ts', () => {
     it('should keep whitespace inside the string literal', () => {
       assert.strictEqual(parseStringLiteral('"   leading and trailing   "'), '   leading and trailing   ')
       assert.strictEqual(parseStringLiteral('"   multiple   spaces   "'), '   multiple   spaces   ')
-      assert.strictEqual(parseStringLiteral('"\nnewlines\nand\ttabs\t"'), '\nnewlines\nand\ttabs\t')
+      assert.strictEqual(parseStringLiteral('" spaces   and\ttabs\t"'), ' spaces   and\ttabs\t')
     })
   })
 })


### PR DESCRIPTION
This patch disallows newline and carriage return characters in string literals. For example:

```
// now invalid
foo = "hello
world"

// still allowed (newline is escaped)
foo = "hello\nworld"
```

The reason behind this change is that there is simply no use-case for multiline string literals at the moment or in the foreseeable future. Strings represent module names, sample URLs, and other values that are not expected to contain newlines. Disallowing them has the benefit of not consuming the rest of the file for unterminated string literals, i.e. exiting early on invalid input, and not producing broken syntax highlighting while the user is typing a string literal.

BREAKING CHANGE: String literal syntax no longer allows CR or LF input.