### PR TITLE
feat: Show hover documentation for global functions

### DIFF
--- a/packages/language-support/src/hover/operation.ts
+++ b/packages/language-support/src/hover/operation.ts
@@ -1,5 +1,5 @@
 import type { Documentation } from '@meyfa/cadence-language'
-import { getDocumentation } from '@meyfa/cadence-language'
+import { getGlobalDocumentation, getModuleDocumentation } from '@meyfa/cadence-language'
 import { findIdentifierAt } from '../model/query.ts'
 import type { SemanticOperation } from '../utilities/operations.ts'
 import type { SourceRange } from '../utilities/range.ts'
@@ -15,10 +15,21 @@ export const getHoverInfo: SemanticOperation<[pos: number], HoverInfoWithRange |
   }
 
   const knownValue = model.knownValues.get(identifier.id)
-  if (knownValue != null) {
-    const info = getDocumentation(knownValue.moduleName, knownValue.exportName)
-    return info == null ? undefined : { ...info, range: identifier.range }
-  }
 
-  return undefined
+  const info = (() => {
+    if (knownValue == null) {
+      return undefined
+    }
+
+    switch (knownValue.type) {
+      case 'global':
+        return getGlobalDocumentation(knownValue.name)
+      case 'module':
+        return getModuleDocumentation(knownValue.moduleName)
+      case 'module_value':
+        return getModuleDocumentation(knownValue.moduleName, knownValue.exportName)
+    }
+  })()
+
+  return info == null ? undefined : { ...info, range: identifier.range }
 }

