### PR TITLE
feat: Support function effects in type notation

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -192,6 +192,7 @@ export interface FunctionType extends ASTNode {
   readonly type: 'FunctionType'
   readonly parameters: readonly Parameter[]
   readonly returnType: Type
+  readonly effects: readonly Identifier[]
 }
 
 export interface RecordType extends ASTNode {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -30,6 +30,8 @@
   "&"
   "@"
 
+  "!"
+
   @precedence { Comment, "/" }
 }
 
@@ -54,7 +56,8 @@ Unit[@dynamicPrecedence=1] {
 
 @precedence {
   multiply @left,
-  plus @left
+  plus @left,
+  functionEffect @right
 }
 
 @top Program {
@@ -142,6 +145,7 @@ FunctionType {
   "(" parameterList? ")"
   ":"
   atomicType
+  (!functionEffect "!" FunctionEffect { word })*
 }
 
 RecordType {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -751,21 +751,37 @@ function checkFunctionType (expression: ast.FunctionType): Checked<readonly Type
   const parameterCheck = checkParameters(expression.parameters)
   errors.push(...parameterCheck.errors)
 
-  if (parameterCheck.result == null) {
-    return { errors, effects }
-  }
-
   const returnTypeCheck = checkTypeExpression(expression.returnType)
   errors.push(...returnTypeCheck.errors)
 
-  if (returnTypeCheck.result == null) {
+  const seenEffects = new Set<string>()
+
+  for (const effect of expression.effects) {
+    // TODO: The term "effect" is confusing due to the musical context.
+    // Rename to "capability" or "annotation"?
+    if (effect.name !== 'may_block') {
+      errors.push(new CompileError(`Unknown effect "${effect.name}"`, effect.range))
+      continue
+    }
+
+    if (seenEffects.has(effect.name)) {
+      errors.push(new CompileError(`Duplicate effect "${effect.name}"`, effect.range))
+      continue
+    }
+
+    seenEffects.add(effect.name)
+  }
+
+  if (parameterCheck.result == null || returnTypeCheck.result == null) {
     return { errors, effects }
   }
 
   const facet = FunctionFacet.with({
     parameters: parameterCheck.result.schema,
     returnType: returnTypeCheck.result,
-    effects: noEffects
+    effects: {
+      blocking: seenEffects.has('may_block')
+    }
   })
 
   const result = [{ facet, range: expression.range }]

--- a/packages/language/src/lexer/lexer.ts
+++ b/packages/language/src/lexer/lexer.ts
@@ -41,6 +41,8 @@ const commonRules: Rules = [
   { name: '&' },
   { name: '@' },
 
+  { name: '!' },
+
   { name: '~[' },
   { name: '[' },
   { name: ']' },

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -350,7 +350,7 @@ const namedType_: p.Parser<Token, unknown, ast.NamedType> = p.ab(
   }
 )
 
-const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.ab(
+const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.abc(
   combine3(
     literal('('),
     p.recursive(() => parameterList_),
@@ -360,8 +360,19 @@ const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.ab(
     literal(':'),
     p.recursive(() => atomicType_)
   ),
-  ([_lp, parameters, _rp], [_colon, returnType]) => {
-    return ast.make('FunctionType', combineSourceRanges(_lp, returnType), { parameters, returnType })
+  p.many(
+    combine2(literal('!'), identifier_)
+  ),
+  ([_lp, parameters, _rp], [_colon, returnType], effectsTokens) => {
+    const lastToken = effectsTokens.at(-1)?.at(-1) ?? returnType
+
+    const effects = effectsTokens.map(([, effect]) => effect)
+
+    return ast.make('FunctionType', combineSourceRanges(_lp, lastToken), {
+      parameters,
+      returnType,
+      effects
+    })
   }
 )
 

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -258,9 +258,25 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept effects on function-typed parameters', () => {
+      const source = [
+        'apply = (fn: (): instrument !may_block) {',
+        '  & fn()',
+        '}',
+        '',
+        'foo = apply(() { & instrument {} })',
+        '',
+        // calling with a non-blocking function should also be valid
+        'inst = instrument {}',
+        'bar = apply(() { & inst })'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept record types', () => {
       const source = [
-        'my_function = (param: { foo: number, bar: string }) {',
+        'my_function = (param: {foo: number, bar: string}) {',
         '  & param.foo',
         '}'
       ].join('\n')
@@ -1219,6 +1235,16 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Function "blocking_function" may block and cannot be called from a realtime context'
+      ])
+    })
+
+    it('should reject duplicate function effects', () => {
+      const source = [
+        'f = (p: (): instrument !may_block !may_block) { & p() }'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Duplicate effect "may_block"'
       ])
     })
 

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -207,6 +207,32 @@ describe('lexer/lexer.ts', () => {
     })
   })
 
+  it('should lex complex function signatures', () => {
+    const result = lex('apply = (fn: (a: number): number !may_block) {}')
+    assert.deepStrictEqual(stripTokenMeta(result), {
+      complete: true,
+      value: [
+        { name: 'word', text: 'apply' },
+        { name: '=', text: '=' },
+        { name: '(', text: '(' },
+        { name: 'word', text: 'fn' },
+        { name: ':', text: ':' },
+        { name: '(', text: '(' },
+        { name: 'word', text: 'a' },
+        { name: ':', text: ':' },
+        { name: 'word', text: 'number' },
+        { name: ')', text: ')' },
+        { name: ':', text: ':' },
+        { name: 'word', text: 'number' },
+        { name: '!', text: '!' },
+        { name: 'word', text: 'may_block' },
+        { name: ')', text: ')' },
+        { name: '{', text: '{' },
+        { name: '}', text: '}' }
+      ]
+    })
+  })
+
   it('should lex simple patterns', () => {
     const result = lex('[x-x- --xx]')
     assert.deepStrictEqual(stripTokenMeta(result), {

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -1063,7 +1063,7 @@ describe('parser/parser.ts', () => {
     const source = [
       'foo = (x: number.db + (format: string): string, fmt: string) {}',
       'bar = (y: ((number.db) + (format: string): (string + string))) {}',
-      'baz = (z: (): instrument + {foo: number, bar: string}) {}'
+      'baz = (z: (): instrument !hello !world + {foo: number, bar: string}) {}'
     ].join('\n')
 
     const result = parse(lexSource(source))
@@ -1103,7 +1103,8 @@ describe('parser/parser.ts', () => {
                 type: 'NamedType',
                 name: { type: 'Identifier', name: 'string' },
                 generics: []
-              }
+              },
+              effects: []
             }
           ]
         }
@@ -1163,7 +1164,8 @@ describe('parser/parser.ts', () => {
                     generics: []
                   }
                 ]
-              }
+              },
+              effects: []
             }
           ]
         }
