### PR TITLE
feat: Add support for function parameters

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -25,7 +25,7 @@ export function make<T extends keyof NodeByType> (
 }
 
 export interface NodeByType {
-  // Root Type
+  // Root
   Program: Program
 
   // Building Blocks
@@ -33,7 +33,7 @@ export interface NodeByType {
   Statement: Statement
   Identifier: Identifier
 
-  // Expressions
+  // Value Expressions
   UnaryExpression: UnaryExpression
   BinaryExpression: BinaryExpression
   PropertyAccess: PropertyAccess
@@ -41,7 +41,10 @@ export interface NodeByType {
   Argument: Argument
   Parameter: Parameter
 
-  // Primitive Types
+  // Type Expressions
+  TypeExpression: TypeExpression
+
+  // Primitive Values
   Number: Number
   String: String
   Pattern: Pattern
@@ -49,7 +52,7 @@ export interface NodeByType {
   Curve: Curve
   CurveSegment: CurveSegment
 
-  // Constructed Types
+  // Constructed Values
   Function: Function
   Mixer: Mixer
   Bus: Bus
@@ -82,7 +85,7 @@ export type Expression =
   PropertyAccess |
   Call
 
-// Root Type
+// Root
 
 export interface Program extends ASTNode {
   readonly type: 'Program'
@@ -125,7 +128,7 @@ export interface Identifier extends ASTNode {
   readonly name: string
 }
 
-// Expressions
+// Value Expressions
 
 export const unaryOperators = ['+', '-'] as const
 export type UnaryOperator = typeof unaryOperators[number]
@@ -167,10 +170,18 @@ export interface Argument extends ASTNode {
 export interface Parameter extends ASTNode {
   readonly type: 'Parameter'
   readonly name: Identifier
-  readonly parameterType: Identifier
+  readonly parameterType: TypeExpression
 }
 
-// Primitive Types
+// Type Expressions
+
+export interface TypeExpression extends ASTNode {
+  readonly type: 'TypeExpression'
+  readonly name: Identifier
+  readonly generics: readonly Identifier[]
+}
+
+// Primitive Values
 
 export interface Number extends ASTNode {
   readonly type: 'Number'
@@ -207,7 +218,7 @@ export interface CurveSegment extends ASTNode {
   readonly length: Expression
 }
 
-// Constructed Types
+// Constructed Values
 
 export interface Function extends ASTNode {
   readonly type: 'Function'

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -123,8 +123,11 @@ parameterList {
 }
 
 parameter {
-  ParameterName { word } ":"
-  ParameterType { word }
+  VariableDefinition ":" Type
+}
+
+Type {
+  word ("." word)*
 }
 
 primary {

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -84,6 +84,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
+      case 'Function': {
+        const scope = addScope({ kind: 'function', range, parentId: scopeId })
+        nextScopeId = scope.id
+        break
+      }
+
       case 'TrackBlock': {
         const scope = addScope({ kind: 'track', range, parentId: scopeId })
         nextScopeId = scope.id
@@ -150,6 +156,11 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
             // Invalid/incomplete syntax encountered.
             // We still add an identifier as a best-effort approach to provide some level of functionality.
             accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range: nameRange, previousSibling })
+            break
+          }
+
+          case 'Function': {
+            addBinding({ kind: 'regular', scopeId, name, range: nameRange })
             break
           }
 

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -125,6 +125,7 @@ function resolveDefinitionBinding (occurrence: Identifier, model: BaseModel, loo
       return findRegularBinding(occurrence, lookup)
 
     case 'definition':
+    case 'parameter':
       return findBindingAt(model, occurrence.range.offset)
 
     case 'argument-name':

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -32,7 +32,7 @@ export interface Scope {
   readonly range: SourceRange
 }
 
-export type ScopeKind = 'root' | 'track' | 'part' | 'mixer' | 'bus' | 'instrument' | 'voice'
+export type ScopeKind = 'root' | 'function' | 'track' | 'part' | 'mixer' | 'bus' | 'instrument' | 'voice'
 
 // identifier
 
@@ -52,7 +52,7 @@ export interface Identifier {
   readonly previousSibling?: Identifier
 }
 
-export type IdentifierKind = 'plain' | 'definition' | 'argument-name'
+export type IdentifierKind = 'plain' | 'definition' | 'parameter' | 'argument-name'
 
 // binding
 

--- a/packages/language-support/src/parser-metadata.ts
+++ b/packages/language-support/src/parser-metadata.ts
@@ -32,8 +32,7 @@ export const cadenceParserConfig: ParserConfig = {
       VariableDefinition: t.definition(t.variableName),
       VariableName: t.variableName,
       ArgumentName: t.definition(t.propertyName),
-      ParameterName: t.definition(t.propertyName),
-      ParameterType: t.typeName,
+      Type: t.typeName,
       Member: t.propertyName,
 
       Callee: t.function(t.name)

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -29,7 +29,9 @@ describe('model/analysis/base.ts', () => {
       '  & voice note {}',
       '}',
       '',
-      '& track (tempo: tempo) {',
+      'double = (input: number.bpm) { & input * 2 }',
+      '',
+      '& track (tempo: double(64.bpm)) {',
       '  & part intro (4.bars) {',
       '    & play(kick, [x---].loop())',
       '    & automate(kick.gain, ~[hold(-60.db)])',
@@ -64,8 +66,12 @@ describe('model/analysis/base.ts', () => {
         { kind: 'definition', scope: 'root', name: 'synth' },
         { kind: 'definition', scope: 'instrument', name: 'custom_property' },
         { kind: 'definition', scope: 'voice', name: 'note' },
+        { kind: 'definition', scope: 'root', name: 'double' },
+        { kind: 'definition', scope: 'function', name: 'input' },
+        { kind: 'plain', scope: 'function', name: 'input' },
         { kind: 'argument-name', scope: 'root', name: 'tempo' },
-        { kind: 'plain', scope: 'root', name: 'tempo' },
+        { kind: 'plain', scope: 'root', name: 'double' },
+        { kind: 'plain', scope: 'root', name: 'bpm' },
         { kind: 'definition', scope: 'track', name: 'intro' },
         { kind: 'plain', scope: 'track', name: 'bars' },
         { kind: 'plain', scope: 'part', name: 'play' },
@@ -220,6 +226,10 @@ describe('model/analysis/base.ts', () => {
       'kick = sample("/samples/kick.wav")',
       'snare = sample("/samples/snare.wav", gain: -3.db)',
       '',
+      'my_function = (input: number.bpm) {',
+      '  & input * 2',
+      '} // end function',
+      '',
       'my_instrument = instrument {',
       '  @custom_property = 42',
       '  foo = 42',
@@ -250,6 +260,11 @@ describe('model/analysis/base.ts', () => {
 
     const rootRange = getRangeAt(source, 0, source.length)
     const rootScopeId = `root:${rootRange.offset}:${rootRange.length}`
+
+    const functionBlockStart = source.indexOf('(input: number.bpm) {')
+    const functionBlockEnd = source.indexOf('} // end function') + '}'.length
+    const functionRange = getRangeAt(source, functionBlockStart, functionBlockEnd - functionBlockStart)
+    const functionScopeId = `function:${functionRange.offset}:${functionRange.length}`
 
     const instrumentBlockStart = source.indexOf('{', source.indexOf('my_instrument'))
     const instrumentBlockEnd = source.indexOf('} // end instrument') + '}'.length
@@ -290,6 +305,7 @@ describe('model/analysis/base.ts', () => {
       model.scopes.map(({ id, kind, parentId }) => ({ id, kind, parentId })),
       [
         { id: rootScopeId, kind: 'root', parentId: undefined },
+        { id: functionScopeId, kind: 'function', parentId: rootScopeId },
         { id: instrumentScopeId, kind: 'instrument', parentId: rootScopeId },
         { id: voiceScopeId, kind: 'voice', parentId: instrumentScopeId },
         { id: trackScopeId, kind: 'track', parentId: rootScopeId },
@@ -306,6 +322,8 @@ describe('model/analysis/base.ts', () => {
         { kind: 'use-alias', name: 'fx', declaredScopeId: undefined, isExposed: undefined },
         { kind: 'regular', name: 'kick', declaredScopeId: undefined, isExposed: false },
         { kind: 'regular', name: 'snare', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'my_function', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'input', declaredScopeId: undefined, isExposed: undefined },
         { kind: 'regular', name: 'my_instrument', declaredScopeId: undefined, isExposed: false },
         { kind: 'regular', name: 'custom_property', declaredScopeId: undefined, isExposed: true },
         { kind: 'regular', name: 'foo', declaredScopeId: undefined, isExposed: false },

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -72,6 +72,44 @@ describe('model/analysis/references.ts', () => {
     assert.ok(references.includes(identifier))
   })
 
+  it('resolves parameters to their definition', () => {
+    const source = [
+      'my_function = (my_input: number.bpm) {',
+      '  & my_input * 2',
+      '}',
+      'bar = my_input // invalid reference',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('my_input:')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
+    assert.strictEqual(binding.kind, 'regular')
+    assert.strictEqual(binding.name, 'my_input')
+    assert.deepStrictEqual(binding.range, getRangeAt(source, position, 'my_input'.length))
+
+    const referencePosition = source.indexOf('& my_input') + '& '.length
+    const referenceIdentifier = model.identifiers.find((identifier) => identifier.range.offset === referencePosition)
+    assert.ok(referenceIdentifier != null)
+
+    const referenceResolution = model.resolutions.get(referenceIdentifier.id)
+    assert.deepStrictEqual(referenceResolution, resolution)
+
+    const invalidReferencePosition = source.indexOf('bar = my_input') + 'bar = '.length
+    const invalidReferenceIdentifier = model.identifiers.find((identifier) => identifier.range.offset === invalidReferencePosition)
+    assert.ok(invalidReferenceIdentifier != null)
+
+    const invalidReferenceResolution = model.resolutions.get(invalidReferenceIdentifier.id)
+    assert.strictEqual(invalidReferenceResolution, undefined)
+  })
+
   it('resolves bus inputs to variable definitions', () => {
     const source = [
       '& mixer {',

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -39,6 +39,7 @@ import { resolveInScope } from '../resolution.ts'
 import { isSyntaxUnit, toBaseUnit } from '../units.ts'
 import type { MutableScope, Scope } from './scopes.ts'
 import { createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
+import { getFacet } from './type-facets.ts'
 
 export interface SemanticModel {
   readonly getFunctionSpec: (expression: ast.Function) => FunctionSpec
@@ -537,23 +538,42 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   const errors: CompileError[] = []
 
   // Allow blocking calls inside the function. If a blocking call is encountered,
-  // then the function itself will be marked as blocking.
+  // then the function itself will be marked as blocking when called.
   const functionScope = createLocalScope(scope, { blocking: true })
 
-  // TODO Support parameters
-  if (expression.parameters.length > 0) {
-    errors.push(new CompileError('Function parameters are not supported yet', expression.range))
+  // The act of constructing a function does not have any effects.
+  const effects = noEffects
+
+  const parameters: SchemaItem[] = []
+
+  for (const parameter of expression.parameters) {
+    const parameterCheck = checkParameter(functionScope, parameter)
+    errors.push(...parameterCheck.errors)
+
+    if (parameterCheck.result != null) {
+      functionScope.resolutions.set(parameter.name.name, parameterCheck.result)
+      parameters.push({
+        name: parameter.name.name,
+        type: parameterCheck.result,
+        required: true
+      })
+    }
+  }
+
+  // If the parameters are invalid, it makes no sense to continue checking the function body,
+  // as it will produce a lot of irrelevant errors as a consequence.
+  if (errors.length > 0) {
+    return { errors, effects }
   }
 
   let hasReturn = false
   let returnType: FacetType | undefined
-  let blocking = false
+  let callEffects = noEffects
 
   for (const child of expression.children) {
     const statement = checkStatement(functionScope, child)
     errors.push(...statement.errors)
-
-    blocking ||= statement.effects.blocking
+    callEffects = mergeEffects(callEffects, statement.effects)
 
     for (const emission of statement.emissions) {
       if (hasReturn) {
@@ -574,19 +594,54 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   }
 
   if (!hasReturn || returnType == null) {
-    return { errors, effects: noEffects }
+    return { errors, effects }
   }
 
   const spec: FunctionSpec = {
-    parameters: makeSchema([]),
+    parameters: makeSchema(parameters),
     returnType,
-    effects: { blocking }
+    effects: callEffects
   }
 
   const result = FunctionFacet.with(spec).type()
   scope.top.semantic.functions.set(expression, spec)
 
-  return { errors, effects: noEffects, result }
+  return { errors, effects, result }
+}
+
+function checkParameter (scope: Scope, expression: ast.Parameter): Checked<FacetType> {
+  const errors: CompileError[] = []
+
+  const { name } = expression.name
+
+  if (scope.resolutions.has(name)) {
+    errors.push(new CompileError(`Duplicate parameter name "${name}"`, expression.name.range))
+  }
+
+  const typeCheck = checkTypeExpression(expression.parameterType)
+  errors.push(...typeCheck.errors)
+
+  return { ...typeCheck, errors }
+}
+
+function checkTypeExpression (expression: ast.TypeExpression): Checked<FacetType> {
+  const effects = noEffects
+
+  if (expression.generics.length > 1) {
+    return { errors: [new CompileError('Type expressions can have at most one generic', expression.range)], effects }
+  }
+
+  const generic = expression.generics.at(0)?.name
+  const facet = getFacet(expression.name.name, generic)
+
+  if (facet == null) {
+    const typeName = generic != null ? `${expression.name.name}.${generic}` : expression.name.name
+    return { errors: [new CompileError(`Unknown type "${typeName}"`, expression.range)], effects }
+  }
+
+  const result = facet.type()
+
+  return { errors: [], effects, result }
 }
 
 function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<FacetType> {

--- a/packages/language/src/compiler/checker/type-facets.ts
+++ b/packages/language/src/compiler/checker/type-facets.ts
@@ -1,0 +1,61 @@
+import type { Unit } from '@meyfa/cadence-utility'
+import { NumberFacet } from '../../type-system/base/number.ts'
+import { StringFacet } from '../../type-system/base/string.ts'
+import { AutomationFacet } from '../../type-system/domain/automation.ts'
+import { BusFacet } from '../../type-system/domain/bus.ts'
+import { CurveFacet } from '../../type-system/domain/curve.ts'
+import { EffectFacet } from '../../type-system/domain/effect.ts'
+import { InstrumentFacet } from '../../type-system/domain/instrument.ts'
+import { MixerFacet } from '../../type-system/domain/mixer.ts'
+import { ParameterFacet } from '../../type-system/domain/parameter.ts'
+import { PartFacet } from '../../type-system/domain/part.ts'
+import { PatternFacet } from '../../type-system/domain/pattern.ts'
+import { RoutingFacet } from '../../type-system/domain/routing.ts'
+import { SourceFacet } from '../../type-system/domain/source.ts'
+import { TrackFacet } from '../../type-system/domain/track.ts'
+import { VoiceFacet } from '../../type-system/domain/voice.ts'
+import type { Facet } from '../../type-system/types.ts'
+import { isSyntaxUnit, toBaseUnit } from '../units.ts'
+
+type FacetFactory = (generic: string | undefined) => Facet | undefined
+
+export function getFacet (name: string, generic: string | undefined): Facet | undefined {
+  return facets.get(name)?.(generic)
+}
+
+const facets: ReadonlyMap<string, FacetFactory> = new Map<string, FacetFactory>([
+  // base facets
+
+  ['number', createWithUnitGeneric(NumberFacet)],
+  ['string', create(StringFacet)],
+
+  // domain facets
+
+  ['automation', create(AutomationFacet)],
+  ['bus', create(BusFacet)],
+  ['curve', createWithUnitGeneric(CurveFacet)],
+  ['effect', create(EffectFacet)],
+  ['instrument', create(InstrumentFacet)],
+  ['mixer', create(MixerFacet)],
+  ['parameter', createWithUnitGeneric(ParameterFacet)],
+  ['part', create(PartFacet)],
+  ['pattern', create(PatternFacet)],
+  ['routing', create(RoutingFacet)],
+  ['source', create(SourceFacet)],
+  ['track', create(TrackFacet)],
+  ['voice', create(VoiceFacet)]
+])
+
+function create (facet: Facet): FacetFactory {
+  return (generic) => generic == null ? facet : undefined
+}
+
+function createWithUnitGeneric (facet: { readonly with: (unit: Unit) => Facet }): FacetFactory {
+  return (generic) => {
+    if (generic == null || isSyntaxUnit(generic)) {
+      return facet.with(toBaseUnit(generic))
+    }
+
+    return undefined
+  }
+}

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -333,10 +333,14 @@ function generateFunction (scope: Scope, expression: ast.Function): Value {
 
   const spec = scope.top.semantic.getFunctionSpec(expression)
 
-  // TODO Support parameters
-
-  const invoke: Function['invoke'] = (_context, _args) => {
+  const invoke: Function['invoke'] = (_context, args) => {
     const callScope = createLocalScope(frozenScope)
+
+    // Bind arguments to the call scope
+    for (const [name, value] of Object.entries(args)) {
+      assert(!callScope.resolutions.has(name))
+      callScope.resolutions.set(name, value as Value)
+    }
 
     let returnValue: Value | undefined
 

--- a/packages/language/src/compiler/units.ts
+++ b/packages/language/src/compiler/units.ts
@@ -1,10 +1,18 @@
-import type { Numeric, Unit } from '@meyfa/cadence-utility'
-import type { Value } from '../type-system/types.ts'
+import type { Numeric } from '@meyfa/cadence-utility'
 import { Numbers } from '../type-system/helpers.ts'
+import type { Value } from '../type-system/types.ts'
 
 interface Constants {
   readonly beatsPerBar: number
 }
+
+export const BaseUnits = [
+  'bpm',
+  'db',
+  'hz',
+  's',
+  'beats'
+] as const
 
 export const SyntaxUnits = [
   'bpm',
@@ -18,7 +26,12 @@ export const SyntaxUnits = [
   'bars'
 ] as const
 
+export type BaseUnit = typeof BaseUnits[number]
 export type SyntaxUnit = typeof SyntaxUnits[number]
+
+export function isBaseUnit (value: string): value is BaseUnit {
+  return BaseUnits.includes(value as BaseUnit)
+}
 
 export function isSyntaxUnit (value: string): value is SyntaxUnit {
   return SyntaxUnits.includes(value as SyntaxUnit)
@@ -46,7 +59,7 @@ export function toNumberValue (constants: Constants, unit: SyntaxUnit | undefine
 /**
  * Convert from the user-facing (syntax) unit to the base unit used internally.
  */
-export function toBaseUnit (unit: SyntaxUnit | undefined): Unit {
+export function toBaseUnit (unit: SyntaxUnit | undefined): BaseUnit | undefined {
   switch (unit) {
     case undefined:
     case 'bpm':

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -337,10 +337,20 @@ const curve_: p.Parser<Token, unknown, ast.Curve> = p.abc(
   }
 )
 
+const typeExpression_: p.Parser<Token, unknown, ast.TypeExpression> = p.ab(
+  identifier_,
+  p.many(
+    p.right(literal('.'), identifier_)
+  ),
+  (name, generics) => {
+    return ast.make('TypeExpression', combineSourceRanges(name, ...generics), { name, generics })
+  }
+)
+
 const parameter_: p.Parser<Token, unknown, ast.Parameter> = p.abc(
   identifier_,
   literal(':'),
-  identifier_,
+  typeExpression_,
   (name, _colon, type) => {
     return ast.make('Parameter', combineSourceRanges(name, type), { name, parameterType: type })
   }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -234,6 +234,18 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept function definitions with parameters', () => {
+      const source = [
+        'my_function = (param0: number.hz, param1: number, param2: string) {',
+        '  & param0 * param1',
+        '}',
+        '',
+        'foo = my_function(440.hz, 2, "hello")'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should allow blocking calls in functions', () => {
       const source = [
         'use "instruments" as inst',
@@ -1104,6 +1116,20 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Function "blocking_function" may block and cannot be called from a realtime context'
+      ])
+    })
+
+    it('should reject invalid type expressions', () => {
+      const source = [
+        'func0 = (param: invalid_type) { & param }',
+        'func1 = (param: number.foo) { & param }',
+        'func2 = (param: string.hz) { & param }'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown type "invalid_type"',
+        'Unknown type "number.foo"',
+        'Unknown type "string.hz"'
       ])
     })
 

--- a/packages/language/test/compiler/checker/type-facets.test.ts
+++ b/packages/language/test/compiler/checker/type-facets.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { getFacet } from '../../../src/compiler/checker/type-facets.ts'
+import { NumberFacet } from '../../../src/type-system/base/number.ts'
+import { StringFacet } from '../../../src/type-system/base/string.ts'
+import { CurveFacet } from '../../../src/type-system/domain/curve.ts'
+import { ParameterFacet } from '../../../src/type-system/domain/parameter.ts'
+
+describe('compiler/checker/type-facets.ts', () => {
+  describe('getFacet()', () => {
+    it('should resolve known facets without generics', () => {
+      assert.strictEqual(getFacet('string', undefined), StringFacet)
+      assert.strictEqual(getFacet('number', undefined), NumberFacet.with(undefined))
+    })
+
+    it('should normalize syntax-unit generics to base units', () => {
+      assert.strictEqual(getFacet('number', 'ms'), NumberFacet.with('s'))
+      assert.strictEqual(getFacet('curve', 'bars'), CurveFacet.with('beats'))
+      assert.strictEqual(getFacet('parameter', 'beat'), ParameterFacet.with('beats'))
+    })
+
+    it('should reject unsupported generics', () => {
+      assert.strictEqual(getFacet('string', 's'), undefined)
+      assert.strictEqual(getFacet('number', 'samples'), undefined)
+    })
+
+    it('should return undefined for unknown facets', () => {
+      assert.strictEqual(getFacet('unknown', undefined), undefined)
+    })
+  })
+})

--- a/packages/language/test/compiler/units.test.ts
+++ b/packages/language/test/compiler/units.test.ts
@@ -1,9 +1,22 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
+import { SyntaxUnits, isBaseUnit, isSyntaxUnit, toBaseUnit, toNumberValue } from '../../src/compiler/units.ts'
 import { NumberFacet } from '../../src/type-system/base/number.ts'
-import { SyntaxUnits, isSyntaxUnit, toBaseUnit, toNumberValue } from '../../src/compiler/units.ts'
 
 describe('compiler/units.ts', () => {
+  describe('isBaseUnit()', () => {
+    it('should accept every declared base unit', () => {
+      for (const unit of ['bpm', 'db', 'hz', 's', 'beats'] as const) {
+        assert.strictEqual(isBaseUnit(unit), true)
+      }
+    })
+
+    it('should reject unknown units', () => {
+      assert.strictEqual(isBaseUnit('samples'), false)
+      assert.strictEqual(isBaseUnit(''), false)
+    })
+  })
+
   describe('isSyntaxUnit()', () => {
     it('should accept every declared syntax unit', () => {
       for (const unit of SyntaxUnits) {

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -850,7 +850,7 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse functions with parameters', () => {
-    const result = parse(lexSource('my_func = (param1: number, param2: string) { & param1, param2 }'))
+    const result = parse(lexSource('my_func = (param1: number.db, param2: string) { & param1, param2 }'))
     assertResultComplete(result)
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -866,12 +866,22 @@ describe('parser/parser.ts', () => {
               {
                 type: 'Parameter',
                 name: { type: 'Identifier', name: 'param1' },
-                parameterType: { type: 'Identifier', name: 'number' }
+                parameterType: {
+                  type: 'TypeExpression',
+                  name: { type: 'Identifier', name: 'number' },
+                  generics: [
+                    { type: 'Identifier', name: 'db' }
+                  ]
+                }
               },
               {
                 type: 'Parameter',
                 name: { type: 'Identifier', name: 'param2' },
-                parameterType: { type: 'Identifier', name: 'string' }
+                parameterType: {
+                  type: 'TypeExpression',
+                  name: { type: 'Identifier', name: 'string' },
+                  generics: []
+                }
               }
             ],
             children: [


### PR DESCRIPTION
It is now possible to define parameters (name and type) in function declarations. The parameters can be referenced within the function body, and are type-checked at the call site. Example:

```
multiply = (tempo: number.bpm, scalar: number) {
  & tempo * scalar
}

& track (tempo: multiply(60.bpm, 2)) {
  // ...
}
```

The language-support package is also updated so that "go to definition" and reference highlighting work for parameters.