### PR TITLE
feat: Add support for equality comparisons

### DIFF
--- a/packages/ast/src/ast.ts
+++ b/packages/ast/src/ast.ts
@@ -159,8 +159,16 @@ export interface ConditionalBranch extends ASTNode {
 export const unaryOperators = ['+', '-'] as const
 export type UnaryOperator = typeof unaryOperators[number]
 
-export const binaryOperators = ['+', '-', '*', '/'] as const
+export const isUnaryOperator = (value: string): value is UnaryOperator => {
+  return unaryOperators.includes(value as UnaryOperator)
+}
+
+export const binaryOperators = ['+', '-', '*', '/', '==', '!='] as const
 export type BinaryOperator = typeof binaryOperators[number]
+
+export const isBinaryOperator = (value: string): value is BinaryOperator => {
+  return binaryOperators.includes(value as BinaryOperator)
+}
 
 export interface UnaryExpression extends ASTNode {
   readonly type: 'UnaryExpression'

--- a/packages/language-support/src/cadence.grammar
+++ b/packages/language-support/src/cadence.grammar
@@ -33,6 +33,9 @@
   "!"
   "?"
 
+  "=="
+  "!="
+
   @precedence { Comment, "/" }
 }
 
@@ -58,6 +61,7 @@ Unit[@dynamicPrecedence=1] {
 @precedence {
   multiply @left,
   plus @left,
+  comparison @left,
   capability @right
 }
 
@@ -254,7 +258,9 @@ BinaryExpression {
   (expression !plus "+" expression) |
   (expression !plus "-" expression) |
   (expression !multiply "*" expression) |
-  (expression !multiply "/" expression)
+  (expression !multiply "/" expression) |
+  (expression !comparison "==" expression) |
+  (expression !comparison "!=" expression)
 }
 
 Function {

--- a/packages/language-support/src/parser-metadata.ts
+++ b/packages/language-support/src/parser-metadata.ts
@@ -26,6 +26,7 @@ export const cadenceParserConfig: ParserConfig = {
       ':': t.separator,
 
       '+ - "*" "/"': t.arithmeticOperator,
+      '"==" "!="': t.compareOperator,
 
       '&': t.operator,
 

--- a/packages/language-support/test/language-support.test.ts
+++ b/packages/language-support/test/language-support.test.ts
@@ -91,6 +91,7 @@ describe('language-support.ts', () => {
       '}',
       '',
       'if true {}, else {}',
+      'if mix == 0.75 {}',
       ''
     ].join('\n')
 
@@ -130,6 +131,7 @@ describe('language-support.ts', () => {
     assertHighlightAt(spans, source, 'if', source.indexOf('if true {}, else {}'), 'keyword')
     assertHighlightAt(spans, source, 'true', source.indexOf('true {}'), 'keyword')
     assertHighlightAt(spans, source, 'else', source.indexOf('else {}'), 'keyword')
+    assertHighlightAt(spans, source, '==', source.indexOf('=='), 'operator')
   })
 
   it('higlights units only when used as members', () => {

--- a/packages/language/src/compiler/operators/binary.ts
+++ b/packages/language/src/compiler/operators/binary.ts
@@ -7,6 +7,7 @@ import { PatternFacet } from '../../type-system/domain/pattern.ts'
 import { Numbers } from '../../type-system/helpers.ts'
 import type { FacetType, Value } from '../../type-system/types.ts'
 import { fail } from '../assert.ts'
+import { BooleanFacet } from '../../type-system/base/boolean.ts'
 
 export interface BinaryOperation {
   readonly operator: ast.BinaryOperator
@@ -187,9 +188,65 @@ const divide: BinaryOperation = {
   }
 }
 
+const equal: BinaryOperation = {
+  operator: '==',
+
+  check: (left, right) => {
+    if (NumberFacet.is(left) && NumberFacet.is(right)) {
+      const leftUnit = NumberFacet.detail(left)
+      const rightUnit = NumberFacet.detail(right)
+      if (leftUnit === rightUnit) {
+        return BooleanFacet.type()
+      }
+    }
+
+    for (const facet of [BooleanFacet, StringFacet]) {
+      if (facet.is(left) && facet.is(right)) {
+        return BooleanFacet.type()
+      }
+    }
+
+    return undefined
+  },
+
+  compute: (left, right) => {
+    return BooleanFacet.type().of(compare(left, right))
+  }
+}
+
+function compare (left: Value, right: Value): boolean {
+  if (NumberFacet.has(left) && NumberFacet.has(right)) {
+    const leftData = NumberFacet.get(left)
+    const rightData = NumberFacet.get(right)
+    return leftData.unit === rightData.unit && leftData.value === rightData.value
+  }
+
+  for (const facet of [BooleanFacet, StringFacet]) {
+    if (facet.has(left) && facet.has(right)) {
+      const leftData = facet.get(left)
+      const rightData = facet.get(right)
+      return leftData === rightData
+    }
+  }
+
+  fail()
+}
+
+const notEqual: BinaryOperation = {
+  operator: '!=',
+
+  check: (left, right) => equal.check(left, right),
+
+  compute: (left, right) => {
+    return BooleanFacet.type().of(!compare(left, right))
+  }
+}
+
 export const binaryOperations: Readonly<Record<ast.BinaryOperator, BinaryOperation>> = {
   '+': add,
   '-': subtract,
   '*': multiply,
-  '/': divide
+  '/': divide,
+  '==': equal,
+  '!=': notEqual
 }

--- a/packages/language/src/lexer/lexer.ts
+++ b/packages/language/src/lexer/lexer.ts
@@ -38,6 +38,9 @@ const commonRules: Rules = [
 
   { name: '"', push: stringLexer },
 
+  { name: '==' },
+  { name: '!=' },
+
   { name: '&' },
   { name: '@' },
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -538,6 +538,10 @@ const unaryExpression_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
     p.eitherOr(literal('+'), literal('-')),
     p.recursive(() => unaryExpression_),
     (op, operand) => {
+      if (!ast.isUnaryOperator(op.text)) {
+        throw new ParseError(`Unexpected operator: "${op.text}"`, getSourceRange(op))
+      }
+
       // If it's a numeric literal, fold the unary operator directly
       if (operand.type === 'Number') {
         return ast.make('Number', combineSourceRanges(op, operand), {
@@ -546,7 +550,7 @@ const unaryExpression_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
       }
 
       return ast.make('UnaryExpression', combineSourceRanges(op, operand), {
-        operator: op.text as ast.UnaryOperator,
+        operator: op.text,
         operand
       })
     }
@@ -555,8 +559,12 @@ const unaryExpression_: p.Parser<Token, unknown, ast.Expression> = p.eitherOr(
 )
 
 function makeBinaryExpression (operator: Token, left: ast.Expression, right: ast.Expression): ast.BinaryExpression {
+  if (!ast.isBinaryOperator(operator.text)) {
+    throw new ParseError(`Unexpected operator: "${operator.text}"`, getSourceRange(operator))
+  }
+
   return ast.make('BinaryExpression', combineSourceRanges(left, right), {
-    operator: operator.text as ast.BinaryOperator,
+    operator: operator.text,
     left,
     right
   })
@@ -582,8 +590,18 @@ const additiveExpression_: p.Parser<Token, unknown, ast.Expression> = p.leftAsso
   multiplicativeExpression_
 )
 
+// additive ((==|!=) additive)*
+const comparisonExpression_: p.Parser<Token, unknown, ast.Expression> = p.leftAssoc2(
+  additiveExpression_,
+  p.map(
+    p.satisfy((t) => t.name === '==' || t.name === '!='),
+    (op) => makeBinaryExpression.bind(undefined, op)
+  ),
+  additiveExpression_
+)
+
 // The top-level expression parser
-const optionalExpression_: p.Parser<Token, unknown, ast.Expression> = additiveExpression_
+const optionalExpression_: p.Parser<Token, unknown, ast.Expression> = comparisonExpression_
 const expression_: p.Parser<Token, unknown, ast.Expression> = expect(
   optionalExpression_,
   'expression'

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -1,4 +1,5 @@
-import { ast, getEmptySourceRange, type SourceRange } from '@meyfa/cadence-ast'
+import type { SourceRange } from '@meyfa/cadence-ast'
+import { ast, getEmptySourceRange } from '@meyfa/cadence-ast'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { check } from '../../../src/compiler/checker/checker.ts'
@@ -786,6 +787,19 @@ describe('compiler/checker/checker.ts', () => {
         '    @bar = foo + 1',
         '  }',
         '}'
+      ].join('\n')
+
+      assertValid(source)
+    })
+
+    it('should allow valid equality comparisons', () => {
+      const source = [
+        'number_eq = 42 == 100',
+        'number_neq = 42 != 100',
+        'string_eq = "hello" == "world"',
+        'string_neq = "hello" != "world"',
+        'boolean_eq = true == false',
+        'boolean_neq = true != false'
       ].join('\n')
 
       assertValid(source)
@@ -1838,6 +1852,66 @@ describe('compiler/checker/checker.ts', () => {
       assertErrorMessages(source, [
         'Incompatible types for identifier "foo" in conditional branches: number, string',
         'Incompatible types for property "foo" in conditional branches: number, string'
+      ])
+    })
+
+    it('should reject invalid equality comparisons', () => {
+      const source = [
+        'number_string_eq = 42 == "hello"',
+        'number_string_neq = 42 != "hello"',
+
+        'string_number_eq = "hello" == 42',
+        'string_number_neq = "hello" != 42',
+
+        'boolean_string_eq = true == "hello"',
+        'boolean_string_neq = true != "hello"',
+
+        'number_boolean_eq = 42 == true',
+        'number_boolean_neq = 42 != true',
+
+        'number_generics_eq = 42 == 10.hz',
+        'number_generics_neq = 42 != 10.hz'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Incompatible operands for "==": number, string',
+        'Incompatible operands for "!=": number, string',
+
+        'Incompatible operands for "==": string, number',
+        'Incompatible operands for "!=": string, number',
+
+        'Incompatible operands for "==": boolean, string',
+        'Incompatible operands for "!=": boolean, string',
+
+        'Incompatible operands for "==": number, boolean',
+        'Incompatible operands for "!=": number, boolean',
+
+        'Incompatible operands for "==": number, number.hz',
+        'Incompatible operands for "!=": number, number.hz'
+      ])
+    })
+
+    it('should reject equality comparisons between records', () => {
+      const source = [
+        'record_record_eq = {} == {}',
+        'record_record_neq = {} != {}',
+
+        'empty = {}',
+        'empty_self_eq = empty == empty',
+        'empty_self_neq = empty != empty',
+        '',
+        'non_empty = { @foo = 42 }',
+        'non_empty_self_eq = non_empty == non_empty',
+        'non_empty_self_neq = non_empty != non_empty'
+      ].join('\n')
+
+      assertErrorMessages(source, [
+        'Incompatible operands for "==": {}, {}',
+        'Incompatible operands for "!=": {}, {}',
+        'Incompatible operands for "==": {}, {}',
+        'Incompatible operands for "!=": {}, {}',
+        'Incompatible operands for "==": {foo: number}, {foo: number}',
+        'Incompatible operands for "!=": {foo: number}, {foo: number}'
       ])
     })
   })

--- a/packages/language/test/compiler/generator/generator.test.ts
+++ b/packages/language/test/compiler/generator/generator.test.ts
@@ -1027,4 +1027,62 @@ describe('compiler/generator/generator.ts', () => {
       assert.strictEqual(result.track.tempo, expected)
     }
   })
+
+  it('should support equality comparisons for numbers', () => {
+    type TestCase = readonly [number, number]
+
+    const testCases: readonly TestCase[] = [
+      [1, 100],
+      [2, 200],
+      [3, 300]
+    ]
+
+    for (const [input, expected] of testCases) {
+      const source = [
+        'fn_number = (x: number) {',
+        '  if x == 1 {',
+        '    & 100.bpm',
+        '  }, x == 2 {',
+        '    & 200.bpm',
+        '  }, else {',
+        '    & 300.bpm',
+        '  }',
+        '}',
+        '',
+        `& track (tempo: fn_number(${input})) {}`
+      ].join('\n')
+
+      const result = generateSource(source)
+      assert.strictEqual(result.track.tempo, expected)
+    }
+  })
+
+  it('should support equality comparisons for strings', () => {
+    type TestCase = readonly [string, number]
+
+    const testCases: readonly TestCase[] = [
+      ['one', 100],
+      ['two', 200],
+      ['three', 300]
+    ]
+
+    for (const [input, expected] of testCases) {
+      const source = [
+        'fn_string = (x: string) {',
+        '  if x == "one" {',
+        '    & 100.bpm',
+        '  }, x == "two" {',
+        '    & 200.bpm',
+        '  }, else {',
+        '    & 300.bpm',
+        '  }',
+        '}',
+        '',
+        `& track (tempo: fn_string("${input}")) {}`
+      ].join('\n')
+
+      const result = generateSource(source)
+      assert.strictEqual(result.track.tempo, expected)
+    }
+  })
 })

--- a/packages/language/test/lexer/lexer.test.ts
+++ b/packages/language/test/lexer/lexer.test.ts
@@ -501,4 +501,29 @@ describe('lexer/lexer.ts', () => {
       ]
     })
   })
+
+  it('should lex comparison operators', () => {
+    const source = [
+      'a == b',
+      'c != d'
+    ].join('\n')
+
+    const result = lex(source)
+    assert.strictEqual(result.complete, true)
+
+    assert.deepStrictEqual(stripTokenMeta(result), {
+      complete: true,
+      value: [
+        // a == b
+        { name: 'word', text: 'a' },
+        { name: '==', text: '==' },
+        { name: 'word', text: 'b' },
+
+        // c != d
+        { name: 'word', text: 'c' },
+        { name: '!=', text: '!=' },
+        { name: 'word', text: 'd' }
+      ]
+    })
+  })
 })

--- a/packages/language/test/parser/parser.test.ts
+++ b/packages/language/test/parser/parser.test.ts
@@ -322,6 +322,138 @@ describe('parser/parser.ts', () => {
     ])
   })
 
