### PR TITLE
feat: Add support for record values

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -57,6 +57,7 @@ export interface NodeByType {
 
   // Constructed Values
   Function: Function
+  RecordValue: RecordValue
   Mixer: Mixer
   Bus: Bus
   Track: Track
@@ -74,6 +75,7 @@ export type Value =
   Pattern |
   Curve |
   Function |
+  RecordValue |
   Mixer |
   Bus |
   Track |
@@ -244,6 +246,11 @@ export interface CurveSegment extends ASTNode {
 export interface Function extends ASTNode {
   readonly type: 'Function'
   readonly parameters: readonly Parameter[]
+  readonly children: readonly Statement[]
+}
+
+export interface RecordValue extends ASTNode {
+  readonly type: 'RecordValue'
   readonly children: readonly Statement[]
 }
 

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -155,6 +155,7 @@ primary {
   Number |
   String |
   Function |
+  Record |
   Bus |
   Curve |
   Instrument |
@@ -225,6 +226,10 @@ Function {
   FunctionBlock[group=Block] {
     "{" statement* "}"
   }
+}
+
+Record {
+  "{" statement* "}"
 }
 
 Track {

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -90,6 +90,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
+      case 'Record': {
+        const scope = addScope({ kind: 'record', range, parentId: scopeId })
+        nextScopeId = scope.id
+        break
+      }
+
       case 'TrackBlock': {
         const scope = addScope({ kind: 'track', range, parentId: scopeId })
         nextScopeId = scope.id

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -32,7 +32,7 @@ export interface Scope {
   readonly range: SourceRange
 }
 
-export type ScopeKind = 'root' | 'function' | 'track' | 'part' | 'mixer' | 'bus' | 'instrument' | 'voice'
+export type ScopeKind = 'root' | 'function' | 'record' | 'track' | 'part' | 'mixer' | 'bus' | 'instrument' | 'voice'
 
 // identifier
 

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -24,8 +24,12 @@ describe('model/analysis/base.ts', () => {
       'kick = sample("{base_path}/kick.wav")',
       'tempo = 120.bpm',
       '',
+      'record = {',
+      '  @record_property = 42',
+      '}',
+      '',
       'synth = instrument {',
-      '  @custom_property = 42',
+      '  @instrument_property = 42',
       '  & voice note {}',
       '}',
       '',
@@ -63,8 +67,10 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'root', name: 'base_path' },
         { kind: 'definition', scope: 'root', name: 'tempo' },
         { kind: 'plain', scope: 'root', name: 'bpm' },
+        { kind: 'definition', scope: 'root', name: 'record' },
+        { kind: 'definition', scope: 'record', name: 'record_property' },
         { kind: 'definition', scope: 'root', name: 'synth' },
-        { kind: 'definition', scope: 'instrument', name: 'custom_property' },
+        { kind: 'definition', scope: 'instrument', name: 'instrument_property' },
         { kind: 'definition', scope: 'voice', name: 'note' },
         { kind: 'definition', scope: 'root', name: 'double' },
         { kind: 'definition', scope: 'function', name: 'input' },
@@ -230,8 +236,12 @@ describe('model/analysis/base.ts', () => {
       '  & input * 2',
       '} // end function',
       '',
+      'my_record = {',
+      '  @record_property = 42',
+      '} // end record',
+      '',
       'my_instrument = instrument {',
-      '  @custom_property = 42',
+      '  @instrument_property = 42',
       '  foo = 42',
       '  bar = foo * 2',
       '  & voice note {',
@@ -265,6 +275,11 @@ describe('model/analysis/base.ts', () => {
     const functionBlockEnd = source.indexOf('} // end function') + '}'.length
     const functionRange = getRangeAt(source, functionBlockStart, functionBlockEnd - functionBlockStart)
     const functionScopeId = `function:${functionRange.offset}:${functionRange.length}`
+
+    const recordBlockStart = source.indexOf('{', source.indexOf('my_record'))
+    const recordBlockEnd = source.indexOf('} // end record') + '}'.length
+    const recordRange = getRangeAt(source, recordBlockStart, recordBlockEnd - recordBlockStart)
+    const recordScopeId = `record:${recordRange.offset}:${recordRange.length}`
 
     const instrumentBlockStart = source.indexOf('{', source.indexOf('my_instrument'))
     const instrumentBlockEnd = source.indexOf('} // end instrument') + '}'.length
@@ -306,6 +321,7 @@ describe('model/analysis/base.ts', () => {
       [
         { id: rootScopeId, kind: 'root', parentId: undefined },
         { id: functionScopeId, kind: 'function', parentId: rootScopeId },
+        { id: recordScopeId, kind: 'record', parentId: rootScopeId },
         { id: instrumentScopeId, kind: 'instrument', parentId: rootScopeId },
         { id: voiceScopeId, kind: 'voice', parentId: instrumentScopeId },
         { id: trackScopeId, kind: 'track', parentId: rootScopeId },
@@ -324,8 +340,10 @@ describe('model/analysis/base.ts', () => {
         { kind: 'regular', name: 'snare', declaredScopeId: undefined, isExposed: false },
         { kind: 'regular', name: 'my_function', declaredScopeId: undefined, isExposed: false },
         { kind: 'regular', name: 'input', declaredScopeId: undefined, isExposed: undefined },
+        { kind: 'regular', name: 'my_record', declaredScopeId: undefined, isExposed: false },
+        { kind: 'regular', name: 'record_property', declaredScopeId: undefined, isExposed: true },
         { kind: 'regular', name: 'my_instrument', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'custom_property', declaredScopeId: undefined, isExposed: true },
+        { kind: 'regular', name: 'instrument_property', declaredScopeId: undefined, isExposed: true },
         { kind: 'regular', name: 'foo', declaredScopeId: undefined, isExposed: false },
         { kind: 'regular', name: 'bar', declaredScopeId: undefined, isExposed: false },
         { kind: 'regular', name: 'note', declaredScopeId: undefined, isExposed: undefined },

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -310,6 +310,9 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
     case 'Function':
       return checkFunction(scope, expression)
 
+    case 'RecordValue':
+      return checkRecord(scope, expression)
+
     case 'Instrument':
       return checkInstrument(scope, expression)
 
@@ -814,6 +817,30 @@ function checkCombinedType (expression: ast.CombinedType): Checked<readonly Type
   if (errors.length > 0) {
     return { errors, effects }
   }
+
+  return { errors, effects, result }
+}
+
+function checkRecord (scope: Scope, expression: ast.RecordValue): Checked<FacetType> {
+  const errors: CompileError[] = []
+  let effects = noEffects
+
+  const recordScope = createLocalScope(scope)
+  const properties = new Map<string, FacetType>()
+
+  for (const child of expression.children) {
+    const statement = checkStatement(recordScope, child, properties)
+    errors.push(...statement.errors)
+    effects = mergeEffects(effects, statement.effects)
+
+    for (const emission of statement.emissions) {
+      errors.push(new CompileError('Cannot emit values in records', emission.range))
+    }
+
+    putAll(properties, statement.properties)
+  }
+
+  const result = RecordFacet.with(Object.fromEntries(properties)).type()
 
   return { errors, effects, result }
 }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -186,6 +186,9 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
     case 'Function':
       return generateFunction(scope, expression)
 
+    case 'RecordValue':
+      return generateRecord(scope, expression)
+
     case 'Instrument':
       return generateInstrument(scope, expression)
 
@@ -361,6 +364,19 @@ function generateFunction (scope: Scope, expression: ast.Function): Value {
   }
 
   return Functions.of(spec, { invoke })
+}
+
+function generateRecord (scope: Scope, expression: ast.RecordValue): Value {
+  const recordScope = createLocalScope(scope)
+  const recordBuilder = new RecordBuilder()
+
+  for (const child of expression.children) {
+    const { emissions, properties } = processStatement(recordScope, child)
+    assert(emissions.length === 0)
+    recordBuilder.putAll(properties)
+  }
+
+  return recordBuilder.facet.type().of(recordBuilder.record)
 }
 
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -431,6 +431,15 @@ const function_: p.Parser<Token, unknown, ast.Function> = p.ab(
   }
 )
 
+const recordValue_: p.Parser<Token, unknown, ast.RecordValue> = p.abc(
+  literal('{'),
+  p.recursive(() => p.many(statement_)),
+  expectLiteral('}'),
+  (_l, children, _r) => {
+    return ast.make('RecordValue', combineSourceRanges(_l, _r), { children })
+  }
+)
+
 const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast.Value>(
   identifier_,
   number_,
@@ -438,6 +447,7 @@ const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast
   serialPattern_,
   curve_,
   function_,
+  recordValue_,
   p.recursive(() => instrument_),
   p.recursive(() => voice_),
   p.recursive(() => mixer_),

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -268,6 +268,22 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept record values', () => {
+      const source = [
+        'empty_record = {}',
+        '',
+        'my_record = {',
+        '  @foo = 42',
+        '  @bar = "hello"',
+        '}',
+        '',
+        'access_foo = my_record.foo',
+        'access_bar = my_record.bar'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should allow blocking calls in functions', () => {
       const source = [
         'use "instruments" as inst',
@@ -701,6 +717,18 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Duplicate property "gain"'
+      ])
+    })
+
+    it('should reject emission in record values', () => {
+      const source = [
+        'my_record = {',
+        '  & 42',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Cannot emit values in records'
       ])
     })
 

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -103,7 +103,17 @@ describe('compiler/generator/generator.ts', () => {
     ].join('\n')
 
     const result = generateSource(source)
-    assert.deepStrictEqual(result.track.tempo, 15)
+    assert.strictEqual(result.track.tempo, 15)
+  })
+
+  it('should support property exposure in record values', () => {
+    const source = [
+      'my_record = { @foo = 123 }',
+      '& track (tempo: my_record.foo.bpm) {}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.strictEqual(result.track.tempo, 123)
   })
 
   it('should support imported names', () => {

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -286,6 +286,101 @@ describe('parser/parser.ts', () => {
     ])
   })
 
+  it('should parse record values', () => {
+    const source = [
+      'empty_record = {}',
+      'one_field = { @key = "value" }',
+      'complex = {',
+      '  scratch = 42',
+      '  @foo = { @bar = scratch }',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Statement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'empty_record' },
+        values: [
+          {
+            type: 'RecordValue',
+            children: []
+          }
+        ]
+      },
+      {
+        type: 'Statement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'one_field' },
+        values: [
+          {
+            type: 'RecordValue',
+            children: [
+              {
+                type: 'Statement',
+                emit: false,
+                expose: true,
+                name: { type: 'Identifier', name: 'key' },
+                values: [
+                  { type: 'String', parts: ['value'] }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        type: 'Statement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'complex' },
+        values: [
+          {
+            type: 'RecordValue',
+            children: [
+              {
+                type: 'Statement',
+                emit: false,
+                expose: false,
+                name: { type: 'Identifier', name: 'scratch' },
+                values: [
+                  { type: 'Number', value: 42 }
+                ]
+              },
+              {
+                type: 'Statement',
+                emit: false,
+                expose: true,
+                name: { type: 'Identifier', name: 'foo' },
+                values: [
+                  {
+                    type: 'RecordValue',
+                    children: [
+                      {
+                        type: 'Statement',
+                        emit: false,
+                        expose: true,
+                        name: { type: 'Identifier', name: 'bar' },
+                        values: [
+                          { type: 'Identifier', name: 'scratch' }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ])
+  })
+
   it('should parse a serial pattern', () => {
     const result = parse(lexSource('foo = [xx-D4:0.5-G4]'))
     assertResultComplete(result)


### PR DESCRIPTION
It is now possible to construct plain record-typed values without any other facets, using a non-prefixed block expression. Example:

```
my_record = {
  @foo = "Hello, world!"

  a = 1 // temporary variable
  @bar = 42 + a
}
```

This is exactly how all block expressions already work (track, mixer, bus, etc.). For example, an instrument with exposed properties would get the type `instrument + {key: value, ...}`, i.e., the instrument facet plus a record facet; now, it is possible to construct just the record part of that.