### PR TITLE
feat: Add support for conditional emissions

### DIFF
--- a/packages/language/src/compiler/checker/blocks.ts
+++ b/packages/language/src/compiler/checker/blocks.ts
@@ -1,17 +1,18 @@
-import type { ast, SourceRange } from '@meyfa/cadence-ast'
+import type { ast } from '@meyfa/cadence-ast'
 import { setAll } from '@meyfa/cadence-utility'
 import type { Capabilities } from '../../type-system/base/function.ts'
 import { RecordFacet } from '../../type-system/base/record.ts'
 import { makeType } from '../../type-system/factory.ts'
 import type { Schema } from '../../type-system/schema.ts'
 import { makeSchema } from '../../type-system/schema.ts'
-import type { Facet, FacetType, Type } from '../../type-system/types.ts'
+import type { Facet, FacetType } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
 import { checkArguments } from './arguments.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
+import type { MutableEmissions, Slots } from './emissions.ts'
+import { addEmission, validateEmissions } from './emissions.ts'
 import type { Binding, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
-import type { Emission } from './statements.ts'
 import { checkStatement } from './statements.ts'
 
 export interface BlockNode extends ast.ASTNode {
@@ -24,6 +25,7 @@ export interface BlockSchema<TBlock extends BlockNode> {
    * The primary facet that identifies the type of this block.
    */
   readonly facet: Facet
+
   /**
    * The capabilities that are required to construct a value of this type (if any).
    * If the block is used in a context that does not allow these capabilities, an error will be reported.
@@ -45,7 +47,7 @@ export interface BlockSchema<TBlock extends BlockNode> {
    * The emissions that are allowed and expected within this block (if any). If not specified or empty, no emissions are allowed.
    * Required types must be emitted _at least_ once; singular types may be emitted _at most_ once.
    */
-  readonly slots?: readonly Slot[]
+  readonly slots?: Slots
 
   /**
    * The properties that are allowed to be exposed by statements within this block (if any).
@@ -57,13 +59,6 @@ export interface BlockSchema<TBlock extends BlockNode> {
    * Compute the bindings that are available inside this block, if any. These may not be overridden by statements within the block.
    */
   readonly getBindings?: (block: TBlock) => ReadonlyMap<string, Binding>
-}
-
-export interface Slot {
-  readonly name: string
-  readonly type: Type
-  readonly required?: boolean
-  readonly singular?: boolean
 }
 
 export type PropertyOptions =
@@ -92,6 +87,7 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
   const typeName = schema.facet.format()
   const ownCapabilities = schema.ownCapabilities ?? noCapabilities
   const parameters = schema.parameters ?? emptySchema
+  const slots = schema.slots ?? []
 
   const initialProperties = schema.properties?.allow === true && schema.properties.initial != null
     ? schema.properties.initial
@@ -115,16 +111,20 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
       setAll(blockScope.resolutions, schema.getBindings(block))
     }
 
-    const emissionCollector = new EmissionCollector(typeName, schema.slots ?? [])
+    const emissions: MutableEmissions = new Map()
     const properties = new Map<string, FacetType>(initialProperties)
 
     for (const child of block.children) {
-      const statement = checkStatement(blockScope, child, properties)
+      const statement = checkStatement(blockScope, child, {
+        context: typeName,
+        slots,
+        existingProperties: properties
+      })
       errors.push(...statement.errors)
       capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
-      for (const emission of statement.emissions) {
-        errors.push(...emissionCollector.add(emission))
+      for (const emission of statement.emissions.values()) {
+        errors.push(...addEmission(emissions, emission))
       }
 
       if (schema.properties?.allow === true) {
@@ -134,7 +134,7 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
       }
     }
 
-    errors.push(...emissionCollector.validate(block.range))
+    errors.push(...validateEmissions(emissions, slots, block.range))
 
     const result = makeBlockType(schema.facet, properties)
 
@@ -142,62 +142,7 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
   }
 }
 
-// Private implementation
-
 const emptySchema = makeSchema([])
