### PR TITLE
feat: Add support for conditional assignments

### DIFF
--- a/packages/language-support/src/model/analysis/base.ts
+++ b/packages/language-support/src/model/analysis/base.ts
@@ -38,6 +38,40 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     return statement
   }
 
+  // A variable assigned in every reachable branch of a conditional is visible afterward,
+  // even though each assignment's own binding remains scoped to its own branch.
+  const mergeConditionalBindings = (parentScopeId: string, branchScopeIds: readonly string[], endOffset: number): void => {
+    const groups = new Map<string, Binding[]>()
+
+    for (const binding of bindings) {
+      if (binding.kind !== 'regular' || !branchScopeIds.includes(binding.scopeId)) {
+        continue
+      }
+
+      const group = groups.get(binding.name)
+      if (group == null) {
+        groups.set(binding.name, [binding])
+        continue
+      }
+
+      group.push(binding)
+    }
+
+    for (const [name, group] of groups) {
+      const firstDefinition = group.reduce((earliest, binding) => binding.range.offset < earliest.range.offset ? binding : earliest)
+
+      bindings.push({
+        id: conditionalBindingKey(parentScopeId, endOffset, name),
+        kind: 'regular',
+        scopeId: parentScopeId,
+        name,
+        range: firstDefinition.range,
+        visibilityStartOffset: endOffset,
+        mergedFrom: group.map((binding) => binding.id)
+      })
+    }
+  }
+
   const cursor = tree.cursor()
 
   const walk = (
@@ -61,6 +95,7 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
     let nextAssignmentIsExposed = assignmentIsExposed
     let accessChainTail: Identifier | undefined
     let deferredBinding: Omit<Binding, 'id'> | undefined
+    let conditionalBranchScopeIds: string[] | undefined
 
     switch (typeName) {
       case 'Import': {
@@ -84,6 +119,12 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       case 'Voice': {
         const scope = addScope({ node: typeName, range, parentId: scopeId })
         nextScopeId = scope.id
+        break
+      }
+
+      case 'IfStatement': {
+        conditionalBranchScopeIds = cursor.node.getChildren('Block')
+          .map((block) => scopeKey('Block', toSourceRange(document, block.from, block.to)))
         break
       }
 
@@ -192,6 +233,10 @@ export function computeBaseModel (tree: Tree, document: TextLike): BaseModel {
       addBinding(deferredBinding)
     }
 
+    if (typeName === 'IfStatement' && conditionalBranchScopeIds != null) {
+      mergeConditionalBindings(scopeId, conditionalBranchScopeIds, to)
+    }
+
     return accessChainTail
   }
 
@@ -250,6 +295,10 @@ function identifierKey (kind: IdentifierKind, scopeId: string, range: SourceRang
 
 function bindingKey (kind: BindingKind, scopeId: string, range: SourceRange): BindingId {
   return `${kind}:${scopeId}:${range.offset}:${range.length}` as BindingId
+}
+
+function conditionalBindingKey (scopeId: string, endOffset: number, name: string): BindingId {
+  return `merge:${scopeId}:${endOffset}:${name}` as BindingId
 }
 
 function importKey (moduleName: string, range: SourceRange): ImportId {

--- a/packages/language-support/src/model/analysis/references.ts
+++ b/packages/language-support/src/model/analysis/references.ts
@@ -29,6 +29,8 @@ export function computeReferenceModel (model: BaseModel): ReferenceModel {
     }
   }
 
+  mergeConditionalReferences(model.bindings, bindingReferences)
+
   sortReferences(bindingReferences)
   sortReferences(importReferences)
 
@@ -48,6 +50,27 @@ function addReference<Id> (map: Map<Id, Identifier[]>, id: Id, reference: Identi
 function sortReferences<Id> (map: Map<Id, Identifier[]>): void {
   for (const references of map.values()) {
     references.sort((a, b) => a.range.offset - b.range.offset)
+  }
+}
+
+// A merged binding has no references of its own yet.
+// Its per-branch bindings collect their own definitions. Only external usages resolve to it directly.
+function mergeConditionalReferences (bindings: readonly Binding[], bindingReferences: Map<BindingId, Identifier[]>): void {
+  for (const binding of bindings) {
+    if (binding.mergedFrom == null || binding.mergedFrom.length === 0) {
+      continue
+    }
+
+    const ownReferences = bindingReferences.get(binding.id) ?? []
+    const constituentDefinitions: Identifier[] = []
+
+    for (const constituentId of binding.mergedFrom) {
+      const constituentReferences = bindingReferences.get(constituentId) ?? []
+      constituentDefinitions.push(...constituentReferences)
+      bindingReferences.set(constituentId, [...constituentReferences, ...ownReferences])
+    }
+
+    bindingReferences.set(binding.id, [...constituentDefinitions, ...ownReferences])
   }
 }
 
@@ -74,7 +97,9 @@ function buildBindingLookup (model: BaseModel): BindingLookup {
       byScopeAndName.set(binding.scopeId, scopeMap)
     }
 
-    scopeMap.set(binding.name, binding)
+    if (!scopeMap.has(binding.name)) {
+      scopeMap.set(binding.name, binding)
+    }
   }
 
   for (const imp of model.imports) {

--- a/packages/language-support/src/model/model.ts
+++ b/packages/language-support/src/model/model.ts
@@ -83,6 +83,12 @@ export interface Binding {
    * this marks the first offset where the binding is visible.
    */
   readonly visibilityStartOffset?: number
+
+  /**
+   * For synthetic bindings representing a variable assigned in conditional branches,
+   * the bindings (one per branch) that were merged to produce this one.
+   */
+  readonly mergedFrom?: readonly BindingId[]
 }
 
 export type BindingKind = 'regular' | 'use-alias'

--- a/packages/language-support/src/unused-variable/operation.ts
+++ b/packages/language-support/src/unused-variable/operation.ts
@@ -34,6 +34,10 @@ function isUnusedBinding (binding: Binding, model: ReferenceModel): boolean {
     return false
   }
 
+  if (binding.mergedFrom != null) {
+    return false
+  }
+
   const references = model.bindingReferences.get(binding.id)
 
   // At most one reference, which would be the definition itself.

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -146,4 +146,25 @@ describe('go-to-definition/operation.ts', () => {
     assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'foo'.length))
     assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'foo'.length))
   })