--- a/packages/language-support/src/model/analysis/known-values.ts
+++ b/packages/language-support/src/model/analysis/known-values.ts
@@ -1,3 +1,4 @@
+import { globalBuiltins } from '@meyfa/cadence-language'
 import type { BaseModel, Identifier, IdentifierId, KnownValue, KnownValueModel, ReferenceModel } from '../model.ts'
 
 export function computeKnownValueModel (baseModel: BaseModel, referenceModel: ReferenceModel): KnownValueModel {
@@ -21,8 +22,12 @@ function resolve (model: ReferenceModel, identifier: Identifier): KnownValue | u
 
 function resolveForMemberAccess (model: ReferenceModel, object: Identifier, property: string): KnownValue | undefined {
   const objectValue = resolveForIdentifier(model, object)
-  if (objectValue?.moduleName != null) {
-    return { moduleName: objectValue.moduleName, exportName: property }
+  if (objectValue?.type === 'module') {
+    return {
+      type: 'module_value',
+      moduleName: objectValue.moduleName,
+      exportName: property
+    }
   }
 
   return undefined
@@ -33,15 +38,30 @@ function resolveForIdentifier (model: ReferenceModel, identifier: Identifier): K
 
   switch (resolution?.kind) {
     case 'import':
-      return { moduleName: resolution.import.moduleName, exportName: identifier.name }
+      return {
+        type: 'module_value',
+        moduleName: resolution.import.moduleName,
+        exportName: identifier.name
+      }
 
     case 'binding':
       if (resolution.binding.moduleName != null) {
-        return { moduleName: resolution.binding.moduleName }
+        return {
+          type: 'module',
+          moduleName: resolution.binding.moduleName
+        }
       }
       break
 
     default:
-      return undefined
+      if (identifier.kind === 'plain' && globalBuiltins.has(identifier.name)) {
+        return {
+          type: 'global',
+          name: identifier.name
+        }
+      }
+      break
   }
+
+  return undefined
 }

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -123,7 +123,20 @@ export type ResolutionKind = 'binding' | 'import'
 
 // known values
 
-export interface KnownValue {
+export type KnownValue = KnownGlobal | KnownModule | KnownModuleValue
+
+interface KnownGlobal {
+  readonly type: 'global'
+  readonly name: string
+}
+
+interface KnownModule {
+  readonly type: 'module'
   readonly moduleName: string
-  readonly exportName?: string
+}
+
+interface KnownModuleValue {
+  readonly type: 'module_value'
+  readonly moduleName: string
+  readonly exportName: string
 }

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -31,6 +31,37 @@ describe('hover/operation.ts', () => {
     )
   })
 
+  it('returns function docs for global built-ins', () => {
+    const source = [
+      'play(kick, pattern)',
+      'automate(kick.gain, curve)',
+      ''
+    ].join('\n')
+
+    const playPosition = source.indexOf('play(') + 1
+    const automatePosition = source.indexOf('automate(') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, playPosition),
+      {
+        range: getRangeAt(source, source.indexOf('play('), 'play'.length),
+        title: 'play(target: instrument, pattern: pattern) -> routing',
+        summary: 'Sends notes from a pattern to the target instrument.',
+        annotations: []
+      }
+    )
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, automatePosition),
+      {
+        range: getRangeAt(source, source.indexOf('automate('), 'automate'.length),
+        title: 'automate(target: parameter, curve: curve) -> automation',
+        summary: 'Automates a parameter with a curve over time.',
+        annotations: []
+      }
+    )
+  })
+
   it('returns module docs for aliased imports', () => {
     const source = [
       'use "effects" as fx',

--- a/packages/language-support/test/model/analysis/known-values.test.ts
+++ b/packages/language-support/test/model/analysis/known-values.test.ts
@@ -43,12 +43,14 @@ describe('model/analysis/known-values.ts', () => {
     const aliasIdentifier = findIdentifierAt(model, source.indexOf('as fx') + 'as '.length)
     assert.strictEqual(aliasIdentifier?.name, 'fx')
     assert.deepStrictEqual(model.knownValues.get(aliasIdentifier.id), {
+      type: 'module',
       moduleName: 'effects'
     })
 
     const sampleIdentifier = findIdentifierAt(model, source.indexOf('sample("/samples/kick.wav")'))
     assert.strictEqual(sampleIdentifier?.name, 'sample')
     assert.deepStrictEqual(model.knownValues.get(sampleIdentifier.id), {
+      type: 'module_value',
       moduleName: 'instruments',
       exportName: 'sample'
     })
@@ -56,12 +58,14 @@ describe('model/analysis/known-values.ts', () => {
     const fxIdentifier = findIdentifierAt(model, source.indexOf('fx.gain'))
     assert.strictEqual(fxIdentifier?.name, 'fx')
     assert.deepStrictEqual(model.knownValues.get(fxIdentifier.id), {
+      type: 'module',
       moduleName: 'effects'
     })
 
     const gainIdentifier = findIdentifierAt(model, source.indexOf('gain(-3.db)'))
     assert.strictEqual(gainIdentifier?.name, 'gain')
     assert.deepStrictEqual(model.knownValues.get(gainIdentifier.id), {
+      type: 'module_value',
       moduleName: 'effects',
       exportName: 'gain'
     })
@@ -74,6 +78,10 @@ describe('model/analysis/known-values.ts', () => {
       '& mixer {',
       '  & bus main (gain: -3.db) {}',
       '}',
+      '',
+      // This is not valid, but sufficient for the test:
+      // We want to ensure that built-in globals are not resolved for argument names, either.
+      'foo = sample(play: "kick")',
       ''
     ].join('\n')
 
@@ -82,6 +90,10 @@ describe('model/analysis/known-values.ts', () => {
     const gainProperty = findIdentifierAt(model, source.indexOf('gain:'))
     assert.strictEqual(gainProperty?.kind, 'argument-name')
     assert.strictEqual(model.knownValues.get(gainProperty.id), undefined)
+
+    const playProperty = findIdentifierAt(model, source.indexOf('play:'))
+    assert.strictEqual(playProperty?.kind, 'argument-name')
+    assert.strictEqual(model.knownValues.get(playProperty.id), undefined)
   })
 
   it('does not set known values for nested identifiers', () => {
@@ -96,6 +108,7 @@ describe('model/analysis/known-values.ts', () => {
     const panIdentifier = findIdentifierAt(model, source.indexOf('pan'))
     assert.strictEqual(panIdentifier?.name, 'pan')
     assert.deepStrictEqual(model.knownValues.get(panIdentifier.id), {
+      type: 'module_value',
       moduleName: 'effects',
       exportName: 'pan'
     })
@@ -105,5 +118,29 @@ describe('model/analysis/known-values.ts', () => {
     const gainIdentifier = findIdentifierAt(model, source.indexOf('gain'))
     assert.strictEqual(gainIdentifier?.name, 'gain')
     assert.strictEqual(model.knownValues.get(gainIdentifier.id), undefined)
+  })
+
+  it('resolves known values for global built-ins', () => {
+    const source = [
+      'play(kick, pattern)',
+      'automate(kick.gain, curve)',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+
+    const playIdentifier = findIdentifierAt(model, source.indexOf('play('))
+    assert.strictEqual(playIdentifier?.name, 'play')
+    assert.deepStrictEqual(model.knownValues.get(playIdentifier.id), {
+      type: 'global',
+      name: 'play'
+    })
+
+    const automateIdentifier = findIdentifierAt(model, source.indexOf('automate('))
+    assert.strictEqual(automateIdentifier?.name, 'automate')
+    assert.deepStrictEqual(model.knownValues.get(automateIdentifier.id), {
+      type: 'global',
+      name: 'automate'
+    })
   })
 })

--- a/packages/language/src/index.ts
+++ b/packages/language/src/index.ts
@@ -14,5 +14,7 @@ export * from './compiler/checker/checker.ts'
 export * from './compiler/generator/generator.ts'
 
 export type { Documentation } from './library/documentation.ts'
-export { getDocumentation } from './library/documentation.ts'
+export { getGlobalDocumentation, getModuleDocumentation } from './library/documentation.ts'
 export { getStandardModuleNames, getStandardModule } from './library/modules.ts'
+
+export { globalBuiltins } from './compiler/builtins/global.ts'

--- a/packages/language/src/library/documentation.ts
+++ b/packages/language/src/library/documentation.ts
@@ -1,3 +1,4 @@
+import { globalBuiltins } from '../compiler/builtins/global.ts'
 import type { Function } from '../type-system/base/function.ts'
 import { FunctionFacet } from '../type-system/base/function.ts'
 import type { Module } from '../type-system/base/module.ts'
@@ -11,7 +12,16 @@ export interface Documentation {
   readonly annotations?: string[]
 }
 
-export function getDocumentation (moduleName: string, exportName?: string): Documentation | undefined {
+export function getGlobalDocumentation (name: string): Documentation | undefined {
+  const value = globalBuiltins.get(name)
+  if (value == null) {
+    return undefined
+  }
+
+  return describeValue(name, value)
+}
+
+export function getModuleDocumentation (moduleName: string, exportName?: string): Documentation | undefined {
   const module = getStandardModule(moduleName)
   if (module == null) {
     return undefined


### PR DESCRIPTION
This patch adds support for resolving known values for global built-in functions, such as `play` and `automate`, in the language-support package. This allows the hover feature to display documentation for these functions.