### PR TITLE
fix: Use resolved function spec in generator

### DIFF
--- a/packages/language/src/compiler/builtins/global.ts
+++ b/packages/language/src/compiler/builtins/global.ts
@@ -10,17 +10,14 @@ import { makeSchema } from '../../type-system/schema.ts'
 import type { FacetType, Value } from '../../type-system/types.ts'
 
 const play = Functions.of({
-  summary: 'Sends notes from a pattern to the target instrument.',
-
   parameters: makeSchema([
     { name: 'target', type: InstrumentFacet.type(), required: true },
     { name: 'pattern', type: PatternFacet.type(), required: true }
   ]),
-
   returnType: RoutingFacet.type(),
-
-  effects: { blocking: false },
-
+  effects: { blocking: false }
+}, {
+  summary: 'Sends notes from a pattern to the target instrument.',
   invoke: (_context, { target, pattern }) => {
     const targetValue = InstrumentFacet.get(target)
     const patternValue = PatternFacet.get(pattern)
@@ -39,17 +36,12 @@ const play = Functions.of({
 })
 
 const automate = Functions.of({
-  summary: 'Automates a parameter with a curve over time.',
-
   parameters: makeSchema([
     { name: 'target', type: ParameterFacet.type(), required: true },
     { name: 'curve', type: CurveFacet.type(), required: true }
   ]),
-
   returnType: AutomationFacet.type(),
-
   effects: { blocking: false },
-
   check: (args: ReadonlyMap<string, FacetType>) => {
     const errors: ParameterError[] = []
 
@@ -71,8 +63,9 @@ const automate = Functions.of({
     }
 
     return errors
-  },
-
+  }
+}, {
+  summary: 'Automates a parameter with a curve over time.',
   invoke: (_context, { target, curve }) => {
     const targetValue = ParameterFacet.get(target)
     const curveValue = CurveFacet.get(curve)

--- a/packages/language/src/compiler/builtins/patterns.ts
+++ b/packages/language/src/compiler/builtins/patterns.ts
@@ -1,6 +1,7 @@
 import type { Pattern } from '@meyfa/cadence-core'
 import { createSerialPattern, loopPattern } from '@meyfa/cadence-core'
 import type { Numeric } from '@meyfa/cadence-utility'
+import type { FunctionSpec } from '../../type-system/base/function.ts'
 import { FunctionFacet } from '../../type-system/base/function.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
 import { PatternFacet } from '../../type-system/domain/pattern.ts'
@@ -15,20 +16,18 @@ interface Builtin<T> {
 
 export type PatternBuiltin = Builtin<Pattern>
 
-const loopDeclaration = {
+const loopSpec = {
   parameters: makeSchema([
     { name: 'times', type: NumberFacet.with(undefined).type(), required: false }
   ]),
   returnType: PatternFacet.type(),
   effects: { blocking: false }
-} as const
+} satisfies FunctionSpec
 
 const loop: PatternBuiltin = {
-  type: FunctionFacet.with(loopDeclaration).type(),
+  type: FunctionFacet.with(loopSpec).type(),
 
-  bind: (pattern) => Functions.of({
-    ...loopDeclaration,
-
+  bind: (pattern) => Functions.of(loopSpec, {
     summary: 'Repeats a pattern for a fixed number of cycles, or indefinitely when times is omitted.',
 
     invoke: (context, { times }) => {
@@ -53,20 +52,18 @@ const loop: PatternBuiltin = {
   })
 }
 
-const fillDeclaration = {
+const fillSpec = {
   parameters: makeSchema([
     { name: 'duration', type: NumberFacet.with('beats').type(), required: true }
   ]),
   returnType: PatternFacet.type(),
   effects: { blocking: false }
-} as const
+} satisfies FunctionSpec
 
 const fill: PatternBuiltin = {
-  type: FunctionFacet.with(fillDeclaration).type(),
+  type: FunctionFacet.with(fillSpec).type(),
 
-  bind: (pattern) => Functions.of({
-    ...fillDeclaration,
-
+  bind: (pattern) => Functions.of(fillSpec, {
     summary: 'Repeats a pattern until it fills the specified duration. Longer patterns are truncated.',
 
     invoke: (context, { duration }) => {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -1,10 +1,10 @@
 import type { SourceRange } from '@meyfa/cadence-ast'
 import { ast } from '@meyfa/cadence-ast'
-import type { Brand, Unit } from '@meyfa/cadence-utility'
+import type { Unit } from '@meyfa/cadence-utility'
 import { getStandardModuleNames, getStandardModuleValue } from '../../library/modules.ts'
 import { CompoundError } from '../../result/errors.ts'
 import type { Result } from '../../result/result.ts'
-import type { Effects } from '../../type-system/base/function.ts'
+import type { Effects, FunctionSpec } from '../../type-system/base/function.ts'
 import { FunctionFacet } from '../../type-system/base/function.ts'
 import { ModuleFacet } from '../../type-system/base/module.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
@@ -40,7 +40,15 @@ import { isSyntaxUnit, toBaseUnit } from '../units.ts'
 import type { MutableScope, Scope } from './scopes.ts'
 import { createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
 
-export type CheckedProgram = Brand<ast.Program, 'language.CheckedProgram'>
+export interface SemanticModel {
+  readonly getFunctionSpec: (expression: ast.Function) => FunctionSpec
+}
+
+export interface CheckedProgram {
+  readonly ast: ast.Program
+  readonly semantic: SemanticModel
+}
+
 export type CheckResult = Result<CheckedProgram, CompoundError<CompileError>>
 
 const success = (program: CheckedProgram): CheckResult => ({
@@ -105,7 +113,15 @@ export function check (program: ast.Program): CheckResult {
     }
   }
 
-  return errors.length === 0 ? success(program as CheckedProgram) : failure(errors)
+  if (errors.length > 0) {
+    return failure(errors)
+  }
+
+  const semantic: SemanticModel = {
+    getFunctionSpec: (expression) => nonNull(scope.top.semantic.functions.get(expression))
+  }
+
+  return success({ ast: program, semantic })
 }
 
 interface Checked<TValue> {
@@ -561,11 +577,14 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
     return { errors, effects: noEffects }
   }
 
-  const result = FunctionFacet.with({
+  const spec: FunctionSpec = {
     parameters: makeSchema([]),
     returnType,
     effects: { blocking }
-  }).type()
+  }
+
+  const result = FunctionFacet.with(spec).type()
+  scope.top.semantic.functions.set(expression, spec)
 
   return { errors, effects: noEffects, result }
 }

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -1,4 +1,5 @@
-import type { Effects } from '../../type-system/base/function.ts'
+import { ast } from '@meyfa/cadence-ast'
+import type { Effects, FunctionSpec } from '../../type-system/base/function.ts'
 import type { FacetType } from '../../type-system/types.ts'
 
 // scope types
@@ -12,6 +13,9 @@ export interface Scope {
 
 export interface GlobalScope extends Scope {
   readonly namespaces: Map<string, MutableNamespace>
+  readonly semantic: {
+    readonly functions: Map<ast.Function, FunctionSpec>
+  }
 }
 
 export interface MutableScope extends Scope {
@@ -31,7 +35,7 @@ export interface MutableNamespace extends Namespace {
 // factory functions
 
 export function createGlobalScope (initialResolutions: ReadonlyMap<string, FacetType>): GlobalScope {
-  const scope = {
+  const scope: GlobalScope = {
     // from Scope
     get top (): GlobalScope {
       return scope
@@ -45,7 +49,9 @@ export function createGlobalScope (initialResolutions: ReadonlyMap<string, Facet
 
     // from GlobalScope
     namespaces: new Map(),
-    buses: new Map()
+    semantic: {
+      functions: new Map()
+    }
   }
 
   return scope

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -25,7 +25,6 @@ import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeType } from '../../type-system/factory.ts'
 import { Curves, Functions, Numbers, Parameters } from '../../type-system/helpers.ts'
 import type { InferSchema, Schema } from '../../type-system/schema.ts'
-import { makeSchema } from '../../type-system/schema.ts'
 import type { FacetType, Value } from '../../type-system/types.ts'
 import { assert, assertNever, fail, nonNull } from '../assert.ts'
 import { globalBuiltins } from '../builtins/global.ts'
@@ -49,12 +48,12 @@ import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from
  * semantically checked and is valid.
  */
 export function generate (program: CheckedProgram, options: GenerateOptions): Program {
-  const initialResolutions = new Map(processImports(program.imports))
+  const initialResolutions = new Map(processImports(program.ast.imports))
   for (const [name, value] of globalBuiltins) {
     initialResolutions.set(name, value)
   }
 
-  const top = createGlobalScope(options, initialResolutions)
+  const top = createGlobalScope(options, program.semantic, initialResolutions)
 
   const scope = createLocalScope(top)
 
@@ -64,7 +63,7 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
   let mixer: Mixer | undefined
   let track: Track | undefined
 
-  for (const child of program.children) {
+  for (const child of program.ast.children) {
     const { emissions } = processStatement(scope, child)
 
     for (const emission of emissions) {
@@ -332,8 +331,9 @@ function generateCurve (scope: Scope, expression: ast.Curve): Value {
 function generateFunction (scope: Scope, expression: ast.Function): Value {
   const frozenScope: Scope = cloneScope(scope)
 
+  const spec = scope.top.semantic.getFunctionSpec(expression)
+
   // TODO Support parameters
-  // TODO Use correct return type when constructing the function value
 
   const invoke: Function['invoke'] = (_context, _args) => {
     const callScope = createLocalScope(frozenScope)
@@ -352,13 +352,7 @@ function generateFunction (scope: Scope, expression: ast.Function): Value {
     return nonNull(returnValue)
   }
 
-  return Functions.of({
-    parameters: makeSchema([]),
-    returnType: RecordFacet.type(),
-    effects: { blocking: false },
-    // TODO Remove any cast
-    invoke: invoke as any
-  })
+  return Functions.of(spec, { invoke })
 }
 
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {

--- a/packages/language/src/compiler/generator/scopes.ts
+++ b/packages/language/src/compiler/generator/scopes.ts
@@ -1,6 +1,7 @@
 import type { Asset, AssetId, Bus, BusId, Curve, Instrument, InstrumentId, Parameter, ParameterId } from '@meyfa/cadence-core'
 import type { Numeric, Unit } from '@meyfa/cadence-utility'
 import type { Value } from '../../type-system/types.ts'
+import type { SemanticModel } from '../checker/checker.ts'
 import type { GenerateOptions } from './options.ts'
 
 // scope aspects
@@ -34,6 +35,7 @@ export interface Scope {
 
 export interface GlobalScope extends Scope, Context {
   readonly options: GenerateOptions
+  readonly semantic: SemanticModel
 
   readonly namespaces: Map<string, MutableNamespace>
 
@@ -59,7 +61,11 @@ export interface MutableNamespace extends Namespace {
 
 // factory functions
 
-export function createGlobalScope (options: GenerateOptions, initialResolutions: ReadonlyMap<string, Value>): GlobalScope {
+export function createGlobalScope (
+  options: GenerateOptions,
+  semantic: SemanticModel,
+  initialResolutions: ReadonlyMap<string, Value>
+): GlobalScope {
   const scope: GlobalScope = {
     // from Scope
     get top () {
@@ -69,6 +75,7 @@ export function createGlobalScope (options: GenerateOptions, initialResolutions:
 
     // from GlobalScope
     options,
+    semantic,
     namespaces: new Map(),
     buses: new Map(),
     instruments: new Map(),

--- a/packages/language/src/library/modules/effects.ts
+++ b/packages/language/src/library/modules/effects.ts
@@ -45,14 +45,13 @@ const ClipEffectType = makeType(EffectFacet, RecordFacet.with({
 // factories
 
 const gain = Functions.of({
-  summary: 'Applies a gain adjustment to the signal.',
-
   parameters: makeSchema([
     { name: 'gain', type: NumberFacet.with('db').type(), required: true }
   ]),
   returnType: GainEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Applies a gain adjustment to the signal.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'gain',
@@ -66,14 +65,13 @@ const gain = Functions.of({
 })
 
 const pan = Functions.of({
-  summary: 'Places the signal in the stereo field.',
-
   parameters: makeSchema([
     { name: 'pan', type: NumberFacet.with(undefined).type(), required: true }
   ]),
   returnType: PanEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Places the signal in the stereo field.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'pan',
@@ -87,14 +85,13 @@ const pan = Functions.of({
 })
 
 const lowpass = Functions.of({
-  summary: 'Filters out frequencies above the cutoff.',
-
   parameters: makeSchema([
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
   ]),
   returnType: LowpassEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Filters out frequencies above the cutoff.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'lowpass',
@@ -108,14 +105,13 @@ const lowpass = Functions.of({
 })
 
 const highpass = Functions.of({
-  summary: 'Filters out frequencies below the cutoff.',
-
   parameters: makeSchema([
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
   ]),
   returnType: HighpassEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Filters out frequencies below the cutoff.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'highpass',
@@ -129,14 +125,13 @@ const highpass = Functions.of({
 })
 
 const width = Functions.of({
-  summary: 'Adjusts the stereo width of the signal.',
-
   parameters: makeSchema([
     { name: 'width', type: NumberFacet.with(undefined).type(), required: true }
   ]),
   returnType: WidthEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Adjusts the stereo width of the signal.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'width',
@@ -148,8 +143,6 @@ const width = Functions.of({
 })
 
 const delay = Functions.of({
-  summary: 'Adds echoes with configurable mix, time, and feedback.',
-
   parameters: makeSchema([
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'time', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
@@ -157,8 +150,9 @@ const delay = Functions.of({
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
   returnType: DelayEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Adds echoes with configurable mix, time, and feedback.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'delay',
@@ -175,16 +169,15 @@ const delay = Functions.of({
 })
 
 const reverb = Functions.of({
-  summary: 'Adds reverberation with configurable mix and decay.',
-
   parameters: makeSchema([
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
   returnType: ReverbEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Adds reverberation with configurable mix and decay.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'reverb',
@@ -198,14 +191,13 @@ const reverb = Functions.of({
 })
 
 const clip = Functions.of({
-  summary: 'Applies hard clipping to the signal at the specified threshold.',
-
   parameters: makeSchema([
     { name: 'threshold', type: NumberFacet.with('db').type(), required: true }
   ]),
   returnType: ClipEffectType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Applies hard clipping to the signal at the specified threshold.',
   invoke: (context: ParameterContext, args) => {
     const effect: Effect = {
       type: 'clip',

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -94,8 +94,6 @@ function createOscillatorVoice (shape: Oscillator['shape']): Voice {
 }
 
 const sample = Functions.of({
-  summary: 'Creates a sample-backed instrument from a URL.',
-
   parameters: makeSchema([
     { name: 'url', type: StringFacet.type(), required: true },
     { name: 'gain', type: NumberFacet.with('db').type(), required: false },
@@ -103,8 +101,9 @@ const sample = Functions.of({
     { name: 'length', type: NumberFacet.with('s').type(), required: false }
   ]),
   returnType: SampleInstrumentType,
-  effects: { blocking: true },
-
+  effects: { blocking: true }
+}, {
+  summary: 'Creates a sample-backed instrument from a URL.',
   // eslint-disable-next-line camelcase
   invoke: (context: ParameterContext & InstrumentContext & AssetContext, { url, gain, root_note, length }) => {
     const urlValue = StringFacet.get(url)
@@ -137,14 +136,13 @@ const sample = Functions.of({
 
 function createOscillatorFunction (shape: Oscillator['shape']): Value {
   return Functions.of({
-    summary: `Creates an instrument that produces a ${shape} wave.`,
-
     parameters: makeSchema([
       { name: 'gain', type: NumberFacet.with('db').type(), required: false }
     ]),
     returnType: OscillatorInstrumentType,
-    effects: { blocking: true },
-
+    effects: { blocking: true }
+  }, {
+    summary: `Creates an instrument that produces a ${shape} wave.`,
     invoke: (context: ParameterContext & InstrumentContext, { gain }) => {
       const gainValue = gain != null ? NumberFacet.get(gain).value : UNITY_GAIN
       const gainParameter = context.allocateParameter('db', gainValue)

--- a/packages/language/src/library/modules/sources.ts
+++ b/packages/language/src/library/modules/sources.ts
@@ -7,14 +7,13 @@ import type { Value } from '../../type-system/types.ts'
 
 function createOscillatorFunction (shape: Oscillator['shape']): Value {
   return Functions.of({
-    summary: `Creates a source that produces a ${shape} wave.`,
-
     parameters: makeSchema([
       { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
     ]),
     returnType: SourceFacet.type(),
-    effects: { blocking: false },
-
+    effects: { blocking: false }
+  }, {
+    summary: `Creates a source that produces a ${shape} wave.`,
     invoke: (context, { frequency }) => {
       return SourceFacet.type().of({
         type: 'oscillator',

--- a/packages/language/src/type-system/base/function.ts
+++ b/packages/language/src/type-system/base/function.ts
@@ -11,7 +11,10 @@ export interface ParameterError {
   readonly message: string
 }
 
-export interface Function<S extends Schema = Schema, R extends FacetType = FacetType, Context = never> {
+export interface FunctionSpec<
+  S extends Schema = Schema,
+  R extends FacetType = FacetType
+> {
   readonly parameters: S
   readonly returnType: R
   readonly effects: Effects
@@ -23,7 +26,13 @@ export interface Function<S extends Schema = Schema, R extends FacetType = Facet
    * If an argument is missing from the map, do not report an error; this will already be handled by the schema validation.
    */
   readonly check?: (args: ReadonlyMap<string, FacetType>) => readonly ParameterError[]
+}
 
+export interface FunctionRuntime<
+  S extends Schema = Schema,
+  R extends FacetType = FacetType,
+  Context = never
+> {
   /**
    * Compute the return value of the function given the provided arguments.
    */
@@ -33,11 +42,11 @@ export interface Function<S extends Schema = Schema, R extends FacetType = Facet
   readonly summary?: string
 }
 
-interface FunctionSpec<S extends Schema = Schema, R extends FacetType = FacetType> {
-  readonly parameters: S
-  readonly returnType: R
-  readonly effects: Effects
-  readonly check?: (args: ReadonlyMap<string, FacetType>) => readonly ParameterError[]
+export interface Function<
+  S extends Schema = Schema,
+  R extends FacetType = FacetType,
+  Context = never
+> extends FunctionSpec<S, R>, FunctionRuntime<S, R, Context> {
 }
 
 interface FunctionSpecGeneric extends CustomComparable {

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -1,6 +1,6 @@
 import type { Parameter, RelativeCurve } from '@meyfa/cadence-core'
 import type { RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
-import type { Function } from './base/function.ts'
+import type { FunctionRuntime, FunctionSpec } from './base/function.ts'
 import { FunctionFacet } from './base/function.ts'
 import type { Module } from './base/module.ts'
 import { ModuleFacet } from './base/module.ts'
@@ -13,15 +13,12 @@ import type { Schema } from './schema.ts'
 import type { Facet, FacetType, Value } from './types.ts'
 
 export const Functions = {
-  of: <const S extends Schema, const R extends FacetType, const Context> (value: Function<S, R, Context>): Value => {
-    const type = FunctionFacet.with({
-      parameters: value.parameters,
-      returnType: value.returnType,
-      effects: value.effects,
-      check: value.check
-    }).type()
-
-    return type.of(value)
+  of: <const S extends Schema, const R extends FacetType, const Context> (
+    spec: FunctionSpec<S, R>,
+    runtime: FunctionRuntime<S, R, Context>
+  ): Value => {
+    const type = FunctionFacet.with(spec).type()
+    return type.of({ ...spec, ...runtime })
   }
 }
 

--- a/packages/language/test/compiler/builtins/patterns.test.ts
+++ b/packages/language/test/compiler/builtins/patterns.test.ts
@@ -8,12 +8,17 @@ import type { PatternBuiltin } from '../../../src/compiler/builtins/patterns.ts'
 import { patternBuiltins } from '../../../src/compiler/builtins/patterns.ts'
 import type { GlobalScope } from '../../../src/compiler/generator/scopes.ts'
 import { createGlobalScope } from '../../../src/compiler/generator/scopes.ts'
+import type { SemanticModel } from '../../../src/index.ts'
 import { FunctionFacet } from '../../../src/type-system/base/function.ts'
 import { PatternFacet } from '../../../src/type-system/domain/pattern.ts'
 import { Numbers } from '../../../src/type-system/helpers.ts'
 import type { Facet, Value } from '../../../src/type-system/types.ts'
 
 function createFunctionContext (): GlobalScope {
+  const semantic: SemanticModel = {
+    getFunctionSpec: () => assert.fail('not implemented')
+  }
+
   return createGlobalScope({
     beatsPerBar: 4,
     tempo: {
@@ -21,7 +26,7 @@ function createFunctionContext (): GlobalScope {
       minimum: 20 as Numeric<'bpm'>,
       maximum: 300 as Numeric<'bpm'>
     }
-  }, new Map())
+  }, semantic, new Map())
 }
 
 function getPatternBuiltin (name: string): PatternBuiltin {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -1,9 +1,13 @@
+import { ast, getEmptySourceRange } from '@meyfa/cadence-ast'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { check } from '../../../src/compiler/checker/checker.ts'
 import type { CompileError } from '../../../src/compiler/error.ts'
 import { lex } from '../../../src/lexer/lexer.ts'
 import { parse } from '../../../src/parser/parser.ts'
+import { NumberFacet } from '../../../src/type-system/base/number.ts'
+import { InstrumentFacet } from '../../../src/type-system/domain/instrument.ts'
+import { makeSchema } from '../../../src/type-system/schema.ts'
 import { assertResultComplete } from '../../test-utils.ts'
 
 function checkSource (source: string): readonly CompileError[] {
@@ -239,6 +243,71 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertValid(source)
+    })
+
+    it('should register function specs in the semantic model', () => {
+      const pureFunction = ast.make('Function', getEmptySourceRange(), {
+        parameters: [],
+        children: [
+          ast.make('Statement', getEmptySourceRange(), {
+            emit: true,
+            expose: false,
+            values: [
+              ast.make('Number', getEmptySourceRange(), { value: 42 })
+            ]
+          })
+        ]
+      })
+
+      const blockingFunction = ast.make('Function', getEmptySourceRange(), {
+        parameters: [],
+        children: [
+          ast.make('Statement', getEmptySourceRange(), {
+            emit: true,
+            expose: false,
+            values: [
+              ast.make('Instrument', getEmptySourceRange(), { children: [] })
+            ]
+          })
+        ]
+      })
+
+      const program = ast.make('Program', getEmptySourceRange(), {
+        imports: [],
+        children: [
+          ast.make('Statement', getEmptySourceRange(), {
+            emit: false,
+            expose: false,
+            name: ast.make('Identifier', getEmptySourceRange(), { name: 'pure_function' }),
+            values: [pureFunction]
+          }),
+          ast.make('Statement', getEmptySourceRange(), {
+            emit: false,
+            expose: false,
+            name: ast.make('Identifier', getEmptySourceRange(), { name: 'blocking_function' }),
+            values: [blockingFunction]
+          })
+        ]
+      })
+
+      const checkResult = check(program)
+      assertResultComplete(checkResult)
+
+      const semanticModel = checkResult.value.semantic
+
+      const pureFunctionSpec = semanticModel.getFunctionSpec(pureFunction)
+      assert.deepStrictEqual(pureFunctionSpec, {
+        parameters: makeSchema([]),
+        returnType: NumberFacet.with(undefined).type(),
+        effects: { blocking: false }
+      })
+
+      const blockingFunctionSpec = semanticModel.getFunctionSpec(blockingFunction)
+      assert.deepStrictEqual(blockingFunctionSpec, {
+        parameters: makeSchema([]),
+        returnType: InstrumentFacet.type(),
+        effects: { blocking: true }
+      })
     })
 
     it('should accept patterns with step arguments', () => {

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -4,7 +4,8 @@ import { runtimeNumeric } from '@meyfa/cadence-utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GenerateOptions } from '../../../src/compiler/generator/options.ts'
-import { createGlobalScope, cloneScope, createLocalScope, createNamespace } from '../../../src/compiler/generator/scopes.ts'
+import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from '../../../src/compiler/generator/scopes.ts'
+import type { SemanticModel } from '../../../src/index.ts'
 import { Numbers } from '../../../src/type-system/helpers.ts'
 
 const options: GenerateOptions = {
@@ -20,11 +21,15 @@ const scalar = (value: number) => value as Numeric<undefined>
 const db = (value: number) => value as Numeric<'db'>
 
 describe('compiler/generator/scopes.ts', () => {
+  const semantic: SemanticModel = {
+    getFunctionSpec: () => assert.fail('not implemented')
+  }
+
   describe('createGlobalScope()', () => {
     it('should create a global scope with the provided options and initial resolutions', () => {
       const foo = Numbers.of(runtimeNumeric('db', 12))
 
-      const result = createGlobalScope(options, new Map([['foo', foo]]))
+      const result = createGlobalScope(options, semantic, new Map([['foo', foo]]))
 
       assert.strictEqual(result.top, result)
       assert.strictEqual(result.parent, undefined)
@@ -39,7 +44,7 @@ describe('compiler/generator/scopes.ts', () => {
     })
 
     it('should allocate buses with unique IDs', () => {
-      const scope = createGlobalScope(options, new Map())
+      const scope = createGlobalScope(options, semantic, new Map())
 
       const bus0 = {
         name: 'bus0',
@@ -70,7 +75,7 @@ describe('compiler/generator/scopes.ts', () => {
     })
 
     it('should allocate parameters with unique IDs', () => {
-      const scope = createGlobalScope(options, new Map())
+      const scope = createGlobalScope(options, semantic, new Map())
 
       const parameter0 = scope.allocateParameter('db', db(12))
       const parameter1 = scope.allocateParameter('db', db(6))
@@ -85,7 +90,7 @@ describe('compiler/generator/scopes.ts', () => {
     })
 
     it('should allocate instruments with unique IDs', () => {
-      const scope = createGlobalScope(options, new Map())
+      const scope = createGlobalScope(options, semantic, new Map())
 
       const instrument0 = {
         gain: scope.allocateParameter('db', db(-6)),
@@ -110,7 +115,7 @@ describe('compiler/generator/scopes.ts', () => {
     })
 
     it('should allocate assets with unique IDs', () => {
-      const scope = createGlobalScope(options, new Map())
+      const scope = createGlobalScope(options, semantic, new Map())
 
       const asset0 = {
         url: 'foo.wav'
@@ -135,7 +140,7 @@ describe('compiler/generator/scopes.ts', () => {
 
   describe('createLocalScope()', () => {
     it('should create a local scope with the provided parent and empty resolutions', () => {
-      const globalScope = createGlobalScope(options, new Map([
+      const globalScope = createGlobalScope(options, semantic, new Map([
         ['foo', Numbers.of(runtimeNumeric('db', 12))]
       ]))
 
@@ -160,7 +165,7 @@ describe('compiler/generator/scopes.ts', () => {
 
   describe('cloneScope()', () => {
     it('should create a new scope with the same top and parent, and a copy of the resolutions', () => {
-      const globalScope = createGlobalScope(options, new Map([
+      const globalScope = createGlobalScope(options, semantic, new Map([
         ['foo', Numbers.of(runtimeNumeric('db', 12))]
       ]))
 
@@ -176,7 +181,7 @@ describe('compiler/generator/scopes.ts', () => {
     })
 
     it('should not be affected by changes to the original scope after cloning', () => {
-      const globalScope = createGlobalScope(options, new Map([
+      const globalScope = createGlobalScope(options, semantic, new Map([
         ['foo', Numbers.of(runtimeNumeric('db', 12))]
       ]))
 

--- a/packages/language/test/library/modules/effects.test.ts
+++ b/packages/language/test/library/modules/effects.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GlobalScope } from '../../../src/compiler/generator/scopes.ts'
 import { createGlobalScope } from '../../../src/compiler/generator/scopes.ts'
+import type { SemanticModel } from '../../../src/index.ts'
 import { effectsModule } from '../../../src/library/modules/effects.ts'
 import { RecordFacet } from '../../../src/type-system/base/record.ts'
 import { EffectFacet } from '../../../src/type-system/domain/effect.ts'
@@ -11,6 +12,10 @@ import { Numbers } from '../../../src/type-system/helpers.ts'
 import { getFunctionExport } from './test-utils.ts'
 
 function createFunctionContext (): GlobalScope {
+  const semantic: SemanticModel = {
+    getFunctionSpec: () => assert.fail('not implemented')
+  }
+
   return createGlobalScope({
     beatsPerBar: 4,
     tempo: {
@@ -18,7 +23,7 @@ function createFunctionContext (): GlobalScope {
       minimum: 20 as Numeric<'bpm'>,
       maximum: 300 as Numeric<'bpm'>
     }
-  }, new Map())
+  }, semantic, new Map())
 }
 
 describe('library/modules/effects.ts', () => {

--- a/packages/language/test/library/modules/instruments.test.ts
+++ b/packages/language/test/library/modules/instruments.test.ts
@@ -11,6 +11,7 @@ import { StringFacet } from '../../../src/type-system/base/string.ts'
 import { InstrumentFacet } from '../../../src/type-system/domain/instrument.ts'
 import { Numbers } from '../../../src/type-system/helpers.ts'
 import { getFunctionExport } from './test-utils.ts'
+import type { SemanticModel } from '../../../src/index.ts'
 
 const scalar = (value: number) => value as Numeric<undefined>
 const seconds = (value: number) => value as Numeric<'s'>
@@ -20,6 +21,10 @@ const hz = (value: number) => value as Numeric<'hz'>
 const DEFAULT_TEMPO = 120 as Numeric<'bpm'>
 
 function createFunctionContext (): GlobalScope {
+  const semantic: SemanticModel = {
+    getFunctionSpec: () => assert.fail('not implemented')
+  }
+
   return createGlobalScope({
     beatsPerBar: 4,
     tempo: {
@@ -27,7 +32,7 @@ function createFunctionContext (): GlobalScope {
       minimum: 20 as Numeric<'bpm'>,
       maximum: 300 as Numeric<'bpm'>
     }
-  }, new Map())
+  }, semantic, new Map())
 }
 
 describe('library/modules/instruments.ts', () => {


### PR DESCRIPTION
This patch enriches the CheckedProgram type with additional information about function AST nodes, specifically the resolved function spec. This allows the generator to use a correct function type without placeholder information.