### PR TITLE
feat!: Use emission syntax for effects

### DIFF
--- a/packages/app/src/defaults/demo-code.ts
+++ b/packages/app/src/defaults/demo-code.ts
@@ -47,8 +47,8 @@ clap_pattern = [x:8]
   & bus clap_delay (gain: 3.db, pan: -0.25) {
     & clap
 
-    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)
-    effect fx.reverb(mix: 0.3, decay: 1.s)
+    & fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)
+    & fx.reverb(mix: 0.3, decay: 1.s)
   }
 }
 

--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -138,13 +138,7 @@ export interface Bus extends ASTNode {
   readonly type: 'Bus'
   readonly name?: Identifier
   readonly properties: ArgumentList
-  readonly children: ReadonlyArray<Statement | EffectStatement>
-}
-
-export interface EffectStatement extends ASTNode {
-  readonly type: 'EffectStatement'
-  readonly name?: Identifier
-  readonly expression: Expression
+  readonly children: readonly Statement[]
 }
 
 export interface Track extends ASTNode {
@@ -233,7 +227,6 @@ export interface NodeByType {
 
   Mixer: Mixer
   Bus: Bus
-  EffectStatement: EffectStatement
   Track: Track
   Part: Part
   Routing: Routing

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -235,14 +235,8 @@ Bus {
   VariableDefinition?
   ("(" argumentList? ")")?
   BusBlock[group=Block] {
-    "{" (statement | EffectStatement)* "}"
+    "{" statement* "}"
   }
-}
-
-EffectStatement {
-  kw<"effect">
-  (VariableDefinition "=")?
-  expression
 }
 
 Instrument {

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -165,11 +165,6 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
             break
           }
 
-          case 'EffectStatement': {
-            addBinding({ kind: 'effect', scopeId, name, range: nameRange })
-            break
-          }
-
           case 'Voice': {
             addBinding({ kind: 'regular', scopeId, name, range: nameRange })
             break

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -55,7 +55,6 @@ interface BindingLookup {
   readonly namedImports: ReadonlyMap<string, Binding>
   readonly defaultImports: ReadonlyMap<string, Import>
   readonly buses: ReadonlyMap<string, Binding>
-  readonly effectsByBusName: ReadonlyMap<string, ReadonlyMap<string, Binding>>
   readonly byScopeAndName: ReadonlyMap<string, ReadonlyMap<string, Binding>>
   readonly parentScopes: ReadonlyMap<string, string>
 }
@@ -64,7 +63,6 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
   const namedImports = new Map<string, Binding>()
   const defaultImports = new Map<string, Import>()
   const buses = new Map<string, Binding>()
-  const effectsByBusName = new Map<string, Map<string, Binding>>()
   const byScopeAndName = new Map<string, Map<string, Binding>>()
 
   const busNameByScopeId = new Map<string, string>()
@@ -86,22 +84,6 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
           }
         }
         break
-
-      case 'effect': {
-        const busName = busNameByScopeId.get(binding.scopeId)
-        if (busName != null) {
-          let busEffects = effectsByBusName.get(busName)
-          if (busEffects == null) {
-            busEffects = new Map<string, Binding>()
-            effectsByBusName.set(busName, busEffects)
-          }
-
-          if (!busEffects.has(binding.name)) {
-            busEffects.set(binding.name, binding)
-          }
-        }
-        break
-      }
 
       default:
         break
@@ -134,7 +116,7 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
     }
   }
 