@@ -1187,7 +1189,11 @@ describe('parser/parser.ts', () => {
                 type: 'NamedType',
                 name: { type: 'Identifier', name: 'instrument' },
                 generics: []
-              }
+              },
+              effects: [
+                { type: 'Identifier', name: 'hello' },
+                { type: 'Identifier', name: 'world' }
+              ]
             },
             {
               type: 'RecordType',
@@ -1213,6 +1219,39 @@ describe('parser/parser.ts', () => {
               ]
             }
           ]
+        }
+      }
+    ])
+  })
+
+  it('should attach effects to the nearest function type', () => {
+    const result = parse(lexSource('f = (p: (): (): number !foo !bar) {}'))
+    assertResultComplete(result)
+
+    const func = result.value.children.at(0)?.values.at(0)
+    assert.strictEqual(func?.type, 'Function')
+
+    assert.deepStrictEqual(stripRanges(func.parameters), [
+      {
+        type: 'Parameter',
+        name: { type: 'Identifier', name: 'p' },
+        parameterType: {
+          type: 'FunctionType',
+          parameters: [],
+          returnType: {
+            type: 'FunctionType',
+            parameters: [],
+            returnType: {
+              type: 'NamedType',
+              name: { type: 'Identifier', name: 'number' },
+              generics: []
+            },
+            effects: [
+              { type: 'Identifier', name: 'foo' },
+              { type: 'Identifier', name: 'bar' }
+            ]
+          },
+          effects: []
         }
       }
     ])


### PR DESCRIPTION
When declaring a function type, in addition to the parameters and return type, it is now possible to specify any effects that the function may have. This is done by adding one or more `!effect_name` annotations after the return type. For example:

```
// 'call_function' has one parameter 'fn', which is itself a function,
// and 'fn' may have the effect 'may_block'.
call_function = (fn: (): instrument !may_block) {
  & fn()
}

blocking_function = () { & instrument {} }

prepared_instrument = instrument {}
non_blocking_function = () { & prepared_instrument }

// legal: 'blocking_function' has 'may_block', which is allowed
x = call_function(blocking_function)

// also legal: 'non_blocking_function' has strictly fewer effects than
// allowed by 'call_function'
y = call_function(non_blocking_function)
```