### PR TITLE
feat: Support record type notation

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -44,6 +44,7 @@ export interface NodeByType {
   // Type Expressions
   NamedType: NamedType
   FunctionType: FunctionType
+  RecordType: RecordType
   CombinedType: CombinedType
 
   // Primitive Values
@@ -177,7 +178,7 @@ export interface Parameter extends ASTNode {
 
 // Type Expressions
 
-export type Type = NamedType | FunctionType | CombinedType
+export type Type = NamedType | FunctionType | RecordType | CombinedType
 
 export interface NamedType extends ASTNode {
   readonly type: 'NamedType'
@@ -189,6 +190,11 @@ export interface FunctionType extends ASTNode {
   readonly type: 'FunctionType'
   readonly parameters: readonly Parameter[]
   readonly returnType: Type
+}
+
+export interface RecordType extends ASTNode {
+  readonly type: 'RecordType'
+  readonly parameters: readonly Parameter[]
 }
 
 export interface CombinedType extends ASTNode {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -131,7 +131,7 @@ Type {
 }
 
 atomicType {
-  NamedType | FunctionType | ("(" Type ")")
+  NamedType | FunctionType | RecordType | ("(" Type ")")
 }
 
 NamedType {
@@ -142,6 +142,10 @@ FunctionType {
   "(" parameterList? ")"
   ":"
   atomicType
+}
+
+RecordType {
+  "{" parameterList? "}"
 }
 
 primary {

--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -24,7 +24,7 @@ describe('hover/operation.ts', () => {
       applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, position),
       {
         range: getRangeAt(source, source.indexOf('gain('), 'gain'.length),
-        title: 'gain = (gain: number.db): effect + record(gain)',
+        title: 'gain = (gain: number.db): effect + {gain: parameter.db}',
         summary: 'Applies a gain adjustment to the signal.',
         annotations: ['may block']
       }
@@ -104,7 +104,7 @@ describe('hover/operation.ts', () => {
       applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, delayPosition),
       {
         range: getRangeAt(source, source.indexOf('delay('), 'delay'.length),
-        title: 'delay = (mix: number, time: number.beats | number.s, feedback: number, wet?: number.db): effect + record(feedback)',
+        title: 'delay = (mix: number, time: number.beats | number.s, feedback: number, wet?: number.db): effect + {feedback: parameter}',
         summary: 'Adds echoes with configurable mix, time, and feedback.',
         annotations: ['may block']
       }

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -707,6 +707,9 @@ function checkTypeComponents (expression: ast.Type): Checked<readonly TypeCompon
     case 'FunctionType':
       return checkFunctionType(expression)
 
+    case 'RecordType':
+      return checkRecordType(expression)
+
     case 'CombinedType':
       return checkCombinedType(expression)
   }
@@ -756,6 +759,38 @@ function checkFunctionType (expression: ast.FunctionType): Checked<readonly Type
     effects: noEffects
   })
 
+  const result = [{ facet, range: expression.range }]
+
+  return { errors, effects, result }
+}
+
+function checkRecordType (expression: ast.RecordType): Checked<readonly TypeComponent[]> {
+  const errors: CompileError[] = []
+  const effects = noEffects
+
+  const properties = new Map<string, FacetType>()
+
+  for (const property of expression.parameters) {
+    const propertyCheck = checkTypeExpression(property.parameterType)
+    errors.push(...propertyCheck.errors)
+
+    if (propertyCheck.result == null) {
+      continue
+    }
+
+    if (properties.has(property.name.name)) {
+      errors.push(new CompileError(`Duplicate property name "${property.name.name}"`, property.name.range))
+      continue
+    }
+
+    properties.set(property.name.name, propertyCheck.result)
+  }
+
+  if (errors.length > 0) {
+    return { errors, effects }
+  }
+
+  const facet = RecordFacet.with(Object.fromEntries(properties))
   const result = [{ facet, range: expression.range }]
 
   return { errors, effects, result }

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -338,7 +338,10 @@ const curve_: p.Parser<Token, unknown, ast.Curve> = p.abc(
 )
 
 const namedType_: p.Parser<Token, unknown, ast.NamedType> = p.ab(
-  identifier_,
+  // Do not use identifier_ as it excludes keywords, but keywords are valid type names (e.g. "effect" and "instrument")
+  p.token((t) => {
+    return t.name === 'word' ? ast.make('Identifier', getSourceRange(t), { name: t.text }) : undefined
+  }),
   p.many(
     p.right(literal('.'), identifier_)
   ),
@@ -362,9 +365,19 @@ const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.ab(
   }
 )
 
+const recordType_: p.Parser<Token, unknown, ast.RecordType> = p.abc(
+  literal('{'),
+  p.recursive(() => parameterList_),
+  expectLiteral('}'),
+  (_l, parameters, _r) => {
+    return ast.make('RecordType', combineSourceRanges(_l, _r), { parameters })
+  }
+)
+
 const atomicType_: p.Parser<Token, unknown, ast.Type> = p.choice<Token, unknown, ast.Type>(
   namedType_,
   functionType_,
+  recordType_,
   p.abc(
     literal('('),
     p.recursive((): p.Parser<Token, unknown, ast.Type> => type_),

--- a/packages/language/src/type-system/base/function.ts
+++ b/packages/language/src/type-system/base/function.ts
@@ -105,7 +105,7 @@ function isAssignableFrom (spec: FunctionSpec, other: FunctionSpec): boolean {
   // - same parameter names
   //     Example: (a: string) is not assignable to (b: string)
   // - assignable parameter types (contravariant)
-  //     Example: (a: record(gain)) is assignable to (a: record(gain, pan)), but not vice versa
+  //     Example: (a: { gain }) is assignable to (a: { gain, pan }), but not vice versa
 
   // Note (future improvement): We could allow different parameter names by mapping from the
   // call-site parameter names to the function value's internal parameter names in the compiler.

--- a/packages/language/src/type-system/base/record.ts
+++ b/packages/language/src/type-system/base/record.ts
@@ -42,7 +42,13 @@ export const RecordFacet = {
     const safeFields = cloneOwnProperties(fields)
 
     return makeFacet<typeof FACET_NAME, RecordDataForFields<Fields>>(FACET_NAME, safeFields, {
-      format: () => `${FACET_NAME}(${Object.keys(safeFields).join(', ')})`,
+      format: () => {
+        const fields = Object.entries(safeFields)
+          .map(([name, type]) => `${name}: ${type?.format()}`)
+          .join(', ')
+
+        return `{${fields}}`
+      },
       normalize: (data) => normalizeRecordData<Fields>(data)
     })
   },

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -258,6 +258,16 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept record types', () => {
+      const source = [
+        'my_function = (param: { foo: number, bar: string }) {',
+        '  & param.foo',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should allow blocking calls in functions', () => {
       const source = [
         'use "instruments" as inst',
@@ -957,11 +967,11 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Module "instruments" has no export named "__proto__"',
-        'Type instrument + record(gain) has no property named "__proto__"',
+        'Type instrument + {gain: parameter.db} has no property named "__proto__"',
         'Module "instruments" has no export named "constructor"',
-        'Type instrument + record(gain) has no property named "constructor"',
+        'Type instrument + {gain: parameter.db} has no property named "constructor"',
         'Module "instruments" has no export named "toString"',
-        'Type instrument + record(gain) has no property named "toString"'
+        'Type instrument + {gain: parameter.db} has no property named "toString"'
       ])
     })
 
@@ -1061,7 +1071,7 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Identifier "note" is already defined',
-        'Expected type number.hz for argument "frequency", got record(frequency, gate, velocity)'
+        'Expected type number.hz for argument "frequency", got {frequency: number.hz, gate: number.beats, velocity: number}'
       ])
     })
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -907,11 +907,68 @@ describe('parser/parser.ts', () => {
     ])
   })
 