-
-class EmissionCollector {
-  private readonly typeName: string
-  private readonly slots: readonly Slot[]
-  private readonly emissions: Emission[][]
-
-  constructor (typeName: string, slots: readonly Slot[]) {
-    this.typeName = typeName
-    this.slots = slots
-    this.emissions = slots.map(() => [])
-  }
-
-  public add (emission: Emission): readonly CompileError[] {
-    const errors: CompileError[] = []
-
-    if (this.slots.length === 0) {
-      errors.push(new CompileError(`Cannot emit values in this context (${this.typeName})`, emission.range))
-      return errors
-    }
-
-    const slotIndex = this.slots.findIndex(({ type }) => type.is(emission.type))
-    if (slotIndex === -1) {
-      const expectedTypes = this.slots.map((slot) => slot.type.format()).join(', ')
-      errors.push(new CompileError(`Unexpected emitted value of type ${emission.type.format()}; expected one of: ${expectedTypes}`, emission.range))
-      return errors
-    }
-
-    this.emissions[slotIndex].push(emission)
-
-    return errors
-  }
-
-  public validate (range: SourceRange): readonly CompileError[] {
-    const errors: CompileError[] = []
-
-    for (const [index, slot] of this.slots.entries()) {
-      const emitted = this.emissions[index]
-
-      if (slot.required && emitted.length === 0) {
-        errors.push(new CompileError(`Expected at least one emission into slot "${slot.name}" of type ${slot.type.format()}`, range))
-        continue
-      }
-
-      if (slot.singular) {
-        for (let j = 1; j < emitted.length; ++j) {
-          errors.push(new CompileError(`Duplicate emission into slot "${slot.name}" of type ${slot.type.format()} which accepts at most one value`, emitted[j].range))
-        }
-      }
-    }
-
-    return errors
-  }
-}
 
 function makeBlockType (facet: Facet, properties: ReadonlyMap<string, FacetType>): FacetType {
   if (facet === RecordFacet) {

--- a/packages/language/src/compiler/checker/checker.ts
+++ b/packages/language/src/compiler/checker/checker.ts
@@ -7,9 +7,12 @@ import { TrackFacet } from '../../type-system/domain/track.ts'
 import { nonNull } from '../assert.ts'
 import { globalBuiltins } from '../builtins/global.ts'
 import { CompileError } from '../error.ts'
+import type { MutableEmissions, SlotName } from './emissions.ts'
+import { addEmission, validateEmissions } from './emissions.ts'
 import { checkImports } from './imports.ts'
 import type { Binding } from './scopes.ts'
 import { createGlobalScope, createLocalScope } from './scopes.ts'
+import type { StatementOptions } from './statements.ts'
 import { checkStatement } from './statements.ts'
 
 export interface SemanticModel {
@@ -50,37 +53,22 @@ export function check (program: ast.Program): CheckResult {
 
   const errors: CompileError[] = []
 
-  let hasTrack = false
-  let hasMixer = false
+  const emissions: MutableEmissions = new Map()
 
   for (const child of program.children) {
-    const statement = checkStatement(scope, child)
+    const statement = checkStatement(scope, child, programStatementOptions)
     errors.push(...statement.errors)
 
-    for (const emission of statement.emissions) {
-      if (MixerFacet.is(emission.type)) {
-        if (hasMixer) {
-          errors.push(new CompileError('Multiple mixers', emission.range))
-        }
-        hasMixer = true
-        continue
-      }
-
-      if (TrackFacet.is(emission.type)) {
-        if (hasTrack) {
-          errors.push(new CompileError('Multiple tracks', emission.range))
-        }
-        hasTrack = true
-        continue
-      }
-
-      errors.push(new CompileError(`Unexpected type ${emission.type.format()}, expected track or mixer`, emission.range))
+    for (const emission of statement.emissions.values()) {
+      errors.push(...addEmission(emissions, emission))
     }
 
     if (statement.properties.size > 0) {
       errors.push(new CompileError('Cannot expose properties in the global scope', child.range))
     }
   }
+
+  errors.push(...validateEmissions(emissions, programStatementOptions.slots ?? [], program.range))
 
   if (errors.length > 0) {
     return failure(errors)
@@ -91,4 +79,25 @@ export function check (program: ast.Program): CheckResult {
   }
 
   return success({ ast: program, semantic })
+}
+
+const mixerSlotName = 'mixer' as SlotName
+const trackSlotName = 'track' as SlotName
+
+const programStatementOptions: StatementOptions = {
+  context: 'program',
+  slots: [
+    {
+      name: mixerSlotName,
+      type: MixerFacet.type(),
+      required: false,
+      singular: true
+    },
+    {
+      name: trackSlotName,
+      type: TrackFacet.type(),
+      required: false,
+      singular: true
+    }
+  ]
 }

--- a/packages/language/src/compiler/checker/emissions.ts
+++ b/packages/language/src/compiler/checker/emissions.ts
@@ -1,0 +1,136 @@
+import type { SourceRange } from '@meyfa/cadence-ast'
+import type { Brand } from '@meyfa/cadence-utility'
+import type { Result } from '../../result/result.ts'
+import type { FacetType, Type } from '../../type-system/types.ts'
+import { assert } from '../assert.ts'
+import { CompileError } from '../error.ts'
+
+export type SlotName = Brand<string, 'language.SlotName'>
+
+export type Slots = readonly Slot[]
+
+export interface Slot {
+  /**
+   * The name of the slot.
+   */
+  readonly name: SlotName
+
+  /**
+   * The type of value that is expected to be emitted into this slot, or 'infer' if the type
+   * should be inferred from the values that are emitted into the slot.
+   */
+  readonly type: Type | 'infer'
+
+  /**
+   * Whether this slot is required to be emitted into at least once (default false).
+   */
+  readonly required?: boolean
+
+  /**
+   * Whether this slot is allowed to be emitted into more than once (default false).
+   */
+  readonly singular?: boolean
+}
+
+export type Emissions = ReadonlyMap<SlotName, Emission>
+export type MutableEmissions = Map<SlotName, Emission>
+
+export interface Emission {
+  /**
+   * The slot into which the values are emitted.
+   */
+  readonly slot: Slot
+
+  /**
+   * For inferred slots, the type of the emitted value. For typed slots, this field is absent.
+   */
+  readonly type?: FacetType
+
+  /**
+   * The minimum amount of emissions into the slot over all conditional branches.
+   */
+  readonly minimum: number
+
+  /**
+   * The maximum amount of emissions into the slot over all conditional branches.
+   */
+  readonly maximum: number
+
+  /**
+   * The source ranges of the emitted value.
+   */
+  readonly ranges: readonly SourceRange[]
+}
+
+export function addEmission (target: MutableEmissions, emission: Emission): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  const existing = target.get(emission.slot.name)
+  if (existing == null) {
+    target.set(emission.slot.name, emission)
+    return errors
+  }
+
+  assert(existing.slot.type === emission.slot.type, `Slot "${existing.slot.name}" type mismatch when merging emissions`)
+
+  let type: FacetType | undefined
+
+  if (existing.slot.type === 'infer') {
+    const intersection = intersectTypes(existing, emission)
+    if (!intersection.complete) {
+      errors.push(intersection.error)
+      return errors
+    }
+
+    type = intersection.value
+  }
+
+  target.set(emission.slot.name, {
+    slot: existing.slot,
+    type,
+    minimum: existing.minimum + emission.minimum,
+    maximum: existing.maximum + emission.maximum,
+    ranges: [...existing.ranges, ...emission.ranges]
+  })
+
+  return errors
+}
+
+export function validateEmissions (emissions: Emissions, slots: Slots, range: SourceRange): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  for (const slot of slots) {
+    const emitted = emissions.get(slot.name)
+
+    if (slot.required && (emitted == null || emitted.minimum < 1)) {
+      const message = slot.type === 'infer'
+        ? `Expected at least one emission into slot "${slot.name}"`
+        : `Expected at least one emission into slot "${slot.name}" of type ${slot.type.format()}`
+      errors.push(new CompileError(message, range))
+    }
+
+    if (slot.singular && emitted != null && emitted.maximum > 1) {
+      const message = slot.type === 'infer'
+        ? `Duplicate emission into slot "${slot.name}" which accepts at most one value`
+        : `Duplicate emission into slot "${slot.name}" of type ${slot.type.format()} which accepts at most one value`
+      errors.push(new CompileError(message, range))
+    }
+  }
+
+  return errors
+}
+
+function intersectTypes (existing: Emission, emission: Emission): Result<FacetType | undefined, CompileError> {
+  if (existing.type == null || emission.type == null) {
+    return { complete: true, value: existing.type ?? emission.type }
+  }
+
+  const intersection = existing.type.intersect(emission.type)
+  if (intersection == null) {
+    const types = [existing.type.format(), emission.type.format()].join(', ')
+    const message = `Incompatible types for slot "${emission.slot.name}": ${types}`
+    return { complete: false, error: new CompileError(message, emission.ranges[0]) }
+  }
+
+  return { complete: true, value: intersection }
+}

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -24,6 +24,7 @@ import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeUnion } from '../../type-system/factory.ts'
 import type { FacetType, Type } from '../../type-system/types.ts'
+import { nonNull } from '../assert.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
 import { busSchema, instrumentSchema, mixerSchema, noteType, partSchema, stepSchema, trackSchema } from '../common.ts'
 import { getCurveSegmentType } from '../curves.ts'
@@ -35,9 +36,12 @@ import { isSyntaxUnit, toBaseUnit } from '../units.ts'
 import { checkArguments } from './arguments.ts'
 import { createBlockChecker } from './blocks.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
+import type { MutableEmissions, SlotName } from './emissions.ts'
+import { addEmission } from './emissions.ts'
 import { checkParameters } from './parameters.ts'
 import type { Binding, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
+import type { StatementOptions } from './statements.ts'
 import { checkStatement } from './statements.ts'
 
 export interface Checked<TValue> {
@@ -345,6 +349,20 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
   return { errors, capabilities, result }
 }
 
+const returnSlotName = 'return' as SlotName
+
+const functionStatementOptions: StatementOptions = {
+  context: 'function',
+  slots: [
+    {
+      name: returnSlotName,
+      type: 'infer',
+      required: true,
+      singular: true
+    }
+  ]
+}
+
 function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetType> {
   const errors: CompileError[] = []
 
@@ -369,22 +387,16 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   })
   setAll(functionScope.resolutions, bindings)
 
-  let hasReturn = false
-  let returnType: FacetType | undefined
+  const emissions: MutableEmissions = new Map()
   let callCapabilities = noCapabilities
 
   for (const child of expression.children) {
-    const statement = checkStatement(functionScope, child)
+    const statement = checkStatement(functionScope, child, functionStatementOptions)
     errors.push(...statement.errors)
     callCapabilities = mergeCapabilities(callCapabilities, statement.capabilities)
 
-    for (const emission of statement.emissions) {
-      if (hasReturn) {
-        errors.push(new CompileError('Function has multiple return statements', emission.range))
-      }
-
-      hasReturn = true
-      returnType ??= emission.type
+    for (const emission of statement.emissions.values()) {
+      errors.push(...addEmission(emissions, emission))
     }
 
     if (statement.properties.size > 0) {
@@ -392,13 +404,23 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
     }
   }
 
-  if (!hasReturn) {
-    errors.push(new CompileError('Function is missing a return statement', expression.range))
-  }
-
-  if (!hasReturn || returnType == null) {
+  if (errors.length > 0) {
+    // If there are errors here, the return type most likely cannot be determined correctly.
     return { errors, capabilities }
   }
+
+  const returnEmission = emissions.get(returnSlotName)
+
+  if (returnEmission == null || returnEmission.minimum < 1) {
+    errors.push(new CompileError('Function must return exactly one value, but can return zero values', expression.range))
+    return { errors, capabilities }
+  }
+
+  if (returnEmission.maximum > 1) {
+    errors.push(new CompileError('Function must return exactly one value, but can return more than one value', expression.range))
+  }
+
+  const returnType = nonNull(returnEmission.type)
 
   const spec: FunctionSpec = { parameters, returnType, capabilities: callCapabilities }
   const result = FunctionFacet.with(spec).type()
@@ -425,7 +447,7 @@ const checkInstrument = createBlockChecker<ast.Instrument>({
 
   slots: [
     {
-      name: 'voice',
+      name: 'voice' as SlotName,
       type: VoiceFacet.type()
     }
   ],
@@ -443,13 +465,13 @@ const checkVoice = createBlockChecker<ast.Voice>({
 
   slots: [
     {
-      name: 'envelope',
+      name: 'envelope' as SlotName,
       type: CurveFacet.with('db').type(),
       required: true,
       singular: true
     },
     {
-      name: 'output',
+      name: 'output' as SlotName,
       type: SourceFacet.type(),
       required: true,
       singular: true
@@ -482,7 +504,7 @@ const checkMixer = createBlockChecker<ast.Mixer>({
 
   slots: [
     {
-      name: 'bus',
+      name: 'bus' as SlotName,
       type: BusFacet.type()
     }
   ],
@@ -502,11 +524,11 @@ const checkBus = createBlockChecker<ast.Bus>({
 
   slots: [
     {
-      name: 'input',
+      name: 'input' as SlotName,
       type: makeUnion(BusFacet.type(), InstrumentFacet.type())
     },
     {
-      name: 'effect',
+      name: 'effect' as SlotName,
       type: EffectFacet.type()
     }
   ],
@@ -530,7 +552,7 @@ const checkTrack = createBlockChecker<ast.Track>({
 
   slots: [
     {
-      name: 'part',
+      name: 'part' as SlotName,
       type: PartFacet.type()
     }
   ],
@@ -550,11 +572,11 @@ const checkPart = createBlockChecker<ast.Part>({
 
   slots: [
     {
-      name: 'routing',
+      name: 'routing' as SlotName,
       type: RoutingFacet.type()
     },
     {
-      name: 'automation',
+      name: 'automation' as SlotName,
       type: AutomationFacet.type()
     }
   ],
@@ -599,7 +621,7 @@ function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression):
 
   const result = binaryOperations[expression.operator].check(left, right)
   if (result == null) {
-    errors.push(new CompileError(`Incompatible operands for "${expression.operator}": ${left.format()} and ${right.format()}`, expression.range))
+    errors.push(new CompileError(`Incompatible operands for "${expression.operator}": ${left.format()}, ${right.format()}`, expression.range))
     return { errors, capabilities }
   }
 

--- a/packages/language/src/compiler/checker/statements.ts
+++ b/packages/language/src/compiler/checker/statements.ts
@@ -1,50 +1,65 @@
-import type { SourceRange, ast } from '@meyfa/cadence-ast'
+import type { ast, SourceRange } from '@meyfa/cadence-ast'
 import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import type { Capabilities } from '../../type-system/base/function.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
 import type { FacetType } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
+import type { Emission, Emissions, MutableEmissions, Slot, SlotName, Slots } from './emissions.ts'
+import { addEmission } from './emissions.ts'
 import { checkExpression } from './expressions.ts'
-import type { MutableScope } from './scopes.ts'
+import type { MutableScope, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
-import { nonNull } from '../assert.ts'
+
+export interface StatementOptions {
+  /**
+   * For error messages: The name of the context in which the statement is being checked.
+   */
+  readonly context: string
+
+  /**
+   * The emissions that are allowed and expected within the statement (if any). If not specified or empty, no emissions are allowed.
+   * Required types must be emitted _at least_ once; singular types may be emitted _at most_ once.
+   */
+  readonly slots?: Slots
+
+  /**
+   * The properties that are already exposed in the current scope (if any).
+   * The statement may not expose names already present in this map.
+   */
+  readonly existingProperties?: ReadonlyMap<string, FacetType>
+}
 
 export interface CheckedStatement {
   readonly errors: readonly CompileError[]
   readonly capabilities: Capabilities
-  readonly emissions: readonly Emission[]
+
+  /**
+   * A map from slot names to emission information.
+   */
+  readonly emissions: ReadonlyMap<SlotName, Emission>
+
+  /**
+   * A map from property names to their types.
+   */
   readonly properties: ReadonlyMap<string, FacetType>
 }
 
-export interface Emission {
-  readonly type: FacetType
-  readonly range: SourceRange
-}
-
-export function checkStatement (
-  scope: MutableScope,
-  statement: ast.Statement,
-  existingProperties?: ReadonlyMap<string, FacetType>
-): CheckedStatement {
+export function checkStatement (scope: MutableScope, statement: ast.Statement, options: StatementOptions): CheckedStatement {
   switch (statement.type) {
     case 'SimpleStatement':
-      return checkSimpleStatement(scope, statement, existingProperties)
+      return checkSimpleStatement(scope, statement, options)
 
     case 'IfStatement':
-      return checkIfStatement(scope, statement, existingProperties)
+      return checkIfStatement(scope, statement, options)
   }
 }
 
-function checkSimpleStatement (
-  scope: MutableScope,
-  statement: ast.SimpleStatement,
-  existingProperties?: ReadonlyMap<string, FacetType>
-): CheckedStatement {
+function checkSimpleStatement (scope: MutableScope, statement: ast.SimpleStatement, options: StatementOptions): CheckedStatement {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
 
-  const emissions: Emission[] = []
+  const emissions: MutableEmissions = new Map()
   const properties = new Map<string, FacetType>()
 
   const values: Array<FacetType | undefined> = []
@@ -61,11 +76,9 @@ function checkSimpleStatement (
       const { range } = statement.values[i]
 
       const type = values[i]
-      if (type == null) {
-        continue
+      if (type != null) {
+        errors.push(...checkEmission(emissions, type, range, options))
       }
-
-      emissions.push({ type, range })
     }
   }
 
@@ -87,7 +100,7 @@ function checkSimpleStatement (
     const propertyName = statement.name.name
     const propertyValue = values.at(0)
 
-    if (existingProperties?.has(propertyName) === true) {
+    if (options.existingProperties?.has(propertyName) === true) {
       errors.push(new CompileError(`Duplicate property "${propertyName}"`, statement.name.range))
     } else if (propertyValue != null) {
       properties.set(propertyName, values.at(0) ?? StringFacet.type())
@@ -97,15 +110,38 @@ function checkSimpleStatement (
   return { errors, capabilities, emissions, properties }
 }
 
-function checkIfStatement (
-  scope: MutableScope,
-  statement: ast.IfStatement,
-  existingProperties?: ReadonlyMap<string, FacetType>
-): CheckedStatement {
+function checkEmission (emissions: MutableEmissions, type: FacetType, range: SourceRange, options: StatementOptions): readonly CompileError[] {
+  const { context, slots = [] } = options
+
+  if (slots.length === 0) {
+    return [new CompileError(`Cannot emit values in this context (${context})`, range)]
+  }
+
+  const slot = slots.find((slot) => slot.type == 'infer' || slot.type.is(type))
+  if (slot == null) {
+    const expectedTypes = slots
+      .filter((slot): slot is Slot & { type: FacetType } => slot.type != 'infer')
+      .map((slot) => slot.type.format())
+      .join(', ')
+    return [new CompileError(`Unexpected emitted value of type ${type.format()}; expected one of: ${expectedTypes}`, range)]
+  }
+
+  const emission: Emission = {
+    slot,
+    type: slot.type === 'infer' ? type : undefined,
+    minimum: 1,
+    maximum: 1,
+    ranges: [range]
+  }
+
+  return addEmission(emissions, emission)
+}
+
+function checkIfStatement (scope: MutableScope, statement: ast.IfStatement, options: StatementOptions): CheckedStatement {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
 
-  const emissions: Emission[] = []
+  const emissions: MutableEmissions = new Map()
   const properties = new Map<string, FacetType>()
 
   const conditionCheck = checkExpression(scope, statement.condition)
@@ -119,71 +155,41 @@ function checkIfStatement (
   const thenScope = createLocalScope(scope)
   const elseScope = createLocalScope(scope)
 
-  const thenBranch = checkBranch(thenScope, statement.thenBranch, existingProperties)
+  const thenBranch = checkBranch(thenScope, statement.thenBranch, options)
   errors.push(...thenBranch.errors)
   capabilities = mergeCapabilities(capabilities, thenBranch.capabilities)
 
-  const elseBranch = checkBranch(elseScope, statement.elseBranch ?? [], existingProperties)
+  const elseBranch = checkBranch(elseScope, statement.elseBranch ?? [], options)
   errors.push(...elseBranch.errors)
   capabilities = mergeCapabilities(capabilities, elseBranch.capabilities)
 
-  const assignedNames = new Set<string>([...thenScope.resolutions.keys(), ...elseScope.resolutions.keys()])
+  errors.push(...applyBranchAssignments(scope, [
+    thenScope,
+    elseScope
+  ], statement.range))
 
-  for (const name of assignedNames) {
-    const thenBinding = thenScope.resolutions.get(name)
-    const elseBinding = elseScope.resolutions.get(name)
-
-    if (scope.resolutions.has(name)) {
-      const message = `Identifier "${name}" is already defined`
-      if (thenBinding != null) {
-        errors.push(new CompileError(message, thenBinding.range))
-      }
-      if (elseBinding != null) {
-        errors.push(new CompileError(message, elseBinding.range))
-      }
-      continue
-    }
-
-    if (thenBinding == null || elseBinding == null) {
-      const binding = nonNull(thenBinding ?? elseBinding)
-      scope.resolutions.set(name, { ...binding, definite: false })
-      continue
-    }
-
-    if (!thenBinding.type.is(elseBinding.type) || !elseBinding.type.is(thenBinding.type)) {
-      const range = elseBinding.range ?? thenBinding.range ?? statement.range
-      errors.push(new CompileError(`Incompatible types for "${name}" in conditional branches: ${thenBinding.type.format()} and ${elseBinding.type.format()}`, range))
-      continue
-    }
-
-    scope.resolutions.set(name, {
-      ...thenBinding,
-      definite: thenBinding.definite && elseBinding.definite,
-      range: undefined
-    })
-  }
+  errors.push(...applyBranchEmissions(emissions, [
+    thenBranch.emissions,
+    elseBranch.emissions
+  ], statement.range))
 
   return { errors, capabilities, emissions, properties }
 }
 
-function checkBranch (
-  scope: MutableScope,
-  statements: readonly ast.Statement[],
-  existingProperties?: ReadonlyMap<string, FacetType>
-): CheckedStatement {
+function checkBranch (scope: MutableScope, statements: readonly ast.Statement[], options: StatementOptions): CheckedStatement {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
 
-  const emissions: Emission[] = []
+  const emissions: MutableEmissions = new Map()
   const properties = new Map<string, FacetType>()
 
   for (const child of statements) {
-    const statement = checkStatement(scope, child, existingProperties)
+    const statement = checkStatement(scope, child, options)
     errors.push(...statement.errors)
     capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
-    if (statement.emissions.length > 0) {
-      errors.push(new CompileError('Emissions in conditional branches are not yet supported', child.range))
+    for (const emission of statement.emissions.values()) {
+      errors.push(...addEmission(emissions, emission))
     }
 
     if (statement.properties.size > 0) {
@@ -192,4 +198,99 @@ function checkBranch (
   }
 
   return { errors, capabilities, emissions, properties }
+}
+
+function applyBranchAssignments (
+  scope: MutableScope,
+  branches: readonly Scope[],
+  statementRange: SourceRange
+): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  const assignedNames = new Set(branches.flatMap((branch) => [...branch.resolutions.keys()]))
+
+  for (const name of assignedNames) {
+    const bindings = branches.map((branch) => branch.resolutions.get(name))
+
+    if (scope.resolutions.has(name)) {
+      const message = `Identifier "${name}" is already defined`
+      for (const binding of bindings) {
+        if (binding != null) {
+          errors.push(new CompileError(message, binding.range ?? statementRange))
+        }
+      }
+      continue
+    }
+
+    const definite = bindings.every((binding) => binding?.definite === true)
+
+    const types = bindings.map((binding) => binding?.type).filter((type) => type != null)
+    const type = intersectTypes(types)
+
+    const ranges = bindings.map((binding) => binding?.range).filter((range) => range != null)
+    const range = ranges.length === 1 ? ranges[0] : undefined
+
+    if (type == null) {
+      const typeStrings = bindings.map((binding) => binding?.type.format() ?? '?').join(', ')
+      const message = typeStrings !== ''
+        ? `Incompatible types for "${name}" in conditional branches: ${typeStrings}`
+        : `Incompatible types for "${name}" in conditional branches`
+      errors.push(new CompileError(message, range ?? statementRange))
+      continue
+    }
+
+    scope.resolutions.set(name, { name, type, definite, range })
+  }
+
+  return errors
+}
+
+function applyBranchEmissions (
+  target: MutableEmissions,
+  branches: readonly Emissions[],
+  statementRange: SourceRange
+): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  const emittedSlotNames = new Set(branches.flatMap((branch) => [...branch.keys()]))
+
+  for (const slotName of emittedSlotNames) {
+    const emissions = branches.map((branch) => branch.get(slotName)).filter((item) => item != null)
+
+    const slot = emissions.at(0)?.slot
+    if (slot == null) {
+      continue
+    }
+
+    const complete = emissions.length === branches.length
+
+    const minimum = complete ? Math.min(...emissions.map((item) => item.minimum)) : 0
+    const maximum = Math.max(...emissions.map((item) => item.maximum))
+
+    const ranges = emissions.flatMap((item) => item.ranges)
+
+    let type: FacetType | undefined
+
+    if (slot.type === 'infer') {
+      const types = emissions.map((item) => item.type).filter((item) => item != null)
+      type = intersectTypes(types)
+
+      if (type == null) {
+        const typeStrings = types.map((type) => type.format()).join(', ')
+        const message = typeStrings !== ''
+          ? `Incompatible types for slot "${slotName}" in conditional branches: ${typeStrings}`
+          : `Incompatible types for slot "${slotName}" in conditional branches`
+        errors.push(new CompileError(message, ranges.at(0) ?? statementRange))
+        continue
+      }
+    }
+
+    target.set(slotName, { slot, type, minimum, maximum, ranges })
+  }
+
+  return errors
+}
+
+function intersectTypes (types: readonly FacetType[]): FacetType | undefined {
+  return types.reduce((acc, type) => acc?.intersect(type), types.at(0))
 }

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -433,8 +433,10 @@ describe('compiler/checker/checker.ts', () => {
     it('should allow instruments as sources in bus', () => {
       const source = [
         'use "instruments" as *',
+        '',
         'kick = sample("kick.wav")',
         'synth = sample("synth.wav")',
+        '',
         '& mixer {',
         '  & bus {',
         '    & kick',
@@ -452,6 +454,21 @@ describe('compiler/checker/checker.ts', () => {
         '& mixer {',
         '  & bus0 = bus {}',
         '  & bus { & bus0 }',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should accept both instruments and buses as sources in bus', () => {
+      const source = [
+        'inst = instrument {}',
+        '& mixer {',
+        '  & bus0 = bus {}',
+        '  & bus {',
+        '    & inst',
+        '    & bus0',
+        '  }',
         '}'
       ].join('\n')
 
@@ -627,12 +644,73 @@ describe('compiler/checker/checker.ts', () => {
 
       assertValid(source)
     })
+
+    it('should allow emission within if statements', () => {
+      const source = [
+        'use "sources" as src',
+        '',
+        'if true {',
+        '  & track (123.bpm) {}',
+        '} else {',
+        '  & track (234.bpm) {}',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow conditional function returns of the same type', () => {
+      const source = [
+        'my_function = () {',
+        '  if true {',
+        '    & 42',
+        '  } else {',
+        '    & 100',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should intersect types of conditional function returns', () => {
+      const source = [
+        'my_function = () {',
+        '  if true {',
+        '    & instrument {',
+        '      @foo = 42',
+        '      @bar = "hello"',
+        '    }',
+        '  } else {',
+        '    & instrument {',
+        '      @foo = 100',
+        '      @baz = 3.db',
+        '    }',
+        '  }',
+        '}',
+        '',
+        'access_foo = my_function().foo',
+        'access_instrument = play(my_function(), [C5])'
+      ].join('\n')
+
+      assertValid(source)
+    })
   })
 
   describe('invalid', () => {
     it('should reject number literals with invalid units', () => {
       assertErrorMessages('foo = 120.unknownunit', [
         'Unknown unit "unknownunit"'
+      ])
+    })
+
+    it('should reject addition of incompatible types', () => {
+      const source = [
+        'foo = 42 + "hello"'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Incompatible operands for "+": number, string'
       ])
     })
 
@@ -778,7 +856,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Multiple tracks'
+        'Duplicate emission into slot "track" of type track which accepts at most one value'
       ])
     })
 
@@ -958,7 +1036,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Multiple mixers'
+        'Duplicate emission into slot "mixer" of type mixer which accepts at most one value'
       ])
     })
 
@@ -1405,21 +1483,152 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Incompatible types for "foo" in conditional branches: number and string'
+        'Incompatible types for "foo" in conditional branches: number, string'
       ])
     })
 
-    it('should reject emissions within if statements', () => {
-      // TODO Remove this test once checking is implemented for emission
+    it('should reject conditional emission with minimum less than 1 for required slots', () => {
       const source = [
-        'if true { & 100 }',
-        'if false { & 101 } else { & 102 }'
+        'use "sources" as src',
+        '',
+        'foo = instrument {',
+        '  & voice {',
+        '    & ~[lin(0.db, -60.db):100.ms]',
+        '    if true { & src.sine(440.hz) }',
+        '  }',
+        '}'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Emissions in conditional branches are not yet supported', // 100
-        'Emissions in conditional branches are not yet supported', // 101
-        'Emissions in conditional branches are not yet supported' // 102
+        'Expected at least one emission into slot "output" of type source'
+      ])
+    })
+
+    it('should reject conditional emission with maximum greater than 1 for single-value slots', () => {
+      const source = [
+        'use "sources" as src',
+        '',
+        'foo = instrument {',
+        '  & voice {',
+        '    & ~[lin(0.db, -60.db):100.ms]',
+        '    if true {',
+        '      & src.sine(440.hz)',
+        '      & src.sine(880.hz)',
+        '    } else {',
+        '      & src.sine(1760.hz)',
+        '    }',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Duplicate emission into slot "output" of type source which accepts at most one value'
+      ])
+    })
+
+    it('should reject conditional emission when the maximum has already been reached', () => {
+      const source = [
+        'use "sources" as src',
+        '',
+        'foo = instrument {',
+        '  & voice {',
+        '    & ~[lin(0.db, -60.db):100.ms]',
+        '    & src.sine(440.hz)',
+        '    if true { & src.sine(880.hz) }',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Duplicate emission into slot "output" of type source which accepts at most one value'
+      ])
+    })
+
+    it('should reject functions that do not return a value in all conditional branches', () => {
+      const source = [
+        'my_function = () {',
+        '  if true {',
+        '    & 42',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Function must return exactly one value, but can return zero values'
+      ])
+    })
+
+    it('should reject functions that return more than one value in any conditional branch', () => {
+      const source = [
+        'my_function = () {',
+        '  if true {',
+        '    & 42',
+        '  } else {',
+        '    & 100',
+        '    & 200',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Function must return exactly one value, but can return more than one value'
+      ])
+    })
+
+    it('should reject functions that already return a value before a conditional return', () => {
+      const source = [
+        'my_function = () {',
+        '  & 42',
+        '  if true {',
+        '    & 100',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Function must return exactly one value, but can return more than one value'
+      ])
+    })
+
+    it('should reject incompatible function return types in conditional branches', () => {
+      const source = [
+        'my_function = () {',
+        '  if true {',
+        '    & 42.bpm',
+        '  } else {',
+        '    & 100.hz',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Incompatible types for slot "return" in conditional branches: number.bpm, number.hz'
+      ])
+    })
+
+    it('should reject access to properties not part of the intersection of conditional branches', () => {
+      const source = [
+        'my_function = () {',
+        '  if true {',
+        '    & instrument {',
+        '      @foo = 42',
+        '      @bar = "hello"',
+        '    }',
+        '  } else {',
+        '    & instrument {',
+        '      @foo = 100',
+        '      @baz = 3.db',
+        '    }',
+        '  }',
+        '}',
+        '',
+        'access_bar = my_function().bar',
+        'access_baz = my_function().baz'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Type (instrument + {foo: number}) has no property named "bar"',
+        'Type (instrument + {foo: number}) has no property named "baz"'
       ])
     })
 

--- a/packages/language/test/compiler/checker/emissions.test.ts
+++ b/packages/language/test/compiler/checker/emissions.test.ts
@@ -1,0 +1,151 @@
+import { getEmptySourceRange } from '@meyfa/cadence-ast'
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import type { Emission, Slot, SlotName, Slots } from '../../../src/compiler/checker/emissions.ts'
+import { addEmission, validateEmissions } from '../../../src/compiler/checker/emissions.ts'
+import { NumberFacet } from '../../../src/type-system/base/number.ts'
+import { SourceFacet } from '../../../src/type-system/domain/source.ts'
+
+describe('compiler/checker/emissions.ts', () => {
+  describe('addEmission()', () => {
+    it('should merge compatible emissions for the same slot', () => {
+      const target = new Map<SlotName, Emission>()
+
+      const outputSlot: Slot = {
+        name: 'output' as SlotName,
+        type: NumberFacet.with('hz').type()
+      }
+
+      const firstRange = getEmptySourceRange()
+      const secondRange = { ...getEmptySourceRange(), offset: 10, column: 11 }
+
+      const first = addEmission(target, {
+        slot: outputSlot,
+        minimum: 1,
+        maximum: 1,
+        ranges: [firstRange]
+      })
+      assert.deepStrictEqual(first, [])
+
+      const second = addEmission(target, {
+        slot: outputSlot,
+        minimum: 0,
+        maximum: 2,
+        ranges: [secondRange]
+      })
+      assert.deepStrictEqual(second, [])
+
+      assert.deepStrictEqual(target.get(outputSlot.name), {
+        slot: outputSlot,
+        type: undefined,
+        minimum: 1,
+        maximum: 3,
+        ranges: [firstRange, secondRange]
+      })
+    })
+
+    it('should reject incompatible inferred emission types and keep the original emission', () => {
+      const target = new Map<SlotName, Emission>()
+
+      const inferredSlot: Slot = {
+        name: 'inferred' as SlotName,
+        type: 'infer'
+      }
+
+      const original: Emission = {
+        slot: inferredSlot,
+        type: NumberFacet.with('hz').type(),
+        minimum: 1,
+        maximum: 1,
+        ranges: [getEmptySourceRange()]
+      }
+
+      const incompatible: Emission = {
+        slot: inferredSlot,
+        type: SourceFacet.type(),
+        minimum: 1,
+        maximum: 1,
+        ranges: [
+          { ...getEmptySourceRange(), offset: 20, column: 21 }
+        ]
+      }
+
+      addEmission(target, original)
+      const errors = addEmission(target, incompatible)
+
+      assert.strictEqual(errors.length, 1)
+      assert.strictEqual(errors[0]?.message, 'Incompatible types for slot "inferred": number.hz, source')
+      assert.strictEqual(errors[0]?.range, incompatible.ranges[0])
+      assert.strictEqual(target.get(inferredSlot.name), original)
+    })
+  })
+
+  describe('validateEmissions()', () => {
+    it('should reject required slots when their minimum emission count is zero', () => {
+      const range = getEmptySourceRange()
+
+      const slots: Slots = [
+        { name: 'typed' as SlotName, type: NumberFacet.with('hz').type(), required: true },
+        { name: 'inferred' as SlotName, type: 'infer', required: true }
+      ]
+
+      const emissions = new Map<SlotName, Emission>([
+        [
+          'typed' as SlotName,
+          {
+            slot: slots[0],
+            minimum: 0,
+            maximum: 1,
+            ranges: [range]
+          }
+        ]
+      ])
+
+      assert.deepStrictEqual(
+        validateEmissions(emissions, slots, range).map((error) => error.message),
+        [
+          'Expected at least one emission into slot "typed" of type number.hz',
+          'Expected at least one emission into slot "inferred"'
+        ]
+      )
+    })
+
+    it('should reject singular slots when their maximum emission count exceeds one', () => {
+      const range = getEmptySourceRange()
+
+      const slots: Slots = [
+        { name: 'typed' as SlotName, type: NumberFacet.with('hz').type(), singular: true },
+        { name: 'inferred' as SlotName, type: 'infer', singular: true }
+      ]
+
+      const emissions = new Map<SlotName, Emission>([
+        [
+          'typed' as SlotName,
+          {
+            slot: slots[0],
+            minimum: 1,
+            maximum: 2,
+            ranges: [range]
+          }
+        ],
+        [
+          'inferred' as SlotName,
+          {
+            slot: slots[1],
+            type: SourceFacet.type(),
+            minimum: 1,
+            maximum: 3,
+            ranges: [range]
+          }]
+      ])
+
+      assert.deepStrictEqual(
+        validateEmissions(emissions, slots, range).map((error) => error.message),
+        [
+          'Duplicate emission into slot "typed" of type number.hz which accepts at most one value',
+          'Duplicate emission into slot "inferred" which accepts at most one value'
+        ]
+      )
+    })
+  })
+})

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -938,4 +938,47 @@ describe('compiler/generator/generator.ts', () => {
       assert.strictEqual(result.track.tempo, condition === 'true' ? 90 : 150)
     }
   })
+
+  it('should use emissions from conditional branches', () => {
+    const source = [
+      'if true {',
+      '  & track (123.bpm) {}',
+      '} else {',
+      '  & track (234.bpm) {}',
+      '}',
+      '',
+      '& mixer {',
+      '  if false {',
+      '    & bus (gain: -6.db) {}',
+      '  } else {',
+      '    & bus (gain: -12.db) {}',
+      '  }',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.strictEqual(result.track.tempo, 123)
+    assert.strictEqual(result.mixer.buses[0].gain.initial, db(-12))
+  })
+
+  it('should support conditional function returns', () => {
+    const source = [
+      'my_function = (condition: boolean) {',
+      '  if condition {',
+      '    & -6.db',
+      '  } else {',
+      '    & -10.db',
+      '  }',
+      '}',
+      '',
+      '& mixer {',
+      '  & bus (gain: my_function(true)) {}',
+      '  & bus (gain: my_function(false)) {}',
+      '}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.strictEqual(result.mixer.buses[0].gain.initial, db(-6))
+    assert.strictEqual(result.mixer.buses[1].gain.initial, db(-10))
+  })
 })


### PR DESCRIPTION
It is now possible to emit values within if/else blocks. The checker keeps track of the minimum and maximum number of values that could be emitted for each slot, across the different branches. These counts are then validated against the slot's requirements. E.g., a function return slot must have exactly one value emitted; therefore, the minimum and maximum must both be equal to 1.

For functions specifically, we also need to infer the return type, which is the intersection of all values that could be emitted.

As a drive-by, intersection is extended to assignments as well, so that conditional assignment to the same variable with different types is now allowed as long as the intersection is not empty.