### PR TITLE
feat: Introduce property exposure operator

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -113,6 +113,7 @@ export type Statement = NamedStatement | UnnamedStatement
 interface NamedStatement extends ASTNode {
   readonly type: 'Statement'
   readonly emit: boolean
+  readonly expose: boolean
   readonly name: Identifier
   readonly values: readonly [Expression]
 }
@@ -120,6 +121,7 @@ interface NamedStatement extends ASTNode {
 interface UnnamedStatement extends ASTNode {
   readonly type: 'Statement'
   readonly emit: true
+  readonly expose: false
   readonly name?: undefined
   readonly values: readonly [Expression, ...Expression[]]
 }

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -29,6 +29,7 @@
   "/"
 
   "&"
+  "@"
 
   @precedence { Comment, "/" }
 }
@@ -170,6 +171,7 @@ Import {
 }
 
 Assignment {
+  "@"?
   VariableDefinition
   "="
   expression

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -50,6 +50,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     scopeId: string,
     pendingScope: Scope | undefined,
     assignmentHasEquals: boolean,
+    assignmentIsExposed: boolean,
     previousSibling?: Identifier
   ): Identifier | undefined => {
     const typeName = cursor.type.name
@@ -63,6 +64,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     let nextScopeId = scopeId
     let nextPendingScope = pendingScope
     let nextAssignmentHasEquals = assignmentHasEquals
+    let nextAssignmentIsExposed = assignmentIsExposed
     let accessChainTail: Identifier | undefined
 
     switch (typeName) {
@@ -130,16 +132,9 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       }
 
       case 'Assignment': {
-        nextAssignmentHasEquals = false
-
-        cursor.node.cursor().iterate((node) => {
-          if (node.type.name === '=') {
-            nextAssignmentHasEquals = true
-            return false
-          }
-          return true
-        })
-
+        const { hasEquals, isExposed } = parseAssignment(cursor.node)
+        nextAssignmentHasEquals = hasEquals
+        nextAssignmentIsExposed = isExposed
         break
       }
 
@@ -149,7 +144,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         switch (parentType) {
           case 'Assignment': {
             if (assignmentHasEquals) {
-              addBinding({ kind: 'regular', scopeId, name, range: nameRange })
+              addBinding({ kind: 'regular', scopeId, name, range: nameRange, isExposed: assignmentIsExposed })
               break
             }
             // Invalid/incomplete syntax encountered.
@@ -225,6 +220,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
           nextScopeId,
           nextPendingScope,
           nextAssignmentHasEquals,
+          nextAssignmentIsExposed,
           childPreviousSibling
         )
 
@@ -244,7 +240,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     return accessChainTail
   }
 
-  walk(cursor, undefined, rootScopeId, undefined, false)
+  walk(cursor, undefined, rootScopeId, undefined, false, false)
 
   sortByOffset(scopes)
   sortByOffset(identifiers)
@@ -329,4 +325,31 @@ function parseImport (document: TextLike, node: SyntaxNode): Omit<Import, 'id'> 
   }
 
   return { ...result, alias }
+}
+
+interface AssignmentParseResult {
+  readonly hasEquals: boolean
+  readonly isExposed: boolean
+}
+
+function parseAssignment (node: SyntaxNode): AssignmentParseResult {
+  let hasEquals = false
+  let isExposed = false
+
+  const cursor = node.cursor()
+
+  if (cursor.firstChild()) {
+    do {
+      switch (cursor.type.name) {
+        case '=':
+          hasEquals = true
+          break
+        case '@':
+          isExposed = true
+          break
+      }
+    } while (cursor.nextSibling())
+  }
+
+  return { hasEquals, isExposed }
 }

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -79,6 +79,11 @@ export interface Binding {
    * The scope declared by this binding, if applicable (e.g. for bus bindings).
    */
   readonly declaredScopeId?: string
+
+  /**
+   * For regular bindings, whether this is an exposed property.
+   */
+  readonly isExposed?: boolean
 }
 
 export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus' | 'effect'

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -35,6 +35,11 @@ function isUnusedBinding (binding: Binding, model: ReferenceModel): boolean {
     return false
   }
 
