### PR TITLE
refactor: Rename ast.UseStatement to ast.Import

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -52,8 +52,8 @@ export interface Curve extends ASTNode {
 
 // Imports
 
-export interface UseStatement extends ASTNode {
-  readonly type: 'UseStatement'
+export interface Import extends ASTNode {
+  readonly type: 'Import'
   readonly library: String
 
   /**
@@ -182,7 +182,7 @@ export interface Voice extends ASTNode {
 
 export interface Program extends ASTNode {
   readonly type: 'Program'
-  readonly imports: readonly UseStatement[]
+  readonly imports: readonly Import[]
   readonly children: ReadonlyArray<Assignment | Emission>
 }
 
@@ -214,7 +214,7 @@ export interface NodeByType {
   CurveSegment: CurveSegment
   Curve: Curve
 
-  UseStatement: UseStatement
+  Import: Import
 
   UnaryExpression: UnaryExpression
   BinaryExpression: BinaryExpression

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -58,7 +58,7 @@ Unit[@dynamicPrecedence=1] {
 }
 
 @top Program {
-  (UseStatement | Assignment | Emission)*
+  (Import | Assignment | Emission)*
 }
 
 interpolationExpression {
@@ -164,7 +164,7 @@ Property {
   expression
 }
 
-UseStatement {
+Import {
   kw<"use"> String
   kw<"as"> UseAlias { word | "*" }
 }

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -66,8 +66,8 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     let accessChainTail: Identifier | undefined
 
     switch (typeName) {
-      case 'UseStatement': {
-        const statement = parseUseStatement(document, cursor.node)
+      case 'Import': {
+        const statement = parseImport(document, cursor.node)
         if (statement == null) {
           break
         }
@@ -296,7 +296,7 @@ function importKey (moduleName: string, range: SourceRange): ImportId {
   return `${moduleName}:${range.offset}:${range.length}` as ImportId
 }
 
-function parseUseStatement (document: TextLike, node: SyntaxNode): Omit<Import, 'id'> | undefined {
+function parseImport (document: TextLike, node: SyntaxNode): Omit<Import, 'id'> | undefined {
   let moduleName: string | undefined
   let alias: string | undefined
   let aliasRange: SourceRange | undefined

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -136,7 +136,7 @@ function checkType (expected: Pick<Type, 'is' | 'format'>, actual: Type, range?:
   return []
 }
 
-function checkImports (imports: readonly ast.UseStatement[]): Checked<ReadonlyMap<string, FacetType>> {
+function checkImports (imports: readonly ast.Import[]): Checked<ReadonlyMap<string, FacetType>> {
   const standardLibraryModuleNames = getStandardModuleNames()
 
   const errors: CompileError[] = []

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -118,7 +118,7 @@ function clamped<U extends Unit> (value: RuntimeNumeric<U>, minimum: number, max
   }
 }
 
-function processImports (imports: readonly ast.UseStatement[]): ReadonlyMap<string, Value> {
+function processImports (imports: readonly ast.Import[]): ReadonlyMap<string, Value> {
   const getModule = (library: ast.String) => {
     assert(library.parts.every((part) => typeof part === 'string'))
     const module = getStandardModuleValue(library.parts.join(''))

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -478,7 +478,7 @@ const argumentList_: p.Parser<Token, unknown, ast.ArgumentList> = p.sepBy(
   literal(',')
 )
 
-const useStatement_: p.Parser<Token, unknown, ast.UseStatement> = p.ab(
+const import_: p.Parser<Token, unknown, ast.Import> = p.ab(
   combine2(
     keyword('use'),
     expect(string_, 'module name')
@@ -493,10 +493,10 @@ const useStatement_: p.Parser<Token, unknown, ast.UseStatement> = p.ab(
   ([_use, libraryToken], [_as, aliasToken]) => {
     const range = combineSourceRanges(_use, aliasToken)
     if (aliasToken.name === '*') {
-      return ast.make('UseStatement', range, { library: libraryToken })
+      return ast.make('Import', range, { library: libraryToken })
     }
 
-    return ast.make('UseStatement', range, { library: libraryToken, alias: (aliasToken as ast.Identifier).name })
+    return ast.make('Import', range, { library: libraryToken, alias: (aliasToken as ast.Identifier).name })
   }
 )
 
@@ -728,7 +728,7 @@ const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.ab(
 )
 
 const program_: p.Parser<Token, unknown, ast.Program> = p.abc(
-  p.many(useStatement_),
+  p.many(import_),
   p.many(
     p.eitherOr(
       p.eitherOr(assignment_, emission_),

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -60,7 +60,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.imports), [
       {
-        type: 'UseStatement',
+        type: 'Import',
         library: {
           type: 'String',
           parts: ['mylib']
@@ -68,7 +68,7 @@ describe('parser/parser.ts', () => {
         alias: 'myalias'
       },
       {
-        type: 'UseStatement',
+        type: 'Import',
         library: {
           type: 'String',
           parts: ['otherlib']


### PR DESCRIPTION
Updates the internal AST node name "UseStatement" to "Import", matching other parts of the codebase and slightly shortening the name.