### PR TITLE
feat!: Remove bus namespace

### DIFF
--- a/packages/app/src/modules/mixer/MixerPanel.tsx
+++ b/packages/app/src/modules/mixer/MixerPanel.tsx
@@ -255,7 +255,7 @@ const BusNodeInfo: FunctionComponent<{
 }> = ({ object }) => {
   return (
     <>
-      <div className='font-bold'>{object.name != null ? `bus.${object.name}` : '(unnamed bus)'}</div>
+      <div className='font-bold'>{object.name ?? '(unnamed bus)'}</div>
       <div>gain: {object.gain.initial.toFixed(2)} dB</div>
       <div>pan: {object.pan.initial.toFixed(2)}</div>
       {object.effects.length > 0 && (

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -72,7 +72,6 @@ interpolationExpression {
 
 VariableDefinition { word }
 VariableName { word }
-BusNamespace { kw<"bus"> }
 
 Boolean { kw<"true"> | kw<"false"> }
 
@@ -179,7 +178,7 @@ Call {
 }
 
 AccessOrCall {
-  (primary | BusNamespace "." Member { Unit | word })
+  primary
   (
     "." Call |
     "." Member { Unit | word }
@@ -249,7 +248,7 @@ Track {
 
 Part {
   kw<"part">
-  VariableDefinition?
+  PartName { word }?
   ("(" argumentList? ")")?
   PartBlock[group=Block] {
     "{" statement* "}"
@@ -266,7 +265,7 @@ Mixer {
 
 Bus {
   kw<"bus">
-  VariableDefinition?
+  BusName { word }?
   ("(" argumentList? ")")?
   BusBlock[group=Block] {
     "{" statement* "}"

--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -58,7 +58,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     const nextParentType = typeName
 
     let nextScopeId = scopeId
-    let nextPendingScope = pendingScope
+    const nextPendingScope = pendingScope
     let nextAssignmentHasEquals = assignmentHasEquals
     let nextAssignmentIsExposed = assignmentIsExposed
     let accessChainTail: Identifier | undefined
@@ -85,30 +85,11 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       case 'TrackBlock':
       case 'PartBlock':
       case 'MixerBlock':
+      case 'BusBlock':
       case 'InstrumentBlock':
-      case 'Voice':
-      {
+      case 'Voice': {
         const scope = addScope({ node: typeName, range, parentId: scopeId })
         nextScopeId = scope.id
-        break
-      }
-
-      // Bus requires special handling because we need the declaredScopeId up front for the binding,
-      // but the scope only becomes effective after the BusBlock node is entered.
-      case 'Bus': {
-        const block = cursor.node.getChild('BusBlock')
-        if (block != null) {
-          const blockRange = toSourceRange(document, block.from, block.to)
-          nextPendingScope = addScope({ node: typeName, range: blockRange, parentId: scopeId })
-        }
-        break
-      }
-
-      case 'BusBlock': {
-        if (pendingScope != null) {
-          nextScopeId = pendingScope.id
-          nextPendingScope = undefined
-        }
         break
       }
 
@@ -134,23 +115,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
             break
           }
 
-          case 'Function': {
-            addBinding({ kind: 'regular', scopeId, name, range: nameRange })
-            break
-          }
-
-          case 'Part': {
-            addBinding({ kind: 'part', scopeId, name, range: nameRange })
-            break
-          }
-
-          case 'Bus': {
-            if (pendingScope != null) {
-              addBinding({ kind: 'bus', scopeId, name, range: nameRange, declaredScopeId: pendingScope.id })
-            }
-            break
-          }
-
+          case 'Function':
           case 'Voice': {
             addBinding({ kind: 'regular', scopeId, name, range: nameRange })
             break
@@ -167,8 +132,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
 
       case 'VariableName':
       case 'Callee':
-      case 'Member':
-      case 'BusNamespace': {
+      case 'Member': {
         const { name, range: nameRange } = getVariableName(document, from, to)
         accessChainTail = addIdentifier({ kind: 'plain', scopeId, name, range: nameRange, previousSibling })
         break
@@ -258,8 +222,7 @@ function shouldKeepPreviousSibling (node: SyntaxNode): boolean {
     type === 'Callee' ||
     type === 'Call' ||
     type === 'Member' ||
-    type === 'VariableName' ||
-    type === 'BusNamespace'
+    type === 'VariableName'
 }
 
 function scopeKey (node: string, range: SourceRange): ScopeId {

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -65,28 +65,9 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
   const buses = new Map<string, Binding>()
   const byScopeAndName = new Map<string, Map<string, Binding>>()
 
-  const busNameByScopeId = new Map<string, string>()
-
   for (const binding of model.bindings) {
-    switch (binding.kind) {
-      case 'use-alias':
-        if (!namedImports.has(binding.name)) {
-          namedImports.set(binding.name, binding)
-        }
-        break
-
-      case 'bus':
-        if (!buses.has(binding.name)) {
-          buses.set(binding.name, binding)
-
-          if (binding.declaredScopeId != null) {
-            busNameByScopeId.set(binding.declaredScopeId, binding.name)
-          }
-        }
-        break
-
-      default:
-        break
+    if (binding.kind === 'use-alias' && !namedImports.has(binding.name)) {
+      namedImports.set(binding.name, binding)
     }
 
     let scopeMap = byScopeAndName.get(binding.scopeId)
@@ -95,12 +76,7 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
       byScopeAndName.set(binding.scopeId, scopeMap)
     }
 
-    // Only regular variables and use-aliases are available via plain lexical lookup.
-    // Part and bus names are not injected into scope and must be referenced via
-    // explicit assignment (regular binding) or namespace access (e.g. bus.foo).
-    if (binding.kind === 'regular' || binding.kind === 'use-alias') {
-      scopeMap.set(binding.name, binding)
-    }
+    scopeMap.set(binding.name, binding)
   }
 
   for (const imp of model.imports) {

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -74,17 +74,12 @@ export interface Binding {
   readonly moduleName?: string
 
   /**
-   * The scope declared by this binding, if applicable (e.g. for bus bindings).
-   */
-  readonly declaredScopeId?: string
-
-  /**
    * For regular bindings, whether this is an exposed property.
    */
   readonly isExposed?: boolean
 }
 
-export type BindingKind = 'regular' | 'use-alias' | 'part' | 'bus'
+export type BindingKind = 'regular' | 'use-alias'
 
 // import
 

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -30,12 +30,6 @@ function getUnusedImports (model: Model): readonly LanguageDiagnostic[] {
 }
 
 function isUnusedBinding (binding: Binding, model: ReferenceModel): boolean {
-  // Buses and parts are implicitly used by the runtime.
-  if (binding.kind === 'bus' || binding.kind === 'part') {
-    return false
-  }
-
-  // Do not report exposed properties as unused.
   if (binding.isExposed) {
     return false
   }

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -50,26 +50,6 @@ describe('go-to-definition/operation.ts', () => {
     }
   })
 
-  it('resolves bus references in mixer via bus namespace', () => {
-    const source = [
-      '& mixer {',
-      '  & bus a {}',
-      '  & bus {',
-      '    & bus.a',
-      '  }',
-      '}',
-      ''
-    ].join('\n')
-
-    const defPos = source.indexOf('bus a') + 'bus '.length
-    const refPos = source.indexOf('bus.a') + 'bus.'.length
-
-    const result = applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos)
-
-    assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'a'.length))
-    assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'a'.length))
-  })
-
   it('does not resolve bus references in mixer via bus name', () => {
     const source = [
       '& mixer {',
@@ -146,28 +126,6 @@ describe('go-to-definition/operation.ts', () => {
 
     const result = applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos)
     assert.strictEqual(result, undefined)
-  })
-
-  it('resolves explicit bus namespace access to the bus definition', () => {
-    const source = [
-      '& track (120.bpm) {',
-      '  & part foo {',
-      '    & automate(bus.foo.gain, ~[hold(-60.db):3 lin(0.db):1])',
-      '  }',
-      '}',
-      '& mixer {',
-      '  & bus foo {}',
-      '}',
-      ''
-    ].join('\n')
-
-    const defPos = source.indexOf('bus foo') + 'bus '.length
-    const refPos = source.indexOf('bus.foo.gain') + 'bus.'.length
-
-    const result = applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos)
-
-    assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'foo'.length))
-    assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'foo'.length))
   })
 
   it('does not resolve named argument keys', () => {

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -49,30 +49,6 @@ describe('highlight-occurrences/operation.ts', () => {
     )
   })
 
-  it('normalizes explicit bus namespace references to the bus member range', () => {
-    const source = [
-      '& track (120.bpm) {',
-      '  & part foo {',
-      '    & automate(bus.foo.gain, ~[hold(-60.db):3 lin(0.db):1])',
-      '  }',
-      '}',
-      '& mixer {',
-      '  & bus foo {}',
-      '}',
-      ''
-    ].join('\n')
-
-    const position = source.indexOf('bus.foo.gain') + 'bus.'.length + 1
-
-    assert.deepStrictEqual(
-      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
-      [
-        getRangeAt(source, source.indexOf('bus.foo.gain') + 'bus.'.length, 'foo'.length),
-        getRangeAt(source, source.indexOf('bus foo') + 'bus '.length, 'foo'.length)
-      ]
-    )
-  })
-
   it('does not highlight named argument keys', () => {
     const source = [
       'tempo = 128.bpm',

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -78,7 +78,6 @@ describe('model/analysis/base.ts', () => {
         { kind: 'argument-name', scope: 'Program', name: 'tempo' },
         { kind: 'plain', scope: 'Program', name: 'double' },
         { kind: 'plain', scope: 'Program', name: 'bpm' },
-        { kind: 'definition', scope: 'TrackBlock', name: 'intro' },
         { kind: 'plain', scope: 'TrackBlock', name: 'bars' },
         { kind: 'plain', scope: 'PartBlock', name: 'play' },
         { kind: 'plain', scope: 'PartBlock', name: 'kick' },
@@ -87,13 +86,12 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'PartBlock', name: 'kick' },
         { kind: 'plain', scope: 'PartBlock', name: 'gain' },
         { kind: 'plain', scope: 'PartBlock', name: 'db' },
-        { kind: 'definition', scope: 'MixerBlock', name: 'drums' },
-        { kind: 'definition', scope: 'Bus', name: 'crush' },
-        { kind: 'plain', scope: 'Bus', name: 'fx' },
-        { kind: 'plain', scope: 'Bus', name: 'clip' },
-        { kind: 'plain', scope: 'Bus', name: 'db' },
-        { kind: 'plain', scope: 'Bus', name: 'kick' },
-        { kind: 'plain', scope: 'Bus', name: 'snare' }
+        { kind: 'definition', scope: 'BusBlock', name: 'crush' },
+        { kind: 'plain', scope: 'BusBlock', name: 'fx' },
+        { kind: 'plain', scope: 'BusBlock', name: 'clip' },
+        { kind: 'plain', scope: 'BusBlock', name: 'db' },
+        { kind: 'plain', scope: 'BusBlock', name: 'kick' },
+        { kind: 'plain', scope: 'BusBlock', name: 'snare' }
       ]
     )
   })
@@ -115,7 +113,6 @@ describe('model/analysis/base.ts', () => {
       model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
       [
         { kind: 'plain', name: 'sample' },
-        { kind: 'definition', name: 'intro' },
         { kind: 'plain', name: 'kick' }
       ]
     )
@@ -169,7 +166,6 @@ describe('model/analysis/base.ts', () => {
     assert.deepStrictEqual(
       model.identifiers.map((identifier) => ({ kind: identifier.kind, name: identifier.name })),
       [
-        { kind: 'definition', name: 'main' },
         { kind: 'definition', name: 'foo' },
         { kind: 'plain', name: 'foo' }
       ]
@@ -250,16 +246,16 @@ describe('model/analysis/base.ts', () => {
       '} // end instrument',
       '',
       '& track (120.bpm) {',
-      '  & part intro (4.bars) {',
+      '  & part (4.bars) {',
       '    & play(kick, [x---])',
       '  } // end part',
       '} // end track',
       '',
       '& mixer {',
-      '  & bus drums (gain: -1.5.db) {',
+      '  & drums = bus (gain: -1.5.db) {',
       '    & kick, snare',
       '  }',
-      '  & bus delay {',
+      '  & @delay = bus {',
       '    & fx.delay(mix: 0.75, time: 0.5.beats, feedback: 0.6)',
       '  }',
       '} // end mixer',
@@ -296,7 +292,7 @@ describe('model/analysis/base.ts', () => {
     const trackRange = getRangeAt(source, trackBlockStart, trackEnd - trackBlockStart)
     const trackScopeId = `TrackBlock:${trackRange.offset}:${trackRange.length}`
 
-    const partBlockStart = source.indexOf('{', source.indexOf('part intro'))
+    const partBlockStart = source.indexOf('{', source.indexOf('& part'))
     const partEnd = source.indexOf('} // end part') + '}'.length
     const partRange = getRangeAt(source, partBlockStart, partEnd - partBlockStart)
     const partScopeId = `PartBlock:${partRange.offset}:${partRange.length}`
@@ -306,15 +302,15 @@ describe('model/analysis/base.ts', () => {
     const mixerRange = getRangeAt(source, mixerBlockStart, mixerEnd - mixerBlockStart)
     const mixerScopeId = `MixerBlock:${mixerRange.offset}:${mixerRange.length}`
 
-    const drumsBusBlockStart = source.indexOf('{', source.indexOf('bus drums'))
-    const drumsBusEnd = source.indexOf('  }', source.indexOf('bus drums')) + '  }'.length
+    const drumsBusBlockStart = source.indexOf('{', source.indexOf('& drums = '))
+    const drumsBusEnd = source.indexOf('}', drumsBusBlockStart) + '}'.length
     const drumsBusRange = getRangeAt(source, drumsBusBlockStart, drumsBusEnd - drumsBusBlockStart)
-    const drumsBusScopeId = `Bus:${drumsBusRange.offset}:${drumsBusRange.length}`
+    const drumsBusScopeId = `BusBlock:${drumsBusRange.offset}:${drumsBusRange.length}`
 
-    const delayBusBlockStart = source.indexOf('{', source.indexOf('bus delay'))
-    const delayBusEnd = source.indexOf('  }', source.indexOf('bus delay')) + '  }'.length
+    const delayBusBlockStart = source.indexOf('{', source.indexOf('& @delay = '))
+    const delayBusEnd = source.indexOf('}', delayBusBlockStart) + '}'.length
     const delayBusRange = getRangeAt(source, delayBusBlockStart, delayBusEnd - delayBusBlockStart)
-    const delayBusScopeId = `Bus:${delayBusRange.offset}:${delayBusRange.length}`
+    const delayBusScopeId = `BusBlock:${delayBusRange.offset}:${delayBusRange.length}`
 
     assert.deepStrictEqual(
       model.scopes.map(({ id, node, parentId }) => ({ id, node, parentId })),
@@ -327,30 +323,29 @@ describe('model/analysis/base.ts', () => {
         { id: trackScopeId, node: 'TrackBlock', parentId: rootScopeId },
         { id: partScopeId, node: 'PartBlock', parentId: trackScopeId },
         { id: mixerScopeId, node: 'MixerBlock', parentId: rootScopeId },
-        { id: drumsBusScopeId, node: 'Bus', parentId: mixerScopeId },
-        { id: delayBusScopeId, node: 'Bus', parentId: mixerScopeId }
+        { id: drumsBusScopeId, node: 'BusBlock', parentId: mixerScopeId },
+        { id: delayBusScopeId, node: 'BusBlock', parentId: mixerScopeId }
       ]
     )
 
     assert.deepStrictEqual(
-      model.bindings.map(({ kind, name, declaredScopeId, isExposed }) => ({ kind, name, declaredScopeId, isExposed })),
+      model.bindings.map(({ kind, name, isExposed }) => ({ kind, name, isExposed })),
       [
-        { kind: 'use-alias', name: 'fx', declaredScopeId: undefined, isExposed: undefined },
-        { kind: 'regular', name: 'kick', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'snare', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'my_function', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'input', declaredScopeId: undefined, isExposed: undefined },
-        { kind: 'regular', name: 'my_record', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'record_property', declaredScopeId: undefined, isExposed: true },
-        { kind: 'regular', name: 'my_instrument', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'instrument_property', declaredScopeId: undefined, isExposed: true },
-        { kind: 'regular', name: 'foo', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'bar', declaredScopeId: undefined, isExposed: false },
-        { kind: 'regular', name: 'note', declaredScopeId: undefined, isExposed: undefined },
-        { kind: 'regular', name: 'baz', declaredScopeId: undefined, isExposed: false },
-        { kind: 'part', name: 'intro', declaredScopeId: undefined, isExposed: undefined },
-        { kind: 'bus', name: 'drums', declaredScopeId: drumsBusScopeId, isExposed: undefined },
-        { kind: 'bus', name: 'delay', declaredScopeId: delayBusScopeId, isExposed: undefined }
+        { kind: 'use-alias', name: 'fx', isExposed: undefined },
+        { kind: 'regular', name: 'kick', isExposed: false },
+        { kind: 'regular', name: 'snare', isExposed: false },
+        { kind: 'regular', name: 'my_function', isExposed: false },
+        { kind: 'regular', name: 'input', isExposed: undefined },
+        { kind: 'regular', name: 'my_record', isExposed: false },
+        { kind: 'regular', name: 'record_property', isExposed: true },
+        { kind: 'regular', name: 'my_instrument', isExposed: false },
+        { kind: 'regular', name: 'instrument_property', isExposed: true },
+        { kind: 'regular', name: 'foo', isExposed: false },
+        { kind: 'regular', name: 'bar', isExposed: false },
+        { kind: 'regular', name: 'note', isExposed: undefined },
+        { kind: 'regular', name: 'baz', isExposed: false },
+        { kind: 'regular', name: 'drums', isExposed: false },
+        { kind: 'regular', name: 'delay', isExposed: true }
       ]
     )
   })
@@ -367,13 +362,13 @@ describe('model/analysis/base.ts', () => {
       '}',
       '',
       '& track (120.bpm) {',
-      '  & part intro (4.bars) {',
+      '  & @intro = part (4.bars) {',
       '    & play(kick, [x---])',
       '  }',
       '}',
       '',
       '& mixer {',
-      '  & bus drums (gain: -1.5.db) {',
+      '  & @drums = bus (gain: -1.5.db) {',
       '    & kick, snare',
       '  }',
       '}',
@@ -411,14 +406,14 @@ describe('model/analysis/base.ts', () => {
           range: getRangeAt(source, source.indexOf('bar ='), 'bar'.length)
         },
         {
-          kind: 'part',
+          kind: 'regular',
           name: 'intro',
-          range: getRangeAt(source, source.indexOf('intro (4.bars)'), 'intro'.length)
+          range: getRangeAt(source, source.indexOf('@intro') + 1, 'intro'.length)
         },
         {
-          kind: 'bus',
+          kind: 'regular',
           name: 'drums',
-          range: getRangeAt(source, source.indexOf('bus drums') + 'bus '.length, 'drums'.length)
+          range: getRangeAt(source, source.indexOf('@drums') + 1, 'drums'.length)
         }
       ]
     )

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -140,38 +140,6 @@ describe('model/analysis/references.ts', () => {
     assert.ok(references.includes(identifier))
   })
 
-  it('resolves explicit bus namespace access to the bus binding', () => {
-    const source = [
-      '& track (120.bpm) {',
-      '  & part foo (4.bars) {',
-      '    & automate(bus.foo.gain, ~[hold(0.db)])',
-      '  }',
-      '}',
-      '& mixer {',
-      '  & bus foo {}',
-      '}',
-      ''
-    ].join('\n')
-
-    const model = analyzeSource(source)
-
-    const position = source.indexOf('bus.foo.gain') + 'bus.'.length
-    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
-    assert.ok(identifier != null)
-
-    const resolution = model.resolutions.get(identifier.id)
-    assert.strictEqual(resolution?.kind, 'binding')
-
-    const binding = resolution.binding
-    assert.strictEqual(binding.kind, 'bus')
-    assert.strictEqual(binding.name, 'foo')
-    assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('bus foo') + 'bus '.length, 'foo'.length))
-
-    const references = model.bindingReferences.get(binding.id)
-    assert.ok(references != null)
-    assert.ok(references.includes(identifier))
-  })
-
   it('does not resolve named argument keys', () => {
     const source = [
       'tempo = 128.bpm',
@@ -245,30 +213,6 @@ describe('model/analysis/references.ts', () => {
 
     const model = analyzeSource(source)
     const position = source.indexOf('synth.gain') + 'synth.'.length
-
-    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
-    assert.ok(identifier != null)
-
-    const binding = model.resolutions.get(identifier.id)
-    assert.strictEqual(binding, undefined)
-  })
-
-  it('does not resolve member access of an explicit bus access', () => {
-    const source = [
-      '& track (120.bpm) {',
-      '  & part main (4.bars) {',
-      '    & automate(bus.foo.gain, ~[hold(0.db)])',
-      '  }',
-      '}',
-      '',
-      '& mixer {',
-      '  & bus foo {}',
-      '}',
-      ''
-    ].join('\n')
-
-    const model = analyzeSource(source)
-    const position = source.indexOf('bus.foo.gain') + 'bus.foo.'.length
 
     const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
     assert.ok(identifier != null)

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -81,32 +81,6 @@ describe('unused-variable/operation.ts', () => {
     )
   })
 
-  it('does not treat explicit bus namespace access as an assignment reference', () => {
-    const source = [
-      'foo = sample("...")',
-      '& track (120.bpm) {',
-      '  & part intro (4.bars) {',
-      '    & automate(bus.foo.gain, ~[hold(-60.db):3 lin(0.db):1])',
-      '  }',
-      '}',
-      '& mixer {',
-      '  & bus foo {}',
-      '}',
-      ''
-    ].join('\n')
-
-    assert.deepStrictEqual(
-      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
-      [
-        {
-          name: 'foo',
-          message: 'Unused variable "foo"',
-          range: getRangeAt(source, source.indexOf('foo ='), 'foo'.length)
-        }
-      ]
-    )
-  })
-
   it('reports unused named imports', () => {
     const source = [
       'use "instruments" as instruments',

--- a/packages/language/src/compiler/checker/blocks.ts
+++ b/packages/language/src/compiler/checker/blocks.ts
@@ -55,11 +55,6 @@ export interface BlockSchema<TBlock extends BlockNode> {
   readonly properties?: PropertyOptions
 
   /**
-   * The namespace to which this block belongs (if any). This will take effect for blocks with a name field.
-   */
-  readonly namespace?: string
-
-  /**
    * Compute the bindings that are available inside this block, if any. These may not be overridden by statements within the block.
    */
   readonly getBindings?: (block: TBlock) => ReadonlyMap<string, FacetType>
@@ -144,10 +139,6 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
 
     const result = makeBlockType(schema.facet, properties)
 
-    if (schema.namespace != null) {
-      errors.push(...checkBlockName(scope, schema.namespace, block, result))
-    }
-
     return { errors, capabilities, result }
   }
 }
@@ -207,29 +198,6 @@ class EmissionCollector {
 
     return errors
   }
-}
-
-function checkBlockName (scope: Scope, namespace: string, block: BlockNode, type: FacetType): readonly CompileError[] {
-  const errors: CompileError[] = []
-  if (block.name == null) {
-    return errors
-  }
-
-  const namespaceObject = scope.top.namespaces.get(namespace)
-  if (namespaceObject == null) {
-    errors.push(new CompileError(`Namespace "${namespace}" is not defined`, block.range))
-    return errors
-  }
-
-  const duplicate = namespaceObject.resolutions.has(block.name.name)
-  if (duplicate) {
-    errors.push(new CompileError(`Duplicate definition of "${block.name.name}" in namespace "${namespace}"`, block.name.range))
-    return errors
-  }
-
-  namespaceObject.resolutions.set(block.name.name, type)
-
-  return errors
 }
 
 function makeBlockType (facet: Facet, properties: ReadonlyMap<string, FacetType>): FacetType {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -7,10 +7,9 @@ import { TrackFacet } from '../../type-system/domain/track.ts'
 import type { FacetType } from '../../type-system/types.ts'
 import { nonNull } from '../assert.ts'
 import { globalBuiltins } from '../builtins/global.ts'
-import { BUS_NAMESPACE } from '../common.ts'
 import { CompileError } from '../error.ts'
 import { checkImports } from './imports.ts'
-import { createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
+import { createGlobalScope, createLocalScope } from './scopes.ts'
 import { checkStatement } from './statements.ts'
 
 export interface SemanticModel {
@@ -47,10 +46,6 @@ export function check (program: ast.Program): CheckResult {
   }
 
   const globalScope = createGlobalScope(initialResolutions)
-
-  const busNamespace = createNamespace()
-  globalScope.namespaces.set(BUS_NAMESPACE, busNamespace)
-
   const scope = createLocalScope(globalScope)
 
   const errors: CompileError[] = []

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -25,7 +25,7 @@ import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeUnion } from '../../type-system/factory.ts'
 import type { FacetType, Type } from '../../type-system/types.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
-import { BUS_NAMESPACE, busSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
+import { busSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
 import { getCurveSegmentType } from '../curves.ts'
 import { CompileError } from '../error.ts'
 import { binaryOperations } from '../operators/binary.ts'
@@ -492,9 +492,7 @@ const checkBus = createBlockChecker<ast.Bus>({
       ['gain', ParameterFacet.with('db').type()],
       ['pan', ParameterFacet.with(undefined).type()]
     ])
-  },
-
-  namespace: BUS_NAMESPACE
+  }
 })
 
 const checkTrack = createBlockChecker<ast.Track>({
@@ -585,19 +583,6 @@ function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression):
 
 function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Checked<FacetType> {
   const errors: CompileError[] = []
-
-  if (expression.object.type === 'Identifier') {
-    const namespace = scope.top.namespaces.get(expression.object.name)
-    if (namespace != null) {
-      const propertyType = namespace.resolutions.get(expression.property.name)
-      if (propertyType == null) {
-        errors.push(new CompileError(`Namespace "${expression.object.name}" has no member named "${expression.property.name}"`, expression.property.range))
-        return { errors, capabilities: noCapabilities }
-      }
-
-      return { errors, capabilities: noCapabilities, result: propertyType }
-    }
-  }
 
   const objectCheck = checkExpression(scope, expression.object)
   errors.push(...objectCheck.errors)

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -12,23 +12,12 @@ export interface Scope {
 }
 
 export interface GlobalScope extends Scope {
-  readonly namespaces: Map<string, MutableNamespace>
   readonly semantic: {
     readonly functions: Map<ast.Function, FunctionSpec>
   }
 }
 
 export interface MutableScope extends Scope {
-  readonly resolutions: Map<string, FacetType>
-}
-
-// namespace
-
-export interface Namespace {
-  readonly resolutions: ReadonlyMap<string, FacetType>
-}
-
-export interface MutableNamespace extends Namespace {
   readonly resolutions: Map<string, FacetType>
 }
 
@@ -48,7 +37,6 @@ export function createGlobalScope (initialResolutions: ReadonlyMap<string, Facet
     },
 
     // from GlobalScope
-    namespaces: new Map(),
     semantic: {
       functions: new Map()
     }
@@ -63,11 +51,5 @@ export function createLocalScope (parent: Scope, overrideCapabilities?: Capabili
     parent,
     resolutions: new Map(),
     allowedCapabilities: overrideCapabilities ?? parent.allowedCapabilities
-  }
-}
-
-export function createNamespace (): MutableNamespace {
-  return {
-    resolutions: new Map()
   }
 }

--- a/packages/language/src/compiler/common.ts
+++ b/packages/language/src/compiler/common.ts
@@ -5,8 +5,6 @@ import { makeSchema } from '../type-system/schema.ts'
 
 export const DEFAULT_ROOT_NOTE = convertPitchToMidi('C5')
 
-export const BUS_NAMESPACE = 'bus'
-
 export const trackSchema = makeSchema([
   {
     name: 'tempo',

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -32,7 +32,7 @@ import { globalBuiltins } from '../builtins/global.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
 import type { CheckedProgram } from '../checker/checker.ts'
 import type { NoteValue } from '../common.ts'
-import { BUS_NAMESPACE, busSchema, DEFAULT_ROOT_NOTE, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
+import { busSchema, DEFAULT_ROOT_NOTE, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
 import type { RenderCurveOptions } from '../curves.ts'
 import { createCurve, createCurveSegment, getCurveSegmentType, mergeCurvePoints, renderCurvePoints } from '../curves.ts'
 import { binaryOperations } from '../operators/binary.ts'
@@ -42,7 +42,7 @@ import { isSyntaxUnit, toNumberValue } from '../units.ts'
 import type { GenerateOptions } from './options.ts'
 import { RecordBuilder } from './properties.ts'
 import type { GlobalScope, MutableScope, Scope } from './scopes.ts'
-import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from './scopes.ts'
+import { cloneScope, createGlobalScope, createLocalScope } from './scopes.ts'
 
 /**
  * Generate a runnable program from an AST. This assumes the AST has already been
@@ -54,11 +54,7 @@ export function generate (program: CheckedProgram, options: GenerateOptions): Pr
   setAll(initialResolutions, globalBuiltins)
 
   const top = createGlobalScope(options, program.semantic, initialResolutions)
-
   const scope = createLocalScope(top)
-
-  const busNamespace = createNamespace()
-  scope.top.namespaces.set(BUS_NAMESPACE, busNamespace)
 
   let mixer: Mixer | undefined
   let track: Track | undefined
@@ -595,12 +591,6 @@ function generateBus (scope: Scope, expression: ast.Bus): Value {
   const bus = scope.top.allocateBus({ name, sources, gain, pan, effects })
   const value = makeType(BusFacet, recordBuilder.facet).of(bus, recordBuilder.record)
 
-  if (name != null) {
-    const namespace = nonNull(scope.top.namespaces.get(BUS_NAMESPACE))
-    assert(!namespace.resolutions.has(name))
-    namespace.resolutions.set(name, value)
-  }
-
   return value
 }
 
@@ -709,13 +699,6 @@ function computeBinaryExpression (scope: Scope, expression: ast.BinaryExpression
 }
 
 function resolvePropertyAccess (scope: Scope, expression: ast.PropertyAccess): Value {
-  if (expression.object.type === 'Identifier') {
-    const namespace = scope.top.namespaces.get(expression.object.name)
-    if (namespace != null) {
-      return nonNull(namespace.resolutions.get(expression.property.name))
-    }
-  }
-
   const object = resolve(scope, expression.object)
   const property = expression.property.name
 

--- a/packages/language/src/compiler/generator/scopes.ts
+++ b/packages/language/src/compiler/generator/scopes.ts
@@ -37,8 +37,6 @@ export interface GlobalScope extends Scope, Context {
   readonly options: GenerateOptions
   readonly semantic: SemanticModel
 
-  readonly namespaces: Map<string, MutableNamespace>
-
   readonly buses: Map<BusId, Bus>
   readonly instruments: Map<InstrumentId, Instrument>
   readonly automations: Map<ParameterId, Curve<'s', Unit>>
@@ -46,16 +44,6 @@ export interface GlobalScope extends Scope, Context {
 }
 
 export interface MutableScope extends Scope {
-  readonly resolutions: Map<string, Value>
-}
-
-// namespace
-
-export interface Namespace {
-  readonly resolutions: ReadonlyMap<string, Value>
-}
-
-export interface MutableNamespace extends Namespace {
   readonly resolutions: Map<string, Value>
 }
 
@@ -76,7 +64,6 @@ export function createGlobalScope (
     // from GlobalScope
     options,
     semantic,
-    namespaces: new Map(),
     buses: new Map(),
     instruments: new Map(),
     automations: new Map(),
@@ -111,12 +98,6 @@ export function cloneScope (scope: Scope): MutableScope {
     top: scope.top,
     parent: scope.parent,
     resolutions: new Map(scope.resolutions)
-  }
-}
-
-export function createNamespace (): MutableNamespace {
-  return {
-    resolutions: new Map()
   }
 }
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -78,11 +78,6 @@ const identifier_: p.Parser<Token, unknown, ast.Identifier> = p.token((t) => {
     : undefined
 })
 
-const busNamespaceRoot_: p.Parser<Token, unknown, ast.Identifier> = p.map(
-  keyword('bus'),
-  (token) => ast.make('Identifier', getSourceRange(token), { name: token.text })
-)
-
 const boolean_: p.Parser<Token, unknown, ast.Boolean> = p.token((t) => {
   return t.name === 'word' && (t.text === 'true' || t.text === 'false')
     ? ast.make('Boolean', getSourceRange(t), { value: t.text === 'true' })
@@ -486,7 +481,7 @@ const primary_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
 
 // Parse a primary value, a property access, or a call; chained as needed.
 const accessOrCall_: p.Parser<Token, unknown, ast.Expression> = p.ab(
-  p.eitherOr(primary_, busNamespaceRoot_),
+  primary_,
   p.many(
     p.eitherOr(
       p.ab(

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -455,34 +455,6 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
-    it('should allow buses as sources in bus via namespace', () => {
-      const source = [
-        '& mixer {',
-        '  & bus bus0 {}',
-        '  & bus { & bus.bus0 }',
-        '}'
-      ].join('\n')
-
-      assertValid(source)
-    })
-
-    it('should accept bus references after the mixer declaration', () => {
-      const source = [
-        '& mixer {',
-        '  & bus foo {}',
-        '  & bus bar {}',
-        '}',
-        'foo_gain = bus.foo.gain',
-        '& track {',
-        '  & part intro (4.bars) {',
-        '    & automate(bus.bar.pan, ~[lin(-1, 1):1.bar])',
-        '  }',
-        '}'
-      ].join('\n')
-
-      assertValid(source)
-    })
-
     it('should accept curves with beat and bar length units', () => {
       assertValid('my_curve = ~[lin((-60).db, 0.db):4.bars lin(0.db, -60.db):16.beats]')
     })
@@ -521,14 +493,14 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
-    it('should accept bus gain automation via explicit namespace', () => {
+    it('should accept bus gain automation', () => {
       const source = [
-        '& mixer {',
-        '  & bus main {}',
+        '& m = mixer {',
+        '  & @test_bus = bus main {}',
         '}',
         '& track {',
         '  & part intro (4.bars) {',
-        '    & automate(bus.main.gain, ~[lin((-20).db, 0.db):4.bars])',
+        '    & automate(m.test_bus.gain, ~[lin((-20).db, 0.db):4.bars])',
         '  }',
         '}'
       ].join('\n')
@@ -536,17 +508,17 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
-    it('should accept bus effect automation via explicit namespace', () => {
+    it('should accept bus effect automation', () => {
       const source = [
         'use "effects" as fx',
-        '& mixer {',
-        '  & bus main {',
+        '& m = mixer {',
+        '  & @test_bus = bus {',
         '    & @lp = fx.lowpass(1000.hz)',
         '  }',
         '}',
         '& track {',
         '  & part intro (4.bars) {',
-        '    & automate(bus.main.lp.frequency, ~[lin(100.hz, 4000.hz):4.bars])',
+        '    & automate(m.test_bus.lp.frequency, ~[lin(100.hz, 4000.hz):4.bars])',
         '  }',
         '}'
       ].join('\n')
@@ -951,34 +923,6 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
-    it('should reject duplicate bus blocks within a mixer', () => {
-      const source = [
-        '& mixer {',
-        '  & bus foo {}',
-        '  & bus foo {}',
-        '}'
-      ].join('\n')
-
-      assertErrorMessages(source, [
-        'Duplicate definition of "foo" in namespace "bus"'
-      ])
-    })
-
-    it('should reject duplicate bus names across different mixers', () => {
-      const source = [
-        'm1 = mixer {',
-        '  & bus foo {}',
-        '}',
-        'm2 = mixer {',
-        '  & bus foo {}',
-        '}'
-      ].join('\n')
-
-      assertErrorMessages(source, [
-        'Duplicate definition of "foo" in namespace "bus"'
-      ])
-    })
-
     it('should reject buses as sources in bus before their declaration', () => {
       const source = [
         '& mixer {',
@@ -1314,26 +1258,6 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Unknown identifier "my_tempo"'
-      ])
-    })
-
-    it('should reject bus references before the mixer declaration', () => {
-      const source = [
-        'foo_gain = bus.foo.gain',
-        '& track {',
-        '  & part intro (4.bars) {',
-        '    & automate(bus.bar.pan, ~[lin(-1, 1):1.bar])',
-        '  }',
-        '}',
-        '& mixer {',
-        '  & bus foo {}',
-        '  & bus bar {}',
-        '}'
-      ].join('\n')
-
-      assertErrorMessages(source, [
-        'Namespace "bus" has no member named "foo"',
-        'Namespace "bus" has no member named "bar"'
       ])
     })
 

--- a/packages/language/test/compiler/checker/scopes.test.ts
+++ b/packages/language/test/compiler/checker/scopes.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { createGlobalScope, createLocalScope, createNamespace } from '../../../src/compiler/checker/scopes.ts'
+import { createGlobalScope, createLocalScope } from '../../../src/compiler/checker/scopes.ts'
 import { NumberFacet } from '../../../src/type-system/base/number.ts'
 
 describe('compiler/checker/scopes.ts', () => {
@@ -14,8 +14,6 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(result.parent, undefined)
       assert.strictEqual(result.resolutions.get('foo'), foo)
       assert.deepStrictEqual(result.allowedCapabilities, { mayBlock: true })
-
-      assert.strictEqual(result.namespaces.size, 0)
     })
   })
 
@@ -54,14 +52,6 @@ describe('compiler/checker/scopes.ts', () => {
 
       const localScopeWithOverride = createLocalScope(globalScope, { mayBlock: false })
       assert.deepStrictEqual(localScopeWithOverride.allowedCapabilities, { mayBlock: false })
-    })
-  })
-
-  describe('createNamespace()', () => {
-    it('should create a namespace with empty resolutions', () => {
-      const namespace = createNamespace()
-
-      assert.strictEqual(namespace.resolutions.size, 0)
     })
   })
 })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -610,14 +610,14 @@ describe('compiler/generator/generator.ts', () => {
     ])
   })
 
-  it('should automate bus gain via explicit namespace', () => {
+  it('should automate bus gain', () => {
     const source = [
-      '& mixer {',
-      '  & bus main {}',
+      '& m = mixer {',
+      '  & @test_bus = bus {}',
       '}',
       '& track (120.bpm) {',
       '  & part intro (4.bars) {',
-      '    & automate(bus.main.gain, ~[lin((-20).db, 0.db):4.bars])',
+      '    & automate(m.test_bus.gain, ~[lin((-20).db, 0.db):4.bars])',
       '  }',
       '}'
     ].join('\n')
@@ -632,17 +632,17 @@ describe('compiler/generator/generator.ts', () => {
     ])
   })
 
-  it('should automate bus effect parameters via explicit namespace', () => {
+  it('should automate bus effect parameters', () => {
     const source = [
       'use "effects" as fx',
-      '& mixer {',
-      '  & bus main {',
+      '& m = mixer {',
+      '  & @test_bus = bus {',
       '    & @lp = fx.lowpass(123.hz)',
       '  }',
       '}',
       '& track (120.bpm) {',
       '  & part intro (4.bars) {',
-      '    & automate(bus.main.lp.frequency, ~[lin(100.hz, 4000.hz):4.bars])',
+      '    & automate(m.test_bus.lp.frequency, ~[lin(100.hz, 4000.hz):4.bars])',
       '  }',
       '}'
     ].join('\n')

--- a/packages/language/test/compiler/generator/scopes.test.ts
+++ b/packages/language/test/compiler/generator/scopes.test.ts
@@ -4,7 +4,7 @@ import { runtimeNumeric } from '@meyfa/cadence-utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import type { GenerateOptions } from '../../../src/compiler/generator/options.ts'
-import { cloneScope, createGlobalScope, createLocalScope, createNamespace } from '../../../src/compiler/generator/scopes.ts'
+import { cloneScope, createGlobalScope, createLocalScope } from '../../../src/compiler/generator/scopes.ts'
 import type { SemanticModel } from '../../../src/index.ts'
 import { Numbers } from '../../../src/type-system/helpers.ts'
 
@@ -193,14 +193,6 @@ describe('compiler/generator/scopes.ts', () => {
       localScope.resolutions.set('baz', Numbers.of(runtimeNumeric('db', 3)))
 
       assert.strictEqual(clonedScope.resolutions.get('baz'), undefined)
-    })
-  })
-
-  describe('createNamespace()', () => {
-    it('should create a namespace with empty resolutions', () => {
-      const namespace = createNamespace()
-
-      assert.strictEqual(namespace.resolutions.size, 0)
     })
   })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -278,31 +278,6 @@ describe('parser/parser.ts', () => {
     }
   })
 
-  it('should parse explicit bus parameter access', () => {
-    const result = parse(lexSource('target = bus.main.gain'))
-    assertResultComplete(result)
-
-    assert.deepStrictEqual(stripRanges(result.value.children), [
-      {
-        type: 'Statement',
-        emit: false,
-        expose: false,
-        name: { type: 'Identifier', name: 'target' },
-        values: [
-          {
-            type: 'PropertyAccess',
-            object: {
-              type: 'PropertyAccess',
-              object: { type: 'Identifier', name: 'bus' },
-              property: { type: 'Identifier', name: 'main' }
-            },
-            property: { type: 'Identifier', name: 'gain' }
-          }
-        ]
-      }
-    ])
-  })
-
   it('should parse string literals with escapes and interpolations', () => {
     const result = parse(lexSource('foo = "a \\{ b {x} c"'))
     assertResultComplete(result)


### PR DESCRIPTION
This patch removes the ability to access named buses (`bus foo {}`) via the `bus` namespace (`bus.foo`), bypassing regular scoping rules and property exposure. There were a number of issues with the namespace approach, notably that any bus construction anywhere in the program would have to reserve the name, even if this was not meaningful:

```
// Problematic example

function_that_creates_a_bus = () {
  & bus foo {}
}

& mixer {
  // The function is never called! Still, the following is an error:
  & bus foo {}
}

// What would this even refer to?
automation = automate(bus.foo.gain, ~[lin(-30.db, 0.db):4.bars])
```

There are better ways to make buses accessible; specifically, exposing them them as properties on the mixer:

```
// Suggested alternative

& m = mixer {
  & @foo = bus {}
}

automation = automate(m.foo.gain, ~[lin(-30.db, 0.db):4.bars])
```

Note that the editor experience, e.g. go-to-definition, does not support exposed properties yet, but this is a separate issue that needs to be addressed either way. Overall, the language and tooling implementation will be much simpler without the special case of namespaces.

BREAKING CHANGE: The `bus` namespace is no longer available.