+  // Do not report exposed properties as unused.
+  if (binding.isExposed) {
+    return false
+  }
+
   const references = model.bindingReferences.get(binding.id)
 
   // At most one reference, which would be the definition itself.

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -25,6 +25,7 @@ describe('model/analysis/base.ts', () => {
       'tempo = 120.bpm',
       '',
       'synth = instrument {',
+      '  @custom_property = 42',
       '  & voice note {}',
       '}',
       '',
@@ -61,6 +62,7 @@ describe('model/analysis/base.ts', () => {
         { kind: 'definition', scope: 'root', name: 'tempo' },
         { kind: 'plain', scope: 'root', name: 'bpm' },
         { kind: 'definition', scope: 'root', name: 'synth' },
+        { kind: 'definition', scope: 'instrument', name: 'custom_property' },
         { kind: 'definition', scope: 'voice', name: 'note' },
         { kind: 'property-name', scope: 'root', name: 'tempo' },
         { kind: 'plain', scope: 'root', name: 'tempo' },
@@ -217,6 +219,7 @@ describe('model/analysis/base.ts', () => {
       'snare = sample("/samples/snare.wav", gain: -3.db)',
       '',
       'my_instrument = instrument {',
+      '  @custom_property = 42',
       '  foo = 42',
       '  bar = foo * 2',
       '  & voice note {',
@@ -296,19 +299,20 @@ describe('model/analysis/base.ts', () => {
     )
 
     assert.deepStrictEqual(
-      model.bindings.map(({ kind, name, declaredScopeId }) => ({ kind, name, declaredScopeId })),
+      model.bindings.map(({ kind, name, declaredScopeId, isExposed }) => ({ kind, name, declaredScopeId, isExposed })),
       [
-        { kind: 'use-alias', name: 'fx', declaredScopeId: undefined },
-        { kind: 'regular', name: 'kick', declaredScopeId: undefined },
-        { kind: 'regular', name: 'snare', declaredScopeId: undefined },
-        { kind: 'regular', name: 'my_instrument', declaredScopeId: undefined },
-        { kind: 'regular', name: 'foo', declaredScopeId: undefined },
-        { kind: 'regular', name: 'bar', declaredScopeId: undefined },
-        { kind: 'regular', name: 'note', declaredScopeId: undefined },
-        { kind: 'regular', name: 'baz', declaredScopeId: undefined },
-        { kind: 'part', name: 'intro', declaredScopeId: undefined },
-        { kind: 'bus', name: 'drums', declaredScopeId: drumsBusScopeId },
-        { kind: 'bus', name: 'delay', declaredScopeId: delayBusScopeId }
+        { kind: 'use-alias', name: 'fx', declaredScopeId: undefined, isExposed: undefined },
+        { kind: 'regular', name: 'kick', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'snare', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'my_instrument', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'custom_property', declaredScopeId: undefined, isExposed: true },
+        { kind: 'regular', name: 'foo', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'bar', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'note', declaredScopeId: undefined, isExposed: undefined },
+        { kind: 'regular', name: 'baz', declaredScopeId: undefined, isExposed: false },
+        { kind: 'part', name: 'intro', declaredScopeId: undefined, isExposed: undefined },
+        { kind: 'bus', name: 'drums', declaredScopeId: drumsBusScopeId, isExposed: undefined },
+        { kind: 'bus', name: 'delay', declaredScopeId: delayBusScopeId, isExposed: undefined }
       ]
     )
   })

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -31,7 +31,7 @@ describe('unused-variable/operation.ts', () => {
     )
   })
 
-  it('does not report parts or buses as unused', () => {
+  it('does not report emitted parts or buses as unused', () => {
     const source = [
       '& track (120.bpm) {',
       '  & part intro (4.bars) {',
@@ -40,6 +40,20 @@ describe('unused-variable/operation.ts', () => {
       '& mixer {',
       '  & bus drums {',
       '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      []
+    )
+  })
+
+  it('does not report exposed properties as unused', () => {
+    const source = [
+      '& mixer {',
+      '  @foo = 42',
       '}',
       ''
     ].join('\n')

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -71,6 +71,10 @@ export function check (program: ast.Program): CheckResult {
     const statement = checkStatement(scope, child)
     errors.push(...statement.errors)
 
+    if (statement.properties.size > 0) {
+      errors.push(new CompileError('Cannot expose properties in the global scope', child.range))
+    }
+
     for (const emission of statement.emissions) {
       if (MixerFacet.is(emission.type)) {
         if (hasMixer) {
@@ -107,6 +111,12 @@ function ensureStandardModule (moduleName: string): Value<typeof ModuleFacet> {
   }
 
   return module
+}
+
+function putAll<K, V> (map: Map<K, V>, entries: Iterable<readonly [K, V]>): void {
+  for (const [key, value] of entries) {
+    map.set(key, value)
+  }
 }
 
 function checkType (expected: Pick<Type, 'is' | 'format'>, actual: Type, range?: SourceRange): readonly CompileError[] {
@@ -182,6 +192,7 @@ function checkImports (imports: readonly ast.Import[]): Checked<ReadonlyMap<stri
 interface CheckedStatement {
   readonly errors: readonly CompileError[]
   readonly emissions: readonly Emission[]
+  readonly properties: ReadonlyMap<string, FacetType>
 }
 
 interface Emission {
@@ -189,9 +200,10 @@ interface Emission {
   readonly range: SourceRange
 }
 
-function checkStatement (scope: MutableScope, statement: ast.Statement): CheckedStatement {
+function checkStatement (scope: MutableScope, statement: ast.Statement, existingProperties?: ReadonlyMap<string, FacetType>): CheckedStatement {
   const errors: CompileError[] = []
   const emissions: Emission[] = []
+  const properties = new Map<string, FacetType>()
 
   const values: Array<FacetType | undefined> = []
 
@@ -226,7 +238,18 @@ function checkStatement (scope: MutableScope, statement: ast.Statement): Checked
     }
   }
 
-  return { errors, emissions }
+  if (statement.expose) {
+    const propertyName = statement.name.name
+    const propertyValue = values.at(0)
+
+    if (existingProperties?.has(propertyName) === true) {
+      errors.push(new CompileError(`Duplicate property "${propertyName}"`, statement.name.range))
+    } else if (propertyValue != null) {
+      properties.set(propertyName, values.at(0) ?? StringFacet.type())
+    }
+  }
+
+  return { errors, emissions, properties }
 }
 
 function checkExpression (scope: Scope, expression: ast.Expression): Checked<FacetType> {
@@ -467,17 +490,24 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
   }
 
   const instrumentScope = createLocalScope(scope)
+  const properties = new Map<string, FacetType>()
 
   for (const child of expression.children) {
-    const statement = checkStatement(instrumentScope, child)
+    const statement = checkStatement(instrumentScope, child, properties)
     errors.push(...statement.errors)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(VoiceFacet.type(), emission.type, emission.range))
     }
+
+    putAll(properties, statement.properties)
   }
 
-  return { errors, result: InstrumentFacet.type() }
+  const result = properties.size > 0
+    ? makeType(InstrumentFacet, RecordFacet.with(Object.fromEntries(properties)))
+    : InstrumentFacet.type()
+
+  return { errors, result }
 }
 
 function checkVoice (scope: Scope, voice: ast.Voice): Checked<FacetType> {
@@ -488,11 +518,12 @@ function checkVoice (scope: Scope, voice: ast.Voice): Checked<FacetType> {
     voiceScope.resolutions.set(voice.bindings.note.name, noteType)
   }
 
+  const properties = new Map<string, FacetType>()
   let hasEnvelope = false
   let hasOutput = false
 
   for (const child of voice.children) {
-    const statement = checkStatement(voiceScope, child)
+    const statement = checkStatement(voiceScope, child, properties)
     errors.push(...statement.errors)
 
     for (const emission of statement.emissions) {
@@ -514,6 +545,8 @@ function checkVoice (scope: Scope, voice: ast.Voice): Checked<FacetType> {
 
       errors.push(new CompileError(`Unexpected type ${emission.type.format()}, expected envelope or output`, emission.range))
     }
+
+    putAll(properties, statement.properties)
   }
 
   if (!hasEnvelope) {
@@ -524,7 +557,10 @@ function checkVoice (scope: Scope, voice: ast.Voice): Checked<FacetType> {
     errors.push(new CompileError('Voice is missing an output', voice.range))
   }
 
-  return { errors, result: VoiceFacet.type() }
+  // Properties cannot be used to extend the voice as the voice is generated at runtime.
+  const result = VoiceFacet.type()
+
+  return { errors, result }
 }
 
 function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
@@ -537,16 +573,24 @@ function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
 
   errors.push(...checkArgumentList(mixerScope, expression.properties, mixerSchema, expression.range, 'property'))
 
+  const properties = new Map<string, FacetType>()
+
   for (const child of expression.children) {
-    const statement = checkStatement(mixerScope, child)
+    const statement = checkStatement(mixerScope, child, properties)
     errors.push(...statement.errors)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(BusFacet.type(), emission.type, emission.range))
     }
+
+    putAll(properties, statement.properties)
   }
 
-  return { errors, result: MixerFacet.type() }
+  const result = properties.size > 0
+    ? makeType(MixerFacet, RecordFacet.with(Object.fromEntries(properties)))
+    : MixerFacet.type()
+
+  return { errors, result }
 }
 
 const busInputType = makeUnion(InstrumentFacet.type(), BusFacet.type())
@@ -557,23 +601,21 @@ function checkBus (scope: Scope, bus: ast.Bus): Checked<FacetType> {
 
   errors.push(...checkArgumentList(scope, bus.properties, busSchema, bus.range, 'property'))
 
-  const properties = {
-    gain: ParameterFacet.with('db').type(),
-    pan: ParameterFacet.with(undefined).type()
-  }
-
-  const record: Record<string, FacetType> = Object.create(null)
-  Object.assign(record, properties)
+  const properties = new Map<string, FacetType>()
+  properties.set('gain', ParameterFacet.with('db').type())
+  properties.set('pan', ParameterFacet.with(undefined).type())
 
   for (const child of bus.children) {
     switch (child.type) {
       case 'Statement': {
-        const statement = checkStatement(busScope, child)
+        const statement = checkStatement(busScope, child, properties)
         errors.push(...statement.errors)
 
         for (const emission of statement.emissions) {
           errors.push(...checkType(busInputType, emission.type, emission.range))
         }
+
+        putAll(properties, statement.properties)
 
         break
       }
@@ -602,13 +644,13 @@ function checkBus (scope: Scope, bus: ast.Bus): Checked<FacetType> {
           continue
         }
 
-        if (Object.hasOwn(record, child.name.name)) {
-          errors.push(new CompileError(`Duplicate effect name "${child.name.name}"`, child.name.range))
+        if (properties.has(child.name.name)) {
+          errors.push(new CompileError(`Duplicate property "${child.name.name}"`, child.name.range))
           continue
         }
 
         if (effectType != null) {
-          record[child.name.name] = effectType
+          properties.set(child.name.name, effectType)
         }
 
         break
@@ -619,18 +661,18 @@ function checkBus (scope: Scope, bus: ast.Bus): Checked<FacetType> {
     }
   }
 
-  const type = makeType(BusFacet, RecordFacet.with(record))
+  const result = makeType(BusFacet, RecordFacet.with(Object.fromEntries(properties)))
 
   if (bus.name != null) {
     const namespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
     if (namespace.resolutions.has(bus.name.name)) {
       errors.push(new CompileError(`Duplicate bus named "${bus.name.name}"`, bus.range))
     } else {
-      namespace.resolutions.set(bus.name.name, type)
+      namespace.resolutions.set(bus.name.name, result)
     }
   }
 
-  return { errors, result: type }
+  return { errors, result }
 }
 
 function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
@@ -643,16 +685,24 @@ function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
 
   errors.push(...checkArgumentList(trackScope, expression.properties, trackSchema, expression.range, 'property'))
 
+  const properties = new Map<string, FacetType>()
+
   for (const child of expression.children) {
-    const statement = checkStatement(trackScope, child)
+    const statement = checkStatement(trackScope, child, properties)
     errors.push(...statement.errors)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(PartFacet.type(), emission.type, emission.range))
     }
+
+    putAll(properties, statement.properties)
   }
 
-  return { errors, result: TrackFacet.type() }
+  const result = properties.size > 0
+    ? makeType(TrackFacet, RecordFacet.with(Object.fromEntries(properties)))
+    : TrackFacet.type()
+
+  return { errors, result }
 }
 
 const partEmissionType = makeUnion(RoutingFacet.type(), AutomationFacet.type())
@@ -663,16 +713,24 @@ function checkPart (scope: Scope, part: ast.Part): Checked<FacetType> {
 
   errors.push(...checkArgumentList(scope, part.properties, partSchema, part.range, 'property'))
 
+  const properties = new Map<string, FacetType>()
+
   for (const child of part.children) {
-    const statement = checkStatement(partScope, child)
+    const statement = checkStatement(partScope, child, properties)
     errors.push(...statement.errors)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(partEmissionType, emission.type, emission.range))
     }
+
+    putAll(properties, statement.properties)
   }
 
-  return { errors, result: PartFacet.type() }
+  const result = properties.size > 0
+    ? makeType(PartFacet, RecordFacet.with(Object.fromEntries(properties)))
+    : PartFacet.type()
+
+  return { errors, result }
 }
 
 function checkRouting (scope: Scope, routing: ast.Routing): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -41,6 +41,7 @@ import { isSyntaxUnit, toNumberValue } from '../units.ts'
 import type { GenerateOptions } from './options.ts'
 import type { GlobalScope, MutableScope, Scope } from './scopes.ts'
 import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
+import { RecordBuilder } from './properties.ts'
 
 /**
  * Generate a runnable program from an AST. This assumes the AST has already been
@@ -58,7 +59,9 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
   let track: Track | undefined
 
   for (const child of program.children) {
-    for (const emission of processStatement(scope, child)) {
+    const { emissions } = processStatement(scope, child)
+
+    for (const emission of emissions) {
       if (MixerFacet.has(emission)) {
         assert(mixer == null)
         mixer = MixerFacet.get(emission)
@@ -132,7 +135,12 @@ function processImports (imports: readonly ast.Import[]): ReadonlyMap<string, Va
   return result
 }
 
-function processStatement (scope: MutableScope, statement: ast.Statement): readonly Value[] {
+interface Statement {
+  readonly emissions: readonly Value[]
+  readonly properties: ReadonlyMap<string, Value>
+}
+
+function processStatement (scope: MutableScope, statement: ast.Statement): Statement {
   const values = statement.values.map((value) => resolve(scope, value))
 
   if (statement.name != null) {
@@ -141,7 +149,12 @@ function processStatement (scope: MutableScope, statement: ast.Statement): reado
     scope.resolutions.set(statement.name.name, values[0])
   }
 
-  return statement.emit ? values : []
+  const emissions = statement.emit ? values : []
+  const properties = statement.expose
+    ? new Map([[statement.name.name, nonNull(values.at(0))]])
+    : new Map<string, Value>()
+
+  return { emissions, properties }
 }
 
 /**
@@ -157,7 +170,7 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
       return toNumberValue(scope.top.options, undefined, expression.value)
 
     case 'String':
-      return generateString(scope, expression.parts)
+      return generateString(scope, expression)
 
     case 'Pattern':
       return generatePattern(scope, expression)
@@ -207,8 +220,8 @@ function resolveIdentifier (scope: Scope, identifier: ast.Identifier): Value {
   return nonNull(resolveInScope(scope, identifier.name))
 }
 
-function generateString (scope: Scope, parts: ReadonlyArray<string | ast.Expression>): Value {
-  const resolvedParts = parts.map((part) => {
+function generateString (scope: Scope, expression: ast.String): Value {
+  const resolvedParts = expression.parts.map((part) => {
     if (typeof part === 'string') {
       return part
     }
@@ -277,9 +290,9 @@ function generateStep (scope: Scope, expression: ast.Step): Step {
   return { value, length, gate, velocity }
 }
 
-function generateCurve (scope: Scope, curve: ast.Curve): Value {
-  const segments = curve.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
-  const otherChildren = curve.children.filter((c) => c.type !== 'CurveSegment')
+function generateCurve (scope: Scope, expression: ast.Curve): Value {
+  const segments = expression.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
+  const otherChildren = expression.children.filter((c) => c.type !== 'CurveSegment')
   assert(segments.length > 0)
   assert(otherChildren.length === 0)
 
@@ -316,34 +329,39 @@ function generateCurve (scope: Scope, curve: ast.Curve): Value {
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   const instrumentScope = createLocalScope(scope)
 
+  const recordBuilder = new RecordBuilder()
   const voices: Voice[] = []
 
   for (const child of expression.children) {
-    for (const emission of processStatement(instrumentScope, child)) {
+    const { emissions, properties } = processStatement(instrumentScope, child)
+    for (const emission of emissions) {
       voices.push(VoiceFacet.get(emission))
     }
+    recordBuilder.putAll(properties)
   }
 
   const gainParameter = scope.top.allocateParameter('db', 0 as Numeric<'db'>)
   const instrument = scope.top.allocateInstrument({ gain: gainParameter, voices })
 
-  return InstrumentFacet.type().of(instrument)
+  return !recordBuilder.empty
+    ? makeType(InstrumentFacet, recordBuilder.facet).of(instrument, recordBuilder.record)
+    : InstrumentFacet.type().of(instrument)
 }
 
-function generateVoice (scope: Scope, voice: ast.Voice): Value {
+function generateVoice (scope: Scope, expression: ast.Voice): Value {
   const frozenScope: Scope = cloneScope(scope)
 
   const invoke: Voice['invoke'] = (note, tempo) => {
     const instanceScope = createLocalScope(frozenScope)
 
-    if (voice.bindings.note != null) {
+    if (expression.bindings.note != null) {
       const noteBinding = createNoteBinding(note)
 
-      assert(!instanceScope.resolutions.has(voice.bindings.note.name))
-      instanceScope.resolutions.set(voice.bindings.note.name, noteBinding)
+      assert(!instanceScope.resolutions.has(expression.bindings.note.name))
+      instanceScope.resolutions.set(expression.bindings.note.name, noteBinding)
     }
 
-    return createVoiceInstance(voice, instanceScope, tempo)
+    return createVoiceInstance(expression, instanceScope, tempo)
   }
 
   return VoiceFacet.type().of({ invoke })
@@ -374,7 +392,9 @@ function createVoiceInstance (voice: ast.Voice, scope: MutableScope, tempo: Nume
   let outputValue: Source | undefined
 
   for (const child of voice.children) {
-    for (const emission of processStatement(scope, child)) {
+    const { emissions } = processStatement(scope, child)
+
+    for (const emission of emissions) {
       if (CurveFacet.with('db').has(emission)) {
         assert(envelopeValue == null)
         envelopeValue = CurveFacet.with('db').get(emission)
@@ -405,14 +425,17 @@ function createVoiceInstance (voice: ast.Voice, scope: MutableScope, tempo: Nume
   }
 }
 
-function generateMixer (scope: Scope, mixer: ast.Mixer): Value {
+function generateMixer (scope: Scope, expression: ast.Mixer): Value {
   const mixerScope = createLocalScope(scope)
 
+  const recordBuilder = new RecordBuilder()
   const buses: Bus[] = []
   const routings: MixerRouting[] = []
 
-  for (const child of mixer.children) {
-    for (const emission of processStatement(mixerScope, child)) {
+  for (const child of expression.children) {
+    const { emissions, properties } = processStatement(mixerScope, child)
+
+    for (const emission of emissions) {
       const bus = BusFacet.get(emission)
       buses.push(bus)
 
@@ -423,9 +446,15 @@ function generateMixer (scope: Scope, mixer: ast.Mixer): Value {
         destination
       })))
     }
+
+    recordBuilder.putAll(properties)
   }
 
-  return MixerFacet.type().of({ buses, routings })
+  const mixer = { buses, routings }
+
+  return !recordBuilder.empty
+    ? makeType(MixerFacet, recordBuilder.facet).of(mixer, recordBuilder.record)
+    : MixerFacet.type().of(mixer)
 }
 
 function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRouting[] {
@@ -462,22 +491,33 @@ function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRo
   return routings
 }
 
-function generateBus (scope: Scope, bus: ast.Bus): Value {
+function generateBus (scope: Scope, expression: ast.Bus): Value {
   const busScope = createLocalScope(scope)
 
-  const name = bus.name?.name
-  const properties = resolveArgumentList(scope, bus.properties, busSchema)
+  const name = expression.name?.name
 
-  const valueRecord: Record<string, Value> = Object.create(null)
-  const typeRecord: Record<string, FacetType> = Object.create(null)
-
+  const recordBuilder = new RecordBuilder()
   const sources: MixerSource[] = []
   const effects: Effect[] = []
 
-  for (const child of bus.children) {
+  const properties = resolveArgumentList(scope, expression.properties, busSchema)
+
+  // These must always be allocated even if not explicitly set,
+  // as they could still be automated.
+  const gainData = properties.gain != null ? NumberFacet.get(properties.gain).value : 0 as Numeric<'db'>
+  const panData = properties.pan != null ? NumberFacet.get(properties.pan).value : 0 as Numeric<undefined>
+
+  const gain = scope.top.allocateParameter('db', gainData)
+  const pan = scope.top.allocateParameter(undefined, panData)
+  recordBuilder.put('gain', Parameters.of(gain))
+  recordBuilder.put('pan', Parameters.of(pan))
+
+  for (const child of expression.children) {
     switch (child.type) {
       case 'Statement': {
-        for (const emission of processStatement(busScope, child)) {
+        const { emissions, properties } = processStatement(busScope, child)
+
+        for (const emission of emissions) {
           if (InstrumentFacet.has(emission)) {
             sources.push({ type: 'instrument', id: InstrumentFacet.get(emission).id })
           } else if (BusFacet.has(emission)) {
@@ -487,6 +527,8 @@ function generateBus (scope: Scope, bus: ast.Bus): Value {
           }
         }
 
+        recordBuilder.putAll(properties)
+
         break
       }
 
@@ -494,10 +536,8 @@ function generateBus (scope: Scope, bus: ast.Bus): Value {
         const effectValue = resolve(busScope, child.expression)
         effects.push(EffectFacet.get(effectValue))
 
-        const effectName = child.name?.name
-        if (effectName != null) {
-          valueRecord[effectName] = effectValue
-          typeRecord[effectName] = effectValue.type
+        if (child.name?.name != null) {
+          recordBuilder.put(child.name.name, effectValue)
         }
 
         break
@@ -508,21 +548,8 @@ function generateBus (scope: Scope, bus: ast.Bus): Value {
     }
   }
 
-  // These must always be allocated even if not explicitly set,
-  // as they could still be automated.
-  const gainData = properties.gain != null ? NumberFacet.get(properties.gain).value : 0 as Numeric<'db'>
-  const panData = properties.pan != null ? NumberFacet.get(properties.pan).value : 0 as Numeric<undefined>
-
-  const gain = scope.top.allocateParameter('db', gainData)
-  valueRecord.gain = Parameters.of(gain)
-  typeRecord.gain = valueRecord.gain.type
-
-  const pan = scope.top.allocateParameter(undefined, panData)
-  valueRecord.pan = Parameters.of(pan)
-  typeRecord.pan = valueRecord.pan.type
-
-  const data = scope.top.allocateBus({ name, sources, gain, pan, effects })
-  const value = makeType(BusFacet, RecordFacet.with(typeRecord)).of(data, valueRecord)
+  const bus = scope.top.allocateBus({ name, sources, gain, pan, effects })
+  const value = makeType(BusFacet, recordBuilder.facet).of(bus, recordBuilder.record)
 
   if (name != null) {
     const namespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
@@ -533,22 +560,26 @@ function generateBus (scope: Scope, bus: ast.Bus): Value {
   return value
 }
 
-function generateTrack (scope: Scope, track: ast.Track): Value {
+function generateTrack (scope: Scope, expression: ast.Track): Value {
   const { options } = scope.top
 
-  const properties = resolveArgumentList(scope, track.properties, trackSchema)
+  const trackScope = createLocalScope(scope)
+
+  const recordBuilder = new RecordBuilder()
+  const parts: Part[] = []
+
+  const properties = resolveArgumentList(scope, expression.properties, trackSchema)
 
   const tempo = properties.tempo != null
     ? clamped(NumberFacet.get(properties.tempo), options.tempo.minimum, options.tempo.maximum).value
     : options.tempo.default
 
-  const trackScope = createLocalScope(scope)
-  const parts: Part[] = []
-
   let currentTime = 0 as Numeric<'beats'>
 
-  for (const child of track.children) {
-    for (const emission of processStatement(trackScope, child)) {
+  for (const child of expression.children) {
+    const { emissions, properties } = processStatement(trackScope, child)
+
+    for (const emission of emissions) {
       const part = PartFacet.get(emission)
       parts.push(part)
 
@@ -564,23 +595,33 @@ function generateTrack (scope: Scope, track: ast.Track): Value {
 
       currentTime = currentTime + part.length as Numeric<'beats'>
     }
+
+    recordBuilder.putAll(properties)
   }
 
-  return TrackFacet.type().of({ tempo, parts })
+  const track = { tempo, parts }
+
+  return !recordBuilder.empty
+    ? makeType(TrackFacet, recordBuilder.facet).of(track, recordBuilder.record)
+    : TrackFacet.type().of(track)
 }
 
-function generatePart (scope: Scope, part: ast.Part): Value {
+function generatePart (scope: Scope, expression: ast.Part): Value {
   const partScope = createLocalScope(scope)
 
-  const name = part.name?.name
-  const properties = resolveArgumentList(scope, part.properties, partSchema)
-  const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)
+  const name = expression.name?.name
 
+  const recordBuilder = new RecordBuilder()
   const routings: InstrumentRouting[] = []
   const automations: Automation[] = []
 
-  for (const child of part.children) {
-    for (const emission of processStatement(partScope, child)) {
+  const properties = resolveArgumentList(scope, expression.properties, partSchema)
+  const length = clamped(NumberFacet.get(properties.length), 0, Number.POSITIVE_INFINITY)
+
+  for (const child of expression.children) {
+    const { emissions, properties } = processStatement(partScope, child)
+
+    for (const emission of emissions) {
       if (RoutingFacet.has(emission)) {
         routings.push(RoutingFacet.get(emission))
       } else if (AutomationFacet.has(emission)) {
@@ -589,14 +630,20 @@ function generatePart (scope: Scope, part: ast.Part): Value {
         fail()
       }
     }
+
+    recordBuilder.putAll(properties)
   }
 
-  return PartFacet.type().of({ name, length: length.value, routings, automations })
+  const part = { name, length: length.value, routings, automations }
+
+  return !recordBuilder.empty
+    ? makeType(PartFacet, recordBuilder.facet).of(part, recordBuilder.record)
+    : PartFacet.type().of(part)
 }
 
-function generateRouting (scope: Scope, routing: ast.Routing): Value {
-  const destination = InstrumentFacet.get(resolve(scope, routing.destination))
-  const source = PatternFacet.get(resolve(scope, routing.source))
+function generateRouting (scope: Scope, expression: ast.Routing): Value {
+  const destination = InstrumentFacet.get(resolve(scope, expression.destination))
+  const source = PatternFacet.get(resolve(scope, expression.source))
 
   return RoutingFacet.type().of({
     destination: { type: 'instrument', id: destination.id },
@@ -604,9 +651,9 @@ function generateRouting (scope: Scope, routing: ast.Routing): Value {
   })
 }
 
-function generateAutomation (scope: Scope, statement: ast.Automation): Value {
-  const target = ParameterFacet.get(resolve(scope, statement.target))
-  const curve = CurveFacet.get(resolve(scope, statement.curve))
+function generateAutomation (scope: Scope, expression: ast.Automation): Value {
+  const target = ParameterFacet.get(resolve(scope, expression.target))
+  const curve = CurveFacet.get(resolve(scope, expression.curve))
 
   return AutomationFacet.type().of({ parameterId: target.id, curve })
 }

--- a/packages/language/src/compiler/generator/properties.ts
+++ b/packages/language/src/compiler/generator/properties.ts
@@ -1,0 +1,32 @@
+import { RecordFacet } from '../../type-system/base/record.ts'
+import type { Facet, FacetType, Value } from '../../type-system/types.ts'
+import { assert } from '../assert.ts'
+
+export class RecordBuilder {
+  private readonly types: Record<string, FacetType> = Object.create(null)
+  private readonly values: Record<string, Value> = Object.create(null)
+
+  public put (name: string, value: Value): void {
+    assert(!Object.hasOwn(this.types, name))
+    this.types[name] = value.type
+    this.values[name] = value
+  }
+
+  public putAll (properties: Iterable<readonly [string, Value]>): void {
+    for (const [name, value] of properties) {
+      this.put(name, value)
+    }
+  }
+
+  get empty (): boolean {
+    return Object.keys(this.types).length === 0
+  }
+
+  get facet (): Facet {
+    return RecordFacet.with(this.types)
+  }
+
+  get record (): Readonly<Record<string, Value>> {
+    return this.values
+  }
+}

--- a/packages/language/src/lexer/lexer.ts
+++ b/packages/language/src/lexer/lexer.ts
@@ -39,6 +39,7 @@ const commonRules: Rules = [
   { name: '"', push: stringLexer },
 
   { name: '&' },
+  { name: '@' },
 
   { name: '~[' },
   { name: '[' },

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -500,13 +500,17 @@ const import_: p.Parser<Token, unknown, ast.Import> = p.ab(
   }
 )
 
-const plainAssignment_: p.Parser<Token, unknown, ast.Statement> = p.abc(
-  identifier_,
-  literal('='),
-  expression_,
-  (key, _eq, value) => {
-    return ast.make('Statement', combineSourceRanges(key, value), {
+const plainAssignment_: p.Parser<Token, unknown, ast.Statement> = p.ab(
+  p.option(literal('@'), undefined),
+  combine3(
+    identifier_,
+    literal('='),
+    expression_
+  ),
+  (expose, [key, _eq, value]) => {
+    return ast.make('Statement', combineSourceRanges(expose ?? key, value), {
       emit: false,
+      expose: expose != null,
       name: key,
       values: [value]
     })
@@ -528,21 +532,24 @@ const plainEmission_: p.Parser<Token, unknown, ast.Statement> = p.abc(
 
     return ast.make('Statement', combineSourceRanges(_amp, lastValue), {
       emit: true,
+      expose: false,
       values: [firstValue, ...restValues]
     })
   }
 )
 
-const emissionAssignment_: p.Parser<Token, unknown, ast.Statement> = p.ab(
+const emissionAssignment_: p.Parser<Token, unknown, ast.Statement> = p.abc(
   literal('&'),
+  p.option(literal('@'), undefined),
   combine3(
     identifier_,
     literal('='),
     expression_
   ),
-  (_amp, [key, _eq, value]) => {
+  (_amp, expose, [key, _eq, value]) => {
     return ast.make('Statement', combineSourceRanges(_amp, value), {
       emit: true,
+      expose: expose != null,
       name: key,
       values: [value]
     })

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -49,13 +49,17 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
-    it('should accept use statements without alias', () => {
+    it('should accept imports without alias', () => {
       const source = [
         'use "instruments" as *',
         'use "effects" as *'
       ].join('\n')
 
       assertValid(source)
+    })
+
+    it('should accept imports with alias', () => {
+      assertValid('use "effects" as myalias')
     })
 
     it('should define names from imported libraries', () => {
@@ -65,10 +69,6 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertValid(source)
-    })
-
-    it('should accept imports with alias', () => {
-      assertValid('use "effects" as myalias')
     })
 
     it('should accept a program with one track and unique parts', () => {
@@ -167,6 +167,31 @@ describe('compiler/checker/checker.ts', () => {
         '    shadowed_by_bus = 401',
         '  }',
         '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should accept property exposure', () => {
+      const source = [
+        '& m = mixer {',
+        '  @mixer_property = 42',
+        '  & @b = bus {',
+        '    @bus_property = 42',
+        '  }',
+        '}',
+        '',
+        '& t = track {',
+        '  @track_property = 42',
+        '  & @p = part (4.bars) {',
+        '    @part_property = 42',
+        '  }',
+        '}',
+        '',
+        'access_mixer_property = m.mixer_property',
+        'access_bus_property = m.b.bus_property',
+        'access_track_property = t.track_property',
+        'access_part_property = t.p.part_property'
       ].join('\n')
 
       assertValid(source)
@@ -358,6 +383,17 @@ describe('compiler/checker/checker.ts', () => {
 
       assertValid(source)
     })
+
+    it('should allow property exposure in instrument definitions', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  @foo = -6.db',
+        '}',
+        'access_foo = my_instrument.foo'
+      ].join('\n')
+
+      assertValid(source)
+    })
   })
 
   describe('invalid', () => {
@@ -451,6 +487,42 @@ describe('compiler/checker/checker.ts', () => {
         'Identifier "in_bus" is already defined',
         'Identifier "in_track" is already defined',
         'Identifier "in_part" is already defined'
+      ])
+    })
+
+    it('should reject property exposure in the global scope', () => {
+      const source = [
+        '@foo = 42'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Cannot expose properties in the global scope'
+      ])
+    })
+
+    it('should reject duplicate property exposures', () => {
+      const source = [
+        '& mixer {',
+        '  @foo = 42',
+        '  @foo = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "foo" is already defined',
+        'Duplicate property "foo"'
+      ])
+    })
+
+    it('should reject property exposures that collide with existing names', () => {
+      const source = [
+        'b = bus {',
+        '  @gain = 42',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Duplicate property "gain"'
       ])
     })
 
@@ -646,7 +718,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Duplicate effect name "lp"'
+        'Duplicate property "lp"'
       ])
     })
 
@@ -662,8 +734,8 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Effect name "gain" conflicts with bus property of the same name',
-        'Effect name "pan" conflicts with bus property of the same name'
+        'Duplicate property "gain"',
+        'Duplicate property "pan"'
       ])
     })
 
@@ -957,6 +1029,25 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Unknown identifier "foo"'
+      ])
+    })
+
+    it('should reject property access for voices', () => {
+      // voices generate their value at runtime, so any properties accessed at compile time are invalid
+      const source = [
+        'use "sources" as src',
+        '',
+        'foo = voice {',
+        '  @voice_property = -6.db',
+        '  & ~[lin(0.db, -60.db):100.ms]',
+        '  & src.sine(440.hz)',
+        '}',
+        '',
+        'access_voice_property = foo.voice_property'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Type voice has no property named "voice_property"'
       ])
     })
   })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -90,6 +90,22 @@ describe('compiler/generator/generator.ts', () => {
     assert.deepStrictEqual(result.track.tempo, 90)
   })
 
+  it('should handle property exposure', () => {
+    const source = [
+      'm = mixer { @bit = 1 }',
+      'b = bus { @bit = 2 }',
+      't = track { @bit = 4 }',
+      'p = part (1.bar) { @bit = 8 }',
+      '',
+      'mask = m.bit + b.bit + t.bit + p.bit',
+      '',
+      '& track (tempo: mask.bpm) {}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.track.tempo, 15)
+  })
+
   it('should support imported names', () => {
     const source = [
       'use "instruments" as *',
@@ -781,5 +797,17 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(voice1.source.type, 'oscillator')
     assert.strictEqual(voice1.source.shape, 'sine')
     assert.deepStrictEqual(voice1.source.frequency, pitchFrequency)
+  })
+
+  it('should handle property exposure on instruments', () => {
+    const source = [
+      'my_instrument = instrument {',
+      '  @test_property = 123.bpm',
+      '}',
+      '& track (tempo: my_instrument.test_property) {}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.track.tempo, 123)
   })
 })

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -444,4 +444,32 @@ describe('lexer/lexer.ts', () => {
       ]
     })
   })
+
+  it('should lex exposed properties', () => {
+    const source = [
+      'm = mixer {',
+      '  @exposed_property = 42',
+      '}'
+    ].join('\n')
+
+    const result = lex(source)
+    assert.strictEqual(result.complete, true)
+
+    assert.deepStrictEqual(stripTokenMeta(result), {
+      complete: true,
+      value: [
+        { name: 'word', text: 'm' },
+        { name: '=', text: '=' },
+        { name: 'word', text: 'mixer' },
+        { name: '{', text: '{' },
+
+        { name: '@', text: '@' },
+        { name: 'word', text: 'exposed_property' },
+        { name: '=', text: '=' },
+        { name: 'number', text: '42' },
+
+        { name: '}', text: '}' }
+      ]
+    })
+  })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -97,6 +97,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'foo' },
         values: [
           { type: 'Number', value: 42 }
@@ -113,6 +114,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: true,
+        expose: false,
         values: [
           { type: 'Number', value: 42 }
         ]
@@ -128,6 +130,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: true,
+        expose: false,
         name: { type: 'Identifier', name: 'foo' },
         values: [
           { type: 'Number', value: 42 }
@@ -144,6 +147,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: true,
+        expose: false,
         values: [
           { type: 'Number', value: 1 },
           { type: 'String', parts: ['hello'] },
@@ -163,6 +167,28 @@ describe('parser/parser.ts', () => {
     assert.strictEqual(result.complete, false)
   })
 
+  it('should parse exposed property assignments', () => {
+    const result = parse(lexSource('@foo = 42'))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Statement',
+        emit: false,
+        expose: true,
+        name: { type: 'Identifier', name: 'foo' },
+        values: [
+          { type: 'Number', value: 42 }
+        ]
+      }
+    ])
+  })
+
+  it('should reject exposed property assignments with multiple values', () => {
+    const result = parse(lexSource('@foo = 1, 2'))
+    assert.strictEqual(result.complete, false)
+  })
+
   it('should parse unit suffixes', () => {
     const source = [
       'offset = -1.5.ms',
@@ -176,6 +202,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'offset' },
         values: [
           {
@@ -192,6 +219,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'gain' },
         values: [
           {
@@ -217,6 +245,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'target' },
         values: [
           {
@@ -241,6 +270,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'foo' },
         values: [
           {
@@ -264,6 +294,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'foo' },
         values: [
           {
@@ -291,6 +322,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'foo' },
         values: [
           {
@@ -313,6 +345,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'pattern' },
         values: [
           {
@@ -339,6 +372,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'pattern' },
         values: [
           {
@@ -366,6 +400,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'pattern' },
         values: [
           {
@@ -389,6 +424,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'pattern' },
         values: [
           {
@@ -423,6 +459,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'pattern' },
         values: [
           {
@@ -462,6 +499,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'pattern' },
         values: [
           {
@@ -512,6 +550,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'pattern' },
         values: [
           {
@@ -551,6 +590,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: true,
+        expose: false,
         values: [
           {
             type: 'Routing',
@@ -575,6 +615,7 @@ describe('parser/parser.ts', () => {
         {
           type: 'Statement',
           emit: false,
+          expose: false,
           name: { type: 'Identifier', name: 'x' },
           values: [
             {
@@ -600,6 +641,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'foo' },
         values: [
           {
@@ -645,6 +687,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'foo' },
         values: [
           {
@@ -695,6 +738,7 @@ describe('parser/parser.ts', () => {
         {
           type: 'Statement',
           emit: false,
+          expose: false,
           name: { type: 'Identifier', name: 'x' },
           values: [
             {
@@ -728,6 +772,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'x' },
         values: [
           {
@@ -774,6 +819,7 @@ describe('parser/parser.ts', () => {
           {
             type: 'Statement',
             emit: true,
+            expose: false,
             values: [
               {
                 type: 'Bus',
@@ -793,6 +839,7 @@ describe('parser/parser.ts', () => {
                   {
                     type: 'Statement',
                     emit: true,
+                    expose: false,
                     values: [
                       { type: 'Identifier', name: 'kick' },
                       { type: 'Identifier', name: 'snare' },
@@ -866,6 +913,7 @@ describe('parser/parser.ts', () => {
           {
             type: 'Statement',
             emit: true,
+            expose: false,
             values: [
               {
                 type: 'Part',
@@ -884,6 +932,7 @@ describe('parser/parser.ts', () => {
           {
             type: 'Statement',
             emit: true,
+            expose: false,
             values: [
               {
                 type: 'Part',
@@ -928,6 +977,7 @@ describe('parser/parser.ts', () => {
           {
             type: 'Statement',
             emit: true,
+            expose: false,
             values: [
               {
                 type: 'Bus',
@@ -950,6 +1000,7 @@ describe('parser/parser.ts', () => {
           {
             type: 'Statement',
             emit: true,
+            expose: false,
             values: [
               {
                 type: 'Bus',
@@ -991,6 +1042,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: true,
+        expose: false,
         values: [
           {
             type: 'Track',
@@ -999,6 +1051,7 @@ describe('parser/parser.ts', () => {
               {
                 type: 'Statement',
                 emit: false,
+                expose: false,
                 name: { type: 'Identifier', name: 'foo' },
                 values: [
                   { type: 'Number', value: 42 }
@@ -1011,6 +1064,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: true,
+        expose: false,
         values: [
           {
             type: 'Mixer',
@@ -1019,6 +1073,7 @@ describe('parser/parser.ts', () => {
               {
                 type: 'Statement',
                 emit: false,
+                expose: false,
                 name: { type: 'Identifier', name: 'bar' },
                 values: [
                   { type: 'Number', value: 43 }
@@ -1049,6 +1104,7 @@ describe('parser/parser.ts', () => {
       {
         type: 'Statement',
         emit: false,
+        expose: false,
         name: { type: 'Identifier', name: 'my_synth' },
         values: [
           {
@@ -1057,6 +1113,7 @@ describe('parser/parser.ts', () => {
               {
                 type: 'Statement',
                 emit: false,
+                expose: false,
                 name: { type: 'Identifier', name: 'foo' },
                 values: [
                   {
@@ -1073,6 +1130,7 @@ describe('parser/parser.ts', () => {
               {
                 type: 'Statement',
                 emit: true,
+                expose: false,
                 values: [
                   {
                     type: 'Voice',
@@ -1083,6 +1141,7 @@ describe('parser/parser.ts', () => {
                       {
                         type: 'Statement',
                         emit: false,
+                        expose: false,
                         name: { type: 'Identifier', name: 'bar' },
                         values: [
                           {
@@ -1099,6 +1158,7 @@ describe('parser/parser.ts', () => {
               {
                 type: 'Statement',
                 emit: true,
+                expose: false,
                 values: [
                   {
                     type: 'Voice',


### PR DESCRIPTION
This patch introduces a new operator `@`. When the variable name in an assignment (or emission assignment) is prefixed with `@`, in addition to the regular binding, the surrounding object will also have a property of the same name and value. Compare the following examples:

```
// regular local variable
synth = instrument {
  foo = 42
  bar = foo // valid
}
baz = synth.foo // invalid

// exposed property
synth = instrument {
  @foo = 42
  bar = foo // valid
}
baz = synth.foo // valid
```

It is possible to use exposure in combination with emission. In a future patch, this will be used for bus effects, allowing an effect to be created, applied, and exposed for automation in a single statement.

Exposure is supported on all block-like constructs.