### PR TITLE
feat!: Introduce multi-branch if statements

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -34,6 +34,7 @@ export interface NodeByType {
   // Statements
   SimpleStatement: SimpleStatement
   IfStatement: IfStatement
+  ConditionalBranch: ConditionalBranch
 
   // Value Expressions
   UnaryExpression: UnaryExpression
@@ -143,9 +144,14 @@ interface UnnamedSimpleStatement extends ASTNode {
 
 export interface IfStatement extends ASTNode {
   readonly type: 'IfStatement'
-  readonly condition: Expression
-  readonly thenBranch: readonly Statement[]
+  readonly branches: readonly [ConditionalBranch, ...readonly ConditionalBranch[]]
   readonly elseBranch?: readonly Statement[]
+}
+
+export interface ConditionalBranch extends ASTNode {
+  readonly type: 'ConditionalBranch'
+  readonly condition: Expression
+  readonly children: readonly Statement[]
 }
 
 // Value Expressions

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -204,9 +204,9 @@ compoundStatement {
 
 IfStatement {
   kw<"if">
-  expression
-  Block
-  (kw<"else"> Block)?
+  expression Block
+  ("," expression Block)*
+  ("," kw<"else"> Block)?
 }
 
 primary {

--- a/packages/language-support/test/go-to-definition/operation.test.ts
+++ b/packages/language-support/test/go-to-definition/operation.test.ts
@@ -151,7 +151,7 @@ describe('go-to-definition/operation.ts', () => {
     const source = [
       'if true {',
       '  foo = 60.bpm',
-      '} else {',
+      '}, else {',
       '  foo = 70.bpm',
       '}',
       '',

--- a/packages/language-support/test/highlight-occurrences/operation.test.ts
+++ b/packages/language-support/test/highlight-occurrences/operation.test.ts
@@ -193,7 +193,7 @@ describe('highlight-occurrences/operation.ts', () => {
     const source = [
       'if true {',
       '  foo = 42',
-      '} else {',
+      '}, else {',
       '  foo = 43',
       '}',
       '',

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -90,7 +90,7 @@ describe('language-support.ts', () => {
       '  }',
       '}',
       '',
-      'if true {} else {}',
+      'if true {}, else {}',
       ''
     ].join('\n')
 
@@ -127,7 +127,7 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, ':', source.indexOf(':2'), 'separator')
     assertHighlightAt(spans, source, 'inst', useInstrumentStart, 'variable')
     assertHighlightAt(spans, source, 'fx', source.indexOf('fx.pan'), 'variable')
-    assertHighlightAt(spans, source, 'if', source.indexOf('if true {} else {}'), 'keyword')
+    assertHighlightAt(spans, source, 'if', source.indexOf('if true {}, else {}'), 'keyword')
     assertHighlightAt(spans, source, 'true', source.indexOf('true {}'), 'keyword')
     assertHighlightAt(spans, source, 'else', source.indexOf('else {}'), 'keyword')
   })

--- a/packages/language-support/test/model/analysis/references.test.ts
+++ b/packages/language-support/test/model/analysis/references.test.ts
@@ -394,7 +394,7 @@ describe('model/analysis/references.ts', () => {
     const source = [
       'if true {',
       '  foo = 128.bpm',
-      '} else {',
+      '}, else {',
       '  foo = 140.bpm',
       '}',
       '',
@@ -421,7 +421,7 @@ describe('model/analysis/references.ts', () => {
       'if true {',
       '  if false {',
       '    foo = 60.bpm',
-      '  } else {',
+      '  }, else {',
       '    bar = 70.bpm',
       '  }',
       '}',
@@ -451,7 +451,7 @@ describe('model/analysis/references.ts', () => {
     const source = [
       'if true {',
       '  foo = 128.bpm',
-      '} else {',
+      '}, else {',
       '  bar = foo // invalid reference',
       '}',
       ''
@@ -474,7 +474,7 @@ describe('model/analysis/references.ts', () => {
       '',
       'if true {',
       '  foo = 2',
-      '} else {',
+      '}, else {',
       '  foo = 3',
       '}',
       '',

--- a/packages/language-support/test/unused-variable/operation.test.ts
+++ b/packages/language-support/test/unused-variable/operation.test.ts
@@ -135,7 +135,7 @@ describe('unused-variable/operation.ts', () => {
     const source = [
       'if (true) {',
       '  used = sample("sound.wav")',
-      '} else {',
+      '}, else {',
       '  used = sample("sound.wav")',
       '}',
       '& track (120.bpm) {',

--- a/packages/language/src/compiler/checker/statements.ts
+++ b/packages/language/src/compiler/checker/statements.ts
@@ -8,7 +8,7 @@ import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import type { Emission, Emissions, MutableEmissions, Slot, SlotName, Slots } from './emissions.ts'
 import { addEmission } from './emissions.ts'
 import { checkExpression } from './expressions.ts'
-import type { Binding, MutableScope } from './scopes.ts'
+import type { Binding, MutableScope, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
 
 export interface StatementOptions {
@@ -148,39 +148,38 @@ function checkIfStatement (scope: MutableScope, statement: ast.IfStatement, opti
   const emissions: MutableEmissions = new Map()
   const properties = new Map<string, Binding>()
 
-  const conditionCheck = checkExpression(scope, statement.condition)
-  errors.push(...conditionCheck.errors)
-  capabilities = mergeCapabilities(capabilities, conditionCheck.capabilities)
+  const branchScopes: Scope[] = []
+  const branchChecks: CheckedStatement[] = []
 
-  if (conditionCheck.result != null && !BooleanFacet.is(conditionCheck.result)) {
-    errors.push(new CompileError(`Condition must be of type ${BooleanFacet.format()}, got ${conditionCheck.result.format()}`, statement.condition.range))
+  for (const branch of statement.branches) {
+    const conditionCheck = checkExpression(scope, branch.condition)
+    errors.push(...conditionCheck.errors)
+    capabilities = mergeCapabilities(capabilities, conditionCheck.capabilities)
+
+    if (conditionCheck.result != null && !BooleanFacet.is(conditionCheck.result)) {
+      errors.push(new CompileError(`Condition must be of type ${BooleanFacet.format()}, got ${conditionCheck.result.format()}`, branch.condition.range))
+    }
+
+    const branchScope = createLocalScope(scope)
+    branchScopes.push(branchScope)
+
+    const branchCheck = checkBranch(branchScope, branch.children, options)
+    errors.push(...branchCheck.errors)
+    capabilities = mergeCapabilities(capabilities, branchCheck.capabilities)
+    branchChecks.push(branchCheck)
   }
 
-  const thenScope = createLocalScope(scope)
   const elseScope = createLocalScope(scope)
-
-  const thenBranch = checkBranch(thenScope, statement.thenBranch, options)
-  errors.push(...thenBranch.errors)
-  capabilities = mergeCapabilities(capabilities, thenBranch.capabilities)
+  branchScopes.push(elseScope)
 
   const elseBranch = checkBranch(elseScope, statement.elseBranch ?? [], options)
   errors.push(...elseBranch.errors)
   capabilities = mergeCapabilities(capabilities, elseBranch.capabilities)
+  branchChecks.push(elseBranch)
 
-  errors.push(...applyBranchEmissions(emissions, [
-    thenBranch.emissions,
-    elseBranch.emissions
-  ], statement.range))
-
-  errors.push(...applyBranchBindings(scope.resolutions, [
-    thenScope.resolutions,
-    elseScope.resolutions
-  ], statement.range, 'identifier'))
-
-  errors.push(...applyBranchBindings(properties, [
-    thenBranch.properties,
-    elseBranch.properties
-  ], statement.range, 'property'))
+  errors.push(...applyBranchEmissions(emissions, branchChecks.map((item) => item.emissions), statement.range))
+  errors.push(...applyBranchBindings(scope.resolutions, branchScopes.map((item) => item.resolutions), statement.range, 'identifier'))
+  errors.push(...applyBranchBindings(properties, branchChecks.map((item) => item.properties), statement.range, 'property'))
 
   return { errors, capabilities, emissions, properties }
 }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -167,16 +167,22 @@ function processSimpleStatement (scope: MutableScope, statement: ast.SimpleState
 }
 
 function processIfStatement (scope: MutableScope, statement: ast.IfStatement): Statement {
-  const conditionValue = resolve(scope, statement.condition)
-  const condition = BooleanFacet.get(conditionValue)
+  for (const branch of statement.branches) {
+    const conditionValue = resolve(scope, branch.condition)
+    if (BooleanFacet.get(conditionValue)) {
+      return processStatements(scope, branch.children)
+    }
+  }
 
-  const branch = condition ? statement.thenBranch : statement.elseBranch ?? []
+  return processStatements(scope, statement.elseBranch ?? [])
+}
 
+function processStatements (scope: MutableScope, statements: readonly ast.Statement[]): Statement {
   const emissions: Value[] = []
   const properties = new Map<string, Value>()
 
-  for (const child of branch) {
-    const { emissions: childEmissions, properties: childProperties } = processStatement(scope, child)
+  for (const statement of statements) {
+    const { emissions: childEmissions, properties: childProperties } = processStatement(scope, statement)
     emissions.push(...childEmissions)
     setAll(properties, childProperties)
   }

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -687,18 +687,24 @@ const simpleStatement_ = p.choice<Token, unknown, ast.Statement>(
   plainEmission_
 )
 
-const ifStatement_: p.Parser<Token, unknown, ast.IfStatement> = p.abc(
-  combine2(
-    keyword('if'),
-    expression_
-  ),
+const conditionalBranch_: p.Parser<Token, unknown, ast.ConditionalBranch> = p.ab(
+  optionalExpression_,
   combine3(
     literal('{'),
     p.recursive(() => p.many(statement_)),
     expectLiteral('}')
   ),
+  (condition, [_lb, children, _rb]) => {
+    return ast.make('ConditionalBranch', combineSourceRanges(condition, _rb), { condition, children })
+  }
+)
+
+const ifStatement_: p.Parser<Token, unknown, ast.IfStatement> = p.abc(
+  keyword('if'),
+  p.sepBy1(conditionalBranch_, literal(',')),
   p.option(
-    combine2(
+    combine3(
+      literal(','),
       keyword('else'),
       combine3(
         literal('{'),
@@ -708,15 +714,13 @@ const ifStatement_: p.Parser<Token, unknown, ast.IfStatement> = p.abc(
     ),
     undefined
   ),
-  ([_if, condition], [_lb, thenBranch, _rb], elseClause) => {
-    const elseBranch = elseClause?.[1][1]
-    const lastToken = elseClause?.[1][2] ?? _rb
+  (_if, branches, elseClause) => {
+    const elseBranch = elseClause?.[2][1]
 
-    return ast.make('IfStatement', combineSourceRanges(_if, lastToken), {
-      condition,
-      thenBranch,
-      elseBranch
-    })
+    // The final token or AST node, such that the combined source range covers the entire statement.
+    const lastItem = elseClause?.[2][2] ?? branches.at(-1) ?? _if
+
+    return ast.make('IfStatement', combineSourceRanges(_if, lastItem), { branches, elseBranch })
   }
 )
 

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -647,7 +647,7 @@ describe('compiler/checker/checker.ts', () => {
     it('should allow empty if statements', () => {
       const source = [
         'if true {}',
-        'if false {} else {}'
+        'if false {}, else {}'
       ].join('\n')
 
       assertValid(source)
@@ -658,7 +658,7 @@ describe('compiler/checker/checker.ts', () => {
         'if true {',
         '  foo = 100',
         '  bar = foo + 1', // 101
-        '} else {',
+        '}, else {',
         '  foo = 200',
         '  bar = foo + 2', // 202
         '}',
@@ -677,7 +677,7 @@ describe('compiler/checker/checker.ts', () => {
         '',
         'if true {',
         '  & track (123.bpm) {}',
-        '} else {',
+        '}, else {',
         '  & track (234.bpm) {}',
         '}'
       ].join('\n')
@@ -690,7 +690,7 @@ describe('compiler/checker/checker.ts', () => {
         'my_function = () {',
         '  if true {',
         '    & 42',
-        '  } else {',
+        '  }, else {',
         '    & 100',
         '  }',
         '}'
@@ -707,7 +707,7 @@ describe('compiler/checker/checker.ts', () => {
         '      @foo = 42',
         '      @bar = "hello"',
         '    }',
-        '  } else {',
+        '  }, else {',
         '    & instrument {',
         '      @foo = 100',
         '      @baz = 3.db',
@@ -740,7 +740,7 @@ describe('compiler/checker/checker.ts', () => {
         '  if true {',
         '    @foo = { @bar = 42 @str = "hello" }',
         '    @x = 100.hz',
-        '  } else {',
+        '  }, else {',
         '    @foo = { @bar = 100 @num = 3.db }',
         '    @y = 200.hz',
         '  }',
@@ -1493,7 +1493,7 @@ describe('compiler/checker/checker.ts', () => {
         'foo = 42',
         'bar = ""',
         'if foo {}',
-        'if bar {} else {}'
+        'if bar {}, else {}'
       ].join('\n')
 
       assertErrorMessages(source, [
@@ -1536,7 +1536,7 @@ describe('compiler/checker/checker.ts', () => {
         '',
         'if true {',
         '  x = 100',
-        '} else {',
+        '}, else {',
         '  y = 200',
         '}',
         '',
@@ -1555,7 +1555,7 @@ describe('compiler/checker/checker.ts', () => {
       const source = [
         'if true {',
         '  foo = 42',
-        '} else {',
+        '}, else {',
         '  foo = "test"',
         '}'
       ].join('\n')
@@ -1592,7 +1592,7 @@ describe('compiler/checker/checker.ts', () => {
         '    if true {',
         '      & src.sine(100.hz)',
         '      & src.sine(200.hz)',
-        '    } else {',
+        '    }, else {',
         '      & src.sine(300.hz)',
         '    }',
         '  }',
@@ -1647,7 +1647,7 @@ describe('compiler/checker/checker.ts', () => {
         'my_function = () {',
         '  if true {',
         '    & 42',
-        '  } else {',
+        '  }, else {',
         '    & 100',
         '    & 200',
         '  }',
@@ -1679,7 +1679,7 @@ describe('compiler/checker/checker.ts', () => {
         'my_function = () {',
         '  if true {',
         '    & 42.bpm',
-        '  } else {',
+        '  }, else {',
         '    & 100.hz',
         '  }',
         '}'
@@ -1698,7 +1698,7 @@ describe('compiler/checker/checker.ts', () => {
         '      @foo = 42',
         '      @bar = "hello"',
         '    }',
-        '  } else {',
+        '  }, else {',
         '    & instrument {',
         '      @foo = 100',
         '      @baz = 3.db',
@@ -1722,7 +1722,7 @@ describe('compiler/checker/checker.ts', () => {
         '  if true {',
         '    @foo = { @bar = 42 @str = "" }',
         '    @x = 100.hz',
-        '  } else {',
+        '  }, else {',
         '    @foo = { @bar = 100 @num = 3.db }',
         '    @y = 200.hz',
         '  }',
@@ -1778,7 +1778,7 @@ describe('compiler/checker/checker.ts', () => {
         'my_record = {',
         '  if true {',
         '    @foo = 42',
-        '  } else {',
+        '  }, else {',
         '    @foo = "test"',
         '  }',
         '}'

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -914,7 +914,7 @@ describe('compiler/generator/generator.ts', () => {
     const source = [
       '& track {',
       '  if true {}',
-      '  if false {} else {}',
+      '  if false {}, else {}',
       '}'
     ].join('\n')
 
@@ -927,7 +927,7 @@ describe('compiler/generator/generator.ts', () => {
       const source = [
         `if ${condition} {`,
         '  my_tempo = 90.bpm',
-        '} else {',
+        '}, else {',
         '  my_tempo = 150.bpm',
         '}',
         '',
@@ -943,14 +943,14 @@ describe('compiler/generator/generator.ts', () => {
     const source = [
       'if true {',
       '  & track (123.bpm) {}',
-      '} else {',
+      '}, else {',
       '  & track (234.bpm) {}',
       '}',
       '',
       '& mixer {',
       '  if false {',
       '    & bus (gain: -6.db) {}',
-      '  } else {',
+      '  }, else {',
       '    & bus (gain: -12.db) {}',
       '  }',
       '}'
@@ -966,7 +966,7 @@ describe('compiler/generator/generator.ts', () => {
       'my_function = (condition: boolean) {',
       '  if condition {',
       '    & -6.db',
-      '  } else {',
+      '  }, else {',
       '    & -10.db',
       '  }',
       '}',
@@ -987,7 +987,7 @@ describe('compiler/generator/generator.ts', () => {
       'my_record = {',
       '  if true {',
       '    @foo = 123.bpm',
-      '  } else {',
+      '  }, else {',
       '    @foo = 456.bpm',
       '  }',
       '}',
@@ -996,5 +996,35 @@ describe('compiler/generator/generator.ts', () => {
 
     const result = generateSource(source)
     assert.strictEqual(result.track.tempo, 123)
+  })
+
+  it('should support multiple conditional branches', () => {
+    type TestCase = readonly [boolean, boolean, number]
+
+    const testCases: readonly TestCase[] = [
+      [true, true, 100],
+      [true, false, 100],
+      [false, true, 200],
+      [false, false, 300]
+    ]
+
+    for (const [one, two, expected] of testCases) {
+      const source = [
+        'fn = (one: boolean, two: boolean) {',
+        '  if one {',
+        '    & 100.bpm',
+        '  }, two {',
+        '    & 200.bpm',
+        '  }, else {',
+        '    & 300.bpm',
+        '  }',
+        '}',
+        '',
+        `& track (tempo: fn(${one}, ${two})) {}`
+      ].join('\n')
+
+      const result = generateSource(source)
+      assert.strictEqual(result.track.tempo, expected)
+    }
   })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -1656,14 +1656,19 @@ describe('parser/parser.ts', () => {
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
         type: 'IfStatement',
-        condition: { type: 'Identifier', name: 'condition' },
-        thenBranch: [
+        branches: [
           {
-            type: 'SimpleStatement',
-            emit: true,
-            expose: false,
-            values: [
-              { type: 'Number', value: 42 }
+            type: 'ConditionalBranch',
+            condition: { type: 'Identifier', name: 'condition' },
+            children: [
+              {
+                type: 'SimpleStatement',
+                emit: true,
+                expose: false,
+                values: [
+                  { type: 'Number', value: 42 }
+                ]
+              }
             ]
           }
         ],
@@ -1676,7 +1681,7 @@ describe('parser/parser.ts', () => {
     const source = [
       'if condition {',
       '  & 42',
-      '} else {',
+      '}, else {',
       '  & 43',
       '}'
     ].join('\n')
@@ -1687,14 +1692,19 @@ describe('parser/parser.ts', () => {
     assert.deepStrictEqual(stripRanges(result.value.children), [
       {
         type: 'IfStatement',
-        condition: { type: 'Identifier', name: 'condition' },
-        thenBranch: [
+        branches: [
           {
-            type: 'SimpleStatement',
-            emit: true,
-            expose: false,
-            values: [
-              { type: 'Number', value: 42 }
+            type: 'ConditionalBranch',
+            condition: { type: 'Identifier', name: 'condition' },
+            children: [
+              {
+                type: 'SimpleStatement',
+                emit: true,
+                expose: false,
+                values: [
+                  { type: 'Number', value: 42 }
+                ]
+              }
             ]
           }
         ],
@@ -1710,6 +1720,85 @@ describe('parser/parser.ts', () => {
         ]
       }
     ])
+  })
+
+  it('should parse if statements with multiple branches', () => {
+    const source = [
+      'if condition0 {',
+      '  & 42',
+      '}, condition1 {',
+      '  & 43',
+      '}, condition2 {',
+      '  & 44',
+      '}'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'IfStatement',
+        branches: [
+          {
+            type: 'ConditionalBranch',
+            condition: { type: 'Identifier', name: 'condition0' },
+            children: [
+              {
+                type: 'SimpleStatement',
+                emit: true,
+                expose: false,
+                values: [
+                  { type: 'Number', value: 42 }
+                ]
+              }
+            ]
+          },
+          {
+            type: 'ConditionalBranch',
+            condition: { type: 'Identifier', name: 'condition1' },
+            children: [
+              {
+                type: 'SimpleStatement',
+                emit: true,
+                expose: false,
+                values: [
+                  { type: 'Number', value: 43 }
+                ]
+              }
+            ]
+          },
+          {
+            type: 'ConditionalBranch',
+            condition: { type: 'Identifier', name: 'condition2' },
+            children: [
+              {
+                type: 'SimpleStatement',
+                emit: true,
+                expose: false,
+                values: [
+                  { type: 'Number', value: 44 }
+                ]
+              }
+            ]
+          }
+        ],
+        elseBranch: undefined
+      }
+    ])
+
+    assert.deepStrictEqual(result.value.children[0].range, {
+      offset: 0,
+      length: source.length,
+      line: 1,
+      column: 1
+    })
+  })
+
+  it('should reject if-else statements without comma', () => {
+    const result = parse(lexSource('if condition {} else {}'))
+    assert.strictEqual(result.complete, false)
+    assert.strictEqual(result.error.message, 'Unexpected statement beginning with "else"')
   })
 
   it('should reject imports within if statements', () => {


### PR DESCRIPTION
This patch introduces support for more than one conditional branch in `if` statements. This is similar to `else if` in other languages, but uses a comma to separate the branches instead of `else if`. A comma is also required before the `else` clause, if an `else` clause is present.

The result is a highly symmetric and scalable syntax, where each condition starts in the same column, as does the `else` keyword. This improves readability over C-style if/else statements.

Example (notice the alignment of the conditions):

```
if condition0 {
}, condition1 {
}, condition2 {
}, else {
}
```

Compared to C-style, where conditions 1 and 2 are positioned further to the right than condition 0:

```
if (condition0) {
} else if (condition1) {
} else if (condition2) {
} else {
}
```

BREAKING CHANGE: An `else` clause now requires a comma before it.