+  it('should parse comparison expressions', () => {
+    const source = [
+      'a = 1 == 2',
+      'b = 3 != 4',
+      'c = 5 == 5 == true',
+      'c = 6 == 6 != false'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'SimpleStatement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'a' },
+        values: [
+          {
+            type: 'BinaryExpression',
+            operator: '==',
+            left: { type: 'Number', value: 1 },
+            right: { type: 'Number', value: 2 }
+          }
+        ]
+      },
+      {
+        type: 'SimpleStatement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'b' },
+        values: [
+          {
+            type: 'BinaryExpression',
+            operator: '!=',
+            left: { type: 'Number', value: 3 },
+            right: { type: 'Number', value: 4 }
+          }
+        ]
+      },
+      {
+        type: 'SimpleStatement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'c' },
+        values: [
+          {
+            type: 'BinaryExpression',
+            operator: '==',
+            left: {
+              type: 'BinaryExpression',
+              operator: '==',
+              left: { type: 'Number', value: 5 },
+              right: { type: 'Number', value: 5 }
+            },
+            right: { type: 'Boolean', value: true }
+          }
+        ]
+      },
+      {
+        type: 'SimpleStatement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'c' },
+        values: [
+          {
+            type: 'BinaryExpression',
+            operator: '!=',
+            left: {
+              type: 'BinaryExpression',
+              operator: '==',
+              left: { type: 'Number', value: 6 },
+              right: { type: 'Number', value: 6 }
+            },
+            right: { type: 'Boolean', value: false }
+          }
+        ]
+      }
+    ])
+  })
+
+  it('should use operator precedence for mixed binary expressions', () => {
+    const source = [
+      'a = 1 + 2 == 3',
+      'b = 4 == 5 + 6'
+    ].join('\n')
+
+    const result = parse(lexSource(source))
+    assertResultComplete(result)
+
+    assert.deepStrictEqual(stripRanges(result.value.children), [
+      {
+        type: 'SimpleStatement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'a' },
+        values: [
+          {
+            type: 'BinaryExpression',
+            operator: '==',
+            left: {
+              type: 'BinaryExpression',
+              operator: '+',
+              left: { type: 'Number', value: 1 },
+              right: { type: 'Number', value: 2 }
+            },
+            right: { type: 'Number', value: 3 }
+          }
+        ]
+      },
+      {
+        type: 'SimpleStatement',
+        emit: false,
+        expose: false,
+        name: { type: 'Identifier', name: 'b' },
+        values: [
+          {
+            type: 'BinaryExpression',
+            operator: '==',
+            left: { type: 'Number', value: 4 },
+            right: {
+              type: 'BinaryExpression',
+              operator: '+',
+              left: { type: 'Number', value: 5 },
+              right: { type: 'Number', value: 6 }
+            }
+          }
+        ]
+      }
+    ])
+  })
+
   it('should parse unit suffixes', () => {
     const source = [
       'offset = -1.5.ms',


### PR DESCRIPTION
It is now possible to compare values for equality using the operators `==` (equal) and `!=` (not equal). Supported types are: number, boolean, and string. The result is a boolean value.