### PR TITLE
fix: Improve ranges for duplicate emission errors

### DIFF
--- a/packages/language/src/compiler/checker/emissions.ts
+++ b/packages/language/src/compiler/checker/emissions.ts
@@ -71,33 +71,41 @@ export function addEmission (target: MutableEmissions, emission: Emission): read
     return errors
   }
 
-  assert(existing.slot.type === emission.slot.type, `Slot "${existing.slot.name}" type mismatch when merging emissions`)
+  const { slot } = existing
+  assert(slot.type === emission.slot.type, `Slot "${slot.name}" type mismatch when merging emissions`)
 
   let type: FacetType | undefined
 
-  if (existing.slot.type === 'infer') {
+  if (slot.type === 'infer') {
     const intersection = intersectTypes(existing, emission)
-    if (!intersection.complete) {
+    if (intersection.complete) {
+      type = intersection.value
+    } else {
       errors.push(intersection.error)
-      return errors
     }
-
-    type = intersection.value
   }
 
-  target.set(emission.slot.name, {
-    slot: existing.slot,
-    type,
-    minimum: existing.minimum + emission.minimum,
-    maximum: existing.maximum + emission.maximum,
-    ranges: [...existing.ranges, ...emission.ranges]
-  })
+  const minimum = existing.minimum + emission.minimum
+  const maximum = existing.maximum + emission.maximum
+  const ranges = [...existing.ranges, ...emission.ranges]
+
+  if (slot.singular && existing.maximum <= 1 && maximum > 1) {
+    const message = slot.type === 'infer'
+      ? `Duplicate emission into slot "${slot.name}" which accepts at most one value`
+      : `Duplicate emission into slot "${slot.name}" of type ${slot.type.format()} which accepts at most one value`
+    errors.push(new CompileError(message, emission.ranges.at(0) ?? existing.ranges.at(0)))
+  }
+
+  target.set(emission.slot.name, { slot, type, minimum, maximum, ranges })
 
   return errors
 }
 
 export function validateEmissions (emissions: Emissions, slots: Slots, range: SourceRange): readonly CompileError[] {
   const errors: CompileError[] = []
+
+  // The maximum has already been validated when adding emissions.
+  // The minimum still needs to be checked for required slots.
 
   for (const slot of slots) {
     const emitted = emissions.get(slot.name)
@@ -106,13 +114,6 @@ export function validateEmissions (emissions: Emissions, slots: Slots, range: So
       const message = slot.type === 'infer'
         ? `Expected at least one emission into slot "${slot.name}"`
         : `Expected at least one emission into slot "${slot.name}" of type ${slot.type.format()}`
-      errors.push(new CompileError(message, range))
-    }
-
-    if (slot.singular && emitted != null && emitted.maximum > 1) {
-      const message = slot.type === 'infer'
-        ? `Duplicate emission into slot "${slot.name}" which accepts at most one value`
-        : `Duplicate emission into slot "${slot.name}" of type ${slot.type.format()} which accepts at most one value`
       errors.push(new CompileError(message, range))
     }
   }

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -37,7 +37,7 @@ import { checkArguments } from './arguments.ts'
 import { createBlockChecker } from './blocks.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import type { MutableEmissions, SlotName } from './emissions.ts'
-import { addEmission } from './emissions.ts'
+import { addEmission, validateEmissions } from './emissions.ts'
 import { checkParameters } from './parameters.ts'
 import type { Binding, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
@@ -404,23 +404,14 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
     }
   }
 
+  errors.push(...validateEmissions(emissions, functionStatementOptions.slots ?? [], expression.range))
+
   if (errors.length > 0) {
     // If there are errors here, the return type most likely cannot be determined correctly.
     return { errors, capabilities }
   }
 
-  const returnEmission = emissions.get(returnSlotName)
-
-  if (returnEmission == null || returnEmission.minimum < 1) {
-    errors.push(new CompileError('Function must return exactly one value, but can return zero values', expression.range))
-    return { errors, capabilities }
-  }
-
-  if (returnEmission.maximum > 1) {
-    errors.push(new CompileError('Function must return exactly one value, but can return more than one value', expression.range))
-  }
-
-  const returnType = nonNull(returnEmission.type)
+  const returnType = nonNull(emissions.get(returnSlotName)?.type)
 
   const spec: FunctionSpec = { parameters, returnType, capabilities: callCapabilities }
   const result = FunctionFacet.with(spec).type()

--- a/packages/language/src/compiler/checker/statements.ts
+++ b/packages/language/src/compiler/checker/statements.ts
@@ -281,7 +281,6 @@ function applyBranchEmissions (
           ? `Incompatible types for slot "${slotName}" in conditional branches: ${typeStrings}`
           : `Incompatible types for slot "${slotName}" in conditional branches`
         errors.push(new CompileError(message, ranges.at(0) ?? statementRange))
-        continue
       }
     }
 

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -1,8 +1,8 @@
-import { ast, getEmptySourceRange } from '@meyfa/cadence-ast'
+import { ast, getEmptySourceRange, type SourceRange } from '@meyfa/cadence-ast'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { check } from '../../../src/compiler/checker/checker.ts'
-import type { CompileError } from '../../../src/compiler/error.ts'
+import { CompileError } from '../../../src/compiler/error.ts'
 import { lex } from '../../../src/lexer/lexer.ts'
 import { parse } from '../../../src/parser/parser.ts'
 import { NumberFacet } from '../../../src/type-system/base/number.ts'
