### PR TITLE
feat: Implement type intersection

### DIFF
--- a/packages/language/src/type-system/base/record.ts
+++ b/packages/language/src/type-system/base/record.ts
@@ -34,7 +34,7 @@ function normalizeRecordData<Fields extends RecordGenerics> (data: unknown): Rec
 const EMPTY_RECORD_GENERICS = cloneOwnProperties({} as Record<string, unknown>) as RecordGenerics
 
 function mergeRecordGenerics (a: RecordGenerics, b: RecordGenerics): RecordGenerics | undefined {
-  const fields: Record<string, FacetType> = {}
+  const fields: Record<string, FacetType> = Object.create(null)
 
   for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
     const aType = a[key]
@@ -56,6 +56,25 @@ function mergeRecordGenerics (a: RecordGenerics, b: RecordGenerics): RecordGener
   return fields
 }
 
+function intersectRecordGenerics (a: RecordGenerics, b: RecordGenerics): RecordGenerics | undefined {
+  const fields: Record<string, FacetType> = Object.create(null)
+
+  for (const key of Object.keys(a)) {
+    const aType = a[key]
+    const bType = b[key]
+
+    const intersection = aType != null && bType != null
+      ? aType.intersect(bType)
+      : undefined
+
+    if (intersection != null) {
+      fields[key] = intersection
+    }
+  }
+
+  return fields
+}
+
 function recordWith<const Fields extends RecordGenerics> (fields: Fields): Facet<typeof FACET_NAME, RecordDataForFields<Fields>> {
   const safeFields = cloneOwnProperties(fields)
 
@@ -67,7 +86,9 @@ function recordWith<const Fields extends RecordGenerics> (fields: Fields): Facet
 
       return `{${fields}}`
     },
+
     normalize: (data) => normalizeRecordData<Fields>(data),
+
     merge: (other: Facet) => {
       if (other.name !== FACET_NAME) {
         return undefined
@@ -75,6 +96,15 @@ function recordWith<const Fields extends RecordGenerics> (fields: Fields): Facet
 
       const merged = mergeRecordGenerics(safeFields, other.generics as RecordGenerics)
       return merged == null ? undefined : recordWith(merged)
+    },
+
+    intersect: (other: Facet) => {
+      if (other.name !== FACET_NAME) {
+        return undefined
+      }
+
+      const intersected = intersectRecordGenerics(safeFields, other.generics as RecordGenerics)
+      return intersected == null ? undefined : recordWith(intersected)
     }
   })
 }
