### PR TITLE
feat: Add syntax support for optional parameters

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -197,6 +197,7 @@ export interface Parameter extends ASTNode {
   readonly type: 'Parameter'
   readonly name: Identifier
   readonly parameterType: Type
+  readonly optional: boolean
 }
 
 // Type Expressions

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -31,6 +31,7 @@
   "@"
 
   "!"
+  "?"
 
   @precedence { Comment, "/" }
 }
@@ -135,7 +136,7 @@ parameterList {
 }
 
 parameter {
-  VariableDefinition ":" Type
+  VariableDefinition "?"? ":" Type
 }
 
 Type {

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -382,10 +382,7 @@ function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetTy
   }
 
   const parameters = parameterCheck.schema
-  const bindings = Array.from(parameterCheck.types.entries(), ([name, type]) => {
-    return [name, { name, type, definite: true }] as const
-  })
-  setAll(functionScope.resolutions, bindings)
+  setAll(functionScope.resolutions, parameterCheck.bindings)
 
   const emissions: MutableEmissions = new Map()
   let callCapabilities = noCapabilities

--- a/packages/language/src/compiler/checker/parameters.ts
+++ b/packages/language/src/compiler/checker/parameters.ts
@@ -1,21 +1,21 @@
 import type { ast } from '@meyfa/cadence-ast'
 import type { Schema, SchemaItem } from '../../type-system/schema.ts'
 import { makeSchema } from '../../type-system/schema.ts'
-import type { FacetType } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
+import type { Binding } from './scopes.ts'
 import { checkType } from './type-expressions.ts'
 
 export interface CheckedParameters {
   readonly errors: readonly CompileError[]
-  readonly types: ReadonlyMap<string, FacetType>
   readonly schema: Schema
+  readonly bindings: ReadonlyMap<string, Binding>
 }
 
 export function checkParameters (expressions: readonly ast.Parameter[]): CheckedParameters {
   const errors: CompileError[] = []
 
-  const types = new Map<string, FacetType>()
   const items: SchemaItem[] = []
+  const bindings = new Map<string, Binding>()
 
   for (const parameter of expressions) {
     const parameterCheck = checkType(parameter.parameterType)
@@ -25,20 +25,26 @@ export function checkParameters (expressions: readonly ast.Parameter[]): Checked
       continue
     }
 
-    if (types.has(parameter.name.name)) {
+    if (bindings.has(parameter.name.name)) {
       errors.push(new CompileError(`Duplicate parameter name "${parameter.name.name}"`, parameter.name.range))
       continue
     }
 
-    types.set(parameter.name.name, parameterCheck.result)
     items.push({
       name: parameter.name.name,
       type: parameterCheck.result,
-      required: true
+      required: !parameter.optional
+    })
+
+    bindings.set(parameter.name.name, {
+      name: parameter.name.name,
+      type: parameterCheck.result,
+      definite: !parameter.optional,
+      range: parameter.name.range
     })
   }
 
   const schema = makeSchema(items)
 
-  return { errors, types, schema }
+  return { errors, schema, bindings }
 }