@@ -26,11 +26,37 @@ function assertValid (source: string): void {
   assert.deepStrictEqual(checkSource(source), [])
 }
 
-function assertErrorMessages (source: string, expectedMessages: string[]): void {
+function assertErrors (source: string, expectedErrors: readonly CompileError[]): void {
+  const actualErrors = checkSource(source)
+
+  // Cannot compare the objects directly due to differences in stack traces.
+  assert.deepStrictEqual(
+    actualErrors.map((error) => error.message),
+    expectedErrors.map((error) => error.message)
+  )
+
+  assert.deepStrictEqual(
+    actualErrors.map((error) => error.range),
+    expectedErrors.map((error) => error.range)
+  )
+}
+
+function assertErrorMessages (source: string, expectedMessages: readonly string[]): void {
   assert.deepStrictEqual(
     checkSource(source).map((error) => error.message),
     expectedMessages
   )
+}
+
+function rangeOf (source: string, substring: string, position?: number): SourceRange {
+  const offset = position ?? source.indexOf(substring)
+
+  return {
+    offset,
+    length: substring.length,
+    line: source.slice(0, offset).split('\n').length,
+    column: offset - source.lastIndexOf('\n', offset - 1)
+  }
 }
 
 describe('compiler/checker/checker.ts', () => {
@@ -851,12 +877,15 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject duplicate track emissions', () => {
       const source = [
-        '& track {}',
-        '& track {}'
+        '& track {} // 0',
+        '& track {} // 1'
       ].join('\n')
 
-      assertErrorMessages(source, [
-        'Duplicate emission into slot "track" of type track which accepts at most one value'
+      assertErrors(source, [
+        new CompileError(
+          'Duplicate emission into slot "track" of type track which accepts at most one value',
+          rangeOf(source, 'track {}', source.indexOf('track {} // 1'))
+        )
       ])
     })
 
@@ -1031,12 +1060,15 @@ describe('compiler/checker/checker.ts', () => {
 
     it('should reject duplicate mixer emissions', () => {
       const source = [
-        '& mixer {}',
-        '& mixer {}'
+        '& mixer {} // 0',
+        '& mixer {} // 1'
       ].join('\n')
 
-      assertErrorMessages(source, [
-        'Duplicate emission into slot "mixer" of type mixer which accepts at most one value'
+      assertErrors(source, [
+        new CompileError(
+          'Duplicate emission into slot "mixer" of type mixer which accepts at most one value',
+          rangeOf(source, 'mixer {}', source.indexOf('mixer {} // 1'))
+        )
       ])
     })
 
@@ -1205,8 +1237,8 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Expected at least one emission into slot "envelope" of type curve.db',
-        'Duplicate emission into slot "output" of type source which accepts at most one value'
+        'Duplicate emission into slot "output" of type source which accepts at most one value',
+        'Expected at least one emission into slot "envelope" of type curve.db'
       ])
     })
 
@@ -1216,15 +1248,18 @@ describe('compiler/checker/checker.ts', () => {
         '',
         'my_instrument = instrument {',
         '  & voice {',
-        '    & ~[lin(0.db, -60.db):100.ms]',
-        '    & ~[lin(-60.db, 0.db):100.ms]',
+        '    & ~[hold(0.db):100.ms]',
+        '    & ~[hold(0.db):200.ms]',
         '    & src.sine(440.hz)',
         '  }',
         '}'
       ].join('\n')
 
-      assertErrorMessages(source, [
-        'Duplicate emission into slot "envelope" of type curve.db which accepts at most one value'
+      assertErrors(source, [
+        new CompileError(
+          'Duplicate emission into slot "envelope" of type curve.db which accepts at most one value',
+          rangeOf(source, '~[hold(0.db):200.ms]')
+        )
       ])
     })
 
@@ -1512,17 +1547,20 @@ describe('compiler/checker/checker.ts', () => {
         '  & voice {',
         '    & ~[lin(0.db, -60.db):100.ms]',
         '    if true {',
-        '      & src.sine(440.hz)',
-        '      & src.sine(880.hz)',
+        '      & src.sine(100.hz)',
+        '      & src.sine(200.hz)',
         '    } else {',
-        '      & src.sine(1760.hz)',
+        '      & src.sine(300.hz)',
         '    }',
         '  }',
         '}'
       ].join('\n')
 
-      assertErrorMessages(source, [
-        'Duplicate emission into slot "output" of type source which accepts at most one value'
+      assertErrors(source, [
+        new CompileError(
+          'Duplicate emission into slot "output" of type source which accepts at most one value',
+          rangeOf(source, 'src.sine(200.hz)')
+        )
       ])
     })
 
@@ -1533,14 +1571,17 @@ describe('compiler/checker/checker.ts', () => {
         'foo = instrument {',
         '  & voice {',
         '    & ~[lin(0.db, -60.db):100.ms]',
-        '    & src.sine(440.hz)',
-        '    if true { & src.sine(880.hz) }',
+        '    & src.sine(100.hz)',
+        '    if true { & src.sine(200.hz) }',
         '  }',
         '}'
       ].join('\n')
 
-      assertErrorMessages(source, [
-        'Duplicate emission into slot "output" of type source which accepts at most one value'
+      assertErrors(source, [
+        new CompileError(
+          'Duplicate emission into slot "output" of type source which accepts at most one value',
+          rangeOf(source, 'src.sine(200.hz)')
+        )
       ])
     })
 
@@ -1554,7 +1595,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Function must return exactly one value, but can return zero values'
+        'Expected at least one emission into slot "return"'
       ])
     })
 
@@ -1571,7 +1612,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Function must return exactly one value, but can return more than one value'
+        'Duplicate emission into slot "return" which accepts at most one value'
       ])
     })
 