@@ -82,8 +112,17 @@ function recordWith<const Fields extends RecordGenerics> (fields: Fields): Facet
 export const RecordFacet = {
   ...makeFacet<typeof FACET_NAME, RecordDataForFields<RecordGenerics>>(FACET_NAME, EMPTY_RECORD_GENERICS, {
     normalize: (data) => normalizeRecordData<RecordGenerics>(data),
-    merge: (other: Facet) => {
+
+    merge: (other: Facet): Facet | undefined => {
+      // The generics of 'this' are unknown, so return the other facet such that
+      // merge(this, other) yields precisely the known fields of other as the most specific safe type.
       return other.name === FACET_NAME ? other : undefined
+    },
+
+    intersect: (other: Facet): Facet | undefined => {
+      // The generics of 'this' are unknown, which makes intersection generally impossible to compute,
+      // so return an empty record type as the most specific safe type.
+      return other.name === FACET_NAME ? recordWith(EMPTY_RECORD_GENERICS) : undefined
     }
   }),
 

--- a/packages/language/src/type-system/factory.ts
+++ b/packages/language/src/type-system/factory.ts
@@ -5,6 +5,7 @@ export interface FacetOptions<Data = unknown> {
   readonly format?: () => string
   readonly normalize?: (data: unknown) => Data
   readonly merge?: (other: Facet) => Facet | undefined
+  readonly intersect?: (other: Facet) => Facet | undefined
 }
 
 export function makeFacet<const Name extends string, Data> (
@@ -40,17 +41,8 @@ export function makeFacet<const Name extends string, Data> (
       return value.data.get(facet.name) as SpecificFacetDataForValue<V, Name, Data>
     },
 
-    merge: options?.merge ?? ((other: Facet) => {
-      if (facet.name !== other.name) {
-        return undefined
-      }
-
-      if (isFacetAssignableFromFacet(facet, other) && isFacetAssignableFromFacet(other, facet)) {
-        return facet
-      }
-
-      return undefined
-    }),
+    merge: options?.merge ?? ((other: Facet) => mergeFacets(facet, other)),
+    intersect: options?.intersect ?? ((other: Facet) => intersectFacets(facet, other)),
 
     type: () => {
       cachedType ??= makeType(facet)
@@ -61,6 +53,34 @@ export function makeFacet<const Name extends string, Data> (
   }
 
   return facet
+}
+
+function mergeFacets (facet: Facet, other: Facet): Facet | undefined {
+  if (facet.name !== other.name) {
+    return undefined
+  }
+
+  if (isFacetAssignableFromFacet(facet, other) && isFacetAssignableFromFacet(other, facet)) {
+    return facet
+  }
+
+  return undefined
+}
+
+function intersectFacets (facet: Facet, other: Facet): Facet | undefined {
+  if (facet.name !== other.name) {
+    return undefined
+  }
+
+  if (isFacetAssignableFromFacet(facet, other)) {
+    return facet
+  }
+
+  if (isFacetAssignableFromFacet(other, facet)) {
+    return other
+  }
+
+  return undefined
 }
 
 export function makeType<const Facets extends readonly Facet[]> (
@@ -104,32 +124,8 @@ export function makeType<const Facets extends readonly Facet[]> (
       return { type, data: dataMap }
     },
 
-    merge: (other: FacetType): FacetType | undefined => {
-      if (other === type) {
-        return type
-      }
-
-      const mergedFacets: Facet[] = []
-
-      for (const name of new Set([...type.facets.keys(), ...other.facets.keys()])) {
-        const a = type.facets.get(name)
-        const b = other.facets.get(name)
-
-        if (a != null && b != null) {
-          const merged = a.merge(b)
-          if (merged == null) {
-            return undefined
-          }
-          mergedFacets.push(merged)
-        } else if (a != null) {
-          mergedFacets.push(a)
-        } else if (b != null) {
-          mergedFacets.push(b)
-        }
-      }
-
-      return makeType(...mergedFacets)
-    },
+    merge: (other: FacetType): FacetType | undefined => mergeFacetTypes(type, other),
+    intersect: (other: FacetType): FacetType | undefined => intersectFacetTypes(type, other),
 
     getFacet: (name: string): Facets[number] => {
       const facet = type.facets.get(name)
@@ -141,6 +137,61 @@ export function makeType<const Facets extends readonly Facet[]> (
   } satisfies FacetType<Facets>
 
   return type
+}
+
+function mergeFacetTypes (type: FacetType, other: FacetType): FacetType | undefined {
+  if (other === type) {
+    return type
+  }
+
+  const resultFacets: Facet[] = []
+
+  for (const name of new Set([...type.facets.keys(), ...other.facets.keys()])) {
+    const a = type.facets.get(name)
+    const b = other.facets.get(name)
+
+    if (a != null && b != null) {
+      const merged = a.merge(b)
+      if (merged == null) {
+        return undefined
+      }
+      resultFacets.push(merged)
+    } else if (a != null) {
+      resultFacets.push(a)
+    } else if (b != null) {
+      resultFacets.push(b)
+    }
+  }
+
+  return makeType(...resultFacets)
+}
+
+function intersectFacetTypes (type: FacetType, other: FacetType): FacetType | undefined {
+  if (other === type) {
+    return type
+  }
+
+  const resultFacets: Facet[] = []
+
+  for (const [name, a] of type.facets) {
+    const b = other.facets.get(name)
+    if (b == null) {
+      continue
+    }
+
+    const intersected = a.intersect(b)
+    if (intersected == null) {
+      continue
+    }
+
+    resultFacets.push(intersected)
+  }
+
+  if (resultFacets.length === 0) {
+    return undefined
+  }
+
+  return makeType(...resultFacets)
 }
 
 export function makeUnion<const Members extends readonly FacetType[]> (

--- a/packages/language/src/type-system/types.ts
+++ b/packages/language/src/type-system/types.ts
@@ -9,7 +9,10 @@ export interface FacetType<Facets extends readonly Facet[] = readonly Facet[]> {
   readonly is: (other: Type) => boolean
   readonly has: (value: Value) => value is ValueForType<FacetType<Facets>>
   readonly of: (...data: DataForFacets<Facets>) => ValueForType<FacetType<Facets>>
+
   readonly merge: (other: FacetType) => FacetType | undefined
+  readonly intersect: (other: FacetType) => FacetType | undefined
+
   readonly getFacet: (name: string) => Facets[number]
 }
 
@@ -29,7 +32,9 @@ export interface Facet<Name extends string = string, Data = unknown> {
   readonly is: (other: Facet | Type) => boolean
   readonly has: (value: Value) => value is Value<Facet<Name, Data>>
   readonly get: <const V extends Value>(value: V) => SpecificFacetDataForValue<V, Name, Data>
+
   readonly merge: (other: Facet) => Facet | undefined
+  readonly intersect: (other: Facet) => Facet | undefined
 
   readonly type: () => FacetType<[Facet<Name, Data>]>
 

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -39,6 +39,11 @@ describe('type-system/base', () => {
       assert.strictEqual(BooleanFacet.merge(NumberFacet), undefined)
     })
 
+    it('should intersect by identity', () => {
+      assert.strictEqual(BooleanFacet.intersect(BooleanFacet), BooleanFacet)
+      assert.strictEqual(BooleanFacet.intersect(NumberFacet), undefined)
+    })
+
     it('should create a single-facet type', () => {
       const booleanType = BooleanFacet.type()
       assert.deepStrictEqual([...booleanType.facets.keys()], ['boolean'])
@@ -253,6 +258,129 @@ describe('type-system/base', () => {
       assert.strictEqual(mergedCA, undefined)
     })
 
+    it('should intersect function facets based on assignability of parameters and return types', () => {
+      const noParametersReturnString = FunctionFacet.with({
+        parameters: makeSchema([]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const noParametersReturnStringBlocking = FunctionFacet.with({
+        parameters: makeSchema([]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: true }
+      })
+
+      const oneParameterReturnString = FunctionFacet.with({
+        parameters: makeSchema([{ name: 'amount', type: NumberFacet.with(undefined).type(), required: true }]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const optionalParameterReturnString = FunctionFacet.with({
+        parameters: makeSchema([{ name: 'amount', type: NumberFacet.with(undefined).type(), required: false }]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const noParametersReturnNumber = FunctionFacet.with({
+        parameters: makeSchema([]),
+        returnType: NumberFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const sameOneParameterReturnString = FunctionFacet.with({
+        parameters: makeSchema([{ name: 'value', type: NumberFacet.with(undefined).type(), required: true }]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const otherOneParameterReturnString = FunctionFacet.with({
+        parameters: makeSchema([{ name: 'amount', type: NumberFacet.with('db').type(), required: true }]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const identicalA = FunctionFacet.with({
+        parameters: makeSchema([]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const identicalB = FunctionFacet.with({
+        parameters: makeSchema([]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const broadRecord = RecordFacet.with({ gain: NumberFacet.with('db').type() })
+      const narrowRecord = RecordFacet.with({ gain: NumberFacet.with('db').type(), frequency: NumberFacet.with('hz').type() })
+
+      const broadParameter = FunctionFacet.with({
+        parameters: makeSchema([{ name: 'record', type: broadRecord.type(), required: true }]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const narrowParameter = FunctionFacet.with({
+        parameters: makeSchema([{ name: 'record', type: narrowRecord.type(), required: true }]),
+        returnType: StringFacet.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const broadReturn = FunctionFacet.with({
+        parameters: makeSchema([]),
+        returnType: broadRecord.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      const narrowReturn = FunctionFacet.with({
+        parameters: makeSchema([]),
+        returnType: narrowRecord.type(),
+        capabilities: { mayBlock: false }
+      })
+
+      assert.strictEqual(identicalA.intersect(identicalB), identicalA)
+      assert.strictEqual(identicalB.intersect(identicalA), identicalB)
+
+      const intersectedBaseSpecific = FunctionFacet.intersect(noParametersReturnString)
+      assert.ok(intersectedBaseSpecific != null)
+      assert.strictEqual(intersectedBaseSpecific.format(), FunctionFacet.format())
+      assert.strictEqual(intersectedBaseSpecific.is(FunctionFacet), true)
+      assert.strictEqual(FunctionFacet.is(intersectedBaseSpecific), true)
+
+      assert.strictEqual(noParametersReturnString.intersect(FunctionFacet), FunctionFacet)
+
+      assert.strictEqual(noParametersReturnStringBlocking.intersect(noParametersReturnString), noParametersReturnStringBlocking)
+      assert.strictEqual(noParametersReturnString.intersect(noParametersReturnStringBlocking), noParametersReturnStringBlocking)
+
+      assert.strictEqual(oneParameterReturnString.intersect(optionalParameterReturnString), oneParameterReturnString)
+      assert.strictEqual(optionalParameterReturnString.intersect(oneParameterReturnString), oneParameterReturnString)
+
+      assert.strictEqual(noParametersReturnString.intersect(optionalParameterReturnString), noParametersReturnString)
+      assert.strictEqual(optionalParameterReturnString.intersect(noParametersReturnString), noParametersReturnString)
+
+      assert.strictEqual(narrowParameter.intersect(broadParameter), narrowParameter)
+      assert.strictEqual(broadParameter.intersect(narrowParameter), narrowParameter)
+
+      assert.strictEqual(broadReturn.intersect(narrowReturn), broadReturn)
+      assert.strictEqual(narrowReturn.intersect(broadReturn), broadReturn)
+
+      assert.strictEqual(noParametersReturnString.intersect(oneParameterReturnString), undefined)
+      assert.strictEqual(oneParameterReturnString.intersect(noParametersReturnString), undefined)
+
+      assert.strictEqual(oneParameterReturnString.intersect(sameOneParameterReturnString), undefined)
+      assert.strictEqual(sameOneParameterReturnString.intersect(oneParameterReturnString), undefined)
+
+      assert.strictEqual(oneParameterReturnString.intersect(otherOneParameterReturnString), undefined)
+      assert.strictEqual(otherOneParameterReturnString.intersect(oneParameterReturnString), undefined)
+
+      assert.strictEqual(noParametersReturnString.intersect(noParametersReturnNumber), undefined)
+      assert.strictEqual(noParametersReturnNumber.intersect(noParametersReturnString), undefined)
+
+      assert.strictEqual(noParametersReturnString.intersect(StringFacet), undefined)
+    })
+
     it('should create a single-facet type', () => {
       const functionType = FunctionFacet.type()
       assert.deepStrictEqual([...functionType.facets.keys()], ['function'])
@@ -412,6 +540,31 @@ describe('type-system/base', () => {
       assert.strictEqual(mergedDA, undefined)
     })
 
+    it('should intersect number facets with identical units', () => {
+      const facetA = NumberFacet.with('db')
+      const facetB = NumberFacet.with('db')
+      const facetC = NumberFacet.with('hz')
+      const facetD = NumberFacet.with(undefined)
+
+      const intersectionAB = facetA.intersect(facetB)
+      assert.strictEqual(intersectionAB, facetA)
+
+      const intersectionBA = facetB.intersect(facetA)
+      assert.strictEqual(intersectionBA, facetB)
+
+      const intersectionAC = facetA.intersect(facetC)
+      assert.strictEqual(intersectionAC, undefined)
+
+      const intersectionCA = facetC.intersect(facetA)
+      assert.strictEqual(intersectionCA, undefined)
+
+      const intersectionAD = facetA.intersect(facetD)
+      assert.strictEqual(intersectionAD, undefined)
+
+      const intersectionDA = facetD.intersect(facetA)
+      assert.strictEqual(intersectionDA, undefined)
+    })
+
     it('should create a single-facet type', () => {
       const numberType = NumberFacet.type()
       assert.deepStrictEqual([...numberType.facets.keys()], ['number'])
@@ -564,6 +717,100 @@ describe('type-system/base', () => {
       assert.strictEqual(mergedNested.format(), '{foo: {a: (string + number), b: number, c: number.db}}')
     })
 
+    it('should intersect record generics', () => {
+      const emptyRecordFacet = RecordFacet.with({})
+
+      const broadRecordFacet = RecordFacet.with({
+        gain: NumberFacet.with('db').type()
+      })
+
+      const narrowRecordFacet = RecordFacet.with({
+        gain: NumberFacet.with('db').type(),
+        label: StringFacet.type()
+      })
+
+      const incompatibleRecordFacet = RecordFacet.with({
+        gain: NumberFacet.with('hz').type(),
+        label: StringFacet.type()
+      })
+
+      const labelRecordFacet = RecordFacet.with({
+        label: StringFacet.type()
+      })
+
+      const intersectedEmptyEmpty = emptyRecordFacet.intersect(emptyRecordFacet)
+      assert.ok(intersectedEmptyEmpty != null)
+      assert.strictEqual(intersectedEmptyEmpty.name, 'record')
+      assert.deepStrictEqual(intersectedEmptyEmpty.generics, emptyRecordFacet.generics)
+
+      const intersectedBroadBroad = broadRecordFacet.intersect(broadRecordFacet)
+      assert.ok(intersectedBroadBroad != null)
+      assert.strictEqual(intersectedBroadBroad.name, 'record')
+      assert.deepStrictEqual(intersectedBroadBroad.generics, broadRecordFacet.generics)
+
+      const intersectedNarrowNarrow = narrowRecordFacet.intersect(narrowRecordFacet)
+      assert.ok(intersectedNarrowNarrow != null)
+      assert.strictEqual(intersectedNarrowNarrow.name, 'record')
+      assert.deepStrictEqual(intersectedNarrowNarrow.generics, narrowRecordFacet.generics)
+
+      const intersectedBroadNarrow = broadRecordFacet.intersect(narrowRecordFacet)
+      assert.ok(intersectedBroadNarrow != null)
+      assert.strictEqual(intersectedBroadNarrow.name, 'record')
+      assert.deepStrictEqual(intersectedBroadNarrow.generics, broadRecordFacet.generics)
+
+      const intersectedNarrowBroad = narrowRecordFacet.intersect(broadRecordFacet)
+      assert.ok(intersectedNarrowBroad != null)
+      assert.strictEqual(intersectedNarrowBroad.name, 'record')
+      assert.deepStrictEqual(intersectedNarrowBroad.generics, broadRecordFacet.generics)
+
+      const intersectedBroadIncompatible = broadRecordFacet.intersect(incompatibleRecordFacet)
+      assert.ok(intersectedBroadIncompatible != null)
+      assert.strictEqual(intersectedBroadIncompatible.name, 'record')
+      assert.deepStrictEqual(intersectedBroadIncompatible.generics, emptyRecordFacet.generics)
+
+      const intersectedIncompatibleBroad = incompatibleRecordFacet.intersect(broadRecordFacet)
+      assert.ok(intersectedIncompatibleBroad != null)
+      assert.strictEqual(intersectedIncompatibleBroad.name, 'record')
+      assert.deepStrictEqual(intersectedIncompatibleBroad.generics, emptyRecordFacet.generics)
+
+      const intersectedNarrowIncompatible = narrowRecordFacet.intersect(incompatibleRecordFacet)
+      assert.ok(intersectedNarrowIncompatible != null)
+      assert.strictEqual(intersectedNarrowIncompatible.name, 'record')
+      assert.deepStrictEqual(intersectedNarrowIncompatible.generics, labelRecordFacet.generics)
+
+      const intersectedIncompatibleNarrow = incompatibleRecordFacet.intersect(narrowRecordFacet)
+      assert.ok(intersectedIncompatibleNarrow != null)
+      assert.strictEqual(intersectedIncompatibleNarrow.name, 'record')
+      assert.deepStrictEqual(intersectedIncompatibleNarrow.generics, labelRecordFacet.generics)
+
+      const intersectedEmptyOther = emptyRecordFacet.intersect(StringFacet)
+      assert.strictEqual(intersectedEmptyOther, undefined)
+
+      const intersectedBroadOther = broadRecordFacet.intersect(StringFacet)
+      assert.strictEqual(intersectedBroadOther, undefined)
+
+      const nestedRecordFacet0 = RecordFacet.with({
+        foo: RecordFacet.with({
+          a: StringFacet.type(),
+          b: NumberFacet.with(undefined).type()
+        }).type()
+      })
+
+      const nestedRecordFacet1 = RecordFacet.with({
+        foo: RecordFacet.with({
+          a: StringFacet.type(),
+          c: NumberFacet.with('db').type()
+        }).type()
+      })
+
+      const intersectedNested = nestedRecordFacet0.intersect(nestedRecordFacet1)
+      assert.ok(intersectedNested != null)
+      assert.strictEqual(intersectedNested.name, 'record')
+      assert.deepStrictEqual(Object.keys(intersectedNested.generics), ['foo'])
+
+      assert.strictEqual(intersectedNested.format(), '{foo: {a: string}}')
+    })
+
     it('should create a single-facet type', () => {
       const recordType = RecordFacet.type()
       assert.deepStrictEqual([...recordType.facets.keys()], ['record'])
@@ -653,6 +900,11 @@ describe('type-system/base', () => {
     it('should merge by identity', () => {
       assert.strictEqual(StringFacet.merge(StringFacet), StringFacet)
       assert.strictEqual(StringFacet.merge(NumberFacet), undefined)
+    })
+
+    it('should intersect by identity', () => {
+      assert.strictEqual(StringFacet.intersect(StringFacet), StringFacet)
+      assert.strictEqual(StringFacet.intersect(NumberFacet), undefined)
     })
 
     it('should create a single-facet type', () => {

--- a/packages/language/test/type-system/type-system.test.ts
+++ b/packages/language/test/type-system/type-system.test.ts
@@ -171,6 +171,25 @@ describe('type-system', () => {
       assert.strictEqual((mergedFacet.generics as { generic: number }).generic, 2)
     })
 
+    it('should intersect facets', () => {
+      const collapsedFacet = stringFacet.intersect(stringFacet)
+      assert.strictEqual(collapsedFacet, stringFacet)
+
+      const incompatibleFacet = stringFacet.intersect(numberFacet)
+      assert.strictEqual(incompatibleFacet, undefined)
+
+      const customIntersectFacet = makeFacet<'custom', unknown>('custom', { generic: 1 }, {
+        intersect: (other) => {
+          const otherGeneric = (other.generics as { generic: number }).generic
+          return makeFacet<'custom', unknown>('custom', { generic: otherGeneric + 1 })
+        }
+      })
+
+      const intersectedFacet = customIntersectFacet.intersect(customIntersectFacet)
+      assert.strictEqual(intersectedFacet?.name, 'custom')
+      assert.strictEqual((intersectedFacet.generics as { generic: number }).generic, 2)
+    })
+
     it('should cache the single-facet type returned by type()', () => {
       const facetType = stringFacet.type()
       const facetValue = facetType.of('hello')
@@ -256,9 +275,6 @@ describe('type-system', () => {
     })
 
     it('should merge types with compatible facets', () => {
-      const stringType = makeType(stringFacet)
-      const numberType = makeType(numberFacet)
-
       const stringAndNumberType = stringType.merge(numberType)
       assert.ok(stringAndNumberType != null)
       assert.deepStrictEqual([...stringAndNumberType.facets.keys()], ['string', 'number'])
@@ -273,6 +289,28 @@ describe('type-system', () => {
 
       const incompatibleMerge = decibelType.merge(hertzType)
       assert.strictEqual(incompatibleMerge, undefined)
+    })
+
+    it('should intersect types with compatible facets', () => {
+      const intersectedWithString = stringAndNumberType.intersect(stringType)
+      assert.ok(intersectedWithString != null)
+      assert.deepStrictEqual([...intersectedWithString.facets.keys()], ['string'])
+
+      const intersectedWithNumber = stringAndNumberType.intersect(numberType)
+      assert.ok(intersectedWithNumber != null)
+      assert.deepStrictEqual([...intersectedWithNumber.facets.keys()], ['number'])
+
+      const intersectedSame = stringAndNumberType.intersect(stringAndNumberType)
+      assert.ok(intersectedSame != null)
+      assert.deepStrictEqual([...intersectedSame.facets.keys()], ['string', 'number'])
+
+      const incompatibleIntersect = decibelType.intersect(hertzType)
+      assert.strictEqual(incompatibleIntersect, undefined)
+
+      const stringAndDecibelType = makeType(stringFacet, decibelFacet)
+      const intersectedWithDecibel = stringAndDecibelType.intersect(stringAndNumberType)
+      assert.ok(intersectedWithDecibel != null)
+      assert.deepStrictEqual([...intersectedWithDecibel.facets.keys()], ['string'])
     })
   })
 


### PR DESCRIPTION
Types (and their facets) now support two combining operations:

- merge: Combines two types A, B into a new type C, which has all the facets of A and all the facets of B. Certain facets (`record`) are themselves merged (such that C's record facet contains all fields of A and B).
- intersect (added via this commit): Combines two types A, B into a new type C, which contains only the facets that are common to both A and B and are equivalent in both. Certain facets (`record`) are themselves intersected (such that C's record facet contains only the fields that are present in both A and B and are equivalent in both).

This will be used to implement type inference for conditional branches, where the overall type of a conditional expression is the intersection of the types of each branch:

```
if condition {
  // foo: {x: number, y: string}
  foo = { @x = 42 @y = "hello" }
} else {
  // foo: {x: number, z: boolean}
  foo = { @x = 99 @z = true }
}

// At this point, foo could be either of the two types above, so the
// intersection is used:
// foo: {x: number}
```