### PR TITLE
refactor: Remove ScopeKind from language-support

### DIFF
--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -3,20 +3,16 @@ import type { SyntaxNode, Tree, TreeCursor } from '@lezer/common'
 import type { SourceRange } from '../../utilities/range.ts'
 import type { TextLike } from '../../utilities/text.ts'
 import { toSourceRange } from '../../utilities/text.ts'
-import type { BaseModel, Binding, BindingId, BindingKind, Identifier, IdentifierId, IdentifierKind, Import, ImportId, Scope, ScopeId, ScopeKind } from '../model.ts'
+import type { BaseModel, Binding, BindingId, BindingKind, Identifier, IdentifierId, IdentifierKind, Import, ImportId, Scope, ScopeId } from '../model.ts'
 
 export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
-  const rootRange = toSourceRange(document, 0, document.length)
-
-  const rootScopeId = scopeKey('root', rootRange)
-
-  const scopes: Scope[] = [{ id: rootScopeId, kind: 'root', range: rootRange }]
+  const scopes: Scope[] = []
   const identifiers: Identifier[] = []
   const bindings: Binding[] = []
   const imports: Import[] = []
 
   const addScope = (input: Omit<Scope, 'id'>): Scope => {
-    const scope = { ...input, id: scopeKey(input.kind, input.range) }
+    const scope = { ...input, id: scopeKey(input.node, input.range) }
     scopes.push(scope)
     return scope
   }
@@ -84,62 +80,35 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
         break
       }
 