+
+  it('resolves to first definition in conditional branches', () => {
+    const source = [
+      'if true {',
+      '  foo = 60.bpm',
+      '} else {',
+      '  foo = 70.bpm',
+      '}',
+      '',
+      '& track (foo) {}',
+      ''
+    ].join('\n')
+
+    const defPos = source.indexOf('foo = 60.bpm')
+    const refPos = source.lastIndexOf('foo)')
+
+    const result = applySemanticOperationWithParser(goToDefinition, cadenceParser, source, refPos)
+
+    assert.deepStrictEqual(result?.identifier.range, getRangeAt(source, refPos, 'foo'.length))
+    assert.deepStrictEqual(result.binding.range, getRangeAt(source, defPos, 'foo'.length))
+  })
 })

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -188,4 +188,28 @@ describe('highlight-occurrences/operation.ts', () => {
       ]
     )
   })
+
+  it('highlights conditional bindings and their references', () => {
+    const source = [
+      'if true {',
+      '  foo = 42',
+      '} else {',
+      '  foo = 43',
+      '}',
+      '',
+      'bar = foo',
+      ''
+    ].join('\n')
+
+    const position = source.lastIndexOf('foo') + 1
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findHighlightedOccurrences, cadenceParser, source, position),
+      [
+        getRangeAt(source, source.indexOf('foo = 42'), 'foo'.length),
+        getRangeAt(source, source.indexOf('foo = 43'), 'foo'.length),
+        getRangeAt(source, source.lastIndexOf('foo'), 'foo'.length)
+      ]
+    )
+  })
 })