-  return { namedImports, defaultImports, buses, effectsByBusName, byScopeAndName, parentScopes }
+  return { namedImports, defaultImports, buses, byScopeAndName, parentScopes }
 }
 
 function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, lookup: BindingLookup): Binding | undefined {
@@ -154,15 +136,6 @@ function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, loo
 }
 
 function findRegularBinding (occurrence: Identifier, lookup: BindingLookup): Binding | undefined {
-  if (isExplicitBusMemberReference(occurrence)) {
-    const busIdentifier = occurrence.previousSibling
-    if (busIdentifier == null) {
-      return undefined
-    }
-
-    return lookup.effectsByBusName.get(busIdentifier.name)?.get(occurrence.name)
-  }
-
   if (isExplicitBusReference(occurrence)) {
     return lookup.buses.get(occurrence.name)
   }
@@ -195,14 +168,6 @@ function isExplicitBusReference (identifier: Identifier): boolean {
   return identifier.previousSibling != null &&
     identifier.previousSibling.name === 'bus' &&
     identifier.previousSibling.previousSibling == null
-}
-
-function isExplicitBusMemberReference (identifier: Identifier): boolean {
-  const objectIdentifier = identifier.previousSibling
-  const namespaceIdentifier = objectIdentifier?.previousSibling
-
-  return namespaceIdentifier?.name === 'bus' &&
-    namespaceIdentifier.previousSibling == null
 }
 
 const importCache = new WeakMap<BindingLookup, Map<string, Import | undefined>>()

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -86,7 +86,7 @@ export interface Binding {
   readonly isExposed?: boolean
 }
 
-export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus' | 'effect'
+export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus'
 
 // import
 

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -170,31 +170,6 @@ describe('go-to-definition/operation.ts', () => {
     assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'foo'.length))
   })
 