--- a/packages/language/src/lexer/lexer.ts
+++ b/packages/language/src/lexer/lexer.ts
@@ -42,6 +42,7 @@ const commonRules: Rules = [
   { name: '@' },
 
   { name: '!' },
+  { name: '?' },
 
   { name: '~[' },
   { name: '[' },

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -415,11 +415,22 @@ const type_: p.Parser<Token, unknown, ast.Type> = p.leftAssoc2(
 )
 
 const parameter_: p.Parser<Token, unknown, ast.Parameter> = p.abc(
-  identifier_,
+  combine2(
+    identifier_,
+    p.option(
+      literal('?'),
+      undefined
+    )
+  ),
   literal(':'),
   type_,
-  (name, _colon, parameterType) => {
-    return ast.make('Parameter', combineSourceRanges(name, parameterType), { name, parameterType })
+  ([name, _opt], _colon, parameterType) => {
+    const optional = _opt != null
+    return ast.make('Parameter', combineSourceRanges(name, parameterType), {
+      name,
+      parameterType,
+      optional
+    })
   }
 )
 

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -272,6 +272,20 @@ describe('compiler/checker/checker.ts', () => {
       assertValid(source)
     })
 
+    it('should accept function definitions with optional parameters', () => {
+      const source = [
+        'my_function = (param0: number.hz, param1?: number, param2?: string) {',
+        '  & param0',
+        '}',
+        '',
+        'foo = my_function(440.hz)',
+        'bar = my_function(440.hz, 2)',
+        'baz = my_function(440.hz, 2, "hello")'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
     it('should accept higher-order functions', () => {
       const source = [
         'apply = (fn: (arg: number.bpm): number.bpm, value: number) {',
@@ -279,6 +293,18 @@ describe('compiler/checker/checker.ts', () => {
         '}',
         '',
         'foo = apply((arg: number.bpm) { & arg * 2 }, 120)'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should accept higher-order functions with optional parameters', () => {
+      const source = [
+        'apply = (fn: (arg: number.bpm, optional_arg?: number): number.bpm, value: number) {',
+        '  & fn(value.bpm)',
+        '}',
+        '',
+        'foo = apply((arg: number.bpm, optional_arg?: number) { & arg * 2 }, 120)'
       ].join('\n')
 
       assertValid(source)
@@ -1415,6 +1441,18 @@ describe('compiler/checker/checker.ts', () => {
       ])
     })
 
+    it('should reject property exposure in functions', () => {
+      const source = [
+        'f = () {',
+        '  & @foo = 42',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Cannot expose properties in a function'
+      ])
+    })
+
     it('should reject invalid type expressions', () => {
       const source = [
         'func0 = (p: invalid_type) { & p }',
@@ -1548,6 +1586,19 @@ describe('compiler/checker/checker.ts', () => {
         'Identifier "foo" is not definitely assigned',
         'Identifier "x" is not definitely assigned',
         'Identifier "y" is not definitely assigned'
+      ])
+    })
+
+    it('should reject unchecked access to optional parameters', () => {
+      const source = [
+        'my_function = (a: number, b?: number) {',
+        '  & 42',
+        '  foo = a + b',
+        '}'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Identifier "b" is not definitely assigned'
       ])
     })
 

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -208,7 +208,7 @@ describe('lexer/lexer.ts', () => {
   })
 
   it('should lex complex function signatures', () => {
-    const result = lex('apply = (fn: (a: number): number !may_block) {}')
+    const result = lex('apply = (fn: (a: number): number !may_block, param?: string) {}')
     assert.deepStrictEqual(stripTokenMeta(result), {
       complete: true,
       value: [
@@ -226,6 +226,11 @@ describe('lexer/lexer.ts', () => {
         { name: 'word', text: 'number' },
         { name: '!', text: '!' },
         { name: 'word', text: 'may_block' },
+        { name: ',', text: ',' },
+        { name: 'word', text: 'param' },
+        { name: '?', text: '?' },
+        { name: ':', text: ':' },
+        { name: 'word', text: 'string' },
         { name: ')', text: ')' },
         { name: '{', text: '{' },
         { name: '}', text: '}' }

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -989,7 +989,8 @@ describe('parser/parser.ts', () => {
                   generics: [
                     { type: 'Identifier', name: 'db' }
                   ]
-                }
+                },
+                optional: false
               },
               {
                 type: 'Parameter',
@@ -998,7 +999,8 @@ describe('parser/parser.ts', () => {
                   type: 'NamedType',
                   name: { type: 'Identifier', name: 'string' },
                   generics: []
-                }
+                },
+                optional: false
               }
             ],
             children: [
@@ -1035,7 +1037,8 @@ describe('parser/parser.ts', () => {
         parameterType: {
           type: 'RecordType',
           properties: []
-        }
+        },
+        optional: false
       }
     ])
   })
@@ -1058,7 +1061,8 @@ describe('parser/parser.ts', () => {
           type: 'NamedType',
           name: { type: 'Identifier', name: 'track' },
           generics: []
-        }
+        },
+        optional: false
       },
       {
         type: 'Parameter',
@@ -1067,7 +1071,8 @@ describe('parser/parser.ts', () => {
           type: 'NamedType',
           name: { type: 'Identifier', name: 'part' },
           generics: []
-        }
+        },
+        optional: false
       },
       {
         type: 'Parameter',
@@ -1076,14 +1081,15 @@ describe('parser/parser.ts', () => {
           type: 'NamedType',
           name: { type: 'Identifier', name: 'instrument' },
           generics: []
-        }
+        },
+        optional: false
       }
     ])
   })
 
   it('should parse complex type expressions', () => {
     const source = [
-      'foo = (x: number.db + (format: string): string, fmt: string) {}',
+      'foo = (x: number.db + (format: string): string, fmt?: string) {}',
       'bar = (y: ((number.db) + (format: string): (string + string))) {}',
       'baz = (z: (): instrument !hello !world + {foo: number, bar: string}) {}'
     ].join('\n')
@@ -1121,7 +1127,8 @@ describe('parser/parser.ts', () => {
                     type: 'NamedType',
                     name: { type: 'Identifier', name: 'string' },
                     generics: []
-                  }
+                  },
+                  optional: false
                 }
               ],
               returnType: {
@@ -1132,7 +1139,8 @@ describe('parser/parser.ts', () => {
               capabilities: []
             }
           ]
-        }
+        },
+        optional: false
       },
       {
         type: 'Parameter',
@@ -1141,7 +1149,8 @@ describe('parser/parser.ts', () => {
           type: 'NamedType',
           name: { type: 'Identifier', name: 'string' },
           generics: []
-        }
+        },
+        optional: true
       }
     ])
 
@@ -1175,7 +1184,8 @@ describe('parser/parser.ts', () => {
                     type: 'NamedType',
                     name: { type: 'Identifier', name: 'string' },
                     generics: []
-                  }
+                  },
+                  optional: false
                 }
               ],
               returnType: {
@@ -1196,7 +1206,8 @@ describe('parser/parser.ts', () => {
               capabilities: []
             }
           ]
-        }
+        },
+        optional: false
       }
     ])
 
@@ -1250,7 +1261,8 @@ describe('parser/parser.ts', () => {
               ]
             }
           ]
-        }
+        },
+        optional: false
       }
     ])
   })
@@ -1286,7 +1298,8 @@ describe('parser/parser.ts', () => {
             ]
           },
           capabilities: []
-        }
+        },
+        optional: false
       }
     ])
   })


### PR DESCRIPTION
The documentation and diagnostics were already indicating optionality via a trailing `?` after the parameter name. This patch adds support for this syntax to the parser and compiler, such that users can annotate their parameters as optional in source code.