--- a/packages/language-support/test/model/analysis/base.test.ts
+++ b/packages/language-support/test/model/analysis/base.test.ts
@@ -48,6 +48,10 @@ describe('model/analysis/base.ts', () => {
       '    & kick, snare',
       '  }',
       '}',
+      '',
+      'if true {',
+      '  conditional_variable = 42',
+      '}',
       ''
     ].join('\n')
 
@@ -91,7 +95,8 @@ describe('model/analysis/base.ts', () => {
         { kind: 'plain', scope: 'Block', name: 'clip' },
         { kind: 'plain', scope: 'Block', name: 'db' },
         { kind: 'plain', scope: 'Block', name: 'kick' },
-        { kind: 'plain', scope: 'Block', name: 'snare' }
+        { kind: 'plain', scope: 'Block', name: 'snare' },
+        { kind: 'definition', scope: 'Block', name: 'conditional_variable' }
       ]
     )
   })

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -389,4 +389,114 @@ describe('model/analysis/references.ts', () => {
     assert.strictEqual(binding.name, 'synth')
     assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('synth = sine()'), 'synth'.length))
   })
+
+  it('resolves bindings in conditional branches', () => {
+    const source = [
+      'if true {',
+      '  foo = 128.bpm',
+      '} else {',
+      '  foo = 140.bpm',
+      '}',
+      '',
+      '& track (foo) {}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.lastIndexOf('foo)')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution?.kind, 'binding')
+
+    const binding = resolution.binding
+    assert.strictEqual(binding.kind, 'regular')
+    assert.strictEqual(binding.name, 'foo')
+  })
+
+  it('resolves non-definite bindings in conditional branches', () => {
+    const source = [
+      'if true {',
+      '  if false {',
+      '    foo = 60.bpm',
+      '  } else {',
+      '    bar = 70.bpm',
+      '  }',
+      '}',
+      '',
+      '& track (foo + bar) {}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+
+    for (const name of ['foo', 'bar']) {
+      const position = source.lastIndexOf(name)
+
+      const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+      assert.ok(identifier != null)
+
+      const resolution = model.resolutions.get(identifier.id)
+      assert.strictEqual(resolution?.kind, 'binding')
+
+      const binding = resolution.binding
+      assert.strictEqual(binding.kind, 'regular')
+      assert.strictEqual(binding.name, name)
+    }
+  })
+
+  it('does not resolve bindings from within a different conditional branch', () => {
+    const source = [
+      'if true {',
+      '  foo = 128.bpm',
+      '} else {',
+      '  bar = foo // invalid reference',
+      '}',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+    const position = source.indexOf('foo // invalid reference')
+
+    const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+    assert.ok(identifier != null)
+
+    const resolution = model.resolutions.get(identifier.id)
+    assert.strictEqual(resolution, undefined)
+  })
+
+  it('prefers first definition over later definitions in conditional branches', () => {
+    const source = [
+      'foo = 1',
+      'bar = foo',
+      '',
+      'if true {',
+      '  foo = 2',
+      '} else {',
+      '  foo = 3',
+      '}',
+      '',
+      'baz = foo',
+      ''
+    ].join('\n')
+
+    const model = analyzeSource(source)
+
+    for (const name of ['bar', 'baz']) {
+      const position = source.indexOf(name) + name.length + ' = '.length
+
+      const identifier = model.identifiers.find((identifier) => identifier.range.offset === position)
+      assert.ok(identifier != null)
+
+      const resolution = model.resolutions.get(identifier.id)
+      assert.strictEqual(resolution?.kind, 'binding')
+
+      const binding = resolution.binding
+      assert.strictEqual(binding.kind, 'regular')
+      assert.strictEqual(binding.name, 'foo')
+      assert.deepStrictEqual(binding.range, getRangeAt(source, source.indexOf('foo = 1'), 'foo'.length))
+    }
+  })
 })

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -130,4 +130,25 @@ describe('unused-variable/operation.ts', () => {
       ]
     )
   })
+
+  it('does not report conditional assignments that are referenced', () => {
+    const source = [
+      'if (true) {',
+      '  used = sample("sound.wav")',
+      '} else {',
+      '  used = sample("sound.wav")',
+      '}',
+      '& track (120.bpm) {',
+      '  & part (4.bars) {',
+      '    & play(used, [x---])',
+      '  }',
+      '}',
+      ''
+    ].join('\n')
+
+    assert.deepStrictEqual(
+      applySemanticOperationWithParser(findUnusedVariables, cadenceParser, source),
+      []
+    )
+  })
 })

--- a/packages/language/src/compiler/checker/blocks.ts
+++ b/packages/language/src/compiler/checker/blocks.ts
@@ -9,7 +9,7 @@ import type { Facet, FacetType, Type } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
 import { checkArguments } from './arguments.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