-  it('resolves explicit bus namespace effect access to the effect definition', () => {
-    const source = [
-      'use "effects" as fx',
-      '& track (120.bpm) {',
-      '  & part foo {',
-      '    & automate bus.main.lp.frequency as ~[lin(100.hz, 4000.hz)]',
-      '  }',
-      '}',
-      '& mixer {',
-      '  & bus main {',
-      '    effect lp = fx.lowpass(1000.hz)',
-      '  }',
-      '}',
-      ''
-    ].join('\n')
-
-    const defPos = source.indexOf('effect lp') + 'effect '.length
-    const refPos = source.indexOf('bus.main.lp.frequency') + 'bus.main.'.length
-
-    const result = applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos)
-
-    assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'lp'.length))
-    assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'lp'.length))
-  })
-
   it('does not resolve named argument keys', () => {
     const source = [
       'tempo = 128.bpm',

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -12,7 +12,7 @@ describe('hover/operation.ts', () => {
       'use "effects" as *',
       '& mixer {',
       '  & bus drum_bus {',
-      '    effect gain(-6.db)',
+      '    & gain(-6.db)',
       '  }',
       '}',
       ''
@@ -36,7 +36,7 @@ describe('hover/operation.ts', () => {
       'use "effects" as fx',
       '& mixer {',
       '  & bus drum_bus {',
-      '    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
+      '    & fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
       '  }',
       '}',
       ''
@@ -59,8 +59,8 @@ describe('hover/operation.ts', () => {
       'use "effects" as fx',
       '& mixer {',
       '  & bus drum_bus {',
-      '    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
-      '    effect fx.reverb(mix: 0.3, decay: 1.s)',
+      '    & fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
+      '    & fx.reverb(mix: 0.3, decay: 1.s)',
       '  }',
       '}',
       ''
@@ -95,7 +95,7 @@ describe('hover/operation.ts', () => {
       'use "effects" as *',
       '& mixer {',
       '  & bus drum_bus {',
-      '    effect delay(gain: 0.5)',
+      '    & delay(gain: 0.5)',
       '  }',
       '}',
       ''
@@ -157,7 +157,7 @@ describe('hover/operation.ts', () => {
       'delay = 1',
       '& mixer {',
       '  & bus main {',
-      '    effect fx.reverb(delay)',
+      '    & fx.reverb(delay)',
       '  }',
       '}',
       ''

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -83,7 +83,7 @@ describe('language-support.ts', () => {
       '& mixer {',
       '  & bus main {',
       '    & inst',
-      '    effect fx.pan(-1)',
+      '    & fx.pan(-1)',
       '  }',
       '}',
       ''

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -38,7 +38,7 @@ describe('model/analysis/base.ts', () => {
       '',
       '& mixer {',
       '  & bus drums {',
-      '    effect crush = fx.clip(-6.db)',
+      '    & @crush = fx.clip(-6.db)',
       '    & kick, snare',
       '  }',
       '}',
@@ -193,7 +193,7 @@ describe('model/analysis/base.ts', () => {
       'delay = 1',
       '& mixer {',
       '  & bus main {',
-      '    effect fx.delay(time: delay)',
+      '    & fx.delay(time: delay)',
       '  }',
       '}',
       ''
@@ -238,7 +238,7 @@ describe('model/analysis/base.ts', () => {
       '    & kick, snare',
       '  }',
       '  & bus delay {',
-      '    effect fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
+      '    & fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
       '  }',
       '} // end mixer',
       ''

--- a/packages/language-support/test/model/analysis/known-values.test.ts
+++ b/packages/language-support/test/model/analysis/known-values.test.ts
@@ -32,7 +32,7 @@ describe('model/analysis/known-values.ts', () => {
       '',
       '& mixer {',
       '  & bus {',
-      '    effect fx.gain(-3.db)',
+      '    & fx.gain(-3.db)',
       '  }',
       '}',
       ''

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -239,43 +239,6 @@ describe('model/analysis/references.ts', () => {
     assert.strictEqual(binding, undefined)
   })
 
-  it('resolves named effect access of an explicit bus access', () => {
-    const source = [
-      'use "effects" as fx',
-      '',
-      '& track (120.bpm) {',
-      '  & part main (4.bars) {',
-      '    & automate bus.main.lp.frequency as ~[hold(1000.hz)]',
-      '  }',
-      '}',
-      '',
-      '& mixer {',
-      '  & bus main {',
-      '    effect lp = fx.lowpass(1000.hz)',
-      '  }',
-      '}',
-      ''
-    ].join('\n')
-
-    const model = analyzeSource(source)
-    const position = source.indexOf('bus.main.lp.frequency') + 'bus.main.'.length
-
-    const identifier = model.identifiers.find((item) => item.range.offset === position)
-    assert.ok(identifier != null)
-
-    const resolution = model.resolutions.get(identifier.id)
-    assert.strictEqual(resolution?.kind, 'binding')
-
-    const binding = resolution.binding
-    assert.strictEqual(binding.kind, 'effect')
-    assert.strictEqual(binding.name, 'lp')
-    assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('effect lp') + 'effect '.length, 'lp'.length))
-
-    const references = model.bindingReferences.get(binding.id)
-    assert.ok(references != null)
-    assert.ok(references.includes(identifier))
-  })
-
   it('prefers import aliases over assignments with the same name', () => {
     const source = [
       'fx = sample("/samples/fx.wav")',
@@ -304,7 +267,7 @@ describe('model/analysis/references.ts', () => {
       'use "effects" as *',
       '& mixer {',
       '  & bus main {',
-      '    effect lowpass(1000.hz)',
+      '    & lowpass(1000.hz)',
       '  }',
       '}',
       ''

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -114,7 +114,7 @@ describe('unused-variable/operation.ts', () => {
       '',
       '& mixer {',
       '  & bus drums {',
-      '    effect fx.gain(0.db)',
+      '    & fx.gain(0.db)',
       '  }',
       '}',
       ''
@@ -139,7 +139,7 @@ describe('unused-variable/operation.ts', () => {
       '',
       '& mixer {',
       '  & bus drums {',
-      '    effect gain(0.db)',
+      '    & gain(0.db)',
       '  }',
       '}',
       ''

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -25,7 +25,7 @@ import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeType, makeUnion } from '../../type-system/factory.ts'
 import type { Schema, SchemaItem } from '../../type-system/schema.ts'
 import type { FacetType, Type, Value } from '../../type-system/types.ts'
-import { assertNever, nonNull } from '../assert.ts'
+import { nonNull } from '../assert.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
 import { BUS_NAMESPACE, busSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
 import { getCurveSegmentType } from '../curves.ts'
@@ -593,7 +593,7 @@ function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
   return { errors, result }
 }
 
-const busInputType = makeUnion(InstrumentFacet.type(), BusFacet.type())
+const busEmissionType = makeUnion(InstrumentFacet.type(), BusFacet.type(), EffectFacet.type())
 
 function checkBus (scope: Scope, bus: ast.Bus): Checked<FacetType> {
   const busScope = createLocalScope(scope)
@@ -606,59 +606,14 @@ function checkBus (scope: Scope, bus: ast.Bus): Checked<FacetType> {
   properties.set('pan', ParameterFacet.with(undefined).type())
 
   for (const child of bus.children) {
-    switch (child.type) {
-      case 'Statement': {
-        const statement = checkStatement(busScope, child, properties)
-        errors.push(...statement.errors)
+    const statement = checkStatement(busScope, child, properties)
+    errors.push(...statement.errors)
 
-        for (const emission of statement.emissions) {
-          errors.push(...checkType(busInputType, emission.type, emission.range))
-        }
-
-        putAll(properties, statement.properties)
-
-        break
-      }
-
-      case 'EffectStatement': {
-        const effectCheck = checkExpression(busScope, child.expression)
-        errors.push(...effectCheck.errors)
-
-        let effectType: FacetType | undefined
-
-        if (effectCheck.result != null) {
-          const typeErrors = checkType(EffectFacet.type(), effectCheck.result, child.expression.range)
-          errors.push(...typeErrors)
-
-          if (typeErrors.length === 0) {
-            effectType = effectCheck.result
-          }
-        }
-
-        if (child.name == null) {
-          continue
-        }
-
-        if (Object.hasOwn(properties, child.name.name)) {
-          errors.push(new CompileError(`Effect name "${child.name.name}" conflicts with bus property of the same name`, child.name.range))
-          continue
-        }
-
-        if (properties.has(child.name.name)) {
-          errors.push(new CompileError(`Duplicate property "${child.name.name}"`, child.name.range))
-          continue
-        }
-
-        if (effectType != null) {
-          properties.set(child.name.name, effectType)
-        }
-
-        break
-      }
-
-      default:
-        assertNever(child)
+    for (const emission of statement.emissions) {
+      errors.push(...checkType(busEmissionType, emission.type, emission.range))
     }
+
+    putAll(properties, statement.properties)
   }
 
   const result = makeType(BusFacet, RecordFacet.with(Object.fromEntries(properties)))

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -39,9 +39,9 @@ import { unaryOperations } from '../operators/unary.ts'
 import { resolveInScope } from '../resolution.ts'
 import { isSyntaxUnit, toNumberValue } from '../units.ts'
 import type { GenerateOptions } from './options.ts'
+import { RecordBuilder } from './properties.ts'
 import type { GlobalScope, MutableScope, Scope } from './scopes.ts'
 import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
-import { RecordBuilder } from './properties.ts'
 
 /**
  * Generate a runnable program from an AST. This assumes the AST has already been
@@ -513,39 +513,21 @@ function generateBus (scope: Scope, expression: ast.Bus): Value {
   recordBuilder.put('pan', Parameters.of(pan))
 
   for (const child of expression.children) {
-    switch (child.type) {
-      case 'Statement': {
-        const { emissions, properties } = processStatement(busScope, child)
+    const { emissions, properties } = processStatement(busScope, child)
 
-        for (const emission of emissions) {
-          if (InstrumentFacet.has(emission)) {
-            sources.push({ type: 'instrument', id: InstrumentFacet.get(emission).id })
-          } else if (BusFacet.has(emission)) {
-            sources.push({ type: 'bus', id: BusFacet.get(emission).id })
-          } else {
-            fail()
-          }
-        }
-
-        recordBuilder.putAll(properties)
-
-        break
+    for (const emission of emissions) {
+      if (InstrumentFacet.has(emission)) {
+        sources.push({ type: 'instrument', id: InstrumentFacet.get(emission).id })
+      } else if (BusFacet.has(emission)) {
+        sources.push({ type: 'bus', id: BusFacet.get(emission).id })
+      } else if (EffectFacet.has(emission)) {
+        effects.push(EffectFacet.get(emission))
+      } else {
+        fail()
       }
-
-      case 'EffectStatement': {
-        const effectValue = resolve(busScope, child.expression)
-        effects.push(EffectFacet.get(effectValue))
-
-        if (child.name?.name != null) {
-          recordBuilder.put(child.name.name, effectValue)
-        }
-
-        break
-      }
-
-      default:
-        assertNever(child)
     }
+
+    recordBuilder.putAll(properties)
   }
 
   const bus = scope.top.allocateBus({ name, sources, gain, pan, effects })

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -639,26 +639,6 @@ const track_: p.Parser<Token, unknown, ast.Track> = p.abc(
   }
 )
 
-const effectStatement_: p.Parser<Token, unknown, ast.EffectStatement> = p.abc(
-  keyword('effect'),
-  p.option(
-    combine2(
-      identifier_,
-      literal('=')
-    ),
-    undefined
-  ),
-  expression_,
-  (_effect, nameAndEq, expression) => {
-    const name = nameAndEq == null ? undefined : nameAndEq[0]
-
-    return ast.make('EffectStatement', combineSourceRanges(_effect, expression), {
-      name,
-      expression
-    })
-  }
-)
-
 const bus_: p.Parser<Token, unknown, ast.Bus> = p.abc(
   combine2(
     keyword('bus'),
@@ -674,9 +654,7 @@ const bus_: p.Parser<Token, unknown, ast.Bus> = p.abc(
   ),
   combine3(
     literal('{'),
-    p.many(
-      p.eitherOr(statement_, effectStatement_)
-    ),
+    p.many(statement_),
     expectLiteral('}')
   ),
   ([_bus, name], callChain, [_lp, children, _rp]) => {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -105,10 +105,10 @@ describe('compiler/checker/checker.ts', () => {
         'use "effects" as fx',
         '& mixer {',
         '  & bus {',
-        '    effect fx.delay(mix: 0.25, time: 3.beats, feedback: 0.4)',
+        '    & fx.delay(mix: 0.25, time: 3.beats, feedback: 0.4)',
         '  }',
         '  & bus {',
-        '    effect fx.delay(mix: 0.25, time: 1.5.s, feedback: 0.4)',
+        '    & fx.delay(mix: 0.25, time: 1.5.s, feedback: 0.4)',
         '  }',
         '}'
       ].join('\n')
@@ -121,10 +121,10 @@ describe('compiler/checker/checker.ts', () => {
         'use "effects" as fx',
         '& mixer {',
         '  & bus {',
-        '    effect fx.reverb(mix: 0.25, decay: 3.beats)',
+        '    & fx.reverb(mix: 0.25, decay: 3.beats)',
         '  }',
         '  & bus {',
-        '    effect fx.reverb(mix: 0.25, decay: 1.5.s)',
+        '    & fx.reverb(mix: 0.25, decay: 1.5.s)',
         '  }',
         '}'
       ].join('\n')
@@ -319,7 +319,7 @@ describe('compiler/checker/checker.ts', () => {
         'use "effects" as fx',
         '& mixer {',
         '  & bus main {',
-        '    effect lp = fx.lowpass(1000.hz)',
+        '    & @lp = fx.lowpass(1000.hz)',
         '  }',
         '}',
         '& track {',
@@ -338,7 +338,7 @@ describe('compiler/checker/checker.ts', () => {
         'lp = 42',
         '& mixer {',
         '  & bus {',
-        '    effect lp = fx.lowpass(1000.hz)',
+        '    & @lp = fx.lowpass(1000.hz)',
         '  }',
         '}'
       ].join('\n')
@@ -703,39 +703,6 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Duplicate bus named "foo"'
-      ])
-    })
-
-    it('should reject duplicate named effects within the same bus', () => {
-      const source = [
-        'use "effects" as fx',
-        '& mixer {',
-        '  & bus main {',
-        '    effect lp = fx.lowpass(1000.hz)',
-        '    effect lp = fx.highpass(200.hz)',
-        '  }',
-        '}'
-      ].join('\n')
-
-      assertErrorMessages(source, [
-        'Duplicate property "lp"'
-      ])
-    })
-
-    it('should reject named effects that collide with built-in bus fields', () => {
-      const source = [
-        'use "effects" as fx',
-        '& mixer {',
-        '  & bus main {',
-        '    effect gain = fx.lowpass(1000.hz)',
-        '    effect pan = fx.highpass(200.hz)',
-        '  }',
-        '}'
-      ].join('\n')
-
-      assertErrorMessages(source, [
-        'Duplicate property "gain"',
-        'Duplicate property "pan"'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -278,7 +278,7 @@ describe('compiler/generator/generator.ts', () => {
       '& mixer {',
       '  & bus main {',
       '    my_gain = -20.db',
-      '    effect gain(my_gain)',
+      '    & gain(my_gain)',
       '  }',
       '}'
     ].join('\n')
@@ -568,7 +568,7 @@ describe('compiler/generator/generator.ts', () => {
       'use "effects" as fx',
       '& mixer {',
       '  & bus main {',
-      '    effect lp = fx.lowpass(123.hz)',
+      '    & @lp = fx.lowpass(123.hz)',
       '  }',
       '}',
       '& track (120.bpm) {',
@@ -595,7 +595,9 @@ describe('compiler/generator/generator.ts', () => {
   it('should automate effect parameters', () => {
     const source = [
       'use "effects" as fx',
+      '',
       'lp = fx.lowpass(200.hz)',
+      '',
       '& track (120.bpm) {',
       '  & part intro (4.bars) {',
       '    & automate lp.frequency as ~[lin(500.hz, 1000.hz):4.bars]',
@@ -603,7 +605,7 @@ describe('compiler/generator/generator.ts', () => {
       '}',
       '& mixer {',
       '  & bus main {',
-      '    effect lp',
+      '    & lp',
       '  }',
       '}'
     ].join('\n')
@@ -697,7 +699,7 @@ describe('compiler/generator/generator.ts', () => {
       'use "effects" as fx',
       '& mixer {',
       '  & bus bus0 {',
-      '    effect fx.delay(mix: 0.25, time: 1.5.s, feedback: 0.4)',
+      '    & fx.delay(mix: 0.25, time: 1.5.s, feedback: 0.4)',
       '  }',
       '}'
     ].join('\n')
@@ -725,7 +727,7 @@ describe('compiler/generator/generator.ts', () => {
       'use "effects" as fx',
       '& mixer {',
       '  & bus bus0 {',
-      '    effect fx.reverb(mix: 0.25, decay: 2.beats)',
+      '    & fx.reverb(mix: 0.25, decay: 2.beats)',
       '  }',
       '}'
     ].join('\n')

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -797,8 +797,8 @@ describe('parser/parser.ts', () => {
       '& mixer {',
       '  & bus mybus(gain: (-3).db) {',
       '    & kick, snare, hihat',
-      '    effect fx.pan(0.5)',
-      '    effect lp = fx.lowpass(400.hz)',
+      '    & fx.pan(0.5)',
+      '    & @lp = fx.lowpass(400.hz)',
       '  }',
       '}'
     ].join('\n')
@@ -847,38 +847,45 @@ describe('parser/parser.ts', () => {
                     ]
                   },
                   {
-                    type: 'EffectStatement',
-                    name: undefined,
-                    expression: {
-                      type: 'Call',
-                      callee: {
-                        type: 'PropertyAccess',
-                        object: { type: 'Identifier', name: 'fx' },
-                        property: { type: 'Identifier', name: 'pan' }
-                      },
-                      arguments: [
-                        { type: 'Number', value: 0.5 }
-                      ]
-                    }
+                    type: 'Statement',
+                    emit: true,
+                    expose: false,
+                    values: [
+                      {
+                        type: 'Call',
+                        callee: {
+                          type: 'PropertyAccess',
+                          object: { type: 'Identifier', name: 'fx' },
+                          property: { type: 'Identifier', name: 'pan' }
+                        },
+                        arguments: [
+                          { type: 'Number', value: 0.5 }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    type: 'EffectStatement',
+                    type: 'Statement',
+                    emit: true,
+                    expose: true,
                     name: { type: 'Identifier', name: 'lp' },
-                    expression: {
-                      type: 'Call',
-                      callee: {
-                        type: 'PropertyAccess',
-                        object: { type: 'Identifier', name: 'fx' },
-                        property: { type: 'Identifier', name: 'lowpass' }
-                      },
-                      arguments: [
-                        {
+                    values: [
+                      {
+                        type: 'Call',
+                        callee: {
                           type: 'PropertyAccess',
-                          object: { type: 'Number', value: 400 },
-                          property: { type: 'Identifier', name: 'hz' }
-                        }
-                      ]
-                    }
+                          object: { type: 'Identifier', name: 'fx' },
+                          property: { type: 'Identifier', name: 'lowpass' }
+                        },
+                        arguments: [
+                          {
+                            type: 'PropertyAccess',
+                            object: { type: 'Number', value: 400 },
+                            property: { type: 'Identifier', name: 'hz' }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
Due to the prior work in PRs #631 and #638, there is no longer any need for the dedicated effect statement. Instead, effects can be added to buses using the unified emission syntax (`& <expression>`), and made available for automation using property exposure via `@`.

The `effect` keyword no longer has any functionality, but is reserved for future use.