### PR TITLE
feat: Add support for conditional properties

### DIFF
--- a/packages/language/src/compiler/checker/blocks.ts
+++ b/packages/language/src/compiler/checker/blocks.ts
@@ -72,7 +72,7 @@ export type PropertyOptions =
      * Properties that are intrinsic to this block and are always present.
      * Statements within the block may not override these properties.
      */
-    readonly initial?: ReadonlyMap<string, FacetType>
+    readonly initial?: ReadonlyMap<string, Binding>
   }
 
 export type BlockChecker<TBlock extends BlockNode> = (scope: Scope, block: TBlock) => CheckedBlock
@@ -112,7 +112,7 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
     }
 
     const emissions: MutableEmissions = new Map()
-    const properties = new Map<string, FacetType>(initialProperties)
+    const properties = new Map<string, Binding>(initialProperties)
 
     for (const child of block.children) {
       const statement = checkStatement(blockScope, child, {
@@ -144,14 +144,26 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
 
 const emptySchema = makeSchema([])
 
-function makeBlockType (facet: Facet, properties: ReadonlyMap<string, FacetType>): FacetType {
-  if (facet === RecordFacet) {
-    return RecordFacet.with(Object.fromEntries(properties)).type()
+function makeBlockType (facet: Facet, properties: ReadonlyMap<string, Binding>): FacetType {
+  const fields: Record<string, FacetType> = Object.create(null)
+  let hasDefiniteProperties = false
+
+  for (const [name, binding] of properties) {
+    if (!binding.definite) {
+      continue
+    }
+
+    fields[name] = binding.type
+    hasDefiniteProperties = true
   }
 
-  if (properties.size === 0) {
+  if (facet === RecordFacet) {
+    return RecordFacet.with(fields).type()
+  }
+
+  if (!hasDefiniteProperties) {
     return facet.type()
   }
 
-  return makeType(facet, RecordFacet.with(Object.fromEntries(properties)))
+  return makeType(facet, RecordFacet.with(fields))
 }

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -526,9 +526,23 @@ const checkBus = createBlockChecker<ast.Bus>({
 
   properties: {
     allow: true,
-    initial: new Map<string, FacetType>([
-      ['gain', ParameterFacet.with('db').type()],
-      ['pan', ParameterFacet.with(undefined).type()]
+    initial: new Map<string, Binding>([
+      [
+        'gain',
+        {
+          name: 'gain',
+          type: ParameterFacet.with('db').type(),
+          definite: true
+        }
+      ],
+      [
+        'pan',
+        {
+          name: 'pan',
+          type: ParameterFacet.with(undefined).type(),
+          definite: true
+        }
+      ]
     ])
   }
 })

--- a/packages/language/src/compiler/checker/statements.ts
+++ b/packages/language/src/compiler/checker/statements.ts
@@ -1,14 +1,14 @@
 import type { ast, SourceRange } from '@meyfa/cadence-ast'
+import { setAll } from '@meyfa/cadence-utility'
 import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import type { Capabilities } from '../../type-system/base/function.ts'
-import { StringFacet } from '../../type-system/base/string.ts'
 import type { FacetType } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import type { Emission, Emissions, MutableEmissions, Slot, SlotName, Slots } from './emissions.ts'
 import { addEmission } from './emissions.ts'
 import { checkExpression } from './expressions.ts'
-import type { MutableScope, Scope } from './scopes.ts'
+import type { Binding, MutableScope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
 
 export interface StatementOptions {
@@ -27,7 +27,7 @@ export interface StatementOptions {
    * The properties that are already exposed in the current scope (if any).
    * The statement may not expose names already present in this map.
    */
-  readonly existingProperties?: ReadonlyMap<string, FacetType>
+  readonly existingProperties?: ReadonlyMap<string, Binding>
 }
 
 export interface CheckedStatement {
@@ -42,7 +42,7 @@ export interface CheckedStatement {
   /**
    * A map from property names to their types.
    */
-  readonly properties: ReadonlyMap<string, FacetType>
+  readonly properties: ReadonlyMap<string, Binding>
 }
 
 export function checkStatement (scope: MutableScope, statement: ast.Statement, options: StatementOptions): CheckedStatement {
@@ -60,7 +60,7 @@ function checkSimpleStatement (scope: MutableScope, statement: ast.SimpleStateme
   let capabilities = noCapabilities
 
   const emissions: MutableEmissions = new Map()
-  const properties = new Map<string, FacetType>()
+  const properties = new Map<string, Binding>()
 
   const values: Array<FacetType | undefined> = []
 
@@ -98,12 +98,16 @@ function checkSimpleStatement (scope: MutableScope, statement: ast.SimpleStateme
 
   if (statement.expose) {
     const propertyName = statement.name.name
-    const propertyValue = values.at(0)
+    const propertyType = values.at(0)
 
     if (options.existingProperties?.has(propertyName) === true) {
       errors.push(new CompileError(`Duplicate property "${propertyName}"`, statement.name.range))
-    } else if (propertyValue != null) {
-      properties.set(propertyName, values.at(0) ?? StringFacet.type())
+    } else if (propertyType != null) {
+      properties.set(propertyName, {
+        name: propertyName,
+        type: propertyType,
+        definite: true
+      })
     }
   }
 
@@ -142,7 +146,7 @@ function checkIfStatement (scope: MutableScope, statement: ast.IfStatement, opti
   let capabilities = noCapabilities
 
   const emissions: MutableEmissions = new Map()
-  const properties = new Map<string, FacetType>()
+  const properties = new Map<string, Binding>()
 
   const conditionCheck = checkExpression(scope, statement.condition)
   errors.push(...conditionCheck.errors)
@@ -163,15 +167,20 @@ function checkIfStatement (scope: MutableScope, statement: ast.IfStatement, opti
   errors.push(...elseBranch.errors)
   capabilities = mergeCapabilities(capabilities, elseBranch.capabilities)
 
-  errors.push(...applyBranchAssignments(scope, [
-    thenScope,
-    elseScope
-  ], statement.range))
-
   errors.push(...applyBranchEmissions(emissions, [
     thenBranch.emissions,
     elseBranch.emissions
   ], statement.range))
+
+  errors.push(...applyBranchBindings(scope.resolutions, [
+    thenScope.resolutions,
+    elseScope.resolutions
+  ], statement.range, 'identifier'))
+
+  errors.push(...applyBranchBindings(properties, [
+    thenBranch.properties,
+    elseBranch.properties
+  ], statement.range, 'property'))
 
   return { errors, capabilities, emissions, properties }
 }
@@ -181,10 +190,13 @@ function checkBranch (scope: MutableScope, statements: readonly ast.Statement[],
   let capabilities = noCapabilities
 
   const emissions: MutableEmissions = new Map()
-  const properties = new Map<string, FacetType>()
+  const properties = new Map<string, Binding>(options.existingProperties)
 
   for (const child of statements) {
-    const statement = checkStatement(scope, child, options)
+    const statement = checkStatement(scope, child, {
+      ...options,
+      existingProperties: properties
+    })
     errors.push(...statement.errors)
     capabilities = mergeCapabilities(capabilities, statement.capabilities)
 
@@ -192,57 +204,10 @@ function checkBranch (scope: MutableScope, statements: readonly ast.Statement[],
       errors.push(...addEmission(emissions, emission))
     }
 
-    if (statement.properties.size > 0) {
-      errors.push(new CompileError('Property exposure in conditional branches is not yet supported', child.range))
-    }
+    setAll(properties, statement.properties)
   }
 
   return { errors, capabilities, emissions, properties }
-}
-
-function applyBranchAssignments (
-  scope: MutableScope,
-  branches: readonly Scope[],
-  statementRange: SourceRange
-): readonly CompileError[] {
-  const errors: CompileError[] = []
-
-  const assignedNames = new Set(branches.flatMap((branch) => [...branch.resolutions.keys()]))
-
-  for (const name of assignedNames) {
-    const bindings = branches.map((branch) => branch.resolutions.get(name))
-
-    if (scope.resolutions.has(name)) {
-      const message = `Identifier "${name}" is already defined`
-      for (const binding of bindings) {
-        if (binding != null) {
-          errors.push(new CompileError(message, binding.range ?? statementRange))
-        }
-      }
-      continue
-    }
-
-    const definite = bindings.every((binding) => binding?.definite === true)
-
-    const types = bindings.map((binding) => binding?.type).filter((type) => type != null)
-    const type = intersectTypes(types)
-
-    const ranges = bindings.map((binding) => binding?.range).filter((range) => range != null)
-    const range = ranges.length === 1 ? ranges[0] : undefined
-
-    if (type == null) {
-      const typeStrings = bindings.map((binding) => binding?.type.format() ?? '?').join(', ')
-      const message = typeStrings !== ''
-        ? `Incompatible types for "${name}" in conditional branches: ${typeStrings}`
-        : `Incompatible types for "${name}" in conditional branches`
-      errors.push(new CompileError(message, range ?? statementRange))
-      continue
-    }
-
-    scope.resolutions.set(name, { name, type, definite, range })
-  }
-
-  return errors
 }
 
 function applyBranchEmissions (
@@ -285,6 +250,52 @@ function applyBranchEmissions (
     }
 
     target.set(slotName, { slot, type, minimum, maximum, ranges })
+  }
+
+  return errors
+}
+
+function applyBranchBindings (
+  target: Map<string, Binding>,
+  branches: ReadonlyArray<ReadonlyMap<string, Binding>>,
+  statementRange: SourceRange,
+  kind: 'identifier' | 'property'
+): readonly CompileError[] {
+  const errors: CompileError[] = []
+
+  const propertyNames = new Set(branches.flatMap((branch) => [...branch.keys()]))
+
+  for (const name of propertyNames) {
+    const bindings = branches.map((branch) => branch.get(name))
+
+    if (target.has(name)) {
+      const message = `${kind === 'property' ? 'Property' : 'Identifier'} "${name}" is already defined`
+      for (const binding of bindings) {
+        if (binding != null) {
+          errors.push(new CompileError(message, binding.range ?? statementRange))
+        }
+      }
+      continue
+    }
+
+    const definite = bindings.every((binding) => binding?.definite === true)
+
+    const types = bindings.map((binding) => binding?.type).filter((type) => type != null)
+    const type = intersectTypes(types)
+
+    const ranges = bindings.map((binding) => binding?.range).filter((range) => range != null)
+    const range = ranges.length === 1 ? ranges[0] : undefined
+
+    if (type == null) {
+      const typeStrings = bindings.map((binding) => binding?.type.format() ?? '?').join(', ')
+      const message = typeStrings !== ''
+        ? `Incompatible types for ${kind} "${name}" in conditional branches: ${typeStrings}`
+        : `Incompatible types for ${kind} "${name}" in conditional branches`
+      errors.push(new CompileError(message, range ?? statementRange))
+      continue
+    }
+
+    target.set(name, { name, type, definite, range })
   }
 
   return errors

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -721,6 +721,49 @@ describe('compiler/checker/checker.ts', () => {
 
       assertValid(source)
     })
+
+    it('should allow conditional property exposure', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  if true {',
+        '    @foo = 42',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should intersect types of conditional property exposure', () => {
+      const source = [
+        'my_instrument = instrument {',
+        '  if true {',
+        '    @foo = { @bar = 42 @str = "hello" }',
+        '    @x = 100.hz',
+        '  } else {',
+        '    @foo = { @bar = 100 @num = 3.db }',
+        '    @y = 200.hz',
+        '  }',
+        '}',
+        '',
+        'access_bar = my_instrument.foo.bar'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow access to conditional properties in the same branch', () => {
+      const source = [
+        'my_record = {',
+        '  if true {',
+        '    @foo = 42',
+        '    @bar = foo + 1',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
   })
 
   describe('invalid', () => {
@@ -1518,7 +1561,7 @@ describe('compiler/checker/checker.ts', () => {
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Incompatible types for "foo" in conditional branches: number, string'
+        'Incompatible types for identifier "foo" in conditional branches: number, string'
       ])
     })
 
@@ -1673,19 +1716,77 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
-    it('should reject exposure within if statements', () => {
-      // TODO Remove this test once checking is implemented for exposure
+    it('should reject access to conditionally exposed properties', () => {
       const source = [
-        '& mixer {',
-        '  if true { @foo = 200 }',
-        '  if false { @bar = 201 } else { @bar = 202 }',
+        'instrument0 = instrument {',
+        '  if true {',
+        '    @foo = { @bar = 42 @str = "" }',
+        '    @x = 100.hz',
+        '  } else {',
+        '    @foo = { @bar = 100 @num = 3.db }',
+        '    @y = 200.hz',
+        '  }',
+        '}',
+        '',
+        'instrument1 = instrument {',
+        '  if true {',
+        '    @hello = "world"',
+        '  }',
+        '}',
+        '',
+        'access_x = instrument0.x',
+        'access_y = instrument0.y',
+        'access_str = instrument0.foo.str',
+        'access_num = instrument0.foo.num',
+        '',
+        'access_hello = instrument1.hello'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        // All branches expose *some* properties, but not the same ones, so the intersection type
+        // should include the 'record' facet with only the common property "foo".
+        'Type (instrument + {foo: {bar: number}}) has no property named "x"',
+        'Type (instrument + {foo: {bar: number}}) has no property named "y"',
+
+        // The properties of "foo" should be intersected as well.
+        'Type {bar: number} has no property named "str"',
+        'Type {bar: number} has no property named "num"',
+
+        // Only one branch exposes a property, so the intersection type should NOT include the 'record' facet at all.
+        'Type instrument has no property named "hello"'
+      ])
+    })
+
+    it('should reject duplicate property exposure in the same conditional branch', () => {
+      const source = [
+        'my_record = {',
+        '  if true {',
+        '    @foo = 42',
+        '    @foo = 100',
+        '  }',
         '}'
       ].join('\n')
 
       assertErrorMessages(source, [
-        'Property exposure in conditional branches is not yet supported', // 200
-        'Property exposure in conditional branches is not yet supported', // 201
-        'Property exposure in conditional branches is not yet supported' // 202
+        'Identifier "foo" is already defined',
+        'Duplicate property "foo"'
+      ])
+    })
+
+    it('should reject incompatible property types in conditional branches', () => {
+      const source = [
+        'my_record = {',
+        '  if true {',
+        '    @foo = 42',
+        '  } else {',
+        '    @foo = "test"',
+        '  }',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Incompatible types for identifier "foo" in conditional branches: number, string',
+        'Incompatible types for property "foo" in conditional branches: number, string'
       ])
     })
   })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -981,4 +981,20 @@ describe('compiler/generator/generator.ts', () => {
     assert.strictEqual(result.mixer.buses[0].gain.initial, db(-6))
     assert.strictEqual(result.mixer.buses[1].gain.initial, db(-10))
   })
+
+  it('should support conditional property exposure', () => {
+    const source = [
+      'my_record = {',
+      '  if true {',
+      '    @foo = 123.bpm',
+      '  } else {',
+      '    @foo = 456.bpm',
+      '  }',
+      '}',
+      '& track (tempo: my_record.foo) {}'
+    ].join('\n')
+
+    const result = generateSource(source)
+    assert.strictEqual(result.track.tempo, 123)
+  })
 })


### PR DESCRIPTION
It is now possible to conditionally expose properties in a block, for example:

```
if condition {
  @some_property = 100
  @other_property = "hello"
} else {
  @some_property = 200
}
```

In the above example, the `some_property` property is always present. Therefore, accessing it is valid regardless of the condition, and it will become part of the block's type. By contrast, the `other_property` property is not always defined, and therefore will not be part of the final type as it is not safe to access.