### PR TITLE
feat: Support combined emission and assignment

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -114,9 +114,20 @@ export interface Assignment extends ASTNode {
   readonly value: Expression
 }
 
-export interface Emission extends ASTNode {
-  readonly type: 'Emission'
-  readonly values: readonly Expression[]
+export type Statement = NamedStatement | UnnamedStatement
+
+interface NamedStatement extends ASTNode {
+  readonly type: 'Statement'
+  readonly emit: boolean
+  readonly name: Identifier
+  readonly values: readonly [Expression]
+}
+
+interface UnnamedStatement extends ASTNode {
+  readonly type: 'Statement'
+  readonly emit: true
+  readonly name?: undefined
+  readonly values: readonly [Expression, ...Expression[]]
 }
 
 // Domain Types
@@ -131,7 +142,7 @@ export interface Bus extends ASTNode {
   readonly type: 'Bus'
   readonly name: Identifier
   readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Assignment | Emission | EffectStatement>
+  readonly children: ReadonlyArray<Statement | EffectStatement>
 }
 
 export interface EffectStatement extends ASTNode {
@@ -167,12 +178,12 @@ export interface Automation extends ASTNode {
 
 export interface Instrument extends ASTNode {
   readonly type: 'Instrument'
-  readonly children: ReadonlyArray<Assignment | Emission>
+  readonly children: readonly Statement[]
 }
 
 export interface Voice extends ASTNode {
   readonly type: 'Voice'
-  readonly children: ReadonlyArray<Assignment | Emission>
+  readonly children: readonly Statement[]
   readonly bindings: {
     readonly note?: Identifier
   }
@@ -183,7 +194,7 @@ export interface Voice extends ASTNode {
 export interface Program extends ASTNode {
   readonly type: 'Program'
   readonly imports: readonly Import[]
-  readonly children: ReadonlyArray<Assignment | Emission>
+  readonly children: readonly Statement[]
 }
 
 // Factory
@@ -223,7 +234,7 @@ export interface NodeByType {
 
   Property: Property
   Assignment: Assignment
-  Emission: Emission
+  Statement: Statement
 
   Mixer: Mixer
   Bus: Bus

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -58,7 +58,7 @@ Unit[@dynamicPrecedence=1] {
 }
 
 @top Program {
-  (Import | Assignment | Emission)*
+  (Import | statement)*
 }
 
 interpolationExpression {
@@ -181,6 +181,15 @@ Emission {
   ("," expression)*
 }
 
+EmissionAssignment {
+  "&"
+  Assignment
+}
+
+statement {
+  Assignment | Emission | EmissionAssignment
+}
+
 Routing {
   VariableName
   "<<"
@@ -223,7 +232,7 @@ Bus {
   kw<"bus"> VariableDefinition
   ("(" argumentList? ")")?
   BusBlock[group=Block] {
-    "{" (Assignment | Emission | EffectStatement)* "}"
+    "{" (statement | EffectStatement)* "}"
   }
 }
 
@@ -236,7 +245,7 @@ EffectStatement {
 Instrument {
   kw<"instrument">
   InstrumentBlock[group=Block] {
-    "{" (Assignment | Emission)* "}"
+    "{" statement* "}"
   }
 }
 
@@ -244,6 +253,6 @@ Voice {
   kw<"voice">
   VariableDefinition?
   VoiceBlock[group=Block] {
-    "{" (Assignment | Emission)* "}"
+    "{" statement* "}"
   }
 }

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -165,4 +165,20 @@ describe('go-to-definition/operation.ts', () => {
     assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'foo'.length))
     assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'foo'.length))
   })
+
+  it('resolves emission assignment', () => {
+    const source = [
+      '& foo = 42',
+      '& foo // reference',
+      ''
+    ].join('\n')
+
+    const defPos = source.indexOf('& foo =') + '& '.length
+    const refPos = source.lastIndexOf('& foo // reference') + '& '.length
+
+    const result = applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos)
+
+    assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'foo'.length))
+    assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'foo'.length))
+  })
 })

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -31,6 +31,24 @@ describe('highlight-occurrences/operation.ts', () => {
     )
   })
 