-      case 'Function': {
-        const scope = addScope({ kind: 'function', range, parentId: scopeId })
+      case 'Function':
+      case 'Record':
+      case 'TrackBlock':
+      case 'PartBlock':
+      case 'MixerBlock':
+      case 'InstrumentBlock':
+      case 'Voice':
+      {
+        const scope = addScope({ node: typeName, range, parentId: scopeId })
         nextScopeId = scope.id
         break
       }
 
-      case 'Record': {
-        const scope = addScope({ kind: 'record', range, parentId: scopeId })
-        nextScopeId = scope.id
-        break
-      }
-
-      case 'TrackBlock': {
-        const scope = addScope({ kind: 'track', range, parentId: scopeId })
-        nextScopeId = scope.id
-        break
-      }
-
-      case 'PartBlock': {
-        const scope = addScope({ kind: 'part', range, parentId: scopeId })
-        nextScopeId = scope.id
-        break
-      }
-
-      case 'MixerBlock': {
-        const scope = addScope({ kind: 'mixer', range, parentId: scopeId })
-        nextScopeId = scope.id
-        break
-      }
-
+      // Bus requires special handling because we need the declaredScopeId up front for the binding,
+      // but the scope only becomes effective after the BusBlock node is entered.
       case 'Bus': {
         const block = cursor.node.getChild('BusBlock')
         if (block != null) {
           const blockRange = toSourceRange(document, block.from, block.to)
-          nextPendingScope = addScope({ kind: 'bus', range: blockRange, parentId: scopeId })
+          nextPendingScope = addScope({ node: typeName, range: blockRange, parentId: scopeId })
         }
         break
       }
 
       case 'BusBlock': {
-        if (pendingScope?.kind === 'bus') {
+        if (pendingScope != null) {
           nextScopeId = pendingScope.id
           nextPendingScope = undefined
         }
-        break
-      }
-
-      case 'InstrumentBlock': {
-        const scope = addScope({ kind: 'instrument', range, parentId: scopeId })
-        nextScopeId = scope.id
-        break
-      }
-
-      case 'Voice': {
-        const scope = addScope({ kind: 'voice', range, parentId: scopeId })
-        nextScopeId = scope.id
         break
       }
 
@@ -176,7 +145,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
           }
 
           case 'Bus': {
-            if (pendingScope?.kind === 'bus') {
+            if (pendingScope != null) {
               addBinding({ kind: 'bus', scopeId, name, range: nameRange, declaredScopeId: pendingScope.id })
             }
             break
@@ -252,6 +221,11 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     return accessChainTail
   }
 
+  const { id: rootScopeId } = addScope({
+    node: tree.topNode.name,
+    range: toSourceRange(document, 0, document.length)
+  })
+
   walk(cursor, undefined, rootScopeId, undefined, false, false)
 
   sortByOffset(scopes)
@@ -288,8 +262,8 @@ function shouldKeepPreviousSibling (node: SyntaxNode): boolean {
     type === 'BusNamespace'
 }
 
-function scopeKey (kind: ScopeKind, range: SourceRange): ScopeId {
-  return `${kind}:${range.offset}:${range.length}` as ScopeId
+function scopeKey (node: string, range: SourceRange): ScopeId {
+  return `${node}:${range.offset}:${range.length}` as ScopeId
 }
 
 function identifierKey (kind: IdentifierKind, scopeId: string, range: SourceRange): IdentifierId {

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -27,12 +27,10 @@ export type ScopeId = Brand<string, 'language-support.ScopeId'>
 
 export interface Scope {
   readonly id: ScopeId
-  readonly kind: ScopeKind
+  readonly node: string
   readonly parentId?: string
   readonly range: SourceRange
 }
-
-export type ScopeKind = 'root' | 'function' | 'record' | 'track' | 'part' | 'mixer' | 'bus' | 'instrument' | 'voice'
 
 // identifier
 

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -56,44 +56,44 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map(({ kind, scopeId, name }) => ({
         kind,
-        scope: model.scopes.find((scope) => scope.id === scopeId)?.kind,
+        scope: model.scopes.find((scope) => scope.id === scopeId)?.node,
         name
       })),
       [
-        { kind: 'definition', scope: 'root', name: 'fx' },
-        { kind: 'definition', scope: 'root', name: 'base_path' },
-        { kind: 'definition', scope: 'root', name: 'kick' },
-        { kind: 'plain', scope: 'root', name: 'sample' },
-        { kind: 'plain', scope: 'root', name: 'base_path' },
-        { kind: 'definition', scope: 'root', name: 'tempo' },
-        { kind: 'plain', scope: 'root', name: 'bpm' },
-        { kind: 'definition', scope: 'root', name: 'record' },
-        { kind: 'definition', scope: 'record', name: 'record_property' },
-        { kind: 'definition', scope: 'root', name: 'synth' },
-        { kind: 'definition', scope: 'instrument', name: 'instrument_property' },
-        { kind: 'definition', scope: 'voice', name: 'note' },
-        { kind: 'definition', scope: 'root', name: 'double' },
-        { kind: 'definition', scope: 'function', name: 'input' },
-        { kind: 'plain', scope: 'function', name: 'input' },
-        { kind: 'argument-name', scope: 'root', name: 'tempo' },
-        { kind: 'plain', scope: 'root', name: 'double' },
-        { kind: 'plain', scope: 'root', name: 'bpm' },
-        { kind: 'definition', scope: 'track', name: 'intro' },
-        { kind: 'plain', scope: 'track', name: 'bars' },
-        { kind: 'plain', scope: 'part', name: 'play' },
-        { kind: 'plain', scope: 'part', name: 'kick' },
-        { kind: 'plain', scope: 'part', name: 'loop' },
-        { kind: 'plain', scope: 'part', name: 'automate' },
-        { kind: 'plain', scope: 'part', name: 'kick' },
-        { kind: 'plain', scope: 'part', name: 'gain' },
-        { kind: 'plain', scope: 'part', name: 'db' },
-        { kind: 'definition', scope: 'mixer', name: 'drums' },
-        { kind: 'definition', scope: 'bus', name: 'crush' },
-        { kind: 'plain', scope: 'bus', name: 'fx' },
-        { kind: 'plain', scope: 'bus', name: 'clip' },
-        { kind: 'plain', scope: 'bus', name: 'db' },
-        { kind: 'plain', scope: 'bus', name: 'kick' },
-        { kind: 'plain', scope: 'bus', name: 'snare' }
+        { kind: 'definition', scope: 'Program', name: 'fx' },
+        { kind: 'definition', scope: 'Program', name: 'base_path' },
+        { kind: 'definition', scope: 'Program', name: 'kick' },
+        { kind: 'plain', scope: 'Program', name: 'sample' },
+        { kind: 'plain', scope: 'Program', name: 'base_path' },
+        { kind: 'definition', scope: 'Program', name: 'tempo' },
+        { kind: 'plain', scope: 'Program', name: 'bpm' },
+        { kind: 'definition', scope: 'Program', name: 'record' },
+        { kind: 'definition', scope: 'Record', name: 'record_property' },
+        { kind: 'definition', scope: 'Program', name: 'synth' },
+        { kind: 'definition', scope: 'InstrumentBlock', name: 'instrument_property' },
+        { kind: 'definition', scope: 'Voice', name: 'note' },
+        { kind: 'definition', scope: 'Program', name: 'double' },
+        { kind: 'definition', scope: 'Function', name: 'input' },
+        { kind: 'plain', scope: 'Function', name: 'input' },
+        { kind: 'argument-name', scope: 'Program', name: 'tempo' },
+        { kind: 'plain', scope: 'Program', name: 'double' },
+        { kind: 'plain', scope: 'Program', name: 'bpm' },
+        { kind: 'definition', scope: 'TrackBlock', name: 'intro' },
+        { kind: 'plain', scope: 'TrackBlock', name: 'bars' },
+        { kind: 'plain', scope: 'PartBlock', name: 'play' },
+        { kind: 'plain', scope: 'PartBlock', name: 'kick' },
+        { kind: 'plain', scope: 'PartBlock', name: 'loop' },
+        { kind: 'plain', scope: 'PartBlock', name: 'automate' },
+        { kind: 'plain', scope: 'PartBlock', name: 'kick' },
+        { kind: 'plain', scope: 'PartBlock', name: 'gain' },
+        { kind: 'plain', scope: 'PartBlock', name: 'db' },
+        { kind: 'definition', scope: 'MixerBlock', name: 'drums' },
+        { kind: 'definition', scope: 'Bus', name: 'crush' },
+        { kind: 'plain', scope: 'Bus', name: 'fx' },
+        { kind: 'plain', scope: 'Bus', name: 'clip' },
+        { kind: 'plain', scope: 'Bus', name: 'db' },
+        { kind: 'plain', scope: 'Bus', name: 'kick' },
+        { kind: 'plain', scope: 'Bus', name: 'snare' }
       ]
     )
   })
@@ -269,66 +269,66 @@ describe('model/analysis/base.ts', () => {
     const model = analyzeSource(source)
 
     const rootRange = getRangeAt(source, 0, source.length)
-    const rootScopeId = `root:${rootRange.offset}:${rootRange.length}`
+    const rootScopeId = `Program:${rootRange.offset}:${rootRange.length}`
 
     const functionBlockStart = source.indexOf('(input: number.bpm) {')
     const functionBlockEnd = source.indexOf('} // end function') + '}'.length
     const functionRange = getRangeAt(source, functionBlockStart, functionBlockEnd - functionBlockStart)
-    const functionScopeId = `function:${functionRange.offset}:${functionRange.length}`
+    const functionScopeId = `Function:${functionRange.offset}:${functionRange.length}`
 
     const recordBlockStart = source.indexOf('{', source.indexOf('my_record'))
     const recordBlockEnd = source.indexOf('} // end record') + '}'.length
     const recordRange = getRangeAt(source, recordBlockStart, recordBlockEnd - recordBlockStart)
-    const recordScopeId = `record:${recordRange.offset}:${recordRange.length}`
+    const recordScopeId = `Record:${recordRange.offset}:${recordRange.length}`
 
     const instrumentBlockStart = source.indexOf('{', source.indexOf('my_instrument'))
     const instrumentBlockEnd = source.indexOf('} // end instrument') + '}'.length
     const instrumentRange = getRangeAt(source, instrumentBlockStart, instrumentBlockEnd - instrumentBlockStart)
-    const instrumentScopeId = `instrument:${instrumentRange.offset}:${instrumentRange.length}`
+    const instrumentScopeId = `InstrumentBlock:${instrumentRange.offset}:${instrumentRange.length}`
 
     const voiceBlockStart = source.indexOf('voice note')
     const voiceBlockEnd = source.indexOf('} // end voice') + '}'.length
     const voiceRange = getRangeAt(source, voiceBlockStart, voiceBlockEnd - voiceBlockStart)
-    const voiceScopeId = `voice:${voiceRange.offset}:${voiceRange.length}`
+    const voiceScopeId = `Voice:${voiceRange.offset}:${voiceRange.length}`
 
     const trackBlockStart = source.indexOf('{', source.indexOf('track'))
     const trackEnd = source.indexOf('} // end track') + '}'.length
     const trackRange = getRangeAt(source, trackBlockStart, trackEnd - trackBlockStart)
-    const trackScopeId = `track:${trackRange.offset}:${trackRange.length}`
+    const trackScopeId = `TrackBlock:${trackRange.offset}:${trackRange.length}`
 
     const partBlockStart = source.indexOf('{', source.indexOf('part intro'))
     const partEnd = source.indexOf('} // end part') + '}'.length
     const partRange = getRangeAt(source, partBlockStart, partEnd - partBlockStart)
-    const partScopeId = `part:${partRange.offset}:${partRange.length}`
+    const partScopeId = `PartBlock:${partRange.offset}:${partRange.length}`
 
     const mixerBlockStart = source.indexOf('{', source.indexOf('mixer'))
     const mixerEnd = source.indexOf('} // end mixer') + '}'.length
     const mixerRange = getRangeAt(source, mixerBlockStart, mixerEnd - mixerBlockStart)
-    const mixerScopeId = `mixer:${mixerRange.offset}:${mixerRange.length}`
+    const mixerScopeId = `MixerBlock:${mixerRange.offset}:${mixerRange.length}`
 
     const drumsBusBlockStart = source.indexOf('{', source.indexOf('bus drums'))
     const drumsBusEnd = source.indexOf('  }', source.indexOf('bus drums')) + '  }'.length
     const drumsBusRange = getRangeAt(source, drumsBusBlockStart, drumsBusEnd - drumsBusBlockStart)
-    const drumsBusScopeId = `bus:${drumsBusRange.offset}:${drumsBusRange.length}`
+    const drumsBusScopeId = `Bus:${drumsBusRange.offset}:${drumsBusRange.length}`
 
     const delayBusBlockStart = source.indexOf('{', source.indexOf('bus delay'))
     const delayBusEnd = source.indexOf('  }', source.indexOf('bus delay')) + '  }'.length
     const delayBusRange = getRangeAt(source, delayBusBlockStart, delayBusEnd - delayBusBlockStart)
-    const delayBusScopeId = `bus:${delayBusRange.offset}:${delayBusRange.length}`
+    const delayBusScopeId = `Bus:${delayBusRange.offset}:${delayBusRange.length}`
 
     assert.deepStrictEqual(
-      model.scopes.map(({ id, kind, parentId }) => ({ id, kind, parentId })),
+      model.scopes.map(({ id, node, parentId }) => ({ id, node, parentId })),
       [
-        { id: rootScopeId, kind: 'root', parentId: undefined },
-        { id: functionScopeId, kind: 'function', parentId: rootScopeId },
-        { id: recordScopeId, kind: 'record', parentId: rootScopeId },
-        { id: instrumentScopeId, kind: 'instrument', parentId: rootScopeId },
-        { id: voiceScopeId, kind: 'voice', parentId: instrumentScopeId },
-        { id: trackScopeId, kind: 'track', parentId: rootScopeId },
-        { id: partScopeId, kind: 'part', parentId: trackScopeId },
-        { id: mixerScopeId, kind: 'mixer', parentId: rootScopeId },
-        { id: drumsBusScopeId, kind: 'bus', parentId: mixerScopeId },
-        { id: delayBusScopeId, kind: 'bus', parentId: mixerScopeId }
+        { id: rootScopeId, node: 'Program', parentId: undefined },
+        { id: functionScopeId, node: 'Function', parentId: rootScopeId },
+        { id: recordScopeId, node: 'Record', parentId: rootScopeId },
+        { id: instrumentScopeId, node: 'InstrumentBlock', parentId: rootScopeId },
+        { id: voiceScopeId, node: 'Voice', parentId: instrumentScopeId },
+        { id: trackScopeId, node: 'TrackBlock', parentId: rootScopeId },
+        { id: partScopeId, node: 'PartBlock', parentId: trackScopeId },
+        { id: mixerScopeId, node: 'MixerBlock', parentId: rootScopeId },
+        { id: drumsBusScopeId, node: 'Bus', parentId: mixerScopeId },
+        { id: delayBusScopeId, node: 'Bus', parentId: mixerScopeId }
       ]
     )
 

--- a/packages/language-support/test/model/query.test.ts
+++ b/packages/language-support/test/model/query.test.ts
@@ -13,7 +13,7 @@ describe('analysis/query.ts', () => {
       scopes: [
         {
           id: 'root' as ScopeId,
-          kind: 'root',
+          node: 'root',
           range: getRangeAt(source, 0, source.length)
         }
       ],


### PR DESCRIPTION
The language-support model does not need to track the kind of scope, as all scopes are treated the same way in analysis. We do keep a `node` field purely for testability.