### PR TITLE
feat: Rename function effects to capabilities

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -192,7 +192,7 @@ export interface FunctionType extends ASTNode {
   readonly type: 'FunctionType'
   readonly parameters: readonly Parameter[]
   readonly returnType: Type
-  readonly effects: readonly Identifier[]
+  readonly capabilities: readonly Identifier[]
 }
 
 export interface RecordType extends ASTNode {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -57,7 +57,7 @@ Unit[@dynamicPrecedence=1] {
 @precedence {
   multiply @left,
   plus @left,
-  functionEffect @right
+  capability @right
 }
 
 @top Program {
@@ -145,7 +145,7 @@ FunctionType {
   "(" parameterList? ")"
   ":"
   atomicType
-  (!functionEffect "!" FunctionEffect { word })*
+  (!capability "!" Capability { word })*
 }
 
 RecordType {

--- a/packages/language/src/compiler/builtins/global.ts
+++ b/packages/language/src/compiler/builtins/global.ts
@@ -15,7 +15,7 @@ const play = Functions.of({
     { name: 'pattern', type: PatternFacet.type(), required: true }
   ]),
   returnType: RoutingFacet.type(),
-  effects: { blocking: false }
+  capabilities: { mayBlock: false }
 }, {
   summary: 'Sends notes from a pattern to the target instrument.',
   invoke: (_context, { target, pattern }) => {
@@ -41,7 +41,7 @@ const automate = Functions.of({
     { name: 'curve', type: CurveFacet.type(), required: true }
   ]),
   returnType: AutomationFacet.type(),
-  effects: { blocking: false },
+  capabilities: { mayBlock: false },
   check: (args: ReadonlyMap<string, FacetType>) => {
     const errors: ParameterError[] = []
 

--- a/packages/language/src/compiler/builtins/patterns.ts
+++ b/packages/language/src/compiler/builtins/patterns.ts
@@ -21,7 +21,7 @@ const loopSpec = {
     { name: 'times', type: NumberFacet.with(undefined).type(), required: false }
   ]),
   returnType: PatternFacet.type(),
-  effects: { blocking: false }
+  capabilities: { mayBlock: false }
 } satisfies FunctionSpec
 
 const loop: PatternBuiltin = {
@@ -57,7 +57,7 @@ const fillSpec = {
     { name: 'duration', type: NumberFacet.with('beats').type(), required: true }
   ]),
   returnType: PatternFacet.type(),
-  effects: { blocking: false }
+  capabilities: { mayBlock: false }
 } satisfies FunctionSpec
 
 const fill: PatternBuiltin = {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -4,7 +4,7 @@ import type { Unit } from '@meyfa/cadence-utility'
 import { getStandardModuleNames, getStandardModuleValue } from '../../library/modules.ts'
 import { CompoundError } from '../../result/errors.ts'
 import type { Result } from '../../result/result.ts'
-import type { Effects, FunctionSpec } from '../../type-system/base/function.ts'
+import type { Capabilities, FunctionSpec } from '../../type-system/base/function.ts'
 import { FunctionFacet } from '../../type-system/base/function.ts'
 import { ModuleFacet } from '../../type-system/base/module.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
@@ -127,7 +127,7 @@ export function check (program: ast.Program): CheckResult {
 
 interface Checked<TValue> {
   readonly errors: readonly CompileError[]
-  readonly effects: Effects
+  readonly capabilities: Capabilities
   readonly result?: TValue
 }
 
@@ -146,11 +146,11 @@ function putAll<K, V> (map: Map<K, V>, entries: Iterable<readonly [K, V]>): void
   }
 }
 
-const noEffects: Effects = { blocking: false }
+const noCapabilities: Capabilities = { mayBlock: false }
 
-function mergeEffects (target: Effects, source: Effects): Effects {
+function mergeCapabilities (target: Capabilities, source: Capabilities): Capabilities {
   return {
-    blocking: target.blocking || source.blocking
+    mayBlock: target.mayBlock || source.mayBlock
   }
 }
 
@@ -203,7 +203,7 @@ function checkImports (imports: readonly ast.Import[]): Checked<ReadonlyMap<stri
   }
 
   if (errors.length > 0) {
-    return { errors, effects: noEffects }
+    return { errors, capabilities: noCapabilities }
   }
 
   const result = new Map<string, FacetType>()
@@ -221,12 +221,12 @@ function checkImports (imports: readonly ast.Import[]): Checked<ReadonlyMap<stri
     result.set(alias, module.type)
   }
 
-  return { errors, effects: noEffects, result }
+  return { errors, capabilities: noCapabilities, result }
 }
 
 interface CheckedStatement {
   readonly errors: readonly CompileError[]
-  readonly effects: Effects
+  readonly capabilities: Capabilities
   readonly emissions: readonly Emission[]
   readonly properties: ReadonlyMap<string, FacetType>
 }
@@ -238,7 +238,7 @@ interface Emission {
 
 function checkStatement (scope: MutableScope, statement: ast.Statement, existingProperties?: ReadonlyMap<string, FacetType>): CheckedStatement {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
   const emissions: Emission[] = []
   const properties = new Map<string, FacetType>()
 
@@ -248,7 +248,7 @@ function checkStatement (scope: MutableScope, statement: ast.Statement, existing
     const valueCheck = checkExpression(scope, value)
     errors.push(...valueCheck.errors)
     values.push(valueCheck.result)
-    effects = mergeEffects(effects, valueCheck.effects)
+    capabilities = mergeCapabilities(capabilities, valueCheck.capabilities)
   }
 
   if (statement.emit) {
@@ -287,7 +287,7 @@ function checkStatement (scope: MutableScope, statement: ast.Statement, existing
     }
   }
 
-  return { errors, effects, emissions, properties }
+  return { errors, capabilities, emissions, properties }
 }
 
 function checkExpression (scope: Scope, expression: ast.Expression): Checked<FacetType> {
@@ -348,19 +348,19 @@ function checkExpression (scope: Scope, expression: ast.Expression): Checked<Fac
 function checkIdentifier (scope: Scope, expression: ast.Identifier): Checked<FacetType> {
   const valueType = resolveInScope(scope, expression.name)
   if (valueType == null) {
-    return { errors: [new CompileError(`Unknown identifier "${expression.name}"`, expression.range)], effects: noEffects }
+    return { errors: [new CompileError(`Unknown identifier "${expression.name}"`, expression.range)], capabilities: noCapabilities }
   }
 
-  return { errors: [], effects: noEffects, result: valueType }
+  return { errors: [], capabilities: noCapabilities, result: valueType }
 }
 
 function checkNumber (scope: Scope, expression: ast.Number): Checked<FacetType> {
-  return { errors: [], effects: noEffects, result: NumberFacet.with(undefined).type() }
+  return { errors: [], capabilities: noCapabilities, result: NumberFacet.with(undefined).type() }
 }
 
 function checkString (scope: Scope, expression: ast.String): Checked<FacetType> {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
 
   for (const part of expression.parts) {
     if (typeof part === 'string') {
@@ -369,48 +369,48 @@ function checkString (scope: Scope, expression: ast.String): Checked<FacetType> 
 
     const partCheck = checkExpression(scope, part)
     errors.push(...partCheck.errors)
-    effects = mergeEffects(effects, partCheck.effects)
+    capabilities = mergeCapabilities(capabilities, partCheck.capabilities)
 
     if (partCheck.result != null) {
       errors.push(...checkType(StringFacet.type(), partCheck.result, part.range))
     }
   }
 
-  return { errors, effects, result: StringFacet.type() }
+  return { errors, capabilities, result: StringFacet.type() }
 }
 
 function checkPattern (scope: Scope, expression: ast.Pattern): Checked<FacetType> {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
 
   for (const item of expression.children) {
     if (item.type === 'Step') {
       const stepCheck = checkStep(scope, item)
       errors.push(...stepCheck.errors)
-      effects = mergeEffects(effects, stepCheck.effects)
+      capabilities = mergeCapabilities(capabilities, stepCheck.capabilities)
       continue
     }
 
     const itemCheck = checkExpression(scope, item)
     errors.push(...itemCheck.errors)
-    effects = mergeEffects(effects, itemCheck.effects)
+    capabilities = mergeCapabilities(capabilities, itemCheck.capabilities)
 
     if (itemCheck.result != null) {
       errors.push(...checkType(PatternFacet.type(), itemCheck.result, item.range))
     }
   }
 
-  return { errors, effects, result: PatternFacet.type() }
+  return { errors, capabilities, result: PatternFacet.type() }
 }
 
 function checkStep (scope: Scope, expression: ast.Step): Checked<void> {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
 
   if (expression.length != null) {
     const lengthCheck = checkExpression(scope, expression.length)
     errors.push(...lengthCheck.errors)
-    effects = mergeEffects(effects, lengthCheck.effects)
+    capabilities = mergeCapabilities(capabilities, lengthCheck.capabilities)
 
     if (lengthCheck.result != null) {
       errors.push(...checkType(NumberFacet.with(undefined).type(), lengthCheck.result, expression.length.range))
@@ -419,9 +419,9 @@ function checkStep (scope: Scope, expression: ast.Step): Checked<void> {
 
   const argumentListCheck = checkArgumentList(scope, expression.arguments, stepSchema, expression.range)
   errors.push(...argumentListCheck.errors)
-  effects = mergeEffects(effects, argumentListCheck.effects)
+  capabilities = mergeCapabilities(capabilities, argumentListCheck.capabilities)
 
-  return { errors, effects }
+  return { errors, capabilities }
 }
 
 interface CurveDetail {
@@ -430,11 +430,11 @@ interface CurveDetail {
 
 function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
 
   if (expression.children.length === 0) {
     errors.push(new CompileError('Curve must have at least one segment', expression.range))
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   let detail: CurveDetail | undefined
@@ -455,7 +455,7 @@ function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
       case 'CurveSegment': {
         const itemCheck = checkCurveSegment(scope, item, detail)
         errors.push(...itemCheck.errors)
-        effects = mergeEffects(effects, itemCheck.effects)
+        capabilities = mergeCapabilities(capabilities, itemCheck.capabilities)
 
         if (itemCheck.result == null) {
           break
@@ -468,7 +468,7 @@ function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
       default: {
         const itemCheck = checkExpression(scope, item)
         errors.push(...itemCheck.errors)
-        effects = mergeEffects(effects, itemCheck.effects)
+        capabilities = mergeCapabilities(capabilities, itemCheck.capabilities)
 
         if (itemCheck.result == null) {
           break
@@ -486,12 +486,12 @@ function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
   }
 
   if (errors.length > 0) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const result = CurveFacet.with(detail?.unit).type()
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 const curveSegmentLengthType = makeUnion(
@@ -501,11 +501,11 @@ const curveSegmentLengthType = makeUnion(
 
 function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?: CurveDetail): Checked<CurveDetail> {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
 
   const lengthCheck = checkExpression(scope, expression.length)
   errors.push(...lengthCheck.errors)
-  effects = mergeEffects(effects, lengthCheck.effects)
+  capabilities = mergeCapabilities(capabilities, lengthCheck.capabilities)
 
   if (lengthCheck.result != null) {
     errors.push(...checkType(curveSegmentLengthType, lengthCheck.result, expression.length.range))
@@ -513,19 +513,19 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
 
   const expectedParameters = getCurveSegmentType(expression.curveType)?.parameterCount
   if (expectedParameters == null) {
-    return { errors: [new CompileError(`Unknown curve type "${expression.curveType}"`, expression.range)], effects }
+    return { errors: [new CompileError(`Unknown curve type "${expression.curveType}"`, expression.range)], capabilities }
   }
 
   const actualParameters = expression.arguments.length
   const omittedFirstParameter = expectedParameters > 0 && actualParameters === expectedParameters - 1
 
   if (omittedFirstParameter && detail == null) {
-    return { errors: [new CompileError('First curve segment cannot omit its first argument', expression.range)], effects }
+    return { errors: [new CompileError('First curve segment cannot omit its first argument', expression.range)], capabilities }
   }
 
   if (!omittedFirstParameter && actualParameters !== expectedParameters) {
     const message = `Expected ${expectedParameters} ${expectedParameters === 1 ? 'argument' : 'arguments'} for ${expression.curveType} curve, got ${expression.arguments.length}`
-    return { errors: [new CompileError(message, expression.range)], effects }
+    return { errors: [new CompileError(message, expression.range)], capabilities }
   }
 
   const units: Array<Unit | undefined> = []
@@ -533,7 +533,7 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
   for (const point of expression.arguments) {
     const pointCheck = checkExpression(scope, point)
     errors.push(...pointCheck.errors)
-    effects = mergeEffects(effects, pointCheck.effects)
+    capabilities = mergeCapabilities(capabilities, pointCheck.capabilities)
 
     if (pointCheck.result != null) {
       const typeErrors = checkType(NumberFacet.type(), pointCheck.result, point.range)
@@ -546,7 +546,7 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
   }
 
   if (!omittedFirstParameter && units.length === 0) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const firstUnit = omittedFirstParameter ? detail?.unit : units[0]
@@ -558,7 +558,7 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
 
   const result = { unit: firstUnit }
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetType> {
@@ -566,10 +566,10 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
 
   // Allow blocking calls inside the function. If a blocking call is encountered,
   // then the function itself will be marked as blocking when called.
-  const functionScope = createLocalScope(scope, { blocking: true })
+  const functionScope = createLocalScope(scope, { mayBlock: true })
 
-  // The act of constructing a function does not have any effects.
-  const effects = noEffects
+  // The act of constructing a function does not in itself require any capabilities.
+  const capabilities = noCapabilities
 
   const parameterCheck = checkParameters(expression.parameters)
   errors.push(...parameterCheck.errors)
@@ -577,7 +577,7 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   // If the parameters are invalid, it makes no sense to continue checking the function body,
   // as it will produce a lot of irrelevant errors as a consequence.
   if (parameterCheck.result == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const parameters = parameterCheck.result.schema
@@ -585,12 +585,12 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
 
   let hasReturn = false
   let returnType: FacetType | undefined
-  let callEffects = noEffects
+  let callCapabilities = noCapabilities
 
   for (const child of expression.children) {
     const statement = checkStatement(functionScope, child)
     errors.push(...statement.errors)
-    callEffects = mergeEffects(callEffects, statement.effects)
+    callCapabilities = mergeCapabilities(callCapabilities, statement.capabilities)
 
     for (const emission of statement.emissions) {
       if (hasReturn) {
@@ -611,14 +611,14 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   }
 
   if (!hasReturn || returnType == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
-  const spec: FunctionSpec = { parameters, returnType, effects: callEffects }
+  const spec: FunctionSpec = { parameters, returnType, capabilities: callCapabilities }
   const result = FunctionFacet.with(spec).type()
   scope.top.semantic.functions.set(expression, spec)
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 interface Parameters {
@@ -628,7 +628,7 @@ interface Parameters {
 
 function checkParameters (expressions: readonly ast.Parameter[]): Checked<Parameters> {
   const errors: CompileError[] = []
-  const effects = noEffects
+  const capabilities = noCapabilities
 
   const types = new Map<string, FacetType>()
   const items: SchemaItem[] = []
@@ -655,12 +655,12 @@ function checkParameters (expressions: readonly ast.Parameter[]): Checked<Parame
   }
 
   if (errors.length > 0) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const result = { types, schema: makeSchema(items) }
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 interface TypeComponent {
@@ -670,19 +670,19 @@ interface TypeComponent {
 
 function checkTypeExpression (expression: ast.Type): Checked<FacetType> {
   const errors: CompileError[] = []
-  const effects = noEffects
+  const capabilities = noCapabilities
 
   const componentsCheck = checkTypeComponents(expression)
   errors.push(...componentsCheck.errors)
 
   if (componentsCheck.result == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const components = componentsCheck.result
   if (components.length === 0) {
     errors.push(new CompileError('Cannot combine zero types', expression.range))
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const facets = new Map<string, Facet>()
@@ -705,7 +705,7 @@ function checkTypeExpression (expression: ast.Type): Checked<FacetType> {
 
   const result = makeType(...facets.values())
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkTypeComponents (expression: ast.Type): Checked<readonly TypeComponent[]> {
@@ -725,10 +725,10 @@ function checkTypeComponents (expression: ast.Type): Checked<readonly TypeCompon
 }
 
 function checkNamedType (expression: ast.NamedType): Checked<readonly TypeComponent[]> {
-  const effects = noEffects
+  const capabilities = noCapabilities
 
   if (expression.generics.length > 1) {
-    return { errors: [new CompileError('Types can have at most one generic', expression.range)], effects }
+    return { errors: [new CompileError('Types can have at most one generic', expression.range)], capabilities }
   }
 
   const generic = expression.generics.at(0)?.name
@@ -736,17 +736,17 @@ function checkNamedType (expression: ast.NamedType): Checked<readonly TypeCompon
 
   if (facet == null) {
     const typeName = generic != null ? `${expression.name.name}.${generic}` : expression.name.name
-    return { errors: [new CompileError(`Unknown type "${typeName}"`, expression.range)], effects }
+    return { errors: [new CompileError(`Unknown type "${typeName}"`, expression.range)], capabilities }
   }
 
   const result = [{ facet, range: expression.range }]
 
-  return { errors: [], effects, result }
+  return { errors: [], capabilities, result }
 }
 
 function checkFunctionType (expression: ast.FunctionType): Checked<readonly TypeComponent[]> {
   const errors: CompileError[] = []
-  const effects = noEffects
+  const capabilities = noCapabilities
 
   const parameterCheck = checkParameters(expression.parameters)
   errors.push(...parameterCheck.errors)
@@ -754,44 +754,42 @@ function checkFunctionType (expression: ast.FunctionType): Checked<readonly Type
   const returnTypeCheck = checkTypeExpression(expression.returnType)
   errors.push(...returnTypeCheck.errors)
 
-  const seenEffects = new Set<string>()
+  const capabilityAnnotations = new Set<string>()
 
-  for (const effect of expression.effects) {
-    // TODO: The term "effect" is confusing due to the musical context.
-    // Rename to "capability" or "annotation"?
-    if (effect.name !== 'may_block') {
-      errors.push(new CompileError(`Unknown effect "${effect.name}"`, effect.range))
+  for (const capability of expression.capabilities) {
+    if (capability.name !== 'may_block') {
+      errors.push(new CompileError(`Unknown capability "${capability.name}"`, capability.range))
       continue
     }
 
-    if (seenEffects.has(effect.name)) {
-      errors.push(new CompileError(`Duplicate effect "${effect.name}"`, effect.range))
+    if (capabilityAnnotations.has(capability.name)) {
+      errors.push(new CompileError(`Duplicate capability "${capability.name}"`, capability.range))
       continue
     }
 
-    seenEffects.add(effect.name)
+    capabilityAnnotations.add(capability.name)
   }
 
   if (parameterCheck.result == null || returnTypeCheck.result == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const facet = FunctionFacet.with({
     parameters: parameterCheck.result.schema,
     returnType: returnTypeCheck.result,
-    effects: {
-      blocking: seenEffects.has('may_block')
+    capabilities: {
+      mayBlock: capabilityAnnotations.has('may_block')
     }
   })
 
   const result = [{ facet, range: expression.range }]
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkRecordType (expression: ast.RecordType): Checked<readonly TypeComponent[]> {
   const errors: CompileError[] = []
-  const effects = noEffects
+  const capabilities = noCapabilities
 
   const properties = new Map<string, FacetType>()
 
@@ -812,18 +810,18 @@ function checkRecordType (expression: ast.RecordType): Checked<readonly TypeComp
   }
 
   if (errors.length > 0) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const facet = RecordFacet.with(Object.fromEntries(properties))
   const result = [{ facet, range: expression.range }]
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkCombinedType (expression: ast.CombinedType): Checked<readonly TypeComponent[]> {
   const errors: CompileError[] = []
-  const effects = noEffects
+  const capabilities = noCapabilities
 
   const result: TypeComponent[] = []
 
@@ -837,15 +835,15 @@ function checkCombinedType (expression: ast.CombinedType): Checked<readonly Type
   }
 
   if (errors.length > 0) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkRecord (scope: Scope, expression: ast.RecordValue): Checked<FacetType> {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
 
   const recordScope = createLocalScope(scope)
   const properties = new Map<string, FacetType>()
@@ -853,7 +851,7 @@ function checkRecord (scope: Scope, expression: ast.RecordValue): Checked<FacetT
   for (const child of expression.children) {
     const statement = checkStatement(recordScope, child, properties)
     errors.push(...statement.errors)
-    effects = mergeEffects(effects, statement.effects)
+    capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
     for (const emission of statement.emissions) {
       errors.push(new CompileError('Cannot emit values in records', emission.range))
@@ -864,14 +862,14 @@ function checkRecord (scope: Scope, expression: ast.RecordValue): Checked<FacetT
 
   const result = RecordFacet.with(Object.fromEntries(properties)).type()
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<FacetType> {
   const errors: CompileError[] = []
-  let effects: Effects = { blocking: true }
+  let capabilities: Capabilities = { mayBlock: true }
 
-  if (!scope.allowedEffects.blocking) {
+  if (!scope.allowedCapabilities.mayBlock) {
     errors.push(new CompileError('Cannot construct an instrument in a realtime context', expression.range))
   }
 
@@ -881,7 +879,7 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
   for (const child of expression.children) {
     const statement = checkStatement(instrumentScope, child, properties)
     errors.push(...statement.errors)
-    effects = mergeEffects(effects, statement.effects)
+    capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(VoiceFacet.type(), emission.type, emission.range))
@@ -894,11 +892,11 @@ function checkInstrument (scope: Scope, expression: ast.Instrument): Checked<Fac
     ? makeType(InstrumentFacet, RecordFacet.with(Object.fromEntries(properties)))
     : InstrumentFacet.type()
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkVoice (scope: Scope, expression: ast.Voice): Checked<FacetType> {
-  const voiceScope = createLocalScope(scope, { blocking: false })
+  const voiceScope = createLocalScope(scope, { mayBlock: false })
   const errors: CompileError[] = []
 
   if (expression.bindings.note != null) {
@@ -947,28 +945,28 @@ function checkVoice (scope: Scope, expression: ast.Voice): Checked<FacetType> {
   // Properties cannot be used to extend the voice as the voice is generated at runtime.
   const result = VoiceFacet.type()
 
-  return { errors, effects: noEffects, result }
+  return { errors, capabilities: noCapabilities, result }
 }
 
 function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
   const mixerScope = createLocalScope(scope)
   const errors: CompileError[] = []
-  let effects: Effects = { blocking: true }
+  let capabilities: Capabilities = { mayBlock: true }
 
-  if (!scope.allowedEffects.blocking) {
+  if (!scope.allowedCapabilities.mayBlock) {
     errors.push(new CompileError('Cannot construct a mixer in a realtime context', expression.range))
   }
 
   const argumentListCheck = checkArgumentList(mixerScope, expression.arguments, mixerSchema, expression.range)
   errors.push(...argumentListCheck.errors)
-  effects = mergeEffects(effects, argumentListCheck.effects)
+  capabilities = mergeCapabilities(capabilities, argumentListCheck.capabilities)
 
   const properties = new Map<string, FacetType>()
 
   for (const child of expression.children) {
     const statement = checkStatement(mixerScope, child, properties)
     errors.push(...statement.errors)
-    effects = mergeEffects(effects, statement.effects)
+    capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(BusFacet.type(), emission.type, emission.range))
@@ -981,7 +979,7 @@ function checkMixer (scope: Scope, expression: ast.Mixer): Checked<FacetType> {
     ? makeType(MixerFacet, RecordFacet.with(Object.fromEntries(properties)))
     : MixerFacet.type()
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 const busEmissionType = makeUnion(InstrumentFacet.type(), BusFacet.type(), EffectFacet.type())
@@ -989,15 +987,15 @@ const busEmissionType = makeUnion(InstrumentFacet.type(), BusFacet.type(), Effec
 function checkBus (scope: Scope, expression: ast.Bus): Checked<FacetType> {
   const busScope = createLocalScope(scope)
   const errors: CompileError[] = []
-  let effects: Effects = { blocking: true }
+  let capabilities: Capabilities = { mayBlock: true }
 
-  if (!scope.allowedEffects.blocking) {
+  if (!scope.allowedCapabilities.mayBlock) {
     errors.push(new CompileError('Cannot construct a bus in a realtime context', expression.range))
   }
 
   const argumentListCheck = checkArgumentList(busScope, expression.arguments, busSchema, expression.range)
   errors.push(...argumentListCheck.errors)
-  effects = mergeEffects(effects, argumentListCheck.effects)
+  capabilities = mergeCapabilities(capabilities, argumentListCheck.capabilities)
 
   const properties = new Map<string, FacetType>()
   properties.set('gain', ParameterFacet.with('db').type())
@@ -1006,7 +1004,7 @@ function checkBus (scope: Scope, expression: ast.Bus): Checked<FacetType> {
   for (const child of expression.children) {
     const statement = checkStatement(busScope, child, properties)
     errors.push(...statement.errors)
-    effects = mergeEffects(effects, statement.effects)
+    capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(busEmissionType, emission.type, emission.range))
@@ -1026,28 +1024,28 @@ function checkBus (scope: Scope, expression: ast.Bus): Checked<FacetType> {
     }
   }
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
   const trackScope = createLocalScope(scope)
   const errors: CompileError[] = []
-  let effects: Effects = { blocking: true }
+  let capabilities: Capabilities = { mayBlock: true }
 
-  if (!scope.allowedEffects.blocking) {
+  if (!scope.allowedCapabilities.mayBlock) {
     errors.push(new CompileError('Cannot construct a track in a realtime context', expression.range))
   }
 
   const argumentListCheck = checkArgumentList(trackScope, expression.arguments, trackSchema, expression.range)
   errors.push(...argumentListCheck.errors)
-  effects = mergeEffects(effects, argumentListCheck.effects)
+  capabilities = mergeCapabilities(capabilities, argumentListCheck.capabilities)
 
   const properties = new Map<string, FacetType>()
 
   for (const child of expression.children) {
     const statement = checkStatement(trackScope, child, properties)
     errors.push(...statement.errors)
-    effects = mergeEffects(effects, statement.effects)
+    capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(PartFacet.type(), emission.type, emission.range))
@@ -1060,7 +1058,7 @@ function checkTrack (scope: Scope, expression: ast.Track): Checked<FacetType> {
     ? makeType(TrackFacet, RecordFacet.with(Object.fromEntries(properties)))
     : TrackFacet.type()
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 const partEmissionType = makeUnion(RoutingFacet.type(), AutomationFacet.type())
@@ -1068,22 +1066,22 @@ const partEmissionType = makeUnion(RoutingFacet.type(), AutomationFacet.type())
 function checkPart (scope: Scope, expression: ast.Part): Checked<FacetType> {
   const partScope = createLocalScope(scope)
   const errors: CompileError[] = []
-  let effects: Effects = { blocking: true }
+  let capabilities: Capabilities = { mayBlock: true }
 
-  if (!scope.allowedEffects.blocking) {
+  if (!scope.allowedCapabilities.mayBlock) {
     errors.push(new CompileError('Cannot construct a part in a realtime context', expression.range))
   }
 
   const argumentListCheck = checkArgumentList(partScope, expression.arguments, partSchema, expression.range)
   errors.push(...argumentListCheck.errors)
-  effects = mergeEffects(effects, argumentListCheck.effects)
+  capabilities = mergeCapabilities(capabilities, argumentListCheck.capabilities)
 
   const properties = new Map<string, FacetType>()
 
   for (const child of expression.children) {
     const statement = checkStatement(partScope, child, properties)
     errors.push(...statement.errors)
-    effects = mergeEffects(effects, statement.effects)
+    capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
     for (const emission of statement.emissions) {
       errors.push(...checkType(partEmissionType, emission.type, emission.range))
@@ -1096,26 +1094,26 @@ function checkPart (scope: Scope, expression: ast.Part): Checked<FacetType> {
     ? makeType(PartFacet, RecordFacet.with(Object.fromEntries(properties)))
     : PartFacet.type()
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Checked<FacetType> {
   const operandCheck = checkExpression(scope, expression.operand)
   const errors = [...operandCheck.errors]
-  const effects = operandCheck.effects
+  const capabilities = operandCheck.capabilities
 
   const operand = operandCheck.result
   if (operand == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const result = unaryOperations[expression.operator].check(operand)
   if (result == null) {
     errors.push(new CompileError(`Incompatible operand for "${expression.operator}": ${operand.format()}`, expression.range))
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression): Checked<FacetType> {
@@ -1123,22 +1121,22 @@ function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression):
   const rightCheck = checkExpression(scope, expression.right)
 
   const errors = [...leftCheck.errors, ...rightCheck.errors]
-  const effects = mergeEffects(leftCheck.effects, rightCheck.effects)
+  const capabilities = mergeCapabilities(leftCheck.capabilities, rightCheck.capabilities)
 
   const left = leftCheck.result
   const right = rightCheck.result
 
   if (left == null || right == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const result = binaryOperations[expression.operator].check(left, right)
   if (result == null) {
     errors.push(new CompileError(`Incompatible operands for "${expression.operator}": ${left.format()} and ${right.format()}`, expression.range))
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
-  return { errors, effects, result }
+  return { errors, capabilities, result }
 }
 
 function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Checked<FacetType> {
@@ -1150,20 +1148,20 @@ function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Che
       const propertyType = namespace.resolutions.get(expression.property.name)
       if (propertyType == null) {
         errors.push(new CompileError(`Namespace "${expression.object.name}" has no member named "${expression.property.name}"`, expression.property.range))
-        return { errors, effects: noEffects }
+        return { errors, capabilities: noCapabilities }
       }
 
-      return { errors, effects: noEffects, result: propertyType }
+      return { errors, capabilities: noCapabilities, result: propertyType }
     }
   }
 
   const objectCheck = checkExpression(scope, expression.object)
   errors.push(...objectCheck.errors)
 
-  const effects = objectCheck.effects
+  const capabilities = objectCheck.capabilities
 
   if (objectCheck.result == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const { property } = expression
@@ -1172,29 +1170,29 @@ function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Che
   if (NumberFacet.is(object)) {
     if (!isSyntaxUnit(property.name)) {
       errors.push(new CompileError(`Unknown unit "${property.name}"`, property.range))
-      return { errors, effects }
+      return { errors, capabilities }
     }
 
     const existingUnit = NumberFacet.detail(object)
     if (existingUnit != null) {
       errors.push(new CompileError(`Cannot apply unit "${property.name}" to number with existing unit "${existingUnit}"`, property.range))
-      return { errors, effects }
+      return { errors, capabilities }
     }
 
-    return { errors, effects, result: NumberFacet.with(toBaseUnit(property.name)).type() }
+    return { errors, capabilities, result: NumberFacet.with(toBaseUnit(property.name)).type() }
   }
 
   if (PatternFacet.is(object)) {
     const builtin = patternBuiltins.get(property.name)
     if (builtin != null) {
-      return { errors, effects, result: builtin.type }
+      return { errors, capabilities, result: builtin.type }
     }
   }
 
   if (RecordFacet.is(object)) {
     const record = RecordFacet.detail(object)
     if (Object.hasOwn(record, property.name)) {
-      return { errors, effects, result: record[property.name] }
+      return { errors, capabilities, result: record[property.name] }
     }
 
     // Improve error messages for modules
@@ -1202,37 +1200,43 @@ function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Che
       const moduleName = ModuleFacet.detail(object).name
       errors.push(new CompileError(`Module "${moduleName}" has no export named "${property.name}"`, property.range))
 
-      return { errors, effects }
+      return { errors, capabilities }
     }
   }
 
   errors.push(new CompileError(`Type ${object.format()} has no property named "${property.name}"`, property.range))
 
-  return { errors, effects }
+  return { errors, capabilities }
 }
 
 function checkCall (scope: Scope, expression: ast.Call): Checked<FacetType> {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
 
   const calleeCheck = checkExpression(scope, expression.callee)
   errors.push(...calleeCheck.errors)
-  effects = mergeEffects(effects, calleeCheck.effects)
+  capabilities = mergeCapabilities(capabilities, calleeCheck.capabilities)
 
   if (calleeCheck.result == null) {
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
   const callee = calleeCheck.result
   if (!FunctionFacet.is(calleeCheck.result)) {
     errors.push(new CompileError(`Cannot call value of type ${callee.format()}`, expression.range))
-    return { errors, effects }
+    return { errors, capabilities }
   }
 
-  const { parameters, returnType, effects: functionEffects, check: checkParameters } = FunctionFacet.detail(callee)
-  effects = mergeEffects(effects, functionEffects)
+  const {
+    parameters,
+    returnType,
+    capabilities: functionCapabilities,
+    check: checkParameters
+  } = FunctionFacet.detail(callee)
 
-  if (!scope.allowedEffects.blocking && functionEffects.blocking) {
+  capabilities = mergeCapabilities(capabilities, functionCapabilities)
+
+  if (!scope.allowedCapabilities.mayBlock && functionCapabilities.mayBlock) {
     const functionName = tryGetFunctionName(expression.callee)
     const message = functionName != null
       ? `Function "${functionName}" may block and cannot be called from a realtime context`
@@ -1242,7 +1246,7 @@ function checkCall (scope: Scope, expression: ast.Call): Checked<FacetType> {
 
   const argumentListCheck = checkArgumentList(scope, expression.arguments, parameters, expression.range)
   errors.push(...argumentListCheck.errors)
-  effects = mergeEffects(effects, argumentListCheck.effects)
+  capabilities = mergeCapabilities(capabilities, argumentListCheck.capabilities)
 
   if (checkParameters != null) {
     const parameterErrors = checkParameters(argumentListCheck.types)
@@ -1252,12 +1256,12 @@ function checkCall (scope: Scope, expression: ast.Call): Checked<FacetType> {
     }
   }
 
-  return { errors, effects, result: returnType }
+  return { errors, capabilities, result: returnType }
 }
 
 interface ArgumentListCheckResult {
   readonly errors: readonly CompileError[]
-  readonly effects: Effects
+  readonly capabilities: Capabilities
   readonly types: ReadonlyMap<string, FacetType>
   readonly ranges: ReadonlyMap<string, SourceRange>
 }
@@ -1269,7 +1273,7 @@ function checkArgumentList (
   range: SourceRange
 ): ArgumentListCheckResult {
   const errors: CompileError[] = []
-  let effects = noEffects
+  let capabilities = noCapabilities
   const types = new Map<string, FacetType>()
   const ranges = new Map<string, SourceRange>()
 
@@ -1311,7 +1315,7 @@ function checkArgumentList (
 
     const expressionCheck = checkExpression(scope, arg.value)
     errors.push(...expressionCheck.errors)
-    effects = mergeEffects(effects, expressionCheck.effects)
+    capabilities = mergeCapabilities(capabilities, expressionCheck.capabilities)
 
     if (expressionCheck.result != null) {
       if (!spec.type.is(expressionCheck.result)) {
@@ -1329,7 +1333,7 @@ function checkArgumentList (
     }
   }
 
-  return { errors, effects, types, ranges }
+  return { errors, capabilities, types, ranges }
 }
 
 function tryGetFunctionName (callee: ast.Expression): string | undefined {

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -1,5 +1,5 @@
 import { ast } from '@meyfa/cadence-ast'
-import type { Effects, FunctionSpec } from '../../type-system/base/function.ts'
+import type { Capabilities, FunctionSpec } from '../../type-system/base/function.ts'
 import type { FacetType } from '../../type-system/types.ts'
 
 // scope types
@@ -8,7 +8,7 @@ export interface Scope {
   readonly top: GlobalScope
   readonly parent?: Scope
   readonly resolutions: ReadonlyMap<string, FacetType>
-  readonly allowedEffects: Effects
+  readonly allowedCapabilities: Capabilities
 }
 
 export interface GlobalScope extends Scope {
@@ -43,8 +43,8 @@ export function createGlobalScope (initialResolutions: ReadonlyMap<string, Facet
 
     resolutions: new Map(initialResolutions),
 
-    allowedEffects: {
-      blocking: true
+    allowedCapabilities: {
+      mayBlock: true
     },
 
     // from GlobalScope
@@ -57,12 +57,12 @@ export function createGlobalScope (initialResolutions: ReadonlyMap<string, Facet
   return scope
 }
 
-export function createLocalScope (parent: Scope, overrideEffects?: Effects): MutableScope {
+export function createLocalScope (parent: Scope, overrideCapabilities?: Capabilities): MutableScope {
   return {
     top: parent.top,
     parent,
     resolutions: new Map(),
-    allowedEffects: overrideEffects ?? parent.allowedEffects
+    allowedCapabilities: overrideCapabilities ?? parent.allowedCapabilities
   }
 }
 

--- a/packages/language/src/library/documentation.ts
+++ b/packages/language/src/library/documentation.ts
@@ -69,9 +69,9 @@ function getValueAnnotations (value: Value): readonly string[] | undefined {
   const annotations = []
 
   if (FunctionFacet.has(value)) {
-    const functionValue = FunctionFacet.get(value)
+    const { capabilities } = FunctionFacet.get(value)
 
-    if (functionValue.effects.blocking) {
+    if (capabilities.mayBlock) {
       annotations.push('may block')
     }
   }

--- a/packages/language/src/library/modules/effects.ts
+++ b/packages/language/src/library/modules/effects.ts
@@ -49,7 +49,7 @@ const gain = Functions.of({
     { name: 'gain', type: NumberFacet.with('db').type(), required: true }
   ]),
   returnType: GainEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Applies a gain adjustment to the signal.',
   invoke: (context: ParameterContext, args) => {
@@ -69,7 +69,7 @@ const pan = Functions.of({
     { name: 'pan', type: NumberFacet.with(undefined).type(), required: true }
   ]),
   returnType: PanEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Places the signal in the stereo field.',
   invoke: (context: ParameterContext, args) => {
@@ -89,7 +89,7 @@ const lowpass = Functions.of({
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
   ]),
   returnType: LowpassEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Filters out frequencies above the cutoff.',
   invoke: (context: ParameterContext, args) => {
@@ -109,7 +109,7 @@ const highpass = Functions.of({
     { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
   ]),
   returnType: HighpassEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Filters out frequencies below the cutoff.',
   invoke: (context: ParameterContext, args) => {
@@ -129,7 +129,7 @@ const width = Functions.of({
     { name: 'width', type: NumberFacet.with(undefined).type(), required: true }
   ]),
   returnType: WidthEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Adjusts the stereo width of the signal.',
   invoke: (context: ParameterContext, args) => {
@@ -150,7 +150,7 @@ const delay = Functions.of({
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
   returnType: DelayEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Adds echoes with configurable mix, time, and feedback.',
   invoke: (context: ParameterContext, args) => {
@@ -175,7 +175,7 @@ const reverb = Functions.of({
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
   returnType: ReverbEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Adds reverberation with configurable mix and decay.',
   invoke: (context: ParameterContext, args) => {
@@ -195,7 +195,7 @@ const clip = Functions.of({
     { name: 'threshold', type: NumberFacet.with('db').type(), required: true }
   ]),
   returnType: ClipEffectType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Applies hard clipping to the signal at the specified threshold.',
   invoke: (context: ParameterContext, args) => {

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -101,7 +101,7 @@ const sample = Functions.of({
     { name: 'length', type: NumberFacet.with('s').type(), required: false }
   ]),
   returnType: SampleInstrumentType,
-  effects: { blocking: true }
+  capabilities: { mayBlock: true }
 }, {
   summary: 'Creates a sample-backed instrument from a URL.',
   // eslint-disable-next-line camelcase
@@ -140,7 +140,7 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
       { name: 'gain', type: NumberFacet.with('db').type(), required: false }
     ]),
     returnType: OscillatorInstrumentType,
-    effects: { blocking: true }
+    capabilities: { mayBlock: true }
   }, {
     summary: `Creates an instrument that produces a ${shape} wave.`,
     invoke: (context: ParameterContext & InstrumentContext, { gain }) => {

--- a/packages/language/src/library/modules/sources.ts
+++ b/packages/language/src/library/modules/sources.ts
@@ -11,7 +11,7 @@ function createOscillatorFunction (shape: Oscillator['shape']): Value {
       { name: 'frequency', type: NumberFacet.with('hz').type(), required: true }
     ]),
     returnType: SourceFacet.type(),
-    effects: { blocking: false }
+    capabilities: { mayBlock: false }
   }, {
     summary: `Creates a source that produces a ${shape} wave.`,
     invoke: (context, { frequency }) => {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -363,15 +363,15 @@ const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.abc(
   p.many(
     combine2(literal('!'), identifier_)
   ),
-  ([_lp, parameters, _rp], [_colon, returnType], effectsTokens) => {
-    const lastToken = effectsTokens.at(-1)?.at(-1) ?? returnType
+  ([_lp, parameters, _rp], [_colon, returnType], capabilitiesTokens) => {
+    const lastToken = capabilitiesTokens.at(-1)?.at(-1) ?? returnType
 
-    const effects = effectsTokens.map(([, effect]) => effect)
+    const capabilities = capabilitiesTokens.map(([, identifier]) => identifier)
 
     return ast.make('FunctionType', combineSourceRanges(_lp, lastToken), {
       parameters,
       returnType,
-      effects
+      capabilities
     })
   }
 )

--- a/packages/language/src/type-system/base/function.ts
+++ b/packages/language/src/type-system/base/function.ts
@@ -2,8 +2,8 @@ import { makeFacet } from '../factory.ts'
 import type { InferSchema, Schema } from '../schema.ts'
 import type { CustomComparable, FacetType, ValueForType } from '../types.ts'
 
-export interface Effects {
-  readonly blocking: boolean
+export interface Capabilities {
+  readonly mayBlock: boolean
 }
 
 export interface ParameterError {
@@ -17,7 +17,7 @@ export interface FunctionSpec<
 > {
   readonly parameters: S
   readonly returnType: R
-  readonly effects: Effects
+  readonly capabilities: Capabilities
 
   /**
    * Perform additional static checks on the argument types,
@@ -79,9 +79,9 @@ export const FunctionFacet = {
           return `${item.name}${optional}: ${item.type.format()}`
         }).join(', ')
 
-        const effects = spec.effects.blocking ? ' !may_block' : ''
+        const capabilities = spec.capabilities.mayBlock ? ' !may_block' : ''
 
-        return `(${parameters}): ${spec.returnType.format()}${effects}`
+        return `(${parameters}): ${spec.returnType.format()}${capabilities}`
       }
     })
   },
@@ -103,9 +103,9 @@ function isAssignableFrom (spec: FunctionSpec, other: FunctionSpec): boolean {
     return false
   }
 
-  // Effects:
+  // Capabilities:
   // - non-blocking is assignable to blocking, but not vice versa
-  if (!spec.effects.blocking && other.effects.blocking) {
+  if (!spec.capabilities.mayBlock && other.capabilities.mayBlock) {
     return false
   }
 

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -258,7 +258,7 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
-    it('should accept effects on function-typed parameters', () => {
+    it('should accept capabilities on function-typed parameters', () => {
       const source = [
         'apply = (fn: (): instrument !may_block) {',
         '  & fn()',
@@ -377,14 +377,14 @@ describe('compiler/checker/checker.ts', () => {
       assert.deepStrictEqual(pureFunctionSpec, {
         parameters: makeSchema([]),
         returnType: NumberFacet.with(undefined).type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       const blockingFunctionSpec = semanticModel.getFunctionSpec(blockingFunction)
       assert.deepStrictEqual(blockingFunctionSpec, {
         parameters: makeSchema([]),
         returnType: InstrumentFacet.type(),
-        effects: { blocking: true }
+        capabilities: { mayBlock: true }
       })
     })
 
@@ -1167,7 +1167,7 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
-    it('should reject blocking effects in non-blocking contexts', () => {
+    it('should reject blocking calls in non-blocking contexts', () => {
       const source = [
         'use "instruments" as *',
         'use "sources" as src',
@@ -1238,13 +1238,23 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
-    it('should reject duplicate function effects', () => {
+    it('should reject unknown capabilities', () => {
+      const source = [
+        'f = (p: (): instrument !unknown) { & p() }'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Unknown capability "unknown"'
+      ])
+    })
+
+    it('should reject duplicate capabilities', () => {
       const source = [
         'f = (p: (): instrument !may_block !may_block) { & p() }'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Duplicate effect "may_block"'
+        'Duplicate capability "may_block"'
       ])
     })
 

--- a/packages/language/test/compiler/checker/scopes.test.ts
+++ b/packages/language/test/compiler/checker/scopes.test.ts
@@ -13,7 +13,7 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(result.top, result)
       assert.strictEqual(result.parent, undefined)
       assert.strictEqual(result.resolutions.get('foo'), foo)
-      assert.deepStrictEqual(result.allowedEffects, { blocking: true })
+      assert.deepStrictEqual(result.allowedCapabilities, { mayBlock: true })
 
       assert.strictEqual(result.namespaces.size, 0)
     })
@@ -30,7 +30,7 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(localScope.top, globalScope)
       assert.strictEqual(localScope.parent, globalScope)
       assert.strictEqual(localScope.resolutions.get('foo'), undefined)
-      assert.deepStrictEqual(localScope.allowedEffects, globalScope.allowedEffects)
+      assert.deepStrictEqual(localScope.allowedCapabilities, globalScope.allowedCapabilities)
 
       const bar = NumberFacet.with(undefined).type()
       localScope.resolutions.set('bar', bar)
@@ -44,16 +44,16 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(nestedLocalScope.resolutions.get('bar'), undefined)
     })
 
-    it('can override allowedEffects', () => {
+    it('can override allowed capabilities', () => {
       const globalScope = createGlobalScope(new Map([
         ['foo', NumberFacet.with('db').type()]
       ]))
 
       const localScopeWithoutOverride = createLocalScope(globalScope)
-      assert.deepStrictEqual(localScopeWithoutOverride.allowedEffects, { blocking: true })
+      assert.deepStrictEqual(localScopeWithoutOverride.allowedCapabilities, { mayBlock: true })
 
-      const localScopeWithOverride = createLocalScope(globalScope, { blocking: false })
-      assert.deepStrictEqual(localScopeWithOverride.allowedEffects, { blocking: false })
+      const localScopeWithOverride = createLocalScope(globalScope, { mayBlock: false })
+      assert.deepStrictEqual(localScopeWithOverride.allowedCapabilities, { mayBlock: false })
     })
   })
 

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -1104,7 +1104,7 @@ describe('parser/parser.ts', () => {
                 name: { type: 'Identifier', name: 'string' },
                 generics: []
               },
-              effects: []
+              capabilities: []
             }
           ]
         }
@@ -1165,7 +1165,7 @@ describe('parser/parser.ts', () => {
                   }
                 ]
               },
-              effects: []
+              capabilities: []
             }
           ]
         }
@@ -1190,7 +1190,7 @@ describe('parser/parser.ts', () => {
                 name: { type: 'Identifier', name: 'instrument' },
                 generics: []
               },
-              effects: [
+              capabilities: [
                 { type: 'Identifier', name: 'hello' },
                 { type: 'Identifier', name: 'world' }
               ]
@@ -1224,7 +1224,7 @@ describe('parser/parser.ts', () => {
     ])
   })
 
-  it('should attach effects to the nearest function type', () => {
+  it('should attach capabilities to the nearest function type', () => {
     const result = parse(lexSource('f = (p: (): (): number !foo !bar) {}'))
     assertResultComplete(result)
 
@@ -1246,12 +1246,12 @@ describe('parser/parser.ts', () => {
               name: { type: 'Identifier', name: 'number' },
               generics: []
             },
-            effects: [
+            capabilities: [
               { type: 'Identifier', name: 'foo' },
               { type: 'Identifier', name: 'bar' }
             ]
           },
-          effects: []
+          capabilities: []
         }
       }
     ])

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -20,7 +20,7 @@ describe('type-system/base', () => {
       const noParametersReturnString = FunctionFacet.with({
         parameters: makeSchema([]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
       assert.strictEqual(
         noParametersReturnString.format(),
@@ -32,7 +32,7 @@ describe('type-system/base', () => {
           { name: 'amount', type: NumberFacet.with('db').type(), required: true }
         ]),
         returnType: makeType(StringFacet, RecordFacet.with({ gain: NumberFacet.with('db').type() })),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
       assert.strictEqual(
         oneParameterReturnComplex.format(),
@@ -44,67 +44,67 @@ describe('type-system/base', () => {
           { name: 'amount', type: NumberFacet.with('db').type(), required: false }
         ]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
       assert.strictEqual(
         optionalParameterReturnString.format(),
         '(amount?: number.db): string'
       )
 
-      const blockingFunction = FunctionFacet.with({
+      const mayBlockFunction = FunctionFacet.with({
         parameters: makeSchema([]),
         returnType: StringFacet.type(),
-        effects: { blocking: true }
+        capabilities: { mayBlock: true }
       })
       assert.strictEqual(
-        blockingFunction.format(),
+        mayBlockFunction.format(),
         '(): string !may_block'
       )
     })
 
-    it('should compare based on parameters, return type, and effects', () => {
+    it('should compare based on parameters, return type, and capabilities', () => {
       const noParametersReturnString = FunctionFacet.with({
         parameters: makeSchema([]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       const noParametersReturnStringBlocking = FunctionFacet.with({
         parameters: makeSchema([]),
         returnType: StringFacet.type(),
-        effects: { blocking: true }
+        capabilities: { mayBlock: true }
       })
 
       const oneParameterReturnString = FunctionFacet.with({
         parameters: makeSchema([{ name: 'amount', type: NumberFacet.with(undefined).type(), required: true }]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       const optionalParameterReturnString = FunctionFacet.with({
         parameters: makeSchema([{ name: 'amount', type: NumberFacet.with(undefined).type(), required: false }]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       const noParametersReturnNumber = FunctionFacet.with({
         parameters: makeSchema([]),
         returnType: NumberFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       // same parameter count and type but different parameter name
       const sameOneParameterReturnString = FunctionFacet.with({
         parameters: makeSchema([{ name: 'value', type: NumberFacet.with(undefined).type(), required: true }]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       // same parameter count and name, but different parameter type
       const otherOneParameterReturnString = FunctionFacet.with({
         parameters: makeSchema([{ name: 'amount', type: NumberFacet.with('db').type(), required: true }]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       // base facet is assignable from all of its specializations
@@ -126,7 +126,7 @@ describe('type-system/base', () => {
       assert.strictEqual(oneParameterReturnString.is(oneParameterReturnString), true)
       assert.strictEqual(optionalParameterReturnString.is(optionalParameterReturnString), true)
 
-      // non-blocking is assignable to blocking, but not vice versa
+      // non-mayBlock is assignable to mayBlock, but not vice versa
       assert.strictEqual(noParametersReturnStringBlocking.is(noParametersReturnString), true)
       assert.strictEqual(noParametersReturnString.is(noParametersReturnStringBlocking), false)
 
@@ -160,13 +160,13 @@ describe('type-system/base', () => {
       const broadParameter = FunctionFacet.with({
         parameters: makeSchema([{ name: 'record', type: broadRecord.type(), required: true }]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       const narrowParameter = FunctionFacet.with({
         parameters: makeSchema([{ name: 'record', type: narrowRecord.type(), required: true }]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       // broad parameter is assignable to narrow parameter, but not vice versa (contravariant)
@@ -176,13 +176,13 @@ describe('type-system/base', () => {
       const broadReturn = FunctionFacet.with({
         parameters: makeSchema([]),
         returnType: broadRecord.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       const narrowReturn = FunctionFacet.with({
         parameters: makeSchema([]),
         returnType: narrowRecord.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       })
 
       // narrow return is assignable to broad return, but not vice versa (covariant)
@@ -194,7 +194,7 @@ describe('type-system/base', () => {
       const spec: FunctionSpec = {
         parameters: makeSchema([]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       }
 
       const facetA = FunctionFacet.with(spec)
@@ -211,7 +211,7 @@ describe('type-system/base', () => {
           { name: 'amount', type: NumberFacet.with(undefined).type(), required: false }
         ]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       }
 
       const facetC = FunctionFacet.with(differentSpec)
@@ -230,7 +230,7 @@ describe('type-system/base', () => {
       const spec: FunctionSpec = {
         parameters: makeSchema([]),
         returnType: StringFacet.type(),
-        effects: { blocking: false }
+        capabilities: { mayBlock: false }
       }
       const functionTypeWithSpec = FunctionFacet.with(spec).type()
       assert.deepStrictEqual([...functionTypeWithSpec.facets.keys()], ['function'])
@@ -239,19 +239,19 @@ describe('type-system/base', () => {
     it('should preserve function specs through with() and detail()', () => {
       const amountType = NumberFacet.with('db').type()
       const returnType = StringFacet.type()
-      const effects = { blocking: true }
+      const capabilities = { mayBlock: true }
       const schema = makeSchema([
         { name: 'amount', type: amountType, required: true },
         { name: 'label', type: returnType, required: false }
       ])
-      const spec = { parameters: schema, returnType, effects }
+      const spec = { parameters: schema, returnType, capabilities }
       const typedFacet = FunctionFacet.with(spec)
       const typedType = typedFacet.type()
 
       const func: Function<typeof schema, typeof returnType> = {
         parameters: schema,
         returnType,
-        effects,
+        capabilities,
         invoke: (_context, args) => args.label ?? returnType.of('fallback'),
         summary: 'demo function'
       }


### PR DESCRIPTION
While the term "effects" is scientifically accurate, it conflicts with the musical concept of effects. Therefore, this patch renames it to "capabilities".