+  it('should parse empty record types', () => {
+    const result = parse(lexSource('func = (p: {}) { & 42 }'))
+    assertResultComplete(result)
+
+    const func = result.value.children.at(0)?.values.at(0)
+    assert.strictEqual(func?.type, 'Function')
+
+    assert.deepStrictEqual(stripRanges(func.parameters), [
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'p' },
+        parameterType: {
+          type: 'RecordType',
+          parameters: []
+        }
+      }
+    ])
+  })
+
+  it('should parse named types', () => {
+    const result = parse(lexSource('foo = (x: track, y: part, z: instrument) {}'))
+    assertResultComplete(result)
+
+    const func = result.value.children.at(0)?.values.at(0)
+    assert.strictEqual(func?.type, 'Function')
+
+    assert.deepStrictEqual(stripRanges(func.parameters), [
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'x' },
+        parameterType: {
+          type: 'NamedType',
+          name: { type: 'Identifier', name: 'track' },
+          generics: []
+        }
+      },
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'y' },
+        parameterType: {
+          type: 'NamedType',
+          name: { type: 'Identifier', name: 'part' },
+          generics: []
+        }
+      },
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'z' },
+        parameterType: {
+          type: 'NamedType',
+          name: { type: 'Identifier', name: 'instrument' },
+          generics: []
+        }
+      }
+    ])
+  })
+
   it('should parse complex type expressions', () => {
     const source = [
       'foo = (x: number.db + (format: string): string, fmt: string) {}',
       'bar = (y: ((number.db) + (format: string): (string + string))) {}',
-      'baz = (z: (): string + string) {}'
+      'baz = (z: (): instrument + {foo: number, bar: string}) {}'
     ].join('\n')
 
     const result = parse(lexSource(source))
@@ -1033,14 +1090,32 @@ describe('parser/parser.ts', () => {
               parameters: [],
               returnType: {
                 type: 'NamedType',
-                name: { type: 'Identifier', name: 'string' },
+                name: { type: 'Identifier', name: 'instrument' },
                 generics: []
               }
             },
             {
-              type: 'NamedType',
-              name: { type: 'Identifier', name: 'string' },
-              generics: []
+              type: 'RecordType',
+              parameters: [
+                {
+                  type: 'Parameter',
+                  name: { type: 'Identifier', name: 'foo' },
+                  parameterType: {
+                    type: 'NamedType',
+                    name: { type: 'Identifier', name: 'number' },
+                    generics: []
+                  }
+                },
+                {
+                  type: 'Parameter',
+                  name: { type: 'Identifier', name: 'bar' },
+                  parameterType: {
+                    type: 'NamedType',
+                    name: { type: 'Identifier', name: 'string' },
+                    generics: []
+                  }
+                }
+              ]
             }
           ]
         }

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -307,9 +307,12 @@ describe('type-system/base', () => {
   })
 
   describe('RecordFacet', () => {
-    it('should format as facet name with field names', () => {
+    it('should format as facet name with field names and types', () => {
       const recordFacet = RecordFacet.with({ gain: NumberFacet.type(), label: StringFacet.type() })
-      assert.strictEqual(recordFacet.format(), 'record(gain, label)')
+      assert.strictEqual(recordFacet.format(), '{gain: number, label: string}')
+
+      const emptyRecordFacet = RecordFacet.with({})
+      assert.strictEqual(emptyRecordFacet.format(), '{}')
     })
 
     it('should compare by field assignability', () => {


### PR DESCRIPTION
It is now possible to express record types as part of the type system, i.e., for use in function signatures. This uses brace notation and is otherwise similar to parameter lists, e.g.:

```
{gain: number.db, pan: number, frequency: number.hz}
```

With this as a building-block, it is now possible to express many of the library types, for instance, built-in instruments:

```
automate_gain = (object: instrument + {gain: parameter.db}) {
  & automate(object.gain, ~[lin(-6.db, 12.db) : 1.bar])
}

piano = sample("piano.wav")
automation = automate_gain(piano)
```

Note that the `instrument` facet is not strictly needed in the above example, but it demonstrates the concept.