### PR TITLE
feat: Support curve interpolation expressions

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -421,34 +421,64 @@ function checkStep (scope: Scope, expression: ast.Step): Checked<void> {
   return { errors, effects }
 }
 
+interface CurveDetail {
+  readonly unit: Unit
+}
+
 function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
   const errors: CompileError[] = []
   let effects = noEffects
 
-  const segments = expression.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
-  const otherChildren = expression.children.filter((c) => c.type !== 'CurveSegment')
-
-  for (const child of otherChildren) {
-    // TODO Add support for interpolation in curves
-    errors.push(new CompileError('Curve interpolation is not supported yet', child.range))
-  }
-
-  if (segments.length === 0) {
+  if (expression.children.length === 0) {
     errors.push(new CompileError('Curve must have at least one segment', expression.range))
     return { errors, effects }
   }
 
-  const segmentChecks: Array<Checked<Unit>> = []
-  let previousUnit: Unit | undefined
+  let detail: CurveDetail | undefined
 
-  for (let i = 0; i < segments.length; ++i) {
-    const segmentCheck = checkCurveSegment(scope, segments[i], i > 0, previousUnit)
-    segmentChecks.push(segmentCheck)
-    errors.push(...segmentCheck.errors)
-    effects = mergeEffects(effects, segmentCheck.effects)
+  const append = (unit: Unit, range: SourceRange): void => {
+    if (detail == null) {
+      detail = { unit }
+      return
+    }
 
-    if (segmentCheck.result != null) {
-      previousUnit = segmentCheck.result
+    if (detail.unit !== unit) {
+      errors.push(new CompileError('Curve segments must have the same unit', range))
+    }
+  }
+
+  for (const item of expression.children) {
+    switch (item.type) {
+      case 'CurveSegment': {
+        const itemCheck = checkCurveSegment(scope, item, detail)
+        errors.push(...itemCheck.errors)
+        effects = mergeEffects(effects, itemCheck.effects)
+
+        if (itemCheck.result == null) {
+          break
+        }
+
+        append(itemCheck.result.unit, item.range)
+        break
+      }
+
+      default: {
+        const itemCheck = checkExpression(scope, item)
+        errors.push(...itemCheck.errors)
+        effects = mergeEffects(effects, itemCheck.effects)
+
+        if (itemCheck.result == null) {
+          break
+        }
+
+        if (!CurveFacet.is(itemCheck.result)) {
+          errors.push(...checkType(CurveFacet.type(), itemCheck.result, item.range))
+          break
+        }
+
+        append(CurveFacet.detail(itemCheck.result), item.range)
+        break
+      }
     }
   }
 
@@ -456,15 +486,7 @@ function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
     return { errors, effects }
   }
 
-  const firstUnit = segmentChecks[0].result
-
-  for (let i = 1; i < segmentChecks.length; ++i) {
-    if (segmentChecks[i].result !== firstUnit) {
-      errors.push(new CompileError('Curve segments must have the same unit', segments[i].range))
-    }
-  }
-
-  const result = CurveFacet.with(firstUnit).type()
+  const result = CurveFacet.with(detail?.unit).type()
 
   return { errors, effects, result }
 }
@@ -474,7 +496,7 @@ const curveSegmentLengthType = makeUnion(
   NumberFacet.with('s').type()
 )
 
-function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, hasPrevious: boolean, previousUnit: Unit | undefined): Checked<Unit> {
+function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?: CurveDetail): Checked<CurveDetail> {
   const errors: CompileError[] = []
   let effects = noEffects
 
@@ -494,7 +516,7 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, hasPrevi
   const actualParameters = expression.arguments.length
   const omittedFirstParameter = expectedParameters > 0 && actualParameters === expectedParameters - 1
 
-  if (omittedFirstParameter && !hasPrevious) {
+  if (omittedFirstParameter && detail == null) {
     return { errors: [new CompileError('First curve segment cannot omit its first argument', expression.range)], effects }
   }
 
@@ -524,14 +546,16 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, hasPrevi
     return { errors, effects }
   }
 
-  const firstUnit = omittedFirstParameter ? previousUnit : units[0]
+  const firstUnit = omittedFirstParameter ? detail?.unit : units[0]
 
   const expected = NumberFacet.with(firstUnit).type()
   for (let i = omittedFirstParameter ? 0 : 1; i < units.length; ++i) {
     errors.push(...checkType(expected, NumberFacet.with(units[i]).type(), expression.arguments[i].range))
   }
 
-  return { errors, effects, result: firstUnit }
+  const result = { unit: firstUnit }
+
+  return { errors, effects, result }
 }
 
 function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetType> {

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -293,11 +293,6 @@ function generateStep (scope: Scope, expression: ast.Step): Step {
 }
 
 function generateCurve (scope: Scope, expression: ast.Curve): Value {
-  const segments = expression.children.filter((c): c is ast.CurveSegment => c.type === 'CurveSegment')
-  const otherChildren = expression.children.filter((c) => c.type !== 'CurveSegment')
-  assert(segments.length > 0)
-  assert(otherChildren.length === 0)
-
   const generatedSegments: Array<RelativeCurveSegment<Unit>> = []
 
   const getPreviousSegmentEnd = (): RuntimeNumeric<Unit> => {
@@ -306,7 +301,14 @@ function generateCurve (scope: Scope, expression: ast.Curve): Value {
     return definition.end(previous)
   }
 
-  for (const segment of segments) {
+  for (const child of expression.children) {
+    if (child.type !== 'CurveSegment') {
+      const curve = CurveFacet.get(resolve(scope, child))
+      generatedSegments.push(...curve.segments)
+      continue
+    }
+
+    const segment = child
     const args = segment.arguments.map((point) => {
       return NumberFacet.get(resolve(scope, point))
     })
@@ -324,6 +326,8 @@ function generateCurve (scope: Scope, expression: ast.Curve): Value {
 
     generatedSegments.push(createCurveSegment(segment.curveType, resolvedParameters, length))
   }
+
+  assert(generatedSegments.length > 0)
 
   return Curves.of(createCurve(generatedSegments))
 }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -449,6 +449,24 @@ describe('compiler/checker/checker.ts', () => {
       assertValid('my_curve = ~[lin((-60).db, (-30).db):1.bar hold:1.bar]')
     })
 
+    it('should accept interpolated curves and inherit their final segment value', () => {
+      const source = [
+        'previous = ~[lin(-60.db, -30.db):1.bar]',
+        'my_curve = ~[{previous} lin(0.db):1.bar]'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should accept interpolation of curves without units', () => {
+      const source = [
+        'previous = ~[hold(0):1.bar]',
+        'my_curve = ~[{previous} lin(1):1.bar]'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept bus gain automation via explicit namespace', () => {
       const source = [
         '& mixer {',
@@ -764,6 +782,29 @@ describe('compiler/checker/checker.ts', () => {
     it('should reject curves when the units differ between segments', () => {
       assertErrorMessages('my_curve = ~[hold(0.db):1.bar hold(100.hz):1.bar]', [
         'Curve segments must have the same unit'
+      ])
+    })
+
+    it('should reject curves when interpolation units differ from segments', () => {
+      const source = [
+        'previous = ~[hold(0.db):1.bar]',
+        'my_curve = ~[{previous} hold(100.hz):1.bar]'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Curve segments must have the same unit'
+      ])
+    })
+
+    it('should reject empty curves', () => {
+      assertErrorMessages('my_curve = ~[]', [
+        'Curve must have at least one segment'
+      ])
+    })
+
+    it('should reject interpolation of non-curves', () => {
+      assertErrorMessages('my_curve = ~[{42}]', [
+        'Expected type curve, got number'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -410,6 +410,31 @@ describe('compiler/generator/generator.ts', () => {
     ])
   })
 
+  it('should interpolate curves and inherit their final segment value', () => {
+    const source = [
+      'use "instruments" as *',
+      'synth = sample("synth.wav")',
+      'previous = ~[lin(-60.db, -30.db):1.bar lin(-30.db, -15.db):1.bar]',
+      '& track (120.bpm) {',
+      '  & part intro (4.bars) {',
+      '    & automate(synth.gain, ~[{previous} lin(0.db):1.bar])',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+
+    assert.strictEqual(result.automations.size, 1)
+    const [automation] = result.automations.values()
+
+    assert.deepStrictEqual(automation.points, [
+      { time: seconds(0), value: db(-60), shape: 'step' },
+      { time: seconds(2), value: db(-30), shape: 'linear' },
+      { time: seconds(4), value: db(-15), shape: 'linear' },
+      { time: seconds(6), value: db(0), shape: 'linear' }
+    ])
+  })
+
   it('should clip curve lengths to the part length', () => {
     const source = [
       'use "instruments" as *',


### PR DESCRIPTION
With this patch, interpolation expressions are now supported across the three types 'string', 'pattern', and 'curve', with similar semantics.

Example for curve interpolation:

```
attack = ~[lin(-60.db, 0.db) : 20.ms]
release = ~[lin(0.db, -60.db) : 20.ms]

// mix and match curve segments and interpolations
combined = ~[{attack} hold(0.db):1.beat {release}]
```