### PR TITLE
feat!: Add `boolean` type and boolean literals

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -48,6 +48,7 @@ export interface NodeByType {
   CombinedType: CombinedType
 
   // Primitive Values
+  Boolean: Boolean
   Number: Number
   String: String
   Pattern: Pattern
@@ -70,6 +71,7 @@ export type AnyNode = NodeByType[keyof NodeByType]
 
 export type Value =
   Identifier |
+  Boolean |
   Number |
   String |
   Pattern |
@@ -206,6 +208,11 @@ export interface CombinedType extends ASTNode {
 }
 
 // Primitive Values
+
+export interface Boolean extends ASTNode {
+  readonly type: 'Boolean'
+  readonly value: boolean
+}
 
 export interface Number extends ASTNode {
   readonly type: 'Number'

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -74,6 +74,8 @@ VariableDefinition { word }
 VariableName { word }
 BusNamespace { kw<"bus"> }
 
+Boolean { kw<"true"> | kw<"false"> }
+
 Number { number }
 
 @skip {} {
@@ -156,6 +158,7 @@ primary {
   "(" expression ")" |
   Call |
   VariableName |
+  Boolean |
   Number |
   String |
   Function |

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -2,6 +2,7 @@ import type { SourceRange } from '@meyfa/cadence-ast'
 import { ast } from '@meyfa/cadence-ast'
 import type { Unit } from '@meyfa/cadence-utility'
 import { setAll } from '@meyfa/cadence-utility'
+import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import type { Capabilities, FunctionSpec } from '../../type-system/base/function.ts'
 import { FunctionFacet } from '../../type-system/base/function.ts'
 import { ModuleFacet } from '../../type-system/base/module.ts'
@@ -49,6 +50,9 @@ export function checkExpression (scope: Scope, expression: ast.Expression): Chec
   switch (expression.type) {
     case 'Identifier':
       return checkIdentifier(scope, expression)
+
+    case 'Boolean':
+      return checkBoolean(scope, expression)
 
     case 'Number':
       return checkNumber(scope, expression)
@@ -117,6 +121,10 @@ function checkIdentifier (scope: Scope, expression: ast.Identifier): Checked<Fac
   }
 
   return { errors: [], capabilities: noCapabilities, result: valueType }
+}
+
+function checkBoolean (scope: Scope, expression: ast.Boolean): Checked<FacetType> {
+  return { errors: [], capabilities: noCapabilities, result: BooleanFacet.type() }
 }
 
 function checkNumber (scope: Scope, expression: ast.Number): Checked<FacetType> {

--- a/packages/language/src/compiler/checker/type-facets.ts
+++ b/packages/language/src/compiler/checker/type-facets.ts
@@ -1,4 +1,5 @@
 import type { Unit } from '@meyfa/cadence-utility'
+import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
 import { AutomationFacet } from '../../type-system/domain/automation.ts'
@@ -26,6 +27,7 @@ export function getFacet (name: string, generic: string | undefined): Facet | un
 const facets: ReadonlyMap<string, FacetFactory> = new Map<string, FacetFactory>([
   // base facets
 
+  ['boolean', create(BooleanFacet)],
   ['number', createWithUnitGeneric(NumberFacet)],
   ['string', create(StringFacet)],
 

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -4,6 +4,7 @@ import { beatsToSeconds, concatPatterns, convertPitchToMidi, createParallelPatte
 import type { Numeric, RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
 import { runtimeNumeric, setAll } from '@meyfa/cadence-utility'
 import { getStandardModuleValue } from '../../library/modules.ts'
+import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import type { Function } from '../../type-system/base/function.ts'
 import { FunctionFacet } from '../../type-system/base/function.ts'
 import { ModuleFacet } from '../../type-system/base/module.ts'
@@ -168,8 +169,11 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
     case 'Identifier':
       return resolveIdentifier(scope, expression)
 
+    case 'Boolean':
+      return generateBoolean(scope, expression)
+
     case 'Number':
-      return toNumberValue(scope.top.options, undefined, expression.value)
+      return generateNumber(scope, expression)
 
     case 'String':
       return generateString(scope, expression)
@@ -220,6 +224,14 @@ function resolve (scope: Scope, expression: ast.Expression): Value {
 
 function resolveIdentifier (scope: Scope, expression: ast.Identifier): Value {
   return nonNull(resolveInScope(scope, expression.name))
+}
+
+function generateBoolean (scope: Scope, expression: ast.Boolean): Value {
+  return BooleanFacet.type().of(expression.value)
+}
+
+function generateNumber (scope: Scope, expression: ast.Number): Value {
+  return toNumberValue(scope.top.options, undefined, expression.value)
 }
 
 function generateString (scope: Scope, expression: ast.String): Value {

--- a/packages/language/src/parser/constants.ts
+++ b/packages/language/src/parser/constants.ts
@@ -1,4 +1,6 @@
 export const keywords = Object.freeze([
+  'true',
+  'false',
   'use',
   'as',
   'track',

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -83,6 +83,12 @@ const busNamespaceRoot_: p.Parser<Token, unknown, ast.Identifier> = p.map(
   (token) => ast.make('Identifier', getSourceRange(token), { name: token.text })
 )
 
+const boolean_: p.Parser<Token, unknown, ast.Boolean> = p.token((t) => {
+  return t.name === 'word' && (t.text === 'true' || t.text === 'false')
+    ? ast.make('Boolean', getSourceRange(t), { value: t.text === 'true' })
+    : undefined
+})
+
 const number_: p.Parser<Token, unknown, ast.Number> = p.token((t) => {
   return t.name === 'number'
     ? ast.make('Number', getSourceRange(t), { value: Number.parseFloat(t.text) })
@@ -453,6 +459,7 @@ const recordValue_: p.Parser<Token, unknown, ast.RecordValue> = p.abc(
 
 const value_: p.Parser<Token, unknown, ast.Value> = p.choice<Token, unknown, ast.Value>(
   identifier_,
+  boolean_,
   number_,
   string_,
   serialPattern_,

--- a/packages/language/src/type-system/base/boolean.ts
+++ b/packages/language/src/type-system/base/boolean.ts
@@ -1,0 +1,5 @@
+import { makeFacet } from '../factory.ts'
+
+const FACET_NAME = 'boolean'
+
+export const BooleanFacet = makeFacet<typeof FACET_NAME, boolean>(FACET_NAME, {})

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -237,6 +237,47 @@ describe('parser/parser.ts', () => {
     ])
   })
 
+  it('should parse boolean literals', () => {
+    const source = [
+      'flag1 = true',
+      'flag2 = false'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'Statement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'flag1' },
+        values: [
+          { type: 'Boolean', value: true }
+        ]
+      },
+      {
+        type: 'Statement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'flag2' },
+        values: [
+          { type: 'Boolean', value: false }
+        ]
+      }
+    ])
+  })
+
+  it('should reject boolean literals on left-hand side of assignment', () => {
+    for (const lhs of ['true', 'false']) {
+      for (const rhs of ['true', 'false', '0', '1', '"string"']) {
+        const result = parse(lexSource(`${lhs} = ${rhs}`))
+        assert.strictEqual(result.complete, false)
+        assert.strictEqual(result.error.message, `Unexpected statement beginning with "${lhs}"`)
+      }
+    }
+  })
+
   it('should parse explicit bus parameter access', () => {
     const result = parse(lexSource('target = bus.main.gain'))
     assertResultComplete(result)

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -2,6 +2,7 @@ import type { RuntimeNumeric } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
+import { BooleanFacet } from '../../src/type-system/base/boolean.ts'
 import type { Function, FunctionSpec } from '../../src/type-system/base/function.ts'
 import { FunctionFacet } from '../../src/type-system/base/function.ts'
 import type { Module } from '../../src/type-system/base/module.ts'
@@ -9,12 +10,41 @@ import { ModuleFacet } from '../../src/type-system/base/module.ts'
 import { NumberFacet } from '../../src/type-system/base/number.ts'
 import { RecordFacet } from '../../src/type-system/base/record.ts'
 import { StringFacet } from '../../src/type-system/base/string.ts'
+import { makeType } from '../../src/type-system/factory.ts'
 import { makeSchema } from '../../src/type-system/schema.ts'
 import type { ValueForType } from '../../src/type-system/types.ts'
 import { expectTypeEquals } from '../test-utils.ts'
-import { makeType } from '../../src/type-system/factory.ts'
 
 describe('type-system/base', () => {
+  describe('BooleanFacet', () => {
+    it('should format as facet name', () => {
+      assert.strictEqual(BooleanFacet.format(), 'boolean')
+    })
+
+    it('should compare by identity', () => {
+      assert.strictEqual(BooleanFacet.is(BooleanFacet), true)
+      assert.strictEqual(BooleanFacet.is(NumberFacet), false)
+    })
+
+    it('should round-trip values', () => {
+      for (const item of [true, false]) {
+        const value = BooleanFacet.type().of(item)
+        assert.strictEqual(BooleanFacet.has(value), true)
+        assert.strictEqual(BooleanFacet.get(value), item)
+      }
+    })
+
+    it('should merge by identity', () => {
+      assert.strictEqual(BooleanFacet.merge(BooleanFacet), BooleanFacet)
+      assert.strictEqual(BooleanFacet.merge(NumberFacet), undefined)
+    })
+
+    it('should create a single-facet type', () => {
+      const booleanType = BooleanFacet.type()
+      assert.deepStrictEqual([...booleanType.facets.keys()], ['boolean'])
+    })
+  })
+
   describe('FunctionFacet', () => {
     it('should format as function signature', () => {
       const noParametersReturnString = FunctionFacet.with({


### PR DESCRIPTION
This patch introduces a new `boolean` facet to the type system, along with two new keywords: `true` and `false`, representing the two possible values. Operations on these values is future work.

BREAKING CHANGE: Keywords `true` and `false` are now reserved.