### PR TITLE
feat: Add label parameter to instrument block

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -288,6 +288,7 @@ export interface Part extends ASTNode {
 
 export interface Instrument extends ASTNode {
   readonly type: 'Instrument'
+  readonly arguments: readonly Argument[]
   readonly children: readonly Statement[]
 }
 

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -272,6 +272,7 @@ Bus {
 
 Instrument {
   kw<"instrument">
+  ("(" argumentList? ")")?
   InstrumentBlock[group=Block] {
     "{" statement* "}"
   }

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -25,7 +25,7 @@ import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeUnion } from '../../type-system/factory.ts'
 import type { FacetType, Type } from '../../type-system/types.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
-import { busSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
+import { busSchema, instrumentSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
 import { getCurveSegmentType } from '../curves.ts'
 import { CompileError } from '../error.ts'
 import { binaryOperations } from '../operators/binary.ts'
@@ -406,6 +406,8 @@ const checkInstrument = createBlockChecker<ast.Instrument>({
 
   ownCapabilities: { mayBlock: true },
   allowedCapabilities: { mayBlock: true },
+
+  parameters: instrumentSchema,
 
   slots: [
     {

--- a/packages/language/src/compiler/common.ts
+++ b/packages/language/src/compiler/common.ts
@@ -62,6 +62,14 @@ export const stepSchema = makeSchema([
   }
 ])
 
+export const instrumentSchema = makeSchema([
+  {
+    name: 'label',
+    type: StringFacet.type(),
+    required: false
+  }
+])
+
 export const noteType = RecordFacet.with({
   frequency: NumberFacet.with('hz').type(),
   gate: NumberFacet.with('beats').type(),

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -32,7 +32,7 @@ import { globalBuiltins } from '../builtins/global.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
 import type { CheckedProgram } from '../checker/checker.ts'
 import type { NoteValue } from '../common.ts'
-import { busSchema, DEFAULT_ROOT_NOTE, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
+import { busSchema, DEFAULT_ROOT_NOTE, instrumentSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
 import type { RenderCurveOptions } from '../curves.ts'
 import { createCurve, createCurveSegment, getCurveSegmentType, mergeCurvePoints, renderCurvePoints } from '../curves.ts'
 import { binaryOperations } from '../operators/binary.ts'
@@ -387,6 +387,9 @@ function generateRecord (scope: Scope, expression: ast.RecordValue): Value {
 function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   const instrumentScope = createLocalScope(scope)
 
+  const args = resolveArgumentList(scope, expression.arguments, instrumentSchema)
+  const label = args.label != null ? StringFacet.get(args.label) : undefined
+
   const recordBuilder = new RecordBuilder()
   const voices: Voice[] = []
 
@@ -399,7 +402,7 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   }
 
   const gainParameter = scope.top.allocateParameter('db', 0 as Numeric<'db'>)
-  const instrument = scope.top.allocateInstrument({ gain: gainParameter, voices })
+  const instrument = scope.top.allocateInstrument({ label, gain: gainParameter, voices })
 
   return !recordBuilder.empty
     ? makeType(InstrumentFacet, recordBuilder.facet).of(instrument, recordBuilder.record)
@@ -550,14 +553,14 @@ function generateImplicitRoutings (scope: Scope, mixer: Mixer): readonly MixerRo
 }
 
 function generateBus (scope: Scope, expression: ast.Bus): Value {
+  const args = resolveArgumentList(scope, expression.arguments, busSchema)
+  const label = args.label != null ? StringFacet.get(args.label) : undefined
+
   const busScope = createLocalScope(scope)
 
   const recordBuilder = new RecordBuilder()
   const sources: MixerSource[] = []
   const effects: Effect[] = []
-
-  const args = resolveArgumentList(scope, expression.arguments, busSchema)
-  const label = args.label != null ? StringFacet.get(args.label) : undefined
 
   // These must always be allocated even if not explicitly set,
   // as they could still be automated.
@@ -596,16 +599,15 @@ function generateBus (scope: Scope, expression: ast.Bus): Value {
 function generateTrack (scope: Scope, expression: ast.Track): Value {
   const { options } = scope.top
 
+  const args = resolveArgumentList(scope, expression.arguments, trackSchema)
+  const tempo = args.tempo != null
+    ? clamped(NumberFacet.get(args.tempo), options.tempo.minimum, options.tempo.maximum).value
+    : options.tempo.default
+
   const trackScope = createLocalScope(scope)
 
   const recordBuilder = new RecordBuilder()
   const parts: Part[] = []
-
-  const args = resolveArgumentList(scope, expression.arguments, trackSchema)
-
-  const tempo = args.tempo != null
-    ? clamped(NumberFacet.get(args.tempo), options.tempo.minimum, options.tempo.maximum).value
-    : options.tempo.default
 
   let currentTime = 0 as Numeric<'beats'>
 
@@ -640,15 +642,15 @@ function generateTrack (scope: Scope, expression: ast.Track): Value {
 }
 
 function generatePart (scope: Scope, expression: ast.Part): Value {
+  const args = resolveArgumentList(scope, expression.arguments, partSchema)
+  const label = args.label != null ? StringFacet.get(args.label) : undefined
+  const length = clamped(NumberFacet.get(args.length), 0, Number.POSITIVE_INFINITY)
+
   const partScope = createLocalScope(scope)
 
   const recordBuilder = new RecordBuilder()
   const routings: InstrumentRouting[] = []
   const automations: Automation[] = []
-
-  const args = resolveArgumentList(scope, expression.arguments, partSchema)
-  const label = args.label != null ? StringFacet.get(args.label) : undefined
-  const length = clamped(NumberFacet.get(args.length), 0, Number.POSITIVE_INFINITY)
 
   for (const child of expression.children) {
     const { emissions, properties } = processStatement(partScope, child)

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -790,15 +790,24 @@ const voice_: p.Parser<Token, unknown, ast.Voice> = p.abc(
   }
 )
 
-const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.ab(
+const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.abc(
   keyword('instrument'),
+  p.option(
+    combine3(
+      literal('('),
+      argumentList_,
+      expectLiteral(')')
+    ),
+    undefined
+  ),
   combine3(
     expectLiteral('{'),
     p.many(statement_),
     expectLiteral('}')
   ),
-  (_instrument, [_lp, children, _rp]) => {
+  (_instrument, callChain, [_lp, children, _rp]) => {
     return ast.make('Instrument', combineSourceRanges(_instrument, _rp), {
+      arguments: callChain == null ? [] : callChain[1],
       children
     })
   }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -344,7 +344,10 @@ describe('compiler/checker/checker.ts', () => {
             emit: true,
             expose: false,
             values: [
-              ast.make('Instrument', getEmptySourceRange(), { children: [] })
+              ast.make('Instrument', getEmptySourceRange(), {
+                arguments: [],
+                children: []
+              })
             ]
           })
         ]
@@ -584,6 +587,15 @@ describe('compiler/checker/checker.ts', () => {
         '  @foo = -6.db',
         '}',
         'access_foo = my_instrument.foo'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow label for instrument definitions', () => {
+      const source = [
+        'instrument0 = instrument ("My Instrument") {}',
+        'instrument1 = instrument (label: "My Instrument") {}'
       ].join('\n')
 
       assertValid(source)

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -239,6 +239,18 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(result.mixer.buses[1].label, 'Second Bus')
   })
 
+  it('should support instrument labels', () => {
+    const source = [
+      'instrument0 = instrument ("First Instrument") {}',
+      'instrument1 = instrument ("Second Instrument") {}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    const [instrument0, instrument1] = result.instruments.values()
+    assert.strictEqual(instrument0.label, 'First Instrument')
+    assert.strictEqual(instrument1.label, 'Second Instrument')
+  })
+
   it('should resolve variables in track scope', () => {
     const source = [
       'root_scope = 8.beats',

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -1519,7 +1519,9 @@ describe('parser/parser.ts', () => {
       '    bar = 440.hz',
       '  }',
       '  & voice note {}',
-      '}'
+      '}',
+      '',
+      'labeled_instrument = instrument ("my_label") {}'
     ].join('\n')
 
     const result = parse(lexSource(source))
@@ -1534,6 +1536,7 @@ describe('parser/parser.ts', () => {
         values: [
           {
             type: 'Instrument',
+            arguments: [],
             children: [
               {
                 type: 'Statement',
@@ -1595,6 +1598,27 @@ describe('parser/parser.ts', () => {
                 ]
               }
             ]
+          }
+        ]
+      },
+      {
+        type: 'Statement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'labeled_instrument' },
+        values: [
+          {
+            type: 'Instrument',
+            arguments: [
+              {
+                type: 'Argument',
+                value: {
+                  type: 'String',
+                  parts: ['my_label']
+                }
+              }
+            ],
+            children: []
           }
         ]
       }


### PR DESCRIPTION
In the spirit of labels for parts and buses (see PR #681), this patch adds an optional string-typed `label` parameter to the instrument block. This can be used to provide a human-readable name for e.g. the mixer UI. Example:

```
lead = instrument("Lead Synth") {
  // ...
}
```