### PR TITLE
fix: Parenthesize union types when formatting

### DIFF
--- a/packages/language-support/test/hover/operation.test.ts
+++ b/packages/language-support/test/hover/operation.test.ts
@@ -104,7 +104,7 @@ describe('hover/operation.ts', () => {
       applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, delayPosition),
       {
         range: getRangeAt(source, source.indexOf('delay('), 'delay'.length),
-        title: 'delay = (mix: number, time: number.beats | number.s, feedback: number, wet?: number.db): (effect + {feedback: parameter}) !may_block',
+        title: 'delay = (mix: number, time: (number.beats | number.s), feedback: number, wet?: number.db): (effect + {feedback: parameter}) !may_block',
         summary: 'Adds echoes with configurable mix, time, and feedback.',
         annotations: ['may block']
       }
@@ -114,7 +114,7 @@ describe('hover/operation.ts', () => {
       applySemanticOperationWithParser(getHoverInfo, cadenceParser, source, reverbPosition),
       {
         range: getRangeAt(source, source.indexOf('reverb('), 'reverb'.length),
-        title: 'reverb = (mix: number, decay: number.beats | number.s, wet?: number.db): effect !may_block',
+        title: 'reverb = (mix: number, decay: (number.beats | number.s), wet?: number.db): effect !may_block',
         summary: 'Adds reverberation with configurable mix and decay.',
         annotations: ['may block']
       }

--- a/packages/language/src/type-system/factory.ts
+++ b/packages/language/src/type-system/factory.ts
@@ -81,8 +81,8 @@ export function makeType<const Facets extends readonly Facet[]> (
     facets: facetMap,
 
     format: () => {
-      const merged = facets.map((facet) => facet.format()).join(' + ')
-      return facets.length > 1 ? `(${merged})` : merged
+      const joined = facets.map((facet) => facet.format()).join(' + ')
+      return facets.length > 1 ? `(${joined})` : joined
     },
 
     is: (other: Type): boolean => {
@@ -154,7 +154,8 @@ export function makeUnion<const Members extends readonly FacetType[]> (
     members,
 
     format: () => {
-      return members.map((member) => member.format()).join(' | ')
+      const joined = members.map((member) => member.format()).join(' | ')
+      return members.length > 1 ? `(${joined})` : joined
     },
 
     is: (other: Type): boolean => {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -891,7 +891,7 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject curves with invalid length units', () => {
       assertErrorMessages('my_curve = ~[hold((-60).db):42]', [
-        'Expected type number.beats | number.s, got number'
+        'Expected type (number.beats | number.s), got number'
       ])
     })
 
@@ -905,7 +905,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Expected type routing | automation, got number'
+        'Expected type (routing | automation), got number'
       ])
     })
 

--- a/packages/language/test/type-system/type-system.test.ts
+++ b/packages/language/test/type-system/type-system.test.ts
@@ -288,8 +288,11 @@ describe('type-system', () => {
 
     it('should format based on members', () => {
       const primitiveUnion = makeUnion(stringType, numberType)
-      assert.strictEqual(primitiveUnion.format(), 'string | number')
-      assert.strictEqual(numericUnion.format(), 'numeric(db) | numeric(hz)')
+      assert.strictEqual(primitiveUnion.format(), '(string | number)')
+      assert.strictEqual(numericUnion.format(), '(numeric(db) | numeric(hz))')
+
+      const singleMemberUnion = makeUnion(stringType)
+      assert.strictEqual(singleMemberUnion.format(), 'string')
     })
 
     it('should compare assignability against members and other unions', () => {


### PR DESCRIPTION
Union types with more than one member are now correctly wrapped in parentheses when formatting. This avoids ambiguity when union types are used in certain contexts.