-import type { Scope } from './scopes.ts'
+import type { Binding, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
 import type { Emission } from './statements.ts'
 import { checkStatement } from './statements.ts'
@@ -56,7 +56,7 @@ export interface BlockSchema<TBlock extends BlockNode> {
   /**
    * Compute the bindings that are available inside this block, if any. These may not be overridden by statements within the block.
    */
-  readonly getBindings?: (block: TBlock) => ReadonlyMap<string, FacetType>
+  readonly getBindings?: (block: TBlock) => ReadonlyMap<string, Binding>
 }
 
 export interface Slot {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -4,11 +4,11 @@ import type { Result } from '../../result/result.ts'
 import type { FunctionSpec } from '../../type-system/base/function.ts'
 import { MixerFacet } from '../../type-system/domain/mixer.ts'
 import { TrackFacet } from '../../type-system/domain/track.ts'
-import type { FacetType } from '../../type-system/types.ts'
 import { nonNull } from '../assert.ts'
 import { globalBuiltins } from '../builtins/global.ts'
 import { CompileError } from '../error.ts'
 import { checkImports } from './imports.ts'
+import type { Binding } from './scopes.ts'
 import { createGlobalScope, createLocalScope } from './scopes.ts'
 import { checkStatement } from './statements.ts'
 
@@ -40,9 +40,9 @@ export function check (program: ast.Program): CheckResult {
   }
 
   // global builtins win over imported names
-  const initialResolutions = new Map<string, FacetType>(importResult.result)
-  for (const [name, value] of globalBuiltins) {
-    initialResolutions.set(name, value.type)
+  const initialResolutions = new Map<string, Binding>(importResult.result)
+  for (const [name, { type }] of globalBuiltins) {
+    initialResolutions.set(name, { name, type, definite: true })
   }
 
   const globalScope = createGlobalScope(initialResolutions)
@@ -56,10 +56,6 @@ export function check (program: ast.Program): CheckResult {
   for (const child of program.children) {
     const statement = checkStatement(scope, child)
     errors.push(...statement.errors)
-
-    if (statement.properties.size > 0) {
-      errors.push(new CompileError('Cannot expose properties in the global scope', child.range))
-    }
 
     for (const emission of statement.emissions) {
       if (MixerFacet.is(emission.type)) {
@@ -79,6 +75,10 @@ export function check (program: ast.Program): CheckResult {
       }
 
       errors.push(new CompileError(`Unexpected type ${emission.type.format()}, expected track or mixer`, emission.range))
+    }
+
+    if (statement.properties.size > 0) {
+      errors.push(new CompileError('Cannot expose properties in the global scope', child.range))
     }
   }
 

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -36,7 +36,7 @@ import { checkArguments } from './arguments.ts'
 import { createBlockChecker } from './blocks.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import { checkParameters } from './parameters.ts'
-import type { Scope } from './scopes.ts'
+import type { Binding, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
 import { checkStatement } from './statements.ts'
 
@@ -115,12 +115,23 @@ function expectType (expected: Pick<Type, 'is' | 'format'>, actual: Type, range?
 }
 
 function checkIdentifier (scope: Scope, expression: ast.Identifier): Checked<FacetType> {
-  const valueType = resolveInScope(scope, expression.name)
-  if (valueType == null) {
-    return { errors: [new CompileError(`Unknown identifier "${expression.name}"`, expression.range)], capabilities: noCapabilities }
+  const errors: CompileError[] = []
+  const capabilities = noCapabilities
+
+  const binding = resolveInScope(scope, expression.name)
+  if (binding == null) {
+    errors.push(new CompileError(`Unknown identifier "${expression.name}"`, expression.range))
+    return { errors, capabilities }
   }
 
-  return { errors: [], capabilities: noCapabilities, result: valueType }
+  if (!binding.definite) {
+    errors.push(new CompileError(`Identifier "${expression.name}" is not definitely assigned`, expression.range))
+    return { errors, capabilities }
+  }
+
+  const result = binding.type
+
+  return { errors, capabilities, result }
 }
 
 function checkBoolean (scope: Scope, expression: ast.Boolean): Checked<FacetType> {
@@ -353,7 +364,10 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   }
 
   const parameters = parameterCheck.schema
-  setAll(functionScope.resolutions, parameterCheck.types)
+  const bindings = Array.from(parameterCheck.types.entries(), ([name, type]) => {
+    return [name, { name, type, definite: true }] as const
+  })
+  setAll(functionScope.resolutions, bindings)
 
   let hasReturn = false
   let returnType: FacetType | undefined
@@ -443,9 +457,18 @@ const checkVoice = createBlockChecker<ast.Voice>({
   ],
 
   getBindings: (expression) => {
-    return expression.bindings.note != null
-      ? new Map([[expression.bindings.note.name, noteType]])
-      : new Map()
+    const bindings = new Map<string, Binding>()
+
+    if (expression.bindings.note != null) {
+      bindings.set(expression.bindings.note.name, {
+        name: expression.bindings.note.name,
+        type: noteType,
+        definite: true,
+        range: expression.bindings.note.range
+      })
+    }
+
+    return bindings
   }
 })
 

--- a/packages/language/src/compiler/checker/imports.ts
+++ b/packages/language/src/compiler/checker/imports.ts
@@ -1,12 +1,13 @@
 import type { ast } from '@meyfa/cadence-ast'
 import { getStandardModuleNames, getStandardModuleValue } from '../../library/modules.ts'
 import { ModuleFacet } from '../../type-system/base/module.ts'
-import type { FacetType, Value } from '../../type-system/types.ts'
+import type { Value } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
+import type { Binding } from './scopes.ts'
 
 export interface CheckedImports {
   readonly errors: readonly CompileError[]
-  readonly result: ReadonlyMap<string, FacetType>
+  readonly result: ReadonlyMap<string, Binding>
 }
 
 export function checkImports (imports: readonly ast.Import[]): CheckedImports {
@@ -47,7 +48,7 @@ export function checkImports (imports: readonly ast.Import[]): CheckedImports {
     aliases.set(statement.alias, libraryName)
   }
 
-  const result = new Map<string, FacetType>()
+  const result = new Map<string, Binding>()
 
   if (errors.length > 0) {
     return { errors, result }
@@ -56,14 +57,14 @@ export function checkImports (imports: readonly ast.Import[]): CheckedImports {
   // defaults must come before aliases to allow aliasing over default imports
   for (const importName of defaults) {
     const module = ensureStandardModule(importName)
-    for (const [name, value] of ModuleFacet.get(module).exports.entries()) {
-      result.set(name, value.type)
+    for (const [name, { type }] of ModuleFacet.get(module).exports.entries()) {
+      result.set(name, { name, type, definite: true })
     }
   }
 
   for (const [alias, importName] of aliases) {
-    const module = ensureStandardModule(importName)
-    result.set(alias, module.type)
+    const { type } = ensureStandardModule(importName)
+    result.set(alias, { name: alias, type, definite: true })
   }
 
   return { errors, result }

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -1,13 +1,11 @@
-import { ast } from '@meyfa/cadence-ast'
+import type { ast, SourceRange } from '@meyfa/cadence-ast'
 import type { Capabilities, FunctionSpec } from '../../type-system/base/function.ts'
 import type { FacetType } from '../../type-system/types.ts'
-
-// scope types
 
 export interface Scope {
   readonly top: GlobalScope
   readonly parent?: Scope
-  readonly resolutions: ReadonlyMap<string, FacetType>
+  readonly resolutions: ReadonlyMap<string, Binding>
   readonly allowedCapabilities: Capabilities
 }
 
@@ -18,12 +16,17 @@ export interface GlobalScope extends Scope {
 }
 
 export interface MutableScope extends Scope {
-  readonly resolutions: Map<string, FacetType>
+  readonly resolutions: Map<string, Binding>
 }
 
-// factory functions
+export interface Binding {
+  readonly name: string
+  readonly type: FacetType
+  readonly definite: boolean
+  readonly range?: SourceRange
+}
 
-export function createGlobalScope (initialResolutions: ReadonlyMap<string, FacetType>): GlobalScope {
+export function createGlobalScope (initialResolutions: ReadonlyMap<string, Binding>): GlobalScope {
   const scope: GlobalScope = {
     // from Scope
     get top (): GlobalScope {

--- a/packages/language/src/compiler/checker/statements.ts
+++ b/packages/language/src/compiler/checker/statements.ts
@@ -1,4 +1,5 @@
 import type { SourceRange, ast } from '@meyfa/cadence-ast'
+import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import type { Capabilities } from '../../type-system/base/function.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
 import type { FacetType } from '../../type-system/types.ts'
@@ -6,7 +7,8 @@ import { CompileError } from '../error.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import { checkExpression } from './expressions.ts'
 import type { MutableScope } from './scopes.ts'
-import { BooleanFacet } from '../../type-system/base/boolean.ts'
+import { createLocalScope } from './scopes.ts'
+import { nonNull } from '../assert.ts'
 
 export interface CheckedStatement {
   readonly errors: readonly CompileError[]
@@ -41,6 +43,7 @@ function checkSimpleStatement (
 ): CheckedStatement {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
+
   const emissions: Emission[] = []
   const properties = new Map<string, FacetType>()
 
@@ -67,14 +70,16 @@ function checkSimpleStatement (
   }
 
   if (statement.name != null) {
-    const duplicate = scope.resolutions.has(statement.name.name)
+    const name = statement.name.name
+    const type = values.at(0)
+
+    const duplicate = scope.resolutions.has(name)
     if (duplicate) {
-      errors.push(new CompileError(`Identifier "${statement.name.name}" is already defined`, statement.name.range))
+      errors.push(new CompileError(`Identifier "${name}" is already defined`, statement.name.range))
     }
 
-    const type = values.at(0)
     if (type != null && !duplicate) {
-      scope.resolutions.set(statement.name.name, type)
+      scope.resolutions.set(name, { name, type, definite: true })
     }
   }
 
@@ -99,6 +104,7 @@ function checkIfStatement (
 ): CheckedStatement {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
+
   const emissions: Emission[] = []
   const properties = new Map<string, FacetType>()
 
@@ -110,14 +116,79 @@ function checkIfStatement (
     errors.push(new CompileError(`Condition must be of type ${BooleanFacet.format()}, got ${conditionCheck.result.format()}`, statement.condition.range))
   }
 
-  for (const child of statement.thenBranch) {
-    // TODO implement
-    errors.push(new CompileError(`Conditional statements are not yet supported`, child.range))
+  const thenScope = createLocalScope(scope)
+  const elseScope = createLocalScope(scope)
+
+  const thenBranch = checkBranch(thenScope, statement.thenBranch, existingProperties)
+  errors.push(...thenBranch.errors)
+  capabilities = mergeCapabilities(capabilities, thenBranch.capabilities)
+
+  const elseBranch = checkBranch(elseScope, statement.elseBranch ?? [], existingProperties)
+  errors.push(...elseBranch.errors)
+  capabilities = mergeCapabilities(capabilities, elseBranch.capabilities)
+
+  const assignedNames = new Set<string>([...thenScope.resolutions.keys(), ...elseScope.resolutions.keys()])
+
+  for (const name of assignedNames) {
+    const thenBinding = thenScope.resolutions.get(name)
+    const elseBinding = elseScope.resolutions.get(name)
+
+    if (scope.resolutions.has(name)) {
+      const message = `Identifier "${name}" is already defined`
+      if (thenBinding != null) {
+        errors.push(new CompileError(message, thenBinding.range))
+      }
+      if (elseBinding != null) {
+        errors.push(new CompileError(message, elseBinding.range))
+      }
+      continue
+    }
+
+    if (thenBinding == null || elseBinding == null) {
+      const binding = nonNull(thenBinding ?? elseBinding)
+      scope.resolutions.set(name, { ...binding, definite: false })
+      continue
+    }
+
+    if (!thenBinding.type.is(elseBinding.type) || !elseBinding.type.is(thenBinding.type)) {
+      const range = elseBinding.range ?? thenBinding.range ?? statement.range
+      errors.push(new CompileError(`Incompatible types for "${name}" in conditional branches: ${thenBinding.type.format()} and ${elseBinding.type.format()}`, range))
+      continue
+    }
+
+    scope.resolutions.set(name, {
+      ...thenBinding,
+      definite: thenBinding.definite && elseBinding.definite,
+      range: undefined
+    })
   }
 
-  for (const child of statement.elseBranch ?? []) {
-    // TODO implement
-    errors.push(new CompileError(`Conditional statements are not yet supported`, child.range))
+  return { errors, capabilities, emissions, properties }
+}
+
+function checkBranch (
+  scope: MutableScope,
+  statements: readonly ast.Statement[],
+  existingProperties?: ReadonlyMap<string, FacetType>
+): CheckedStatement {
+  const errors: CompileError[] = []
+  let capabilities = noCapabilities
+
+  const emissions: Emission[] = []
+  const properties = new Map<string, FacetType>()
+
+  for (const child of statements) {
+    const statement = checkStatement(scope, child, existingProperties)
+    errors.push(...statement.errors)
+    capabilities = mergeCapabilities(capabilities, statement.capabilities)
+
+    if (statement.emissions.length > 0) {
+      errors.push(new CompileError('Emissions in conditional branches are not yet supported', child.range))
+    }
+
+    if (statement.properties.size > 0) {
+      errors.push(new CompileError('Property exposure in conditional branches is not yet supported', child.range))
+    }
   }
 
   return { errors, capabilities, emissions, properties }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -600,6 +600,33 @@ describe('compiler/checker/checker.ts', () => {
 
       assertValid(source)
     })
+
+    it('should allow empty if statements', () => {
+      const source = [
+        'if true {}',
+        'if false {} else {}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow assignments within if statements', () => {
+      const source = [
+        'if true {',
+        '  foo = 100',
+        '  bar = foo + 1', // 101
+        '} else {',
+        '  foo = 200',
+        '  bar = foo + 2', // 202
+        '}',
+        '',
+        'if true {',
+        '  baz = 200', // non-definite assignment
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
   })
 
   describe('invalid', () => {
@@ -1319,17 +1346,96 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
-    it('should fail type checking for if statements with children', () => {
-      // TODO Remove this test once checking is implemented
+    it('should reject reassignment of a variable defined before a conditional branch', () => {
       const source = [
-        'if true { & 100 }',
-        'if false { & 200 } else { & 300 }'
+        'foo = 42',
+        'if true {',
+        '  foo = 100',
+        '}'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Conditional statements are not yet supported', // 100
-        'Conditional statements are not yet supported', // 200
-        'Conditional statements are not yet supported' // 300
+        'Identifier "foo" is already defined'
+      ])
+    })
+
+    it('should reject reassignment of a variable inside a conditional branch', () => {
+      const source = [
+        'if true {',
+        '  foo = 42',
+        '  foo = 100',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "foo" is already defined'
+      ])
+    })
+
+    it('should reject access to non-definitely assigned variables', () => {
+      const source = [
+        'if true {',
+        '  foo = 42',
+        '}',
+        '',
+        'if true {',
+        '  x = 100',
+        '} else {',
+        '  y = 200',
+        '}',
+        '',
+        'bar = foo',
+        'baz = x + y'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "foo" is not definitely assigned',
+        'Identifier "x" is not definitely assigned',
+        'Identifier "y" is not definitely assigned'
+      ])
+    })
+
+    it('should reject incompatible types in conditional branches', () => {
+      const source = [
+        'if true {',
+        '  foo = 42',
+        '} else {',
+        '  foo = "test"',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Incompatible types for "foo" in conditional branches: number and string'
+      ])
+    })
+
+    it('should reject emissions within if statements', () => {
+      // TODO Remove this test once checking is implemented for emission
+      const source = [
+        'if true { & 100 }',
+        'if false { & 101 } else { & 102 }'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Emissions in conditional branches are not yet supported', // 100
+        'Emissions in conditional branches are not yet supported', // 101
+        'Emissions in conditional branches are not yet supported' // 102
+      ])
+    })
+
+    it('should reject exposure within if statements', () => {
+      // TODO Remove this test once checking is implemented for exposure
+      const source = [
+        '& mixer {',
+        '  if true { @foo = 200 }',
+        '  if false { @bar = 201 } else { @bar = 202 }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Property exposure in conditional branches is not yet supported', // 200
+        'Property exposure in conditional branches is not yet supported', // 201
+        'Property exposure in conditional branches is not yet supported' // 202
       ])
     })
   })

--- a/packages/language/test/compiler/checker/scopes.test.ts
+++ b/packages/language/test/compiler/checker/scopes.test.ts
@@ -1,12 +1,17 @@
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
+import type { Binding } from '../../../src/compiler/checker/scopes.ts'
 import { createGlobalScope, createLocalScope } from '../../../src/compiler/checker/scopes.ts'
 import { NumberFacet } from '../../../src/type-system/base/number.ts'
 
 describe('compiler/checker/scopes.ts', () => {
   describe('createGlobalScope()', () => {
     it('should create a global scope with the provided initial resolutions', () => {
-      const foo = NumberFacet.with('db').type()
+      const foo: Binding = {
+        name: 'foo',
+        type: NumberFacet.with('db').type(),
+        definite: true
+      }
 
       const result = createGlobalScope(new Map([['foo', foo]]))
 
@@ -19,9 +24,13 @@ describe('compiler/checker/scopes.ts', () => {
 
   describe('createLocalScope()', () => {
     it('should create a local scope with the provided parent and empty resolutions', () => {
-      const globalScope = createGlobalScope(new Map([
-        ['foo', NumberFacet.with('db').type()]
-      ]))
+      const foo: Binding = {
+        name: 'foo',
+        type: NumberFacet.with('db').type(),
+        definite: true
+      }
+
+      const globalScope = createGlobalScope(new Map([['foo', foo]]))
 
       const localScope = createLocalScope(globalScope)
 
@@ -30,7 +39,12 @@ describe('compiler/checker/scopes.ts', () => {
       assert.strictEqual(localScope.resolutions.get('foo'), undefined)
       assert.deepStrictEqual(localScope.allowedCapabilities, globalScope.allowedCapabilities)
 
-      const bar = NumberFacet.with(undefined).type()
+      const bar: Binding = {
+        name: 'bar',
+        type: NumberFacet.with(undefined).type(),
+        definite: false
+      }
+
       localScope.resolutions.set('bar', bar)
       assert.strictEqual(localScope.resolutions.get('bar'), bar)
       assert.strictEqual(globalScope.resolutions.get('bar'), undefined)
@@ -43,9 +57,7 @@ describe('compiler/checker/scopes.ts', () => {
     })
 
     it('can override allowed capabilities', () => {
-      const globalScope = createGlobalScope(new Map([
-        ['foo', NumberFacet.with('db').type()]
-      ]))
+      const globalScope = createGlobalScope(new Map())
 
       const localScopeWithoutOverride = createLocalScope(globalScope)
       assert.deepStrictEqual(localScopeWithoutOverride.allowedCapabilities, { mayBlock: true })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -914,10 +914,28 @@ describe('compiler/generator/generator.ts', () => {
     const source = [
       '& track {',
       '  if true {}',
+      '  if false {} else {}',
       '}'
     ].join('\n')
 
     const result = generateSource(source)
     assert.deepStrictEqual(result.track.parts, [])
+  })
+
+  it('should resolve variables defined in if statements', () => {
+    for (const condition of ['true', 'false']) {
+      const source = [
+        `if ${condition} {`,
+        '  my_tempo = 90.bpm',
+        '} else {',
+        '  my_tempo = 150.bpm',
+        '}',
+        '',
+        '& track (tempo: my_tempo) {}'
+      ].join('\n')
+
+      const result = generateSource(source)
+      assert.strictEqual(result.track.tempo, condition === 'true' ? 90 : 150)
+    }
   })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -1711,4 +1711,16 @@ describe('parser/parser.ts', () => {
       }
     ])
   })
+
+  it('should reject imports within if statements', () => {
+    const source = [
+      'if condition {',
+      '  import "foo"',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assert.strictEqual(result.complete, false)
+    assert.strictEqual(result.error.message, 'Unexpected "import"; expected "}"')
+  })
 })


### PR DESCRIPTION
It is now possible to assign variables within if/else blocks. These are the rules:

* For names which are assigned in multiple branches, the types must match; the name is then added to the parent scope as a fully usable variable, too.
* For names which are assigned in only one branch, the name is marked as non-definite in the parent scope. When accessed, non-definite names will be treated as if they are undefined, though a different error message is produced than if they were fully undefined.
* It is not allowed to shadow an existing variable in a conditional branch, and not allowed to reassign a variable after the conditional.
* Within a single branch, assignments are treated as normal (definite).

Property exposure and emissions are yet to be implemented still.