### PR TITLE
refactor: Use single AST node type for arguments

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -38,7 +38,7 @@ export interface NodeByType {
   BinaryExpression: BinaryExpression
   PropertyAccess: PropertyAccess
   Call: Call
-  Property: Property
+  Argument: Argument
 
   // Primitive Types
   Number: Number
@@ -158,14 +158,12 @@ export interface PropertyAccess extends ASTNode {
 export interface Call extends ASTNode {
   readonly type: 'Call'
   readonly callee: Expression
-  readonly arguments: ArgumentList
+  readonly arguments: readonly Argument[]
 }
 
-export type ArgumentList = ReadonlyArray<Expression | Property>
-
-export interface Property extends ASTNode {
-  readonly type: 'Property'
-  readonly key: Identifier
+export interface Argument extends ASTNode {
+  readonly type: 'Argument'
+  readonly name?: Identifier
   readonly value: Expression
 }
 
@@ -191,7 +189,7 @@ export interface Step extends ASTNode {
   readonly type: 'Step'
   readonly value: StepValue
   readonly length?: Expression
-  readonly parameters: ArgumentList
+  readonly parameters: readonly Argument[]
 }
 
 export interface Curve extends ASTNode {
@@ -210,27 +208,27 @@ export interface CurveSegment extends ASTNode {
 
 export interface Mixer extends ASTNode {
   readonly type: 'Mixer'
-  readonly properties: ArgumentList
+  readonly properties: readonly Argument[]
   readonly children: readonly Statement[]
 }
 
 export interface Bus extends ASTNode {
   readonly type: 'Bus'
   readonly name?: Identifier
-  readonly properties: ArgumentList
+  readonly properties: readonly Argument[]
   readonly children: readonly Statement[]
 }
 
 export interface Track extends ASTNode {
   readonly type: 'Track'
-  readonly properties: ArgumentList
+  readonly properties: readonly Argument[]
   readonly children: readonly Statement[]
 }
 
 export interface Part extends ASTNode {
   readonly type: 'Part'
   readonly name?: Identifier
-  readonly properties: ArgumentList
+  readonly properties: readonly Argument[]
   readonly children: readonly Statement[]
 }
 

--- a/packages/ast/test/ast.test.ts
+++ b/packages/ast/test/ast.test.ts
@@ -35,16 +35,25 @@ describe('ast/ast.ts', () => {
     it('should create complex nodes with all required properties', () => {
       const range: SourceRange = { offset: 0, length: 8, line: 1, column: 1 }
 
-      const node = make('Property', range, {
-        key: make('Identifier', range, { name: 'volume' }),
+      const node = make('Argument', range, {
+        name: make('Identifier', range, { name: 'volume' }),
         value: make('Number', range, { value: 0.75 })
       })
 
-      assert.strictEqual(node.type, 'Property')
-      assert.strictEqual(node.key.type, 'Identifier')
-      assert.strictEqual(node.key.name, 'volume')
-      assert.strictEqual(node.value.type, 'Number')
-      assert.strictEqual(node.value.value, 0.75)
+      assert.deepStrictEqual(node, {
+        type: 'Argument',
+        range,
+        name: {
+          type: 'Identifier',
+          range,
+          name: 'volume'
+        },
+        value: {
+          type: 'Number',
+          range,
+          value: 0.75
+        }
+      })
     })
   })
 })

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -111,8 +111,12 @@ curveSegment {
 }
 
 argumentList {
-  (Property | expression)
-  ("," (Property | expression))*
+  argument ("," argument)*
+}
+
+argument {
+  (ArgumentName { word } ":")?
+  expression
 }
 
 primary {
@@ -157,12 +161,6 @@ BinaryExpression {
   (expression !plus "-" expression) |
   (expression !multiply "*" expression) |
   (expression !multiply "/" expression)
-}
-
-Property {
-  PropertyName { word }
-  ":"
-  expression
 }
 
 Import {

--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -10,7 +10,7 @@ export interface HoverInfoWithRange extends Documentation {
 
 export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange | undefined> = (model, pos) => {
   const identifier = findIdentifierAt(model, pos)
-  if (identifier == null || identifier.kind === 'property-name') {
+  if (identifier == null || identifier.kind === 'argument-name') {
     return undefined
   }
 

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -173,9 +173,9 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
-      case 'PropertyName': {
+      case 'ArgumentName': {
         const name = document.sliceString(from, to)
-        addIdentifier({ kind: 'property-name', scopeId, name, range })
+        addIdentifier({ kind: 'argument-name', scopeId, name, range })
         break
       }
 

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -127,7 +127,7 @@ function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, loo
     case 'definition':
       return findBindingAt(model, occurrence.range.offset)
 
-    case 'property-name':
+    case 'argument-name':
       return undefined
 
     default:

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -52,7 +52,7 @@ export interface Identifier {
   readonly previousSibling?: Identifier
 }
 
-export type IdentifierKind = 'plain' | 'definition' | 'property-name'
+export type IdentifierKind = 'plain' | 'definition' | 'argument-name'
 
 // binding
 

--- a/packages/language-support/src/parser-metadata.ts
+++ b/packages/language-support/src/parser-metadata.ts
@@ -33,7 +33,7 @@ export const cadenceParserConfig: ParserConfig = {
       VariableDefinition: t.definition(t.variableName),
       VariableName: t.variableName,
 
-      PropertyName: t.definition(t.propertyName),
+      ArgumentName: t.definition(t.propertyName),
       Member: t.propertyName,
 
       Callee: t.function(t.name)

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -90,7 +90,7 @@ describe('hover/operation.ts', () => {
     )
   })
 
-  it('does not return docs for property names that only textually match wildcard imports', () => {
+  it('does not return docs for argument names that only textually match wildcard imports', () => {
     const source = [
       'use "effects" as *',
       '& mixer {',

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -64,7 +64,7 @@ describe('model/analysis/base.ts', () => {
         { kind: 'definition', scope: 'root', name: 'synth' },
         { kind: 'definition', scope: 'instrument', name: 'custom_property' },
         { kind: 'definition', scope: 'voice', name: 'note' },
-        { kind: 'property-name', scope: 'root', name: 'tempo' },
+        { kind: 'argument-name', scope: 'root', name: 'tempo' },
         { kind: 'plain', scope: 'root', name: 'tempo' },
         { kind: 'definition', scope: 'track', name: 'intro' },
         { kind: 'plain', scope: 'track', name: 'bars' },

--- a/packages/language-support/test/model/analysis/known-values.test.ts
+++ b/packages/language-support/test/model/analysis/known-values.test.ts
@@ -67,7 +67,7 @@ describe('model/analysis/known-values.ts', () => {
     })
   })
 
-  it('does not set known values for property names', () => {
+  it('does not set known values for argument names', () => {
     const source = [
       'use "effects" as *',
       '',
@@ -80,7 +80,7 @@ describe('model/analysis/known-values.ts', () => {
     const model = analyzeSource(source)
 
     const gainProperty = findIdentifierAt(model, source.indexOf('gain:'))
-    assert.strictEqual(gainProperty?.kind, 'property-name')
+    assert.strictEqual(gainProperty?.kind, 'argument-name')
     assert.strictEqual(model.knownValues.get(gainProperty.id), undefined)
   })
 

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -307,7 +307,7 @@ describe('model/analysis/references.ts', () => {
     assert.strictEqual(resolution?.kind, 'binding')
   })
 
-  it('does not resolve default imports for property names', () => {
+  it('does not resolve default imports for argument names', () => {
     const source = [
       'use "effects" as *',
       'foo = bar(gain: 4)',

--- a/packages/language-support/test/model/query.test.ts
+++ b/packages/language-support/test/model/query.test.ts
@@ -34,7 +34,7 @@ describe('analysis/query.ts', () => {
         },
         {
           id: '3' as IdentifierId,
-          kind: 'property-name',
+          kind: 'argument-name',
           scopeId: 'root' as ScopeId,
           name: 'baz',
           range: getRangeAt(source, source.indexOf('baz'), 'baz'.length)

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -876,7 +876,7 @@ function checkCall (scope: Scope, expression: ast.Call): Checked<FacetType> {
 
 function checkArgumentList (
   scope: Scope,
-  args: ast.ArgumentList,
+  args: readonly ast.Argument[],
   schema: Schema,
   range: SourceRange,
   kind = 'argument'
@@ -891,22 +891,22 @@ function checkArgumentList (
 
     let spec: SchemaItem | undefined
 
-    if (arg.type === 'Property' || namedStarted) {
+    if (arg.name != null || namedStarted) {
       namedStarted = true
 
-      if (arg.type !== 'Property') {
+      if (arg.name == null) {
         errors.push(new CompileError(`Unexpected positional ${kind} after named ${kind}s`, arg.range))
         continue
       }
 
-      spec = schema.byName.get(arg.key.name)
+      spec = schema.byName.get(arg.name.name)
       if (spec == null) {
-        errors.push(new CompileError(`Unknown ${kind} "${arg.key.name}"`, arg.key.range))
+        errors.push(new CompileError(`Unknown ${kind} "${arg.name.name}"`, arg.name.range))
         continue
       }
 
       if (seen.has(spec.name)) {
-        errors.push(new CompileError(`Duplicate ${kind} named "${arg.key.name}"`, arg.key.range))
+        errors.push(new CompileError(`Duplicate ${kind} named "${arg.name.name}"`, arg.name.range))
         continue
       }
     } else {
@@ -919,13 +919,11 @@ function checkArgumentList (
 
     seen.add(spec.name)
 
-    const value = arg.type === 'Property' ? arg.value : arg
-
-    const expressionCheck = checkExpression(scope, value)
+    const expressionCheck = checkExpression(scope, arg.value)
     errors.push(...expressionCheck.errors)
 
     if (expressionCheck.result != null) {
-      errors.push(...checkType(spec.type, expressionCheck.result, value.range))
+      errors.push(...checkType(spec.type, expressionCheck.result, arg.value.range))
     }
   }
 

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -703,25 +703,25 @@ function resolveCall (scope: Scope, expression: ast.Call): Value {
   return func.invoke(scope.top, args)
 }
 
-function resolveArgumentList<S extends Schema> (scope: Scope, args: ast.ArgumentList, schema: S): InferSchema<S> {
+function resolveArgumentList<S extends Schema> (scope: Scope, args: readonly ast.Argument[], schema: S): InferSchema<S> {
   const entries: Array<[string, Value]> = []
 
   // positionals
   for (let i = 0; i < args.length; ++i) {
     const arg = args[i]
-    if (arg.type === 'Property') {
+    if (arg.name != null) {
       break
     }
 
     const { name } = nonNull(schema.items.at(i))
-    entries.push([name, resolve(scope, arg)])
+    entries.push([name, resolve(scope, arg.value)])
   }
 
   // named
   for (let i = entries.length; i < args.length; ++i) {
     const arg = args[i]
-    assert(arg.type === 'Property' && schema.byName.has(arg.key.name))
-    entries.push([arg.key.name, resolve(scope, arg.value)])
+    assert(arg.name != null && schema.byName.has(arg.name.name))
+    entries.push([arg.name.name, resolve(scope, arg.value)])
   }
 
   return Object.fromEntries(entries) as InferSchema<S>

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -363,7 +363,7 @@ const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
   value_
 )
 
-// Parse an identifier, a property access, or a call; chained as needed.
+// Parse a primary value, a property access, or a call; chained as needed.
 const accessOrCall_: p.Parser<Token, unknown, ast.Expression> = p.ab(
   p.eitherOr(primary_, busNamespaceRoot_),
   p.many(
@@ -461,20 +461,22 @@ const expression_: p.Parser<Token, unknown, ast.Expression> = expect(
   'expression'
 )
 
-const property_: p.Parser<Token, unknown, ast.Property> = p.abc(
-  identifier_,
-  literal(':'),
-  expression_,
-  (key, _colon, value) => {
-    return ast.make('Property', combineSourceRanges(key, value), { key, value })
-  }
+const argument_: p.Parser<Token, unknown, ast.Argument> = p.eitherOr(
+  p.abc(
+    identifier_,
+    literal(':'),
+    expression_,
+    (name, _colon, value) => {
+      return ast.make('Argument', combineSourceRanges(name, value), { name, value })
+    }
+  ),
+  p.map(optionalExpression_, (value) => {
+    return ast.make('Argument', getSourceRange(value), { value })
+  })
 )
 
-const argumentList_: p.Parser<Token, unknown, ast.ArgumentList> = p.sepBy(
-  p.eitherOr(
-    property_,
-    optionalExpression_
-  ),
+const argumentList_: p.Parser<Token, unknown, readonly ast.Argument[]> = p.sepBy(
+  argument_,
   literal(',')
 )
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -339,7 +339,10 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource('pattern = [C4(2.0)-]'))
     assertResultComplete(result)
 
-    const gate = { type: 'Number', value: 2.0 }
+    const gate = {
+      type: 'Argument',
+      value: { type: 'Number', value: 2.0 }
+    }
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
@@ -365,7 +368,10 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource('pattern = [C4(2.0):1.5-]'))
     assertResultComplete(result)
 
-    const gate = { type: 'Number', value: 2.0 }
+    const gate = {
+      type: 'Argument',
+      value: { type: 'Number', value: 2.0 }
+    }
     const length = { type: 'Number', value: 1.5 }
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -392,8 +398,14 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource('pattern = [C4(2.0, 0.75):1.5-]'))
     assertResultComplete(result)
 
-    const gate = { type: 'Number', value: 2.0 }
-    const velocity = { type: 'Number', value: 0.75 }
+    const gate = {
+      type: 'Argument',
+      value: { type: 'Number', value: 2.0 }
+    }
+    const velocity = {
+      type: 'Argument',
+      value: { type: 'Number', value: 0.75 }
+    }
     const length = { type: 'Number', value: 1.5 }
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -437,8 +449,8 @@ describe('parser/parser.ts', () => {
                 length: { type: 'Number', value: 1.5 },
                 parameters: [
                   {
-                    type: 'Property',
-                    key: { type: 'Identifier', name: 'gate' },
+                    type: 'Argument',
+                    name: { type: 'Identifier', name: 'gate' },
                     value: { type: 'Number', value: 2.0 }
                   }
                 ]
@@ -472,13 +484,13 @@ describe('parser/parser.ts', () => {
                 length: { type: 'Number', value: 1.5 },
                 parameters: [
                   {
-                    type: 'Property',
-                    key: { type: 'Identifier', name: 'vel' },
+                    type: 'Argument',
+                    name: { type: 'Identifier', name: 'vel' },
                     value: { type: 'Number', value: 0.75 }
                   },
                   {
-                    type: 'Property',
-                    key: { type: 'Identifier', name: 'gate' },
+                    type: 'Argument',
+                    name: { type: 'Identifier', name: 'gate' },
                     value: { type: 'Number', value: 2.0 }
                   }
                 ]
@@ -783,8 +795,14 @@ describe('parser/parser.ts', () => {
               arguments: []
             },
             arguments: [
-              { type: 'Identifier', name: 'arg1' },
-              { type: 'Identifier', name: 'arg2' }
+              {
+                type: 'Argument',
+                value: { type: 'Identifier', name: 'arg1' }
+              },
+              {
+                type: 'Argument',
+                value: { type: 'Identifier', name: 'arg2' }
+              }
             ]
           }
         ]
@@ -826,8 +844,8 @@ describe('parser/parser.ts', () => {
                 name: { type: 'Identifier', name: 'mybus' },
                 properties: [
                   {
-                    type: 'Property',
-                    key: { type: 'Identifier', name: 'gain' },
+                    type: 'Argument',
+                    name: { type: 'Identifier', name: 'gain' },
                     value: {
                       type: 'PropertyAccess',
                       object: { type: 'Number', value: -3 },
@@ -859,7 +877,10 @@ describe('parser/parser.ts', () => {
                           property: { type: 'Identifier', name: 'pan' }
                         },
                         arguments: [
-                          { type: 'Number', value: 0.5 }
+                          {
+                            type: 'Argument',
+                            value: { type: 'Number', value: 0.5 }
+                          }
                         ]
                       }
                     ]
@@ -879,9 +900,12 @@ describe('parser/parser.ts', () => {
                         },
                         arguments: [
                           {
-                            type: 'PropertyAccess',
-                            object: { type: 'Number', value: 400 },
-                            property: { type: 'Identifier', name: 'hz' }
+                            type: 'Argument',
+                            value: {
+                              type: 'PropertyAccess',
+                              object: { type: 'Number', value: 400 },
+                              property: { type: 'Identifier', name: 'hz' }
+                            }
                           }
                         ]
                       }
@@ -927,9 +951,12 @@ describe('parser/parser.ts', () => {
                 name: undefined,
                 properties: [
                   {
-                    type: 'PropertyAccess',
-                    object: { type: 'Number', value: 4 },
-                    property: { type: 'Identifier', name: 'bars' }
+                    type: 'Argument',
+                    value: {
+                      type: 'PropertyAccess',
+                      object: { type: 'Number', value: 4 },
+                      property: { type: 'Identifier', name: 'bars' }
+                    }
                   }
                 ],
                 children: []
@@ -946,9 +973,12 @@ describe('parser/parser.ts', () => {
                 name: { type: 'Identifier', name: 'my_part' },
                 properties: [
                   {
-                    type: 'PropertyAccess',
-                    object: { type: 'Number', value: 2 },
-                    property: { type: 'Identifier', name: 'bars' }
+                    type: 'Argument',
+                    value: {
+                      type: 'PropertyAccess',
+                      object: { type: 'Number', value: 2 },
+                      property: { type: 'Identifier', name: 'bars' }
+                    }
                   }
                 ],
                 children: []
@@ -991,8 +1021,8 @@ describe('parser/parser.ts', () => {
                 name: undefined,
                 properties: [
                   {
-                    type: 'Property',
-                    key: { type: 'Identifier', name: 'gain' },
+                    type: 'Argument',
+                    name: { type: 'Identifier', name: 'gain' },
                     value: {
                       type: 'PropertyAccess',
                       object: { type: 'Number', value: -3 },
@@ -1014,8 +1044,8 @@ describe('parser/parser.ts', () => {
                 name: { type: 'Identifier', name: 'my_bus' },
                 properties: [
                   {
-                    type: 'Property',
-                    key: { type: 'Identifier', name: 'gain' },
+                    type: 'Argument',
+                    name: { type: 'Identifier', name: 'gain' },
                     value: {
                       type: 'PropertyAccess',
                       object: { type: 'Number', value: -6 },


### PR DESCRIPTION
Instead of arguments being a union of `Property | Expression`, they are now always `Argument` nodes with an optional name field. This clarifies the intent and avoids the misleading "property" terminology.