### PR TITLE
feat: Support facet merging in type expressions

### DIFF
--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -690,7 +690,13 @@ function checkTypeExpression (expression: ast.Type): Checked<FacetType> {
   for (const component of components) {
     const existing = facets.get(component.facet.name)
     if (existing != null) {
-      errors.push(new CompileError(`Type conflict: (${existing.format()}) + (${component.facet.format()})`, component.range))
+      const merged = existing.merge(component.facet)
+      if (merged == null) {
+        errors.push(new CompileError(`Type conflict: (${existing.format()}) + (${component.facet.format()})`, component.range))
+        continue
+      }
+
+      facets.set(merged.name, merged)
       continue
     }
 

--- a/packages/language/src/type-system/base/record.ts
+++ b/packages/language/src/type-system/base/record.ts
@@ -1,5 +1,5 @@
 import { makeFacet } from '../factory.ts'
-import type { FacetType, ValueForType } from '../types.ts'
+import type { Facet, FacetType, ValueForType } from '../types.ts'
 
 type RecordGenerics = Readonly<Partial<Record<string, FacetType>>>
 
@@ -33,25 +33,61 @@ function normalizeRecordData<Fields extends RecordGenerics> (data: unknown): Rec
 
 const EMPTY_RECORD_GENERICS = cloneOwnProperties({} as Record<string, unknown>) as RecordGenerics
 
+function mergeRecordGenerics (a: RecordGenerics, b: RecordGenerics): RecordGenerics | undefined {
+  const fields: Record<string, FacetType> = {}
+
+  for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+    const aType = a[key]
+    const bType = b[key]
+
+    if (aType != null && bType != null) {
+      const mergedType = aType.merge(bType)
+      if (mergedType == null) {
+        return undefined
+      }
+      fields[key] = mergedType
+    } else if (aType != null) {
+      fields[key] = aType
+    } else if (bType != null) {
+      fields[key] = bType
+    }
+  }
+
+  return fields
+}
+
+function recordWith<const Fields extends RecordGenerics> (fields: Fields): Facet<typeof FACET_NAME, RecordDataForFields<Fields>> {
+  const safeFields = cloneOwnProperties(fields)
+
+  return makeFacet<typeof FACET_NAME, RecordDataForFields<Fields>>(FACET_NAME, safeFields, {
+    format: () => {
+      const fields = Object.entries(safeFields)
+        .map(([name, type]) => `${name}: ${type?.format()}`)
+        .join(', ')
+
+      return `{${fields}}`
+    },
+    normalize: (data) => normalizeRecordData<Fields>(data),
+    merge: (other: Facet) => {
+      if (other.name !== FACET_NAME) {
+        return undefined
+      }
+
+      const merged = mergeRecordGenerics(safeFields, other.generics as RecordGenerics)
+      return merged == null ? undefined : recordWith(merged)
+    }
+  })
+}
+
 export const RecordFacet = {
   ...makeFacet<typeof FACET_NAME, RecordDataForFields<RecordGenerics>>(FACET_NAME, EMPTY_RECORD_GENERICS, {
-    normalize: (data) => normalizeRecordData<RecordGenerics>(data)
+    normalize: (data) => normalizeRecordData<RecordGenerics>(data),
+    merge: (other: Facet) => {
+      return other.name === FACET_NAME ? other : undefined
+    }
   }),
 
-  with: <const Fields extends RecordGenerics> (fields: Fields) => {
-    const safeFields = cloneOwnProperties(fields)
-
-    return makeFacet<typeof FACET_NAME, RecordDataForFields<Fields>>(FACET_NAME, safeFields, {
-      format: () => {
-        const fields = Object.entries(safeFields)
-          .map(([name, type]) => `${name}: ${type?.format()}`)
-          .join(', ')
-
-        return `{${fields}}`
-      },
-      normalize: (data) => normalizeRecordData<Fields>(data)
-    })
-  },
+  with: recordWith,
 
   detail: (type: FacetType): RecordGenerics => {
     return type.getFacet(FACET_NAME).generics as RecordGenerics

--- a/packages/language/src/type-system/factory.ts
+++ b/packages/language/src/type-system/factory.ts
@@ -4,6 +4,7 @@ import type { DataForFacets, Facet, FacetType, Generics, SpecificFacetDataForVal
 export interface FacetOptions<Data = unknown> {
   readonly format?: () => string
   readonly normalize?: (data: unknown) => Data
+  readonly merge?: (other: Facet) => Facet | undefined
 }
 
 export function makeFacet<const Name extends string, Data> (
@@ -38,6 +39,18 @@ export function makeFacet<const Name extends string, Data> (
 
       return value.data.get(facet.name) as SpecificFacetDataForValue<V, Name, Data>
     },
+
+    merge: options?.merge ?? ((other: Facet) => {
+      if (facet.name !== other.name) {
+        return undefined
+      }
+
+      if (isFacetAssignableFromFacet(facet, other) && isFacetAssignableFromFacet(other, facet)) {
+        return facet
+      }
+
+      return undefined
+    }),
 
     type: () => {
       cachedType ??= makeType(facet)
@@ -88,6 +101,33 @@ export function makeType<const Facets extends readonly Facet[]> (
       )
 
       return { type, data: dataMap }
+    },
+
+    merge: (other: FacetType): FacetType | undefined => {
+      if (other === type) {
+        return type
+      }
+
+      const mergedFacets: Facet[] = []
+
+      for (const name of new Set([...type.facets.keys(), ...other.facets.keys()])) {
+        const a = type.facets.get(name)
+        const b = other.facets.get(name)
+
+        if (a != null && b != null) {
+          const merged = a.merge(b)
+          if (merged == null) {
+            return undefined
+          }
+          mergedFacets.push(merged)
+        } else if (a != null) {
+          mergedFacets.push(a)
+        } else if (b != null) {
+          mergedFacets.push(b)
+        }
+      }
+
+      return makeType(...mergedFacets)
     },
 
     getFacet: (name: string): Facets[number] => {

--- a/packages/language/src/type-system/types.ts
+++ b/packages/language/src/type-system/types.ts
@@ -9,6 +9,7 @@ export interface FacetType<Facets extends readonly Facet[] = readonly Facet[]> {
   readonly is: (other: Type) => boolean
   readonly has: (value: Value) => value is ValueForType<FacetType<Facets>>
   readonly of: (...data: DataForFacets<Facets>) => ValueForType<FacetType<Facets>>
+  readonly merge: (other: FacetType) => FacetType | undefined
   readonly getFacet: (name: string) => Facets[number]
 }
 
@@ -28,6 +29,7 @@ export interface Facet<Name extends string = string, Data = unknown> {
   readonly is: (other: Facet | Type) => boolean
   readonly has: (value: Value) => value is Value<Facet<Name, Data>>
   readonly get: <const V extends Value>(value: V) => SpecificFacetDataForValue<V, Name, Data>
+  readonly merge: (other: Facet) => Facet | undefined
 
   readonly type: () => FacetType<[Facet<Name, Data>]>
 

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -268,6 +268,18 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should merge identical and complementary composite types', () => {
+      const source = [
+        'func0 = (p: string + string) { & p }',
+        'func1 = (p: number.db + number.db) { & p }',
+        'func2 = (p: ((arg: number): number) + ((arg: number): number)) { & p(42) }',
+        'func4 = (p: { a: string } + { a: string }) { & p.a }',
+        'func3 = (p: { a: string } + { b: number }) { & { @c = p.a @d = p.b } }'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept record values', () => {
       const source = [
         'empty_record = {}',
@@ -1226,19 +1238,17 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject invalid composite types', () => {
       const source = [
-        'func0 = (p: number + number) { & p }',
-        'func1 = (p: number + number.hz) { & p }',
-        'func2 = (p: number.db + number.hz) { & p }',
-        'func3 = (p: string + string) { & p }',
-        'func4 = (p: ((a: number): number) + ((b: number): number)) { & p }'
+        'func0 = (p: number + number.hz) { & p }',
+        'func1 = (p: number.db + number.hz) { & p }',
+        'func2 = (p: ((a: number): number) + ((b: number): number)) { & p }',
+        'func3 = (p: {a: number.hz} + {a: number.db}) { & p }'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Type conflict: (number) + (number)',
         'Type conflict: (number) + (number.hz)',
         'Type conflict: (number.db) + (number.hz)',
-        'Type conflict: (string) + (string)',
-        'Type conflict: (function) + (function)'
+        'Type conflict: (function) + (function)',
+        'Type conflict: ({a: number.hz}) + ({a: number.db})'
       ])
     })
 

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -147,6 +147,39 @@ describe('type-system/base', () => {
       assert.strictEqual(narrowReturn.is(broadReturn), false)
     })
 
+    it('should merge function facets with identical specs', () => {
+      const spec: FunctionSpec = {
+        parameters: makeSchema([]),
+        returnType: StringFacet.type(),
+        effects: { blocking: false }
+      }
+
+      const facetA = FunctionFacet.with(spec)
+      const facetB = FunctionFacet.with(spec)
+
+      const mergedAB = facetA.merge(facetB)
+      assert.strictEqual(mergedAB, facetA)
+
+      const mergedBA = facetB.merge(facetA)
+      assert.strictEqual(mergedBA, facetB)
+
+      const differentSpec: FunctionSpec = {
+        parameters: makeSchema([
+          { name: 'amount', type: NumberFacet.with(undefined).type(), required: false }
+        ]),
+        returnType: StringFacet.type(),
+        effects: { blocking: false }
+      }
+
+      const facetC = FunctionFacet.with(differentSpec)
+
+      const mergedAC = facetA.merge(facetC)
+      assert.strictEqual(mergedAC, undefined)
+
+      const mergedCA = facetC.merge(facetA)
+      assert.strictEqual(mergedCA, undefined)
+    })
+
     it('should create a single-facet type', () => {
       const functionType = FunctionFacet.type()
       assert.deepStrictEqual([...functionType.facets.keys()], ['function'])
@@ -281,6 +314,31 @@ describe('type-system/base', () => {
       assert.strictEqual(NumberFacet.with('db').is(StringFacet), false)
     })
 
+    it('should merge number facets with identical units', () => {
+      const facetA = NumberFacet.with('db')
+      const facetB = NumberFacet.with('db')
+      const facetC = NumberFacet.with('hz')
+      const facetD = NumberFacet.with(undefined)
+
+      const mergedAB = facetA.merge(facetB)
+      assert.strictEqual(mergedAB, facetA)
+
+      const mergedBA = facetB.merge(facetA)
+      assert.strictEqual(mergedBA, facetB)
+
+      const mergedAC = facetA.merge(facetC)
+      assert.strictEqual(mergedAC, undefined)
+
+      const mergedCA = facetC.merge(facetA)
+      assert.strictEqual(mergedCA, undefined)
+
+      const mergedAD = facetA.merge(facetD)
+      assert.strictEqual(mergedAD, undefined)
+
+      const mergedDA = facetD.merge(facetA)
+      assert.strictEqual(mergedDA, undefined)
+    })
+
     it('should create a single-facet type', () => {
       const numberType = NumberFacet.type()
       assert.deepStrictEqual([...numberType.facets.keys()], ['number'])
@@ -351,6 +409,86 @@ describe('type-system/base', () => {
       assert.strictEqual(RecordFacet.is(StringFacet), false)
       assert.strictEqual(emptyRecordFacet.is(StringFacet), false)
       assert.strictEqual(broadRecordFacet.is(StringFacet), false)
+    })
+
+    it('should merge record generics', () => {
+      const emptyRecordFacet = RecordFacet.with({})
+
+      const broadRecordFacet = RecordFacet.with({
+        gain: NumberFacet.with('db').type()
+      })
+
+      const narrowRecordFacet = RecordFacet.with({
+        gain: NumberFacet.with('db').type(),
+        label: StringFacet.type()
+      })
+
+      const incompatibleRecordFacet = RecordFacet.with({
+        gain: NumberFacet.with('hz').type(),
+        label: StringFacet.type()
+      })
+
+      const mergedEmptyEmpty = emptyRecordFacet.merge(emptyRecordFacet)
+      assert.ok(mergedEmptyEmpty != null)
+      assert.strictEqual(mergedEmptyEmpty.name, 'record')
+      assert.deepStrictEqual(mergedEmptyEmpty.generics, emptyRecordFacet.generics)
+
+      const mergedBroadBroad = broadRecordFacet.merge(broadRecordFacet)
+      assert.ok(mergedBroadBroad != null)
+      assert.strictEqual(mergedBroadBroad.name, 'record')
+      assert.deepStrictEqual(mergedBroadBroad.generics, broadRecordFacet.generics)
+
+      const mergedNarrowNarrow = narrowRecordFacet.merge(narrowRecordFacet)
+      assert.ok(mergedNarrowNarrow != null)
+      assert.strictEqual(mergedNarrowNarrow.name, 'record')
+      assert.deepStrictEqual(mergedNarrowNarrow.generics, narrowRecordFacet.generics)
+
+      const mergedBroadNarrow = broadRecordFacet.merge(narrowRecordFacet)
+      assert.ok(mergedBroadNarrow != null)
+      assert.strictEqual(mergedBroadNarrow.name, 'record')
+      assert.deepStrictEqual(mergedBroadNarrow.generics, narrowRecordFacet.generics)
+
+      const mergedNarrowBroad = narrowRecordFacet.merge(broadRecordFacet)
+      assert.ok(mergedNarrowBroad != null)
+      assert.strictEqual(mergedNarrowBroad.name, 'record')
+      assert.deepStrictEqual(mergedNarrowBroad.generics, narrowRecordFacet.generics)
+
+      const mergedBroadIncompatible = broadRecordFacet.merge(incompatibleRecordFacet)
+      assert.strictEqual(mergedBroadIncompatible, undefined)
+
+      const mergedIncompatibleBroad = incompatibleRecordFacet.merge(broadRecordFacet)
+      assert.strictEqual(mergedIncompatibleBroad, undefined)
+
+      const mergedEmptyOther = emptyRecordFacet.merge(StringFacet)
+      assert.strictEqual(mergedEmptyOther, undefined)
+
+      const mergedBroadOther = broadRecordFacet.merge(StringFacet)
+      assert.strictEqual(mergedBroadOther, undefined)
+
+      const stringType = StringFacet.type()
+      const numberType = NumberFacet.with(undefined).type()
+      const decibelType = NumberFacet.with('db').type()
+
+      const nestedRecordFacet0 = RecordFacet.with({
+        foo: RecordFacet.with({
+          a: stringType,
+          b: numberType
+        }).type()
+      })
+
+      const nestedRecordFacet1 = RecordFacet.with({
+        foo: RecordFacet.with({
+          a: numberType,
+          c: decibelType
+        }).type()
+      })
+
+      const mergedNested = nestedRecordFacet0.merge(nestedRecordFacet1)
+      assert.ok(mergedNested != null)
+      assert.strictEqual(mergedNested.name, 'record')
+      assert.deepStrictEqual(Object.keys(mergedNested.generics), ['foo'])
+
+      assert.strictEqual(mergedNested.format(), '{foo: {a: string + number, b: number, c: number.db}}')
     })
 
     it('should create a single-facet type', () => {
@@ -437,6 +575,11 @@ describe('type-system/base', () => {
       const value = StringFacet.type().of('hello')
       assert.strictEqual(StringFacet.has(value), true)
       assert.strictEqual(StringFacet.get(value), 'hello')
+    })
+
+    it('should merge by identity', () => {
+      assert.strictEqual(StringFacet.merge(StringFacet), StringFacet)
+      assert.strictEqual(StringFacet.merge(NumberFacet), undefined)
     })
 
     it('should create a single-facet type', () => {

--- a/packages/language/test/type-system/type-system.test.ts
+++ b/packages/language/test/type-system/type-system.test.ts
@@ -152,6 +152,25 @@ describe('type-system', () => {
       assert.strictEqual(numericFacet.get(narrowedFacetValue).unit, 'db')
     })
 
+    it('should merge facets', () => {
+      const collapsedFacet = stringFacet.merge(stringFacet)
+      assert.strictEqual(collapsedFacet, stringFacet)
+
+      const incompatibleFacet = stringFacet.merge(numberFacet)
+      assert.strictEqual(incompatibleFacet, undefined)
+
+      const customMergeFacet = makeFacet<'custom', unknown>('custom', { generic: 1 }, {
+        merge: (other) => {
+          const otherGeneric = (other.generics as { generic: number }).generic
+          return makeFacet<'custom', unknown>('custom', { generic: otherGeneric + 1 })
+        }
+      })
+
+      const mergedFacet = customMergeFacet.merge(customMergeFacet)
+      assert.strictEqual(mergedFacet?.name, 'custom')
+      assert.strictEqual((mergedFacet.generics as { generic: number }).generic, 2)
+    })
+
     it('should cache the single-facet type returned by type()', () => {
       const facetType = stringFacet.type()
       const facetValue = facetType.of('hello')
@@ -234,6 +253,26 @@ describe('type-system', () => {
       }
       const narrowedTypeValue: ValueForType<typeof decibelType> = maybeTypeValue
       assert.strictEqual(decibelFacet.get(narrowedTypeValue).unit, 'db')
+    })
+
+    it('should merge types with compatible facets', () => {
+      const stringType = makeType(stringFacet)
+      const numberType = makeType(numberFacet)
+
+      const stringAndNumberType = stringType.merge(numberType)
+      assert.ok(stringAndNumberType != null)
+      assert.deepStrictEqual([...stringAndNumberType.facets.keys()], ['string', 'number'])
+
+      const numberAndStringType = numberType.merge(stringType)
+      assert.ok(numberAndStringType != null)
+      assert.deepStrictEqual([...numberAndStringType.facets.keys()], ['number', 'string'])
+
+      const mergedSame = stringAndNumberType.merge(numberAndStringType)
+      assert.ok(mergedSame != null)
+      assert.deepStrictEqual([...mergedSame.facets.keys()], ['string', 'number'])
+
+      const incompatibleMerge = decibelType.merge(hertzType)
+      assert.strictEqual(incompatibleMerge, undefined)
     })
   })
 


### PR DESCRIPTION
The checker would previously forbid type expressions such as `string + string` or `{foo: string} + {bar: number}` outright because they have duplicate facets. This commit adds support for merging facets.

For simple facets like `string`, the merge is trivial and results in the same facet:

* `string + string` becomes `string`
* `pattern + pattern` becomes `pattern`

For most facets with generics, such as numbers or functions, the merge is possible if and only if the generics are the same:

* `number.db + number.db` becomes `number.db` (same unit generic)
* `number + number.db` is not allowed (different unit generic)
* `(a: number): string + (a: number): string` is allowed
* `(a: number): string + (a: string): string` is not allowed

For the record facet, the merge will combine the fields of both records, if possible:

* `{} + {}` becomes `{}`
* `{a: X} + {}` becomes `{a: X}`
* `{a: X} + {b: Y}` becomes `{a: X, b: Y}`
* `{a: X} + {a: Y}` is determined recursively by the merge of `X + Y`

Combining distinct facets into a single type is still allowed, including recursively for records:

* `(string) + (number)` becomes `(string + number)`
* `{foo: string} + {foo: number}` becomes `{foo: string + number}`
* `{foo: {a: X}} + {foo: {b: Y}}` becomes `{foo: {a: X, b: Y}}`