+  it('returns definition and reference ranges for emission assignments', () => {
+    const source = [
+      '& foo = mixer {}',
+      'bar = foo',
+      ''
+    ].join('\n')
+
+    const position = source.lastIndexOf('foo') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('& foo =') + '& '.length, 'foo'.length),
+        getRangeAt(source, source.indexOf('foo', source.indexOf('bar =')), 'foo'.length)
+      ]
+    )
+  })
+
   it('normalizes explicit bus namespace references to the bus member range', () => {
     const source = [
       '& track (120.bpm) {',

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -68,44 +68,27 @@ export function check (program: ast.Program): CheckResult {
   let hasMixer = false
 
   for (const child of program.children) {
-    switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(scope, child))
-        break
+    const statement = checkStatement(scope, child)
+    errors.push(...statement.errors)
 
-      case 'Emission': {
-        for (const value of child.values) {
-          const valueCheck = checkExpression(scope, value)
-          errors.push(...valueCheck.errors)
-
-          if (valueCheck.result == null) {
-            continue
-          }
-
-          if (MixerFacet.is(valueCheck.result)) {
-            if (hasMixer) {
-              errors.push(new CompileError('Multiple mixers', value.range))
-            }
-            hasMixer = true
-            continue
-          }
-
-          if (TrackFacet.is(valueCheck.result)) {
-            if (hasTrack) {
-              errors.push(new CompileError('Multiple tracks', value.range))
-            }
-            hasTrack = true
-            continue
-          }
-
-          errors.push(new CompileError(`Unexpected type ${valueCheck.result.format()}, expected track or mixer`, value.range))
+    for (const emission of statement.emissions) {
+      if (MixerFacet.is(emission.type)) {
+        if (hasMixer) {
+          errors.push(new CompileError('Multiple mixers', emission.range))
         }
-
-        break
+        hasMixer = true
+        continue
       }
 
-      default:
-        assertNever(child)
+      if (TrackFacet.is(emission.type)) {
+        if (hasTrack) {
+          errors.push(new CompileError('Multiple tracks', emission.range))
+        }
+        hasTrack = true
+        continue
+      }
+
+      errors.push(new CompileError(`Unexpected type ${emission.type.format()}, expected track or mixer`, emission.range))
     }
   }
 
@@ -194,6 +177,56 @@ function checkImports (imports: readonly ast.Import[]): Checked<ReadonlyMap<stri
   }
 
   return { errors, result }
+}
+
+interface CheckedStatement {
+  readonly errors: readonly CompileError[]
+  readonly emissions: readonly Emission[]
+}
+
+interface Emission {
+  readonly type: FacetType
+  readonly range: SourceRange
+}
+
+function checkStatement (scope: MutableScope, statement: ast.Statement): CheckedStatement {
+  const errors: CompileError[] = []
+  const emissions: Emission[] = []
+
+  const values: Array<FacetType | undefined> = []
+
+  for (const value of statement.values) {
+    const valueCheck = checkExpression(scope, value)
+    errors.push(...valueCheck.errors)
+    values.push(valueCheck.result)
+  }
+
+  if (statement.emit) {
+    for (let i = 0; i < values.length; ++i) {
+      const { range } = statement.values[i]
+
+      const type = values[i]
+      if (type == null) {
+        continue
+      }
+
+      emissions.push({ type, range })
+    }
+  }
+
+  if (statement.name != null) {
+    const duplicate = scope.resolutions.has(statement.name.name)
+    if (duplicate) {
+      errors.push(new CompileError(`Identifier "${statement.name.name}" is already defined`, statement.name.range))
+    }
+
+    const type = values.at(0)
+    if (type != null && !duplicate) {
+      scope.resolutions.set(statement.name.name, type)
+    }
+  }
+
+  return { errors, emissions }
 }
 
 function checkAssignment (scope: MutableScope, assignment: ast.Assignment): readonly CompileError[] {
@@ -454,26 +487,11 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
   const instrumentScope = createLocalScope(scope)
 
   for (const child of expression.children) {
-    switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(instrumentScope, child))
-        break
+    const statement = checkStatement(instrumentScope, child)
+    errors.push(...statement.errors)
 
-      case 'Emission': {
-        for (const value of child.values) {
-          const valueCheck = checkExpression(instrumentScope, value)
-          errors.push(...valueCheck.errors)
-
-          if (valueCheck.result != null) {
-            errors.push(...checkType(VoiceFacet.type(), valueCheck.result, value.range))
-          }
-        }
-
-        break
-      }
-
-      default:
-        assertNever(child)
+    for (const emission of statement.emissions) {
+      errors.push(...checkType(VoiceFacet.type(), emission.type, emission.range))
     }
   }
 
@@ -492,41 +510,27 @@ function checkVoice (scope: Scope, voice: ast.Voice): Checked<FacetType> {
   let hasOutput = false
 
   for (const child of voice.children) {
-    switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(voiceScope, child))
-        break
+    const statement = checkStatement(voiceScope, child)
+    errors.push(...statement.errors)
 
-      case 'Emission': {
-        for (const value of child.values) {
-          const valueCheck = checkExpression(voiceScope, value)
-          errors.push(...valueCheck.errors)
-
-          if (valueCheck.result == null) {
-            continue
-          }
-
-          // value can be either curve (envelope) or source (output)
-          if (CurveFacet.with('db').is(valueCheck.result)) {
-            if (hasEnvelope) {
-              errors.push(new CompileError('Multiple envelopes in a voice', value.range))
-            }
-            hasEnvelope = true
-          } else if (SourceFacet.is(valueCheck.result)) {
-            if (hasOutput) {
-              errors.push(new CompileError('Multiple outputs in a voice', value.range))
-            }
-            hasOutput = true
-          } else {
-            errors.push(new CompileError(`Invalid emission type ${valueCheck.result.format()}`, value.range))
-          }
+    for (const emission of statement.emissions) {
+      if (CurveFacet.with('db').is(emission.type)) {
+        if (hasEnvelope) {
+          errors.push(new CompileError('Multiple envelopes in a voice', emission.range))
         }
-
-        break
+        hasEnvelope = true
+        continue
       }
 
-      default:
-        assertNever(child)
+      if (SourceFacet.is(emission.type)) {
+        if (hasOutput) {
+          errors.push(new CompileError('Multiple outputs in a voice', emission.range))
+        }
+        hasOutput = true
+        continue
+      }
+
+      errors.push(new CompileError(`Unexpected type ${emission.type.format()}, expected envelope or output`, emission.range))
     }
   }
 
@@ -600,19 +604,13 @@ function checkBus (scope: Scope, bus: ast.Bus): Checked<FacetType> {
 
   for (const child of bus.children) {
     switch (child.type) {
-      case 'Assignment':
-        errors.push(...checkAssignment(busScope, child))
-        break
+      case 'Statement': {
+        const statement = checkStatement(busScope, child)
+        errors.push(...statement.errors)
 
-      case 'Emission': {
-        for (const value of child.values) {
-          const valueCheck = checkExpression(busScope, value)
-          errors.push(...valueCheck.errors)
-
-          if (valueCheck.result != null) {
-            const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
-            errors.push(...checkType(options, valueCheck.result, value.range))
-          }
+        for (const emission of statement.emissions) {
+          const options = makeUnion(InstrumentFacet.type(), BusFacet.type())
+          errors.push(...checkType(options, emission.type, emission.range))
         }
 
         break

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -58,31 +58,16 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
   let track: Track | undefined
 
   for (const child of program.children) {
-    switch (child.type) {
-      case 'Assignment':
-        processAssignment(scope, child)
-        break
-
-      case 'Emission': {
-        for (const value of child.values) {
-          const emittedValue = resolve(scope, value)
-
-          if (MixerFacet.has(emittedValue)) {
-            assert(mixer == null)
-            mixer = MixerFacet.get(emittedValue)
-          } else if (TrackFacet.has(emittedValue)) {
-            assert(track == null)
-            track = TrackFacet.get(emittedValue)
-          } else {
-            fail()
-          }
-        }
-
-        break
+    for (const emission of processStatement(scope, child)) {
+      if (MixerFacet.has(emission)) {
+        assert(mixer == null)
+        mixer = MixerFacet.get(emission)
+      } else if (TrackFacet.has(emission)) {
+        assert(track == null)
+        track = TrackFacet.get(emission)
+      } else {
+        fail()
       }
-
-      default:
-        assertNever(child)
     }
   }
 
@@ -145,6 +130,18 @@ function processImports (imports: readonly ast.Import[]): ReadonlyMap<string, Va
   }
 
   return result
+}
+
+function processStatement (scope: MutableScope, statement: ast.Statement): readonly Value[] {
+  const values = statement.values.map((value) => resolve(scope, value))
+
+  if (statement.name != null) {
+    assert(values.length === 1)
+    assert(!scope.resolutions.has(statement.name.name))
+    scope.resolutions.set(statement.name.name, values[0])
+  }
+
+  return statement.emit ? values : []
 }
 
 function processAssignment (scope: MutableScope, assignment: ast.Assignment): void {
@@ -327,21 +324,8 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   const voices: Voice[] = []
 
   for (const child of expression.children) {
-    switch (child.type) {
-      case 'Assignment':
-        processAssignment(instrumentScope, child)
-        break
-
-      case 'Emission': {
-        for (const value of child.values) {
-          const emittedValue = resolve(instrumentScope, value)
-          voices.push(VoiceFacet.get(emittedValue))
-        }
-        break
-      }
-
-      default:
-        assertNever(child)
+    for (const emission of processStatement(instrumentScope, child)) {
+      voices.push(VoiceFacet.get(emission))
     }
   }
 
@@ -395,31 +379,16 @@ function createVoiceInstance (voice: ast.Voice, scope: MutableScope, tempo: Nume
   let outputValue: Source | undefined
 
   for (const child of voice.children) {
-    switch (child.type) {
-      case 'Assignment':
-        processAssignment(scope, child)
-        break
-
-      case 'Emission': {
-        for (const value of child.values) {
-          const emittedValue = resolve(scope, value)
-
-          if (CurveFacet.with('db').has(emittedValue)) {
-            assert(envelopeValue == null)
-            envelopeValue = CurveFacet.with('db').get(emittedValue)
-          } else if (SourceFacet.has(emittedValue)) {
-            assert(outputValue == null)
-            outputValue = SourceFacet.get(emittedValue)
-          } else {
-            fail()
-          }
-        }
-
-        break
+    for (const emission of processStatement(scope, child)) {
+      if (CurveFacet.with('db').has(emission)) {
+        assert(envelopeValue == null)
+        envelopeValue = CurveFacet.with('db').get(emission)
+      } else if (SourceFacet.has(emission)) {
+        assert(outputValue == null)
+        outputValue = SourceFacet.get(emission)
+      } else {
+        fail()
       }
-
-      default:
-        assertNever(child)
     }
   }
 
@@ -529,18 +498,12 @@ function generateBus (scope: Scope, bus: ast.Bus): Value {
 
   for (const child of bus.children) {
     switch (child.type) {
-      case 'Assignment':
-        processAssignment(busScope, child)
-        break
-
-      case 'Emission': {
-        for (const value of child.values) {
-          const emittedValue = resolve(busScope, value)
-
-          if (InstrumentFacet.has(emittedValue)) {
-            sources.push({ type: 'instrument', id: InstrumentFacet.get(emittedValue).id })
-          } else if (BusFacet.has(emittedValue)) {
-            sources.push({ type: 'bus', id: BusFacet.get(emittedValue).id })
+      case 'Statement': {
+        for (const emission of processStatement(busScope, child)) {
+          if (InstrumentFacet.has(emission)) {
+            sources.push({ type: 'instrument', id: InstrumentFacet.get(emission).id })
+          } else if (BusFacet.has(emission)) {
+            sources.push({ type: 'bus', id: BusFacet.get(emission).id })
           } else {
             fail()
           }

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -509,7 +509,20 @@ const assignment_: p.Parser<Token, unknown, ast.Assignment> = p.abc(
   }
 )
 
-const emission_: p.Parser<Token, unknown, ast.Emission> = p.abc(
+const plainAssignment_: p.Parser<Token, unknown, ast.Statement> = p.abc(
+  identifier_,
+  literal('='),
+  expression_,
+  (key, _eq, value) => {
+    return ast.make('Statement', combineSourceRanges(key, value), {
+      emit: false,
+      name: key,
+      values: [value]
+    })
+  }
+)
+
+const plainEmission_: p.Parser<Token, unknown, ast.Statement> = p.abc(
   literal('&'),
   expression_,
   p.many(
@@ -518,12 +531,37 @@ const emission_: p.Parser<Token, unknown, ast.Emission> = p.abc(
       expression_
     )
   ),
-  (_amp, firstValue, restValues) => {
-    const values = [firstValue, ...restValues.map(([, value]) => value)]
-    const lastValue = values.at(-1) ?? firstValue
+  (_amp, firstValue, rest) => {
+    const restValues = rest.map(([, value]) => value)
+    const lastValue = restValues.at(-1) ?? firstValue
 
-    return ast.make('Emission', combineSourceRanges(_amp, lastValue), { values })
+    return ast.make('Statement', combineSourceRanges(_amp, lastValue), {
+      emit: true,
+      values: [firstValue, ...restValues]
+    })
   }
+)
+
+const emissionAssignment_: p.Parser<Token, unknown, ast.Statement> = p.ab(
+  literal('&'),
+  combine3(
+    identifier_,
+    literal('='),
+    expression_
+  ),
+  (_amp, [key, _eq, value]) => {
+    return ast.make('Statement', combineSourceRanges(_amp, value), {
+      emit: true,
+      name: key,
+      values: [value]
+    })
+  }
+)
+
+const statement_ = p.choice<Token, unknown, ast.Statement>(
+  plainAssignment_,
+  emissionAssignment_,
+  plainEmission_
 )
 
 const routing_: p.Parser<Token, unknown, ast.Routing> = p.abc(
@@ -646,10 +684,7 @@ const bus_: p.Parser<Token, unknown, ast.Bus> = p.abc(
   combine3(
     expectLiteral('{'),
     p.many(
-      p.eitherOr(
-        assignment_,
-        p.eitherOr(emission_, effectStatement_)
-      )
+      p.eitherOr(statement_, effectStatement_)
     ),
     expectLiteral('}')
   ),
@@ -696,9 +731,7 @@ const voice_: p.Parser<Token, unknown, ast.Voice> = p.abc(
   p.option(identifier_, undefined),
   combine3(
     literal('{'),
-    p.many(
-      p.eitherOr(assignment_, emission_)
-    ),
+    p.many(statement_),
     expectLiteral('}')
   ),
   (_voice, note, [_lp, children, _rp]) => {
@@ -715,9 +748,7 @@ const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.ab(
   keyword('instrument'),
   combine3(
     expectLiteral('{'),
-    p.many(
-      p.eitherOr(assignment_, emission_)
-    ),
+    p.many(statement_),
     expectLiteral('}')
   ),
   (_instrument, [_lp, children, _rp]) => {
@@ -731,7 +762,7 @@ const program_: p.Parser<Token, unknown, ast.Program> = p.abc(
   p.many(import_),
   p.many(
     p.eitherOr(
-      p.eitherOr(assignment_, emission_),
+      statement_,
       p.map(p.any, (token) => {
         const context = truncateString(token.text, ERROR_CONTEXT_LIMIT)
         throw new ParseError(`Unexpected statement beginning with "${context}"`, getSourceRange(token))

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -49,7 +49,7 @@ describe('parser/parser.ts', () => {
     })
   })
 
-  it('should parse use statements', () => {
+  it('should parse imports', () => {
     const source = [
       'use "mylib" as myalias',
       'use "otherlib" as *'
@@ -77,7 +77,7 @@ describe('parser/parser.ts', () => {
     ])
   })
 
-  it('should reject use statements after other statements', () => {
+  it('should reject imports after other statements', () => {
     const source = [
       'foo = 42',
       'use "mylib" as myalias'
@@ -95,11 +95,72 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'foo' },
-        value: { type: 'Number', value: 42 }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          { type: 'Number', value: 42 }
+        ]
       }
     ])
+  })
+
+  it('should parse a simple emission', () => {
+    const result = parse(lexSource('& 42'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Statement',
+        emit: true,
+        values: [
+          { type: 'Number', value: 42 }
+        ]
+      }
+    ])
+  })
+
+  it('should parse an emission assignment', () => {
+    const result = parse(lexSource('& foo = 42'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Statement',
+        emit: true,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          { type: 'Number', value: 42 }
+        ]
+      }
+    ])
+  })
+
+  it('should parse a statement with multiple values', () => {
+    const result = parse(lexSource('& 1, "hello", foo'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Statement',
+        emit: true,
+        values: [
+          { type: 'Number', value: 1 },
+          { type: 'String', parts: ['hello'] },
+          { type: 'Identifier', name: 'foo' }
+        ]
+      }
+    ])
+  })
+
+  it('should reject assignments with multiple values', () => {
+    const result = parse(lexSource('foo = 1, 2'))
+    assert.strictEqual(result.complete, false)
+  })
+
+  it('should reject emission-assignments with multiple values', () => {
+    const result = parse(lexSource('& foo = 1, 2'))
+    assert.strictEqual(result.complete, false)
   })
 
   it('should parse unit suffixes', () => {
@@ -113,31 +174,37 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'offset' },
-        value: {
-          type: 'UnaryExpression',
-          operator: '-',
-          argument: {
-            type: 'PropertyAccess',
-            object: { type: 'Number', value: 1.5 },
-            property: { type: 'Identifier', name: 'ms' }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'offset' },
+        values: [
+          {
+            type: 'UnaryExpression',
+            operator: '-',
+            argument: {
+              type: 'PropertyAccess',
+              object: { type: 'Number', value: 1.5 },
+              property: { type: 'Identifier', name: 'ms' }
+            }
           }
-        }
+        ]
       },
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'gain' },
-        value: {
-          type: 'PropertyAccess',
-          object: {
-            type: 'BinaryExpression',
-            operator: '+',
-            left: { type: 'Number', value: -6 },
-            right: { type: 'Number', value: 3 }
-          },
-          property: { type: 'Identifier', name: 'db' }
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'gain' },
+        values: [
+          {
+            type: 'PropertyAccess',
+            object: {
+              type: 'BinaryExpression',
+              operator: '+',
+              left: { type: 'Number', value: -6 },
+              right: { type: 'Number', value: 3 }
+            },
+            property: { type: 'Identifier', name: 'db' }
+          }
+        ]
       }
     ])
   })
@@ -148,17 +215,20 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'target' },
-        value: {
-          type: 'PropertyAccess',
-          object: {
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'target' },
+        values: [
+          {
             type: 'PropertyAccess',
-            object: { type: 'Identifier', name: 'bus' },
-            property: { type: 'Identifier', name: 'main' }
-          },
-          property: { type: 'Identifier', name: 'gain' }
-        }
+            object: {
+              type: 'PropertyAccess',
+              object: { type: 'Identifier', name: 'bus' },
+              property: { type: 'Identifier', name: 'main' }
+            },
+            property: { type: 'Identifier', name: 'gain' }
+          }
+        ]
       }
     ])
   })
@@ -169,16 +239,19 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'foo' },
-        value: {
-          type: 'String',
-          parts: [
-            'a { b ',
-            { type: 'Identifier', name: 'x' },
-            ' c'
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          {
+            type: 'String',
+            parts: [
+              'a { b ',
+              { type: 'Identifier', name: 'x' },
+              ' c'
+            ]
+          }
+        ]
       }
     ])
   })
@@ -189,20 +262,23 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'foo' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            { type: 'Step', value: 'x', parameters: [] },
-            { type: 'Step', value: 'x', parameters: [] },
-            { type: 'Step', value: '-', parameters: [] },
-            { type: 'Step', value: 'D4', length: { type: 'Number', value: 0.5 }, parameters: [] },
-            { type: 'Step', value: '-', parameters: [] },
-            { type: 'Step', value: 'G4', parameters: [] }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              { type: 'Step', value: 'x', parameters: [] },
+              { type: 'Step', value: 'x', parameters: [] },
+              { type: 'Step', value: '-', parameters: [] },
+              { type: 'Step', value: 'D4', length: { type: 'Number', value: 0.5 }, parameters: [] },
+              { type: 'Step', value: '-', parameters: [] },
+              { type: 'Step', value: 'G4', parameters: [] }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -213,13 +289,16 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'foo' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: []
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: []
+          }
+        ]
       }
     ])
   })
@@ -232,16 +311,19 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'pattern' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            { type: 'Step', value: 'C4', parameters: [gate] },
-            { type: 'Step', value: '-', parameters: [] }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'pattern' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              { type: 'Step', value: 'C4', parameters: [gate] },
+              { type: 'Step', value: '-', parameters: [] }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -255,16 +337,19 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'pattern' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            { type: 'Step', value: 'C4', length, parameters: [gate] },
-            { type: 'Step', value: '-', parameters: [] }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'pattern' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              { type: 'Step', value: 'C4', length, parameters: [gate] },
+              { type: 'Step', value: '-', parameters: [] }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -279,16 +364,19 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'pattern' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            { type: 'Step', value: 'C4', length, parameters: [gate, velocity] },
-            { type: 'Step', value: '-', parameters: [] }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'pattern' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              { type: 'Step', value: 'C4', length, parameters: [gate, velocity] },
+              { type: 'Step', value: '-', parameters: [] }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -299,27 +387,30 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'pattern' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            {
-              type: 'Step',
-              value: 'C4',
-              length: { type: 'Number', value: 1.5 },
-              parameters: [
-                {
-                  type: 'Property',
-                  key: { type: 'Identifier', name: 'gate' },
-                  value: { type: 'Number', value: 2.0 }
-                }
-              ]
-            },
-            { type: 'Step', value: '-', parameters: [] }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'pattern' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              {
+                type: 'Step',
+                value: 'C4',
+                length: { type: 'Number', value: 1.5 },
+                parameters: [
+                  {
+                    type: 'Property',
+                    key: { type: 'Identifier', name: 'gate' },
+                    value: { type: 'Number', value: 2.0 }
+                  }
+                ]
+              },
+              { type: 'Step', value: '-', parameters: [] }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -330,32 +421,35 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'pattern' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            {
-              type: 'Step',
-              value: 'C4',
-              length: { type: 'Number', value: 1.5 },
-              parameters: [
-                {
-                  type: 'Property',
-                  key: { type: 'Identifier', name: 'vel' },
-                  value: { type: 'Number', value: 0.75 }
-                },
-                {
-                  type: 'Property',
-                  key: { type: 'Identifier', name: 'gate' },
-                  value: { type: 'Number', value: 2.0 }
-                }
-              ]
-            },
-            { type: 'Step', value: '-', parameters: [] }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'pattern' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              {
+                type: 'Step',
+                value: 'C4',
+                length: { type: 'Number', value: 1.5 },
+                parameters: [
+                  {
+                    type: 'Property',
+                    key: { type: 'Identifier', name: 'vel' },
+                    value: { type: 'Number', value: 0.75 }
+                  },
+                  {
+                    type: 'Property',
+                    key: { type: 'Identifier', name: 'gate' },
+                    value: { type: 'Number', value: 2.0 }
+                  }
+                ]
+              },
+              { type: 'Step', value: '-', parameters: [] }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -366,37 +460,40 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'pattern' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            {
-              type: 'Pattern',
-              mode: 'parallel',
-              children: [
-                {
-                  type: 'Step',
-                  value: 'C4',
-                  length: { type: 'Number', value: 0.75 },
-                  parameters: []
-                },
-                {
-                  type: 'Step',
-                  value: '-',
-                  length: { type: 'Number', value: 0.25 },
-                  parameters: []
-                }
-              ]
-            },
-            {
-              type: 'Step',
-              value: 'E4',
-              parameters: []
-            }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'pattern' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              {
+                type: 'Pattern',
+                mode: 'parallel',
+                children: [
+                  {
+                    type: 'Step',
+                    value: 'C4',
+                    length: { type: 'Number', value: 0.75 },
+                    parameters: []
+                  },
+                  {
+                    type: 'Step',
+                    value: '-',
+                    length: { type: 'Number', value: 0.25 },
+                    parameters: []
+                  }
+                ]
+              },
+              {
+                type: 'Step',
+                value: 'E4',
+                parameters: []
+              }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -413,22 +510,25 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'pattern' },
-        value: {
-          type: 'Pattern',
-          mode: 'serial',
-          children: [
-            { type: 'Step', value: 'C4', parameters: [] },
-            { type: 'Step', value: '-', parameters: [] },
-            {
-              type: 'BinaryExpression',
-              operator: '*',
-              left: { type: 'Identifier', name: 'some_pattern' },
-              right: { type: 'Number', value: 2 }
-            }
-          ]
-        }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'pattern' },
+        values: [
+          {
+            type: 'Pattern',
+            mode: 'serial',
+            children: [
+              { type: 'Step', value: 'C4', parameters: [] },
+              { type: 'Step', value: '-', parameters: [] },
+              {
+                type: 'BinaryExpression',
+                operator: '*',
+                left: { type: 'Identifier', name: 'some_pattern' },
+                right: { type: 'Number', value: 2 }
+              }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -438,9 +538,9 @@ describe('parser/parser.ts', () => {
     assertResultComplete(result)
 
     const assignment = result.value.children[0]
-    assert.strictEqual(assignment.type, 'Assignment')
-    assert.strictEqual(assignment.value.type, 'Pattern')
-    assert.strictEqual(assignment.value.children[1]?.range.filePath, 'track.cadence')
+    assert.strictEqual(assignment.type, 'Statement')
+    assert.strictEqual(assignment.values[0].type, 'Pattern')
+    assert.strictEqual(assignment.values[0].children[1]?.range.filePath, 'track.cadence')
   })
 
   it('should parse property access expressions', () => {
@@ -454,17 +554,20 @@ describe('parser/parser.ts', () => {
 
       assert.deepStrictEqual(stripRanges(result.value.children), [
         {
-          type: 'Assignment',
-          key: { type: 'Identifier', name: 'x' },
-          value: {
-            type: 'PropertyAccess',
-            object: {
+          type: 'Statement',
+          emit: false,
+          name: { type: 'Identifier', name: 'x' },
+          values: [
+            {
               type: 'PropertyAccess',
-              object: { type: 'Identifier', name: 'object' },
-              property: { type: 'Identifier', name: 'foo' }
-            },
-            property: { type: 'Identifier', name: 'bar' }
-          }
+              object: {
+                type: 'PropertyAccess',
+                object: { type: 'Identifier', name: 'object' },
+                property: { type: 'Identifier', name: 'foo' }
+              },
+              property: { type: 'Identifier', name: 'bar' }
+            }
+          ]
         }
       ])
     }
@@ -476,38 +579,41 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'foo' },
-        value: {
-          type: 'Curve',
-          children: [
-            {
-              type: 'CurveSegment',
-              curveType: 'hold',
-              parameters: [
-                { type: 'Number', value: 0 }
-              ],
-              length: {
-                type: 'PropertyAccess',
-                object: { type: 'Number', value: 1 },
-                property: { type: 'Identifier', name: 'bar' }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          {
+            type: 'Curve',
+            children: [
+              {
+                type: 'CurveSegment',
+                curveType: 'hold',
+                parameters: [
+                  { type: 'Number', value: 0 }
+                ],
+                length: {
+                  type: 'PropertyAccess',
+                  object: { type: 'Number', value: 1 },
+                  property: { type: 'Identifier', name: 'bar' }
+                }
+              },
+              {
+                type: 'CurveSegment',
+                curveType: 'lin',
+                parameters: [
+                  { type: 'Number', value: 0 },
+                  { type: 'Number', value: 1 }
+                ],
+                length: {
+                  type: 'PropertyAccess',
+                  object: { type: 'Number', value: 2 },
+                  property: { type: 'Identifier', name: 'beats' }
+                }
               }
-            },
-            {
-              type: 'CurveSegment',
-              curveType: 'lin',
-              parameters: [
-                { type: 'Number', value: 0 },
-                { type: 'Number', value: 1 }
-              ],
-              length: {
-                type: 'PropertyAccess',
-                object: { type: 'Number', value: 2 },
-                property: { type: 'Identifier', name: 'beats' }
-              }
-            }
-          ]
-        }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -518,33 +624,36 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'foo' },
-        value: {
-          type: 'Curve',
-          children: [
-            {
-              type: 'CurveSegment',
-              curveType: 'hold',
-              parameters: [],
-              length: {
-                type: 'PropertyAccess',
-                object: { type: 'Number', value: 1 },
-                property: { type: 'Identifier', name: 'bar' }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          {
+            type: 'Curve',
+            children: [
+              {
+                type: 'CurveSegment',
+                curveType: 'hold',
+                parameters: [],
+                length: {
+                  type: 'PropertyAccess',
+                  object: { type: 'Number', value: 1 },
+                  property: { type: 'Identifier', name: 'bar' }
+                }
+              },
+              {
+                type: 'CurveSegment',
+                curveType: 'hold',
+                parameters: [],
+                length: {
+                  type: 'PropertyAccess',
+                  object: { type: 'Number', value: 2 },
+                  property: { type: 'Identifier', name: 'bars' }
+                }
               }
-            },
-            {
-              type: 'CurveSegment',
-              curveType: 'hold',
-              parameters: [],
-              length: {
-                type: 'PropertyAccess',
-                object: { type: 'Number', value: 2 },
-                property: { type: 'Identifier', name: 'bars' }
-              }
-            }
-          ]
-        }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -565,25 +674,28 @@ describe('parser/parser.ts', () => {
 
       assert.deepStrictEqual(stripRanges(result.value.children), [
         {
-          type: 'Assignment',
-          key: { type: 'Identifier', name: 'x' },
-          value: {
-            type: 'Call',
-            callee: {
-              type: 'PropertyAccess',
-              object: {
-                type: 'Call',
-                callee: {
-                  type: 'PropertyAccess',
-                  object: { type: 'Identifier', name: 'object' },
-                  property: { type: 'Identifier', name: 'method1' }
+          type: 'Statement',
+          emit: false,
+          name: { type: 'Identifier', name: 'x' },
+          values: [
+            {
+              type: 'Call',
+              callee: {
+                type: 'PropertyAccess',
+                object: {
+                  type: 'Call',
+                  callee: {
+                    type: 'PropertyAccess',
+                    object: { type: 'Identifier', name: 'object' },
+                    property: { type: 'Identifier', name: 'method1' }
+                  },
+                  arguments: []
                 },
-                arguments: []
+                property: { type: 'Identifier', name: 'method2' }
               },
-              property: { type: 'Identifier', name: 'method2' }
-            },
-            arguments: []
-          }
+              arguments: []
+            }
+          ]
         }
       ])
     }
@@ -595,20 +707,23 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'x' },
-        value: {
-          type: 'Call',
-          callee: {
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'x' },
+        values: [
+          {
             type: 'Call',
-            callee: { type: 'Identifier', name: 'factory' },
-            arguments: []
-          },
-          arguments: [
-            { type: 'Identifier', name: 'arg1' },
-            { type: 'Identifier', name: 'arg2' }
-          ]
-        }
+            callee: {
+              type: 'Call',
+              callee: { type: 'Identifier', name: 'factory' },
+              arguments: []
+            },
+            arguments: [
+              { type: 'Identifier', name: 'arg1' },
+              { type: 'Identifier', name: 'arg2' }
+            ]
+          }
+        ]
       }
     ])
   })
@@ -628,7 +743,7 @@ describe('parser/parser.ts', () => {
     assertResultComplete(result)
 
     assert.strictEqual(result.value.children.length, 1)
-    assert.strictEqual(result.value.children[0].type, 'Emission')
+    assert.strictEqual(result.value.children[0].type, 'Statement')
 
     const emissions = result.value.children[0].values
 
@@ -653,7 +768,8 @@ describe('parser/parser.ts', () => {
             ],
             children: [
               {
-                type: 'Emission',
+                type: 'Statement',
+                emit: true,
                 values: [
                   { type: 'Identifier', name: 'kick' },
                   { type: 'Identifier', name: 'snare' },
@@ -712,7 +828,8 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource(source))
     assertResultComplete(result)
 
-    assert.strictEqual(result.value.children[0].type, 'Emission')
+    assert.strictEqual(result.value.children[0].type, 'Statement')
+    assert.strictEqual(result.value.children[0].emit, true)
 
     const emissions = result.value.children[0].values
 
@@ -771,7 +888,8 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Emission',
+        type: 'Statement',
+        emit: true,
         values: [
           {
             type: 'Track',
@@ -787,7 +905,8 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'Emission',
+        type: 'Statement',
+        emit: true,
         values: [
           {
             type: 'Mixer',
@@ -821,60 +940,71 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Assignment',
-        key: { type: 'Identifier', name: 'my_synth' },
-        value: {
-          type: 'Instrument',
-          children: [
-            {
-              type: 'Assignment',
-              key: { type: 'Identifier', name: 'foo' },
-              value: {
-                type: 'UnaryExpression',
-                operator: '-',
-                argument: {
-                  type: 'PropertyAccess',
-                  object: { type: 'Number', value: 6 },
-                  property: { type: 'Identifier', name: 'db' }
-                }
-              }
-            },
-            {
-              type: 'Emission',
-              values: [
-                {
-                  type: 'Voice',
-                  bindings: {
-                    note: undefined
-                  },
-                  children: [
-                    {
-                      type: 'Assignment',
-                      key: { type: 'Identifier', name: 'bar' },
-                      value: {
-                        type: 'PropertyAccess',
-                        object: { type: 'Number', value: 440 },
-                        property: { type: 'Identifier', name: 'hz' }
-                      }
+        type: 'Statement',
+        emit: false,
+        name: { type: 'Identifier', name: 'my_synth' },
+        values: [
+          {
+            type: 'Instrument',
+            children: [
+              {
+                type: 'Statement',
+                emit: false,
+                name: { type: 'Identifier', name: 'foo' },
+                values: [
+                  {
+                    type: 'UnaryExpression',
+                    operator: '-',
+                    argument: {
+                      type: 'PropertyAccess',
+                      object: { type: 'Number', value: 6 },
+                      property: { type: 'Identifier', name: 'db' }
                     }
-                  ]
-                }
-              ]
-            },
-            {
-              type: 'Emission',
-              values: [
-                {
-                  type: 'Voice',
-                  bindings: {
-                    note: { type: 'Identifier', name: 'note' }
-                  },
-                  children: []
-                }
-              ]
-            }
-          ]
-        }
+                  }
+                ]
+              },
+              {
+                type: 'Statement',
+                emit: true,
+                values: [
+                  {
+                    type: 'Voice',
+                    bindings: {
+                      note: undefined
+                    },
+                    children: [
+                      {
+                        type: 'Statement',
+                        emit: false,
+                        name: { type: 'Identifier', name: 'bar' },
+                        values: [
+                          {
+                            type: 'PropertyAccess',
+                            object: { type: 'Number', value: 440 },
+                            property: { type: 'Identifier', name: 'hz' }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                type: 'Statement',
+                emit: true,
+                values: [
+                  {
+                    type: 'Voice',
+                    bindings: {
+                      note: { type: 'Identifier', name: 'note' }
+                    },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ])
   })


### PR DESCRIPTION
It is now possible to emit and assign a value in a single statement. For example, the following statement will emit the value of `bar` and also assign it to `foo`:

```
& foo = bar
```

This is realized via a unified `Statement` AST node that can represent plain emissions, plain assignments, and emission assignments, e.g.:

```
// plain emission (can support multiple values)
& foo, bar

// plain assignment (one value only)
foo = bar

// emission assignment (one value only)
& foo = bar
```