@@ -1586,7 +1627,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Function must return exactly one value, but can return more than one value'
+        'Duplicate emission into slot "return" which accepts at most one value'
       ])
     })
 

--- a/packages/language/test/compiler/checker/emissions.test.ts
+++ b/packages/language/test/compiler/checker/emissions.test.ts
@@ -44,7 +44,7 @@ describe('compiler/checker/emissions.ts', () => {
       })
     })
 
-    it('should reject incompatible inferred emission types and keep the original emission', () => {
+    it('should error for incompatible types', () => {
       const target = new Map<SlotName, Emission>()
 
       const inferredSlot: Slot = {
@@ -76,7 +76,16 @@ describe('compiler/checker/emissions.ts', () => {
       assert.strictEqual(errors.length, 1)
       assert.strictEqual(errors[0]?.message, 'Incompatible types for slot "inferred": number.hz, source')
       assert.strictEqual(errors[0]?.range, incompatible.ranges[0])
-      assert.strictEqual(target.get(inferredSlot.name), original)
+
+      // The emission should still be merged.
+      // This is to avoid errors about missing emissions for required slots when the type is incompatible.
+      assert.deepStrictEqual(target.get(inferredSlot.name), {
+        slot: inferredSlot,
+        type: undefined,
+        minimum: 2,
+        maximum: 2,
+        ranges: [...original.ranges, ...incompatible.ranges]
+      })
     })
   })
 
@@ -110,7 +119,9 @@ describe('compiler/checker/emissions.ts', () => {
       )
     })
 
-    it('should reject singular slots when their maximum emission count exceeds one', () => {
+    it('should not handle exceeding the maximum for singular slots', () => {
+      // Reason: The maximum has already been validated when adding emissions.
+
       const range = getEmptySourceRange()
 
       const slots: Slots = [
@@ -140,11 +151,8 @@ describe('compiler/checker/emissions.ts', () => {
       ])
 
       assert.deepStrictEqual(
-        validateEmissions(emissions, slots, range).map((error) => error.message),
-        [
-          'Duplicate emission into slot "typed" of type number.hz which accepts at most one value',
-          'Duplicate emission into slot "inferred" which accepts at most one value'
-        ]
+        validateEmissions(emissions, slots, range),
+        []
       )
     })
   })


### PR DESCRIPTION
For each slot in a given scope, we keep track of the minimum and maximum number of emissions that could happen for that slot, depending on the control flow. Before this patch, the maximum would be checked at the end of the scope only, and if it was exceeded, the error would be reported for the entire scope. Now, we emit the error immediately once the maximum is exceeded, at the point of the offending emission.