### PR TITLE
refactor: Simplify argument list parsing

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -45,6 +45,7 @@ export interface NodeByType {
   NamedType: NamedType
   FunctionType: FunctionType
   RecordType: RecordType
+  RecordTypeProperty: RecordTypeProperty
   CombinedType: CombinedType
 
   // Primitive Values
@@ -199,7 +200,13 @@ export interface FunctionType extends ASTNode {
 
 export interface RecordType extends ASTNode {
   readonly type: 'RecordType'
-  readonly parameters: readonly Parameter[]
+  readonly properties: readonly RecordTypeProperty[]
+}
+
+export interface RecordTypeProperty extends ASTNode {
+  readonly type: 'RecordTypeProperty'
+  readonly name: Identifier
+  readonly propertyType: Type
 }
 
 export interface CombinedType extends ASTNode {

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -100,7 +100,9 @@ parallelPattern {
 }
 
 step {
-  (word | "-") ("(" argumentList? ")")? (":" AccessOrCall)?
+  (word | "-")
+  argumentList?
+  (":" AccessOrCall)?
 }
 
 Curve {
@@ -110,11 +112,15 @@ Curve {
 }
 
 curveSegment {
-  CurveSegmentShape { word } ("(" argumentList? ")")? (":" AccessOrCall)?
+  CurveSegmentShape { word }
+  argumentList?
+  (":" AccessOrCall)?
 }
 
 argumentList {
-  argument ("," argument)*
+  "("
+  (argument ("," argument)*)?
+  ")"
 }
 
 argument {
@@ -123,7 +129,9 @@ argument {
 }
 
 parameterList {
-  parameter ("," parameter)*
+  "("
+  (parameter ("," parameter)*)?
+  ")"
 }
 
 parameter {
@@ -143,14 +151,20 @@ NamedType {
 }
 
 FunctionType {
-  "(" parameterList? ")"
+  parameterList
   ":"
   atomicType
   (!capability "!" Capability { word })*
 }
 
 RecordType {
-  "{" parameterList? "}"
+  "{"
+  (recordTypeProperty ("," recordTypeProperty)*)?
+  "}"
+}
+
+recordTypeProperty {
+  VariableDefinition ":" Type
 }
 
 Import {
@@ -213,7 +227,7 @@ AccessOrCall {
 
 Call {
   Callee { word }
-  "(" argumentList? ")"
+  argumentList
 }
 
 UnaryExpression {
@@ -228,7 +242,7 @@ BinaryExpression {
 }
 
 Function {
-  "(" parameterList? ")"
+  parameterList
   FunctionBody
 }
 
@@ -246,7 +260,7 @@ Block {
 
 Builder<term> {
   kw<term>
-  ("(" argumentList? ")")?
+  argumentList?
   Block
 }
 

--- a/packages/language/src/compiler/checker/type-expressions.ts
+++ b/packages/language/src/compiler/checker/type-expressions.ts
@@ -147,8 +147,8 @@ function checkRecordType (expression: ast.RecordType): CheckedFacets {
 
   const properties = new Map<string, FacetType>()
 
-  for (const property of expression.parameters) {
-    const propertyCheck = checkType(property.parameterType)
+  for (const property of expression.properties) {
+    const propertyCheck = checkType(property.propertyType)
     errors.push(...propertyCheck.errors)
 
     if (propertyCheck.result == null) {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -182,14 +182,7 @@ const steps_: p.Parser<Token, unknown, readonly ast.Step[]> = p.abc(
     }
     return undefined
   }),
-  p.option(
-    combine3(
-      literal('('),
-      p.recursive(() => argumentList_),
-      expectLiteral(')')
-    ),
-    undefined
-  ),
+  p.option(p.recursive(() => argumentList_), undefined),
   p.option(
     combine2(
       literal(':'),
@@ -352,11 +345,7 @@ const namedType_: p.Parser<Token, unknown, ast.NamedType> = p.ab(
 )
 
 const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.abc(
-  combine3(
-    literal('('),
-    p.recursive(() => parameterList_),
-    literal(')')
-  ),
+  p.recursive(() => parameterList_),
   combine2(
     literal(':'),
     p.recursive(() => atomicType_)
@@ -377,12 +366,24 @@ const functionType_: p.Parser<Token, unknown, ast.FunctionType> = p.abc(
   }
 )
 
+const recordTypeProperty_: p.Parser<Token, unknown, ast.RecordTypeProperty> = p.abc(
+  identifier_,
+  literal(':'),
+  p.recursive(() => type_),
+  (name, _colon, propertyType) => {
+    return ast.make('RecordTypeProperty', combineSourceRanges(name, propertyType), { name, propertyType })
+  }
+)
+
 const recordType_: p.Parser<Token, unknown, ast.RecordType> = p.abc(
   literal('{'),
-  p.recursive(() => parameterList_),
+  p.sepBy(
+    recordTypeProperty_,
+    literal(',')
+  ),
   expectLiteral('}'),
-  (_l, parameters, _r) => {
-    return ast.make('RecordType', combineSourceRanges(_l, _r), { parameters })
+  (_l, properties, _r) => {
+    return ast.make('RecordType', combineSourceRanges(_l, _r), { properties })
   }
 )
 
@@ -417,22 +418,24 @@ const parameter_: p.Parser<Token, unknown, ast.Parameter> = p.abc(
   identifier_,
   literal(':'),
   type_,
-  (name, _colon, type) => {
-    return ast.make('Parameter', combineSourceRanges(name, type), { name, parameterType: type })
+  (name, _colon, parameterType) => {
+    return ast.make('Parameter', combineSourceRanges(name, parameterType), { name, parameterType })
   }
 )
 
-const parameterList_: p.Parser<Token, unknown, readonly ast.Parameter[]> = p.sepBy(
-  parameter_,
-  literal(',')
+type ParameterList = readonly [Token, readonly ast.Parameter[], Token]
+
+const parameterList_: p.Parser<Token, unknown, ParameterList> = combine3(
+  literal('('),
+  p.sepBy(
+    parameter_,
+    literal(',')
+  ),
+  literal(')')
 )
 
 const function_: p.Parser<Token, unknown, ast.Function> = p.ab(
-  combine3(
-    literal('('),
-    parameterList_,
-    literal(')')
-  ),
+  parameterList_,
   combine3(
     literal('{'),
     p.recursive(() => p.many(statement_)),
@@ -489,31 +492,29 @@ const accessOrCall_: p.Parser<Token, unknown, ast.Expression> = p.ab(
         expect(identifier_, 'property name'),
         (_dot, property) => property
       ),
-      combine3(
-        literal('('),
-        p.recursive(() => argumentList_),
-        expectLiteral(')')
-      )
+      p.recursive(() => argumentList_)
     )
   ),
   (object, suffixes) => {
     let currentObject: ast.Expression = object
 
+    const isArgumentList = (suffix: ast.Identifier | ArgumentList): suffix is ArgumentList => {
+      return Array.isArray(suffix)
+    }
+
     for (const suffix of suffixes) {
-      // property access
-      if (!Array.isArray(suffix)) {
-        currentObject = ast.make('PropertyAccess', combineSourceRanges(currentObject, suffix), {
-          object: currentObject,
-          property: suffix
+      if (isArgumentList(suffix)) {
+        const [, args, _rp] = suffix
+        currentObject = ast.make('Call', combineSourceRanges(currentObject, _rp), {
+          callee: currentObject,
+          arguments: args
         })
         continue
       }
 
-      // call
-      const [, args, _rp] = suffix
-      currentObject = ast.make('Call', combineSourceRanges(currentObject, _rp), {
-        callee: currentObject,
-        arguments: args
+      currentObject = ast.make('PropertyAccess', combineSourceRanges(currentObject, suffix), {
+        object: currentObject,
+        property: suffix
       })
     }
 
@@ -591,9 +592,15 @@ const argument_: p.Parser<Token, unknown, ast.Argument> = p.eitherOr(
   })
 )
 
-const argumentList_: p.Parser<Token, unknown, readonly ast.Argument[]> = p.sepBy(
-  argument_,
-  literal(',')
+type ArgumentList = readonly [Token, readonly ast.Argument[], Token]
+
+const argumentList_: p.Parser<Token, unknown, ArgumentList> = combine3(
+  literal('('),
+  p.sepBy(
+    argument_,
+    literal(',')
+  ),
+  literal(')')
 )
 
 const import_: p.Parser<Token, unknown, ast.Import> = p.ab(
@@ -682,14 +689,7 @@ const statement_ = p.choice<Token, unknown, ast.Statement>(
 
 const part_: p.Parser<Token, unknown, ast.Part> = p.abc(
   keyword('part'),
-  p.option(
-    combine3(
-      literal('('),
-      argumentList_,
-      expectLiteral(')')
-    ),
-    undefined
-  ),
+  p.option(argumentList_, undefined),
   combine3(
     literal('{'),
     p.many(statement_),
@@ -705,14 +705,7 @@ const part_: p.Parser<Token, unknown, ast.Part> = p.abc(
 
 const track_: p.Parser<Token, unknown, ast.Track> = p.abc(
   keyword('track'),
-  p.option(
-    combine3(
-      literal('('),
-      argumentList_,
-      expectLiteral(')')
-    ),
-    undefined
-  ),
+  p.option(argumentList_, undefined),
   combine3(
     expectLiteral('{'),
     p.many(statement_),
@@ -728,14 +721,7 @@ const track_: p.Parser<Token, unknown, ast.Track> = p.abc(
 
 const bus_: p.Parser<Token, unknown, ast.Bus> = p.abc(
   keyword('bus'),
-  p.option(
-    combine3(
-      literal('('),
-      argumentList_,
-      expectLiteral(')')
-    ),
-    undefined
-  ),
+  p.option(argumentList_, undefined),
   combine3(
     literal('{'),
     p.many(statement_),
@@ -751,14 +737,7 @@ const bus_: p.Parser<Token, unknown, ast.Bus> = p.abc(
 
 const mixer_: p.Parser<Token, unknown, ast.Mixer> = p.abc(
   keyword('mixer'),
-  p.option(
-    combine3(
-      literal('('),
-      argumentList_,
-      expectLiteral(')')
-    ),
-    undefined
-  ),
+  p.option(argumentList_, undefined),
   combine3(
     expectLiteral('{'),
     p.many(statement_),
@@ -792,14 +771,7 @@ const voice_: p.Parser<Token, unknown, ast.Voice> = p.abc(
 
 const instrument_: p.Parser<Token, unknown, ast.Instrument> = p.abc(
   keyword('instrument'),
-  p.option(
-    combine3(
-      literal('('),
-      argumentList_,
-      expectLiteral(')')
-    ),
-    undefined
-  ),
+  p.option(argumentList_, undefined),
   combine3(
     expectLiteral('{'),
     p.many(statement_),

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -1031,7 +1031,7 @@ describe('parser/parser.ts', () => {
         name: { type: 'Identifier', name: 'p' },
         parameterType: {
           type: 'RecordType',
-          parameters: []
+          properties: []
         }
       }
     ])
@@ -1213,20 +1213,20 @@ describe('parser/parser.ts', () => {
             },
             {
               type: 'RecordType',
-              parameters: [
+              properties: [
                 {
-                  type: 'Parameter',
+                  type: 'RecordTypeProperty',
                   name: { type: 'Identifier', name: 'foo' },
-                  parameterType: {
+                  propertyType: {
                     type: 'NamedType',
                     name: { type: 'Identifier', name: 'number' },
                     generics: []
                   }
                 },
                 {
-                  type: 'Parameter',
+                  type: 'RecordTypeProperty',
                   name: { type: 'Identifier', name: 'bar' },
-                  parameterType: {
+                  propertyType: {
                     type: 'NamedType',
                     name: { type: 'Identifier', name: 'string' },
                     generics: []


### PR DESCRIPTION
This patch restructures parsing of argument lists and parameter lists, in both the parser and the editor grammar. In practice, these lists are always wrapped in parentheses, so we can make the parentheses part of the list node itself, which removes them at each usage site.

One exception is the record type syntax: This requires a parameter list- like syntax, but with braces. To accomodate this, `RecordTypeProperty` is added and used instead of `Parameter` in the `RecordType` AST node. This arguably makes more sense anyway.