### PR TITLE
feat: Support combined and function type notation

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -42,7 +42,9 @@ export interface NodeByType {
   Parameter: Parameter
 
   // Type Expressions
-  TypeExpression: TypeExpression
+  NamedType: NamedType
+  FunctionType: FunctionType
+  CombinedType: CombinedType
 
   // Primitive Values
   Number: Number
@@ -170,15 +172,28 @@ export interface Argument extends ASTNode {
 export interface Parameter extends ASTNode {
   readonly type: 'Parameter'
   readonly name: Identifier
-  readonly parameterType: TypeExpression
+  readonly parameterType: Type
 }
 
 // Type Expressions
 
-export interface TypeExpression extends ASTNode {
-  readonly type: 'TypeExpression'
+export type Type = NamedType | FunctionType | CombinedType
+
+export interface NamedType extends ASTNode {
+  readonly type: 'NamedType'
   readonly name: Identifier
   readonly generics: readonly Identifier[]
+}
+
+export interface FunctionType extends ASTNode {
+  readonly type: 'FunctionType'
+  readonly parameters: readonly Parameter[]
+  readonly returnType: Type
+}
+
+export interface CombinedType extends ASTNode {
+  readonly type: 'CombinedType'
+  readonly children: readonly Type[]
 }
 
 // Primitive Values

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -106,7 +106,7 @@ Curve {
 }
 
 curveSegment {
-  CurveType { word } ("(" argumentList? ")")? (":" AccessOrCall)?
+  CurveSegmentShape { word } ("(" argumentList? ")")? (":" AccessOrCall)?
 }
 
 argumentList {
@@ -127,7 +127,21 @@ parameter {
 }
 
 Type {
+  atomicType ("+" atomicType)*
+}
+
+atomicType {
+  NamedType | FunctionType | ("(" Type ")")
+}
+
+NamedType {
   word ("." word)*
+}
+
+FunctionType {
+  "(" parameterList? ")"
+  ":"
+  atomicType
 }
 
 primary {

--- a/packages/language-support/src/parser-metadata.ts
+++ b/packages/language-support/src/parser-metadata.ts
@@ -10,7 +10,7 @@ export const cadenceParserConfig: ParserConfig = {
       Number: t.number,
       String: t.string,
       Pattern: t.special(t.string),
-      CurveType: t.function(t.name),
+      CurveSegmentShape: t.function(t.name),
 
       keyword: t.keyword,
       unit: t.number,
@@ -32,7 +32,7 @@ export const cadenceParserConfig: ParserConfig = {
       VariableDefinition: t.definition(t.variableName),
       VariableName: t.variableName,
       ArgumentName: t.definition(t.propertyName),
-      Type: t.typeName,
+      NamedType: t.typeName,
       Member: t.propertyName,
 
       Callee: t.function(t.name)

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -18,6 +18,7 @@ const tokenHighlighter = tagHighlighter([
   { tag: t.variableName, class: 'variable' },
   { tag: t.definition(t.propertyName), class: 'definition-property' },
   { tag: t.propertyName, class: 'property' },
+  { tag: t.typeName, class: 'type' },
   { tag: t.function(t.name), class: 'function' },
   { tag: t.definitionOperator, class: 'definition-operator' },
   { tag: t.operator, class: 'operator' },
@@ -74,6 +75,8 @@ describe('language-support.ts', () => {
       'pattern = [D4:2 - x]',
       'inst = sample("kick-{tempo}")',
       '',
+      'func = (num: number) { & num + 1 }',
+      '',
       '& track (tempo: 140.bpm) {',
       '  & part drums {',
       '    automate(lib.gain, ~[hold(-60.db) lin(-60.db, 0.db)])',
@@ -107,6 +110,7 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, 'tempo', source.indexOf('(tempo:') + 1, 'definition-property')
     assertHighlightAt(spans, source, 'lib', source.indexOf('lib', source.indexOf('as lib')), 'definition-variable')
     assertHighlightAt(spans, source, 'gain', source.indexOf('.gain') + 1, 'property')
+    assertHighlightAt(spans, source, 'number', source.indexOf(': number') + 2, 'type')
     assertHighlightAt(spans, source, 'sample', source.indexOf('sample("kick-'), 'function')
     assertHighlightAt(spans, source, 'hold', source.indexOf('hold('), 'function')
     assertHighlightAt(spans, source, 'pan', source.indexOf('.pan') + 1, 'function')

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -26,7 +26,7 @@ import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeType, makeUnion } from '../../type-system/factory.ts'
 import type { Schema, SchemaItem } from '../../type-system/schema.ts'
 import { makeSchema } from '../../type-system/schema.ts'
-import type { FacetType, Type, Value } from '../../type-system/types.ts'
+import type { Facet, FacetType, Type, Value } from '../../type-system/types.ts'
 import { nonNull } from '../assert.ts'
 import { globalBuiltins } from '../builtins/global.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
@@ -544,27 +544,17 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   // The act of constructing a function does not have any effects.
   const effects = noEffects
 
-  const parameters: SchemaItem[] = []
-
-  for (const parameter of expression.parameters) {
-    const parameterCheck = checkParameter(functionScope, parameter)
-    errors.push(...parameterCheck.errors)
-
-    if (parameterCheck.result != null) {
-      functionScope.resolutions.set(parameter.name.name, parameterCheck.result)
-      parameters.push({
-        name: parameter.name.name,
-        type: parameterCheck.result,
-        required: true
-      })
-    }
-  }
+  const parameterCheck = checkParameters(expression.parameters)
+  errors.push(...parameterCheck.errors)
 
   // If the parameters are invalid, it makes no sense to continue checking the function body,
   // as it will produce a lot of irrelevant errors as a consequence.
-  if (errors.length > 0) {
+  if (parameterCheck.result == null) {
     return { errors, effects }
   }
+
+  const parameters = parameterCheck.result.schema
+  putAll(functionScope.resolutions, parameterCheck.result.types)
 
   let hasReturn = false
   let returnType: FacetType | undefined
@@ -597,38 +587,112 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
     return { errors, effects }
   }
 
-  const spec: FunctionSpec = {
-    parameters: makeSchema(parameters),
-    returnType,
-    effects: callEffects
-  }
-
+  const spec: FunctionSpec = { parameters, returnType, effects: callEffects }
   const result = FunctionFacet.with(spec).type()
   scope.top.semantic.functions.set(expression, spec)
 
   return { errors, effects, result }
 }
 
-function checkParameter (scope: Scope, expression: ast.Parameter): Checked<FacetType> {
-  const errors: CompileError[] = []
-
-  const { name } = expression.name
-
-  if (scope.resolutions.has(name)) {
-    errors.push(new CompileError(`Duplicate parameter name "${name}"`, expression.name.range))
-  }
-
-  const typeCheck = checkTypeExpression(expression.parameterType)
-  errors.push(...typeCheck.errors)
-
-  return { ...typeCheck, errors }
+interface Parameters {
+  readonly types: ReadonlyMap<string, FacetType>
+  readonly schema: Schema
 }
 
-function checkTypeExpression (expression: ast.TypeExpression): Checked<FacetType> {
+function checkParameters (expressions: readonly ast.Parameter[]): Checked<Parameters> {
+  const errors: CompileError[] = []
+  const effects = noEffects
+
+  const types = new Map<string, FacetType>()
+  const items: SchemaItem[] = []
+
+  for (const parameter of expressions) {
+    const parameterCheck = checkTypeExpression(parameter.parameterType)
+    errors.push(...parameterCheck.errors)
+
+    if (parameterCheck.result == null) {
+      continue
+    }
+
+    if (types.has(parameter.name.name)) {
+      errors.push(new CompileError(`Duplicate parameter name "${parameter.name.name}"`, parameter.name.range))
+      continue
+    }
+
+    types.set(parameter.name.name, parameterCheck.result)
+    items.push({
+      name: parameter.name.name,
+      type: parameterCheck.result,
+      required: true
+    })
+  }
+
+  if (errors.length > 0) {
+    return { errors, effects }
+  }
+
+  const result = { types, schema: makeSchema(items) }
+
+  return { errors, effects, result }
+}
+
+interface TypeComponent {
+  readonly facet: Facet
+  readonly range: SourceRange
+}
+
+function checkTypeExpression (expression: ast.Type): Checked<FacetType> {
+  const errors: CompileError[] = []
+  const effects = noEffects
+
+  const componentsCheck = checkTypeComponents(expression)
+  errors.push(...componentsCheck.errors)
+
+  if (componentsCheck.result == null) {
+    return { errors, effects }
+  }
+
+  const components = componentsCheck.result
+  if (components.length === 0) {
+    errors.push(new CompileError('Cannot combine zero types', expression.range))
+    return { errors, effects }
+  }
+
+  const facets = new Map<string, Facet>()
+
+  for (const component of components) {
+    const existing = facets.get(component.facet.name)
+    if (existing != null) {
+      errors.push(new CompileError(`Type conflict: (${existing.format()}) + (${component.facet.format()})`, component.range))
+      continue
+    }
+
+    facets.set(component.facet.name, component.facet)
+  }
+
+  const result = makeType(...facets.values())
+
+  return { errors, effects, result }
+}
+
+function checkTypeComponents (expression: ast.Type): Checked<readonly TypeComponent[]> {
+  switch (expression.type) {
+    case 'NamedType':
+      return checkNamedType(expression)
+
+    case 'FunctionType':
+      return checkFunctionType(expression)
+
+    case 'CombinedType':
+      return checkCombinedType(expression)
+  }
+}
+
+function checkNamedType (expression: ast.NamedType): Checked<readonly TypeComponent[]> {
   const effects = noEffects
 
   if (expression.generics.length > 1) {
-    return { errors: [new CompileError('Type expressions can have at most one generic', expression.range)], effects }
+    return { errors: [new CompileError('Types can have at most one generic', expression.range)], effects }
   }
 
   const generic = expression.generics.at(0)?.name
@@ -639,9 +703,60 @@ function checkTypeExpression (expression: ast.TypeExpression): Checked<FacetType
     return { errors: [new CompileError(`Unknown type "${typeName}"`, expression.range)], effects }
   }
 
-  const result = facet.type()
+  const result = [{ facet, range: expression.range }]
 
   return { errors: [], effects, result }
+}
+
+function checkFunctionType (expression: ast.FunctionType): Checked<readonly TypeComponent[]> {
+  const errors: CompileError[] = []
+  const effects = noEffects
+
+  const parameterCheck = checkParameters(expression.parameters)
+  errors.push(...parameterCheck.errors)
+
+  if (parameterCheck.result == null) {
+    return { errors, effects }
+  }
+
+  const returnTypeCheck = checkTypeExpression(expression.returnType)
+  errors.push(...returnTypeCheck.errors)
+
+  if (returnTypeCheck.result == null) {
+    return { errors, effects }
+  }
+
+  const facet = FunctionFacet.with({
+    parameters: parameterCheck.result.schema,
+    returnType: returnTypeCheck.result,
+    effects: noEffects
+  })
+
+  const result = [{ facet, range: expression.range }]
+
+  return { errors, effects, result }
+}
+
+function checkCombinedType (expression: ast.CombinedType): Checked<readonly TypeComponent[]> {
+  const errors: CompileError[] = []
+  const effects = noEffects
+
+  const result: TypeComponent[] = []
+
+  for (const child of expression.children) {
+    const childCheck = checkTypeComponents(child)
+    errors.push(...childCheck.errors)
+
+    if (childCheck.result != null) {
+      result.push(...childCheck.result)
+    }
+  }
+
+  if (errors.length > 0) {
+    return { errors, effects }
+  }
+
+  return { errors, effects, result }
 }
 
 function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<FacetType> {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -337,20 +337,61 @@ const curve_: p.Parser<Token, unknown, ast.Curve> = p.abc(
   }
 )
 
-const typeExpression_: p.Parser<Token, unknown, ast.TypeExpression> = p.ab(
+const namedType_: p.Parser<Token, unknown, ast.NamedType> = p.ab(
   identifier_,
   p.many(
     p.right(literal('.'), identifier_)
   ),
   (name, generics) => {
-    return ast.make('TypeExpression', combineSourceRanges(name, ...generics), { name, generics })
+    return ast.make('NamedType', combineSourceRanges(name, ...generics), { name, generics })
   }
+)
+
+const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.ab(
+  combine3(
+    literal('('),
+    p.recursive(() => parameterList_),
+    literal(')')
+  ),
+  combine2(
+    literal(':'),
+    p.recursive(() => atomicType_)
+  ),
+  ([_lp, parameters, _rp], [_colon, returnType]) => {
+    return ast.make('FunctionType', combineSourceRanges(_lp, returnType), { parameters, returnType })
+  }
+)
+
+const atomicType_: p.Parser<Token, unknown, ast.Type> = p.choice<Token, unknown, ast.Type>(
+  namedType_,
+  functionType_,
+  p.abc(
+    literal('('),
+    p.recursive((): p.Parser<Token, unknown, ast.Type> => type_),
+    literal(')'),
+    (_l, type, _r) => {
+      return ast.make(type.type, combineSourceRanges(_l, _r), { ...type })
+    }
+  )
+)
+
+const type_: p.Parser<Token, unknown, ast.Type> = p.leftAssoc2(
+  atomicType_,
+  p.map(
+    literal('+'),
+    () => (left: ast.Type, right: ast.Type) => {
+      return ast.make('CombinedType', combineSourceRanges(left, right), {
+        children: [left, right]
+      })
+    }
+  ),
+  atomicType_
 )
 
 const parameter_: p.Parser<Token, unknown, ast.Parameter> = p.abc(
   identifier_,
   literal(':'),
-  typeExpression_,
+  type_,
   (name, _colon, type) => {
     return ast.make('Parameter', combineSourceRanges(name, type), { name, parameterType: type })
   }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -246,6 +246,18 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept higher-order functions', () => {
+      const source = [
+        'apply = (fn: (arg: number.bpm): number.bpm, value: number) {',
+        '  & fn(value.bpm)',
+        '}',
+        '',
+        'foo = apply((arg: number.bpm) { & arg * 2 }, 120)'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should allow blocking calls in functions', () => {
       const source = [
         'use "instruments" as inst',
@@ -1121,15 +1133,33 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject invalid type expressions', () => {
       const source = [
-        'func0 = (param: invalid_type) { & param }',
-        'func1 = (param: number.foo) { & param }',
-        'func2 = (param: string.hz) { & param }'
+        'func0 = (p: invalid_type) { & p }',
+        'func1 = (p: number.foo) { & p }',
+        'func2 = (p: string.hz) { & p }'
       ].join('\n')
 
       assertErrorMessages(source, [
         'Unknown type "invalid_type"',
         'Unknown type "number.foo"',
         'Unknown type "string.hz"'
+      ])
+    })
+
+    it('should reject invalid composite types', () => {
+      const source = [
+        'func0 = (p: number + number) { & p }',
+        'func1 = (p: number + number.hz) { & p }',
+        'func2 = (p: number.db + number.hz) { & p }',
+        'func3 = (p: string + string) { & p }',
+        'func4 = (p: ((a: number): number) + ((b: number): number)) { & p }'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Type conflict: (number) + (number)',
+        'Type conflict: (number) + (number.hz)',
+        'Type conflict: (number.db) + (number.hz)',
+        'Type conflict: (string) + (string)',
+        'Type conflict: (function) + (function)'
       ])
     })
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -850,7 +850,13 @@ describe('parser/parser.ts', () => {
   })
 
   it('should parse functions with parameters', () => {
-    const result = parse(lexSource('my_func = (param1: number.db, param2: string) { & param1, param2 }'))
+    const source = [
+      'my_func = (param1: number.db, param2: string) {',
+      '  & param1, param2',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
     assertResultComplete(result)
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
@@ -867,7 +873,7 @@ describe('parser/parser.ts', () => {
                 type: 'Parameter',
                 name: { type: 'Identifier', name: 'param1' },
                 parameterType: {
-                  type: 'TypeExpression',
+                  type: 'NamedType',
                   name: { type: 'Identifier', name: 'number' },
                   generics: [
                     { type: 'Identifier', name: 'db' }
@@ -878,7 +884,7 @@ describe('parser/parser.ts', () => {
                 type: 'Parameter',
                 name: { type: 'Identifier', name: 'param2' },
                 parameterType: {
-                  type: 'TypeExpression',
+                  type: 'NamedType',
                   name: { type: 'Identifier', name: 'string' },
                   generics: []
                 }
@@ -897,6 +903,147 @@ describe('parser/parser.ts', () => {
             ]
           }
         ]
+      }
+    ])
+  })
+
+  it('should parse complex type expressions', () => {
+    const source = [
+      'foo = (x: number.db + (format: string): string, fmt: string) {}',
+      'bar = (y: ((number.db) + (format: string): (string + string))) {}',
+      'baz = (z: (): string + string) {}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    const foo = result.value.children.at(0)?.values.at(0)
+    assert.strictEqual(foo?.type, 'Function')
+
+    assert.deepStrictEqual(stripRanges(foo.parameters), [
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'x' },
+        parameterType: {
+          type: 'CombinedType',
+          children: [
+            {
+              type: 'NamedType',
+              name: { type: 'Identifier', name: 'number' },
+              generics: [
+                { type: 'Identifier', name: 'db' }
+              ]
+            },
+            {
+              type: 'FunctionType',
+              parameters: [
+                {
+                  type: 'Parameter',
+                  name: { type: 'Identifier', name: 'format' },
+                  parameterType: {
+                    type: 'NamedType',
+                    name: { type: 'Identifier', name: 'string' },
+                    generics: []
+                  }
+                }
+              ],
+              returnType: {
+                type: 'NamedType',
+                name: { type: 'Identifier', name: 'string' },
+                generics: []
+              }
+            }
+          ]
+        }
+      },
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'fmt' },
+        parameterType: {
+          type: 'NamedType',
+          name: { type: 'Identifier', name: 'string' },
+          generics: []
+        }
+      }
+    ])
+
+    const bar = result.value.children.at(1)?.values.at(0)
+    assert.strictEqual(bar?.type, 'Function')
+
+    assert.deepStrictEqual(stripRanges(bar.parameters), [
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'y' },
+        parameterType: {
+          type: 'CombinedType',
+          children: [
+            {
+              type: 'NamedType',
+              name: { type: 'Identifier', name: 'number' },
+              generics: [
+                { type: 'Identifier', name: 'db' }
+              ]
+            },
+            {
+              type: 'FunctionType',
+              parameters: [
+                {
+                  type: 'Parameter',
+                  name: { type: 'Identifier', name: 'format' },
+                  parameterType: {
+                    type: 'NamedType',
+                    name: { type: 'Identifier', name: 'string' },
+                    generics: []
+                  }
+                }
+              ],
+              returnType: {
+                type: 'CombinedType',
+                children: [
+                  {
+                    type: 'NamedType',
+                    name: { type: 'Identifier', name: 'string' },
+                    generics: []
+                  },
+                  {
+                    type: 'NamedType',
+                    name: { type: 'Identifier', name: 'string' },
+                    generics: []
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ])
+
+    const baz = result.value.children.at(2)?.values.at(0)
+    assert.strictEqual(baz?.type, 'Function')
+
+    assert.deepStrictEqual(stripRanges(baz.parameters), [
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'z' },
+        parameterType: {
+          type: 'CombinedType',
+          children: [
+            {
+              type: 'FunctionType',
+              parameters: [],
+              returnType: {
+                type: 'NamedType',
+                name: { type: 'Identifier', name: 'string' },
+                generics: []
+              }
+            },
+            {
+              type: 'NamedType',
+              name: { type: 'Identifier', name: 'string' },
+              generics: []
+            }
+          ]
+        }
       }
     ])
   })


### PR DESCRIPTION
It is now possible to spell out function types, which lets us represent higher-order functions, for example:

```
apply = (fn: ((x: number): number), arg: number) {
  & fn(arg)
}

result = apply((x: number) { & x + 1 }, 5)
// result is 6
```

Additionally, it is possible to combine types using the `+` operator, which allows for representing types consisting of multiple facets. This will become useful once record types are supported as well, since many values consist of a base facet plus a record.