### PR TITLE
feat!: Introduce syntax for `if` statements

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -25,13 +25,15 @@ export function make<T extends keyof NodeByType> (
 }
 
 export interface NodeByType {
+  Identifier: Identifier
+
   // Root
   Program: Program
-
-  // Building Blocks
   Import: Import
-  Statement: Statement
-  Identifier: Identifier
+
+  // Statements
+  SimpleStatement: SimpleStatement
+  IfStatement: IfStatement
 
   // Value Expressions
   UnaryExpression: UnaryExpression
@@ -93,6 +95,11 @@ export type Expression =
   PropertyAccess |
   Call
 
+export interface Identifier extends ASTNode {
+  readonly type: 'Identifier'
+  readonly name: string
+}
+
 // Root
 
 export interface Program extends ASTNode {
@@ -100,8 +107,6 @@ export interface Program extends ASTNode {
   readonly imports: readonly Import[]
   readonly children: readonly Statement[]
 }
-
-// Building Blocks
 
 export interface Import extends ASTNode {
   readonly type: 'Import'
@@ -113,27 +118,34 @@ export interface Import extends ASTNode {
   readonly alias?: string
 }
 
-export type Statement = NamedStatement | UnnamedStatement
+// Statements
 
-interface NamedStatement extends ASTNode {
-  readonly type: 'Statement'
+export type Statement = SimpleStatement | CompoundStatement
+export type CompoundStatement = IfStatement
+
+export type SimpleStatement = NamedSimpleStatement | UnnamedSimpleStatement
+
+interface NamedSimpleStatement extends ASTNode {
+  readonly type: 'SimpleStatement'
   readonly emit: boolean
   readonly expose: boolean
   readonly name: Identifier
   readonly values: readonly [Expression]
 }
 
-interface UnnamedStatement extends ASTNode {
-  readonly type: 'Statement'
+interface UnnamedSimpleStatement extends ASTNode {
+  readonly type: 'SimpleStatement'
   readonly emit: true
   readonly expose: false
   readonly name?: undefined
   readonly values: readonly [Expression, ...Expression[]]
 }
 
-export interface Identifier extends ASTNode {
-  readonly type: 'Identifier'
-  readonly name: string
+export interface IfStatement extends ASTNode {
+  readonly type: 'IfStatement'
+  readonly condition: Expression
+  readonly thenBranch: readonly Statement[]
+  readonly elseBranch?: readonly Statement[]
 }
 
 // Value Expressions

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -173,6 +173,10 @@ Import {
 }
 
 statement {
+  simpleStatement | compoundStatement
+}
+
+simpleStatement {
   Assignment | Emission | EmissionAssignment
 }
 
@@ -192,6 +196,17 @@ Emission {
 EmissionAssignment {
   "&"
   Assignment
+}
+
+compoundStatement {
+  IfStatement
+}
+
+IfStatement {
+  kw<"if">
+  expression
+  Block
+  (kw<"else"> Block)?
 }
 
 primary {

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -89,6 +89,8 @@ describe('language-support.ts', () => {
       '    & fx.pan(-1)',
       '  }',
       '}',
+      '',
+      'if true {} else {}',
       ''
     ].join('\n')
 
@@ -125,6 +127,9 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, ':', source.indexOf(':2'), 'separator')
     assertHighlightAt(spans, source, 'inst', useInstrumentStart, 'variable')
     assertHighlightAt(spans, source, 'fx', source.indexOf('fx.pan'), 'variable')
+    assertHighlightAt(spans, source, 'if', source.indexOf('if true {} else {}'), 'keyword')
+    assertHighlightAt(spans, source, 'true', source.indexOf('true {}'), 'keyword')
+    assertHighlightAt(spans, source, 'else', source.indexOf('else {}'), 'keyword')
   })
 
   it('higlights units only when used as members', () => {

--- a/packages/language/src/compiler/checker/statements.ts
+++ b/packages/language/src/compiler/checker/statements.ts
@@ -6,6 +6,7 @@ import { CompileError } from '../error.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import { checkExpression } from './expressions.ts'
 import type { MutableScope } from './scopes.ts'
+import { BooleanFacet } from '../../type-system/base/boolean.ts'
 
 export interface CheckedStatement {
   readonly errors: readonly CompileError[]
@@ -22,6 +23,20 @@ export interface Emission {
 export function checkStatement (
   scope: MutableScope,
   statement: ast.Statement,
+  existingProperties?: ReadonlyMap<string, FacetType>
+): CheckedStatement {
+  switch (statement.type) {
+    case 'SimpleStatement':
+      return checkSimpleStatement(scope, statement, existingProperties)
+
+    case 'IfStatement':
+      return checkIfStatement(scope, statement, existingProperties)
+  }
+}
+
+function checkSimpleStatement (
+  scope: MutableScope,
+  statement: ast.SimpleStatement,
   existingProperties?: ReadonlyMap<string, FacetType>
 ): CheckedStatement {
   const errors: CompileError[] = []
@@ -72,6 +87,37 @@ export function checkStatement (
     } else if (propertyValue != null) {
       properties.set(propertyName, values.at(0) ?? StringFacet.type())
     }
+  }
+
+  return { errors, capabilities, emissions, properties }
+}
+
+function checkIfStatement (
+  scope: MutableScope,
+  statement: ast.IfStatement,
+  existingProperties?: ReadonlyMap<string, FacetType>
+): CheckedStatement {
+  const errors: CompileError[] = []
+  let capabilities = noCapabilities
+  const emissions: Emission[] = []
+  const properties = new Map<string, FacetType>()
+
+  const conditionCheck = checkExpression(scope, statement.condition)
+  errors.push(...conditionCheck.errors)
+  capabilities = mergeCapabilities(capabilities, conditionCheck.capabilities)
+
+  if (conditionCheck.result != null && !BooleanFacet.is(conditionCheck.result)) {
+    errors.push(new CompileError(`Condition must be of type ${BooleanFacet.format()}, got ${conditionCheck.result.format()}`, statement.condition.range))
+  }
+
+  for (const child of statement.thenBranch) {
+    // TODO implement
+    errors.push(new CompileError(`Conditional statements are not yet supported`, child.range))
+  }
+
+  for (const child of statement.elseBranch ?? []) {
+    // TODO implement
+    errors.push(new CompileError(`Conditional statements are not yet supported`, child.range))
   }
 
   return { errors, capabilities, emissions, properties }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -140,6 +140,16 @@ interface Statement {
 }
 
 function processStatement (scope: MutableScope, statement: ast.Statement): Statement {
+  switch (statement.type) {
+    case 'SimpleStatement':
+      return processSimpleStatement(scope, statement)
+
+    case 'IfStatement':
+      return processIfStatement(scope, statement)
+  }
+}
+
+function processSimpleStatement (scope: MutableScope, statement: ast.SimpleStatement): Statement {
   const values = statement.values.map((value) => resolve(scope, value))
 
   if (statement.name != null) {
@@ -152,6 +162,24 @@ function processStatement (scope: MutableScope, statement: ast.Statement): State
   const properties = statement.expose
     ? new Map([[statement.name.name, nonNull(values.at(0))]])
     : new Map<string, Value>()
+
+  return { emissions, properties }
+}
+
+function processIfStatement (scope: MutableScope, statement: ast.IfStatement): Statement {
+  const conditionValue = resolve(scope, statement.condition)
+  const condition = BooleanFacet.get(conditionValue)
+
+  const branch = condition ? statement.thenBranch : statement.elseBranch ?? []
+
+  const emissions: Value[] = []
+  const properties = new Map<string, Value>()
+
+  for (const child of branch) {
+    const { emissions: childEmissions, properties: childProperties } = processStatement(scope, child)
+    emissions.push(...childEmissions)
+    setAll(properties, childProperties)
+  }
 
   return { emissions, properties }
 }

--- a/packages/language/src/parser/constants.ts
+++ b/packages/language/src/parser/constants.ts
@@ -3,6 +3,8 @@ export const keywords = Object.freeze([
   'false',
   'use',
   'as',
+  'if',
+  'else',
   'track',
   'part',
   'for',

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -633,7 +633,7 @@ const plainAssignment_: p.Parser<Token, unknown, ast.Statement> = p.ab(
     expression_
   ),
   (expose, [key, _eq, value]) => {
-    return ast.make('Statement', combineSourceRanges(expose ?? key, value), {
+    return ast.make('SimpleStatement', combineSourceRanges(expose ?? key, value), {
       emit: false,
       expose: expose != null,
       name: key,
@@ -655,7 +655,7 @@ const plainEmission_: p.Parser<Token, unknown, ast.Statement> = p.abc(
     const restValues = rest.map(([, value]) => value)
     const lastValue = restValues.at(-1) ?? firstValue
 
-    return ast.make('Statement', combineSourceRanges(_amp, lastValue), {
+    return ast.make('SimpleStatement', combineSourceRanges(_amp, lastValue), {
       emit: true,
       expose: false,
       values: [firstValue, ...restValues]
@@ -672,7 +672,7 @@ const emissionAssignment_: p.Parser<Token, unknown, ast.Statement> = p.abc(
     expression_
   ),
   (_amp, expose, [key, _eq, value]) => {
-    return ast.make('Statement', combineSourceRanges(_amp, value), {
+    return ast.make('SimpleStatement', combineSourceRanges(_amp, value), {
       emit: true,
       expose: expose != null,
       name: key,
@@ -681,10 +681,48 @@ const emissionAssignment_: p.Parser<Token, unknown, ast.Statement> = p.abc(
   }
 )
 
-const statement_ = p.choice<Token, unknown, ast.Statement>(
+const simpleStatement_ = p.choice<Token, unknown, ast.Statement>(
   plainAssignment_,
   emissionAssignment_,
   plainEmission_
+)
+
+const ifStatement_: p.Parser<Token, unknown, ast.IfStatement> = p.abc(
+  combine2(
+    keyword('if'),
+    expression_
+  ),
+  combine3(
+    literal('{'),
+    p.recursive(() => p.many(statement_)),
+    expectLiteral('}')
+  ),
+  p.option(
+    combine2(
+      keyword('else'),
+      combine3(
+        literal('{'),
+        p.recursive(() => p.many(statement_)),
+        expectLiteral('}')
+      )
+    ),
+    undefined
+  ),
+  ([_if, condition], [_lb, thenBranch, _rb], elseClause) => {
+    const elseBranch = elseClause?.[1][1]
+    const lastToken = elseClause?.[1][2] ?? _rb
+
+    return ast.make('IfStatement', combineSourceRanges(_if, lastToken), {
+      condition,
+      thenBranch,
+      elseBranch
+    })
+  }
+)
+
+const statement_: p.Parser<Token, unknown, ast.Statement> = p.choice<Token, unknown, ast.Statement>(
+  simpleStatement_,
+  ifStatement_
 )
 
 interface BuilderFields {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -327,7 +327,7 @@ describe('compiler/checker/checker.ts', () => {
       const pureFunction = ast.make('Function', getEmptySourceRange(), {
         parameters: [],
         children: [
-          ast.make('Statement', getEmptySourceRange(), {
+          ast.make('SimpleStatement', getEmptySourceRange(), {
             emit: true,
             expose: false,
             values: [
@@ -340,7 +340,7 @@ describe('compiler/checker/checker.ts', () => {
       const blockingFunction = ast.make('Function', getEmptySourceRange(), {
         parameters: [],
         children: [
-          ast.make('Statement', getEmptySourceRange(), {
+          ast.make('SimpleStatement', getEmptySourceRange(), {
             emit: true,
             expose: false,
             values: [
@@ -356,13 +356,13 @@ describe('compiler/checker/checker.ts', () => {
       const program = ast.make('Program', getEmptySourceRange(), {
         imports: [],
         children: [
-          ast.make('Statement', getEmptySourceRange(), {
+          ast.make('SimpleStatement', getEmptySourceRange(), {
             emit: false,
             expose: false,
             name: ast.make('Identifier', getEmptySourceRange(), { name: 'pure_function' }),
             values: [pureFunction]
           }),
-          ast.make('Statement', getEmptySourceRange(), {
+          ast.make('SimpleStatement', getEmptySourceRange(), {
             emit: false,
             expose: false,
             name: ast.make('Identifier', getEmptySourceRange(), { name: 'blocking_function' }),
@@ -1302,6 +1302,34 @@ describe('compiler/checker/checker.ts', () => {
 
       assertErrorMessages(source, [
         'Unknown identifier "foo"'
+      ])
+    })
+
+    it('should enforce boolean type for if statements', () => {
+      const source = [
+        'foo = 42',
+        'bar = ""',
+        'if foo {}',
+        'if bar {} else {}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Condition must be of type boolean, got number',
+        'Condition must be of type boolean, got string'
+      ])
+    })
+
+    it('should fail type checking for if statements with children', () => {
+      // TODO Remove this test once checking is implemented
+      const source = [
+        'if true { & 100 }',
+        'if false { & 200 } else { & 300 }'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Conditional statements are not yet supported', // 100
+        'Conditional statements are not yet supported', // 200
+        'Conditional statements are not yet supported' // 300
       ])
     })
   })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -909,4 +909,15 @@ describe('compiler/generator/generator.ts', () => {
     const result = generateSource(source)
     assert.strictEqual(result.track.tempo, 123)
   })
+
+  it('should ignore empty if statements', () => {
+    const source = [
+      '& track {',
+      '  if true {}',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.deepStrictEqual(result.track.parts, [])
+  })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -95,7 +95,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'foo' },
@@ -112,7 +112,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: true,
         expose: false,
         values: [
@@ -128,7 +128,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: true,
         expose: false,
         name: { type: 'Identifier', name: 'foo' },
@@ -145,7 +145,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: true,
         expose: false,
         values: [
@@ -173,7 +173,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: true,
         name: { type: 'Identifier', name: 'foo' },
@@ -200,7 +200,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'offset' },
@@ -217,7 +217,7 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'gain' },
@@ -248,7 +248,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'flag1' },
@@ -257,7 +257,7 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'flag2' },
@@ -284,7 +284,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'foo' },
@@ -317,7 +317,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'empty_record' },
@@ -329,7 +329,7 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'one_field' },
@@ -338,7 +338,7 @@ describe('parser/parser.ts', () => {
             type: 'RecordValue',
             children: [
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: false,
                 expose: true,
                 name: { type: 'Identifier', name: 'key' },
@@ -351,7 +351,7 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'complex' },
@@ -360,7 +360,7 @@ describe('parser/parser.ts', () => {
             type: 'RecordValue',
             children: [
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: false,
                 expose: false,
                 name: { type: 'Identifier', name: 'scratch' },
@@ -369,7 +369,7 @@ describe('parser/parser.ts', () => {
                 ]
               },
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: false,
                 expose: true,
                 name: { type: 'Identifier', name: 'foo' },
@@ -378,7 +378,7 @@ describe('parser/parser.ts', () => {
                     type: 'RecordValue',
                     children: [
                       {
-                        type: 'Statement',
+                        type: 'SimpleStatement',
                         emit: false,
                         expose: true,
                         name: { type: 'Identifier', name: 'bar' },
@@ -403,7 +403,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'foo' },
@@ -431,7 +431,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'foo' },
@@ -457,7 +457,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'pattern' },
@@ -487,7 +487,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'pattern' },
@@ -521,7 +521,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'pattern' },
@@ -545,7 +545,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'pattern' },
@@ -580,7 +580,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'pattern' },
@@ -620,7 +620,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'pattern' },
@@ -671,7 +671,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'pattern' },
@@ -700,7 +700,7 @@ describe('parser/parser.ts', () => {
     assertResultComplete(result)
 
     const assignment = result.value.children[0]
-    assert.strictEqual(assignment.type, 'Statement')
+    assert.strictEqual(assignment.type, 'SimpleStatement')
     assert.strictEqual(assignment.values[0].type, 'Pattern')
     assert.strictEqual(assignment.values[0].children[1]?.range.filePath, 'track.cadence')
   })
@@ -711,7 +711,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: true,
         expose: false,
         values: [
@@ -745,7 +745,7 @@ describe('parser/parser.ts', () => {
 
       assert.deepStrictEqual(stripRanges(result.value.children), [
         {
-          type: 'Statement',
+          type: 'SimpleStatement',
           emit: false,
           expose: false,
           name: { type: 'Identifier', name: 'x' },
@@ -771,7 +771,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'foo' },
@@ -817,7 +817,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'foo' },
@@ -868,7 +868,7 @@ describe('parser/parser.ts', () => {
 
       assert.deepStrictEqual(stripRanges(result.value.children), [
         {
-          type: 'Statement',
+          type: 'SimpleStatement',
           emit: false,
           expose: false,
           name: { type: 'Identifier', name: 'x' },
@@ -902,7 +902,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'x' },
@@ -936,7 +936,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'my_func' },
@@ -946,7 +946,7 @@ describe('parser/parser.ts', () => {
             parameters: [],
             children: [
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: true,
                 expose: false,
                 values: [
@@ -972,7 +972,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'my_func' },
@@ -1003,7 +1003,7 @@ describe('parser/parser.ts', () => {
             ],
             children: [
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: true,
                 expose: false,
                 values: [
@@ -1022,7 +1022,10 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource('func = (p: {}) { & 42 }'))
     assertResultComplete(result)
 
-    const func = result.value.children.at(0)?.values.at(0)
+    const statement = result.value.children.at(0)
+    assert.strictEqual(statement?.type, 'SimpleStatement')
+
+    const func = statement.values.at(0)
     assert.strictEqual(func?.type, 'Function')
 
     assert.deepStrictEqual(stripRanges(func.parameters), [
@@ -1041,7 +1044,10 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource('foo = (x: track, y: part, z: instrument) {}'))
     assertResultComplete(result)
 
-    const func = result.value.children.at(0)?.values.at(0)
+    const statement = result.value.children.at(0)
+    assert.strictEqual(statement?.type, 'SimpleStatement')
+
+    const func = statement.values.at(0)
     assert.strictEqual(func?.type, 'Function')
 
     assert.deepStrictEqual(stripRanges(func.parameters), [
@@ -1085,7 +1091,10 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource(source))
     assertResultComplete(result)
 
-    const foo = result.value.children.at(0)?.values.at(0)
+    const fooStatement = result.value.children.at(0)
+    assert.strictEqual(fooStatement?.type, 'SimpleStatement')
+
+    const foo = fooStatement.values.at(0)
     assert.strictEqual(foo?.type, 'Function')
 
     assert.deepStrictEqual(stripRanges(foo.parameters), [
@@ -1136,7 +1145,10 @@ describe('parser/parser.ts', () => {
       }
     ])
 
-    const bar = result.value.children.at(1)?.values.at(0)
+    const barStatement = result.value.children.at(1)
+    assert.strictEqual(barStatement?.type, 'SimpleStatement')
+
+    const bar = barStatement.values.at(0)
     assert.strictEqual(bar?.type, 'Function')
 
     assert.deepStrictEqual(stripRanges(bar.parameters), [
@@ -1188,7 +1200,10 @@ describe('parser/parser.ts', () => {
       }
     ])
 
-    const baz = result.value.children.at(2)?.values.at(0)
+    const bazStatement = result.value.children.at(2)
+    assert.strictEqual(bazStatement?.type, 'SimpleStatement')
+
+    const baz = bazStatement.values.at(0)
     assert.strictEqual(baz?.type, 'Function')
 
     assert.deepStrictEqual(stripRanges(baz.parameters), [
@@ -1244,7 +1259,10 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource('f = (p: (): (): number !foo !bar) {}'))
     assertResultComplete(result)
 
-    const func = result.value.children.at(0)?.values.at(0)
+    const statement = result.value.children.at(0)
+    assert.strictEqual(statement?.type, 'SimpleStatement')
+
+    const func = statement.values.at(0)
     assert.strictEqual(func?.type, 'Function')
 
     assert.deepStrictEqual(stripRanges(func.parameters), [
@@ -1288,7 +1306,7 @@ describe('parser/parser.ts', () => {
     assertResultComplete(result)
 
     assert.strictEqual(result.value.children.length, 1)
-    assert.strictEqual(result.value.children[0].type, 'Statement')
+    assert.strictEqual(result.value.children[0].type, 'SimpleStatement')
 
     const emissions = result.value.children[0].values
 
@@ -1298,7 +1316,7 @@ describe('parser/parser.ts', () => {
         arguments: [],
         children: [
           {
-            type: 'Statement',
+            type: 'SimpleStatement',
             emit: true,
             expose: false,
             values: [
@@ -1317,7 +1335,7 @@ describe('parser/parser.ts', () => {
                 ],
                 children: [
                   {
-                    type: 'Statement',
+                    type: 'SimpleStatement',
                     emit: true,
                     expose: false,
                     values: [
@@ -1327,7 +1345,7 @@ describe('parser/parser.ts', () => {
                     ]
                   },
                   {
-                    type: 'Statement',
+                    type: 'SimpleStatement',
                     emit: true,
                     expose: false,
                     values: [
@@ -1348,7 +1366,7 @@ describe('parser/parser.ts', () => {
                     ]
                   },
                   {
-                    type: 'Statement',
+                    type: 'SimpleStatement',
                     emit: true,
                     expose: true,
                     name: { type: 'Identifier', name: 'lp' },
@@ -1393,7 +1411,7 @@ describe('parser/parser.ts', () => {
     const result = parse(lexSource(source))
     assertResultComplete(result)
 
-    assert.strictEqual(result.value.children[0].type, 'Statement')
+    assert.strictEqual(result.value.children[0].type, 'SimpleStatement')
     assert.strictEqual(result.value.children[0].emit, true)
 
     const emissions = result.value.children[0].values
@@ -1404,7 +1422,7 @@ describe('parser/parser.ts', () => {
         arguments: [],
         children: [
           {
-            type: 'Statement',
+            type: 'SimpleStatement',
             emit: true,
             expose: false,
             values: [
@@ -1425,7 +1443,7 @@ describe('parser/parser.ts', () => {
             ]
           },
           {
-            type: 'Statement',
+            type: 'SimpleStatement',
             emit: true,
             expose: false,
             values: [
@@ -1465,7 +1483,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: true,
         expose: false,
         values: [
@@ -1474,7 +1492,7 @@ describe('parser/parser.ts', () => {
             arguments: [],
             children: [
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: false,
                 expose: false,
                 name: { type: 'Identifier', name: 'foo' },
@@ -1487,7 +1505,7 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: true,
         expose: false,
         values: [
@@ -1496,7 +1514,7 @@ describe('parser/parser.ts', () => {
             arguments: [],
             children: [
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: false,
                 expose: false,
                 name: { type: 'Identifier', name: 'bar' },
@@ -1529,7 +1547,7 @@ describe('parser/parser.ts', () => {
 
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'my_synth' },
@@ -1539,7 +1557,7 @@ describe('parser/parser.ts', () => {
             arguments: [],
             children: [
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: false,
                 expose: false,
                 name: { type: 'Identifier', name: 'foo' },
@@ -1556,7 +1574,7 @@ describe('parser/parser.ts', () => {
                 ]
               },
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: true,
                 expose: false,
                 values: [
@@ -1567,7 +1585,7 @@ describe('parser/parser.ts', () => {
                     },
                     children: [
                       {
-                        type: 'Statement',
+                        type: 'SimpleStatement',
                         emit: false,
                         expose: false,
                         name: { type: 'Identifier', name: 'bar' },
@@ -1584,7 +1602,7 @@ describe('parser/parser.ts', () => {
                 ]
               },
               {
-                type: 'Statement',
+                type: 'SimpleStatement',
                 emit: true,
                 expose: false,
                 values: [
@@ -1602,7 +1620,7 @@ describe('parser/parser.ts', () => {
         ]
       },
       {
-        type: 'Statement',
+        type: 'SimpleStatement',
         emit: false,
         expose: false,
         name: { type: 'Identifier', name: 'labeled_instrument' },
@@ -1619,6 +1637,75 @@ describe('parser/parser.ts', () => {
               }
             ],
             children: []
+          }
+        ]
+      }
+    ])
+  })
+
+  it('should parse if statements', () => {
+    const source = [
+      'if condition {',
+      '  & 42',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'IfStatement',
+        condition: { type: 'Identifier', name: 'condition' },
+        thenBranch: [
+          {
+            type: 'SimpleStatement',
+            emit: true,
+            expose: false,
+            values: [
+              { type: 'Number', value: 42 }
+            ]
+          }
+        ],
+        elseBranch: undefined
+      }
+    ])
+  })
+
+  it('should parse if-else statements', () => {
+    const source = [
+      'if condition {',
+      '  & 42',
+      '} else {',
+      '  & 43',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'IfStatement',
+        condition: { type: 'Identifier', name: 'condition' },
+        thenBranch: [
+          {
+            type: 'SimpleStatement',
+            emit: true,
+            expose: false,
+            values: [
+              { type: 'Number', value: 42 }
+            ]
+          }
+        ],
+        elseBranch: [
+          {
+            type: 'SimpleStatement',
+            emit: true,
+            expose: false,
+            values: [
+              { type: 'Number', value: 43 }
+            ]
           }
         ]
       }


### PR DESCRIPTION
This patch adds parser support for `if` statements, including optional `else` clauses. It is not yet possible to have any statements inside the statement's body -- this will be added in future patches.

Example:

```
condition = true

if condition {
  // do something
} else {
  // do something else
}
```

BREAKING CHANGE: Two new keywords are added (`if` and `else`).