### PR TITLE
feat: Prepare UnionType support for operators

### DIFF
--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -23,6 +23,7 @@ import { SourceFacet } from '../../type-system/domain/source.ts'
 import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeUnion } from '../../type-system/factory.ts'
+import { isFacetType } from '../../type-system/guards.ts'
 import type { FacetType, Type } from '../../type-system/types.ts'
 import { nonNull } from '../assert.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
@@ -599,7 +600,9 @@ function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): C
   }
 
   const result = unaryOperations[expression.operator].check(operand)
-  if (result == null) {
+
+  // TODO: Support non-FacetType
+  if (result == null || !isFacetType(result)) {
     errors.push(new CompileError(`Incompatible operand for "${expression.operator}": ${operand.format()}`, expression.range))
     return { errors, capabilities }
   }
@@ -622,7 +625,9 @@ function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression):
   }
 
   const result = binaryOperations[expression.operator].check(left, right)
-  if (result == null) {
+
+  // TODO: Support non-FacetType
+  if (result == null || !isFacetType(result)) {
     errors.push(new CompileError(`Incompatible operands for "${expression.operator}": ${left.format()}, ${right.format()}`, expression.range))
     return { errors, capabilities }
   }

--- a/packages/language/src/compiler/operators/binary.ts
+++ b/packages/language/src/compiler/operators/binary.ts
@@ -6,38 +6,39 @@ import { NumberFacet } from '../../type-system/base/number.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
 import { PatternFacet } from '../../type-system/domain/pattern.ts'
 import { Numbers } from '../../type-system/helpers.ts'
-import type { FacetType, Value } from '../../type-system/types.ts'
+import type { Type, Value } from '../../type-system/types.ts'
 import { fail } from '../assert.ts'
 import { areTypesEqualityComparable, areTypesRelationallyComparable, areValuesEqual, compareValues } from './comparison.ts'
+import { liftOverFacetTypes } from './lifting.ts'
 
 export interface BinaryOperation {
   readonly operator: ast.BinaryOperator
-  readonly check: (left: FacetType, right: FacetType) => FacetType | undefined
+  readonly check: (left: Type, right: Type) => Type | undefined
   readonly compute: (left: Value, right: Value) => Value
 }
 
 const add: BinaryOperation = {
   operator: '+',
 
-  check: (left, right) => {
+  check: (left, right) => liftOverFacetTypes(left, right, (left, right) => {
     if (StringFacet.is(left) && StringFacet.is(right)) {
-      return left
+      return StringFacet.type()
     }
 
     if (PatternFacet.is(left) && PatternFacet.is(right)) {
-      return left
+      return PatternFacet.type()
     }
 
     if (NumberFacet.is(left) && NumberFacet.is(right)) {
       const leftUnit = NumberFacet.detail(left)
       const rightUnit = NumberFacet.detail(right)
       if (leftUnit === rightUnit) {
-        return left
+        return NumberFacet.with(leftUnit).type()
       }
     }
 
     return undefined
-  },
+  }),
 
   compute: (left, right) => {
     if (StringFacet.has(left) && StringFacet.has(right)) {
@@ -68,17 +69,17 @@ const add: BinaryOperation = {
 const subtract: BinaryOperation = {
   operator: '-',
 
-  check: (left, right) => {
+  check: (left, right) => liftOverFacetTypes(left, right, (left, right) => {
     if (NumberFacet.is(left) && NumberFacet.is(right)) {
       const leftUnit = NumberFacet.detail(left)
       const rightUnit = NumberFacet.detail(right)
       if (leftUnit === rightUnit) {
-        return left
+        return NumberFacet.with(leftUnit).type()
       }
     }
 
     return undefined
-  },
+  }),
 
   compute: (left, right) => {
     if (NumberFacet.has(left) && NumberFacet.has(right)) {
@@ -97,7 +98,7 @@ const subtract: BinaryOperation = {
 const multiply: BinaryOperation = {
   operator: '*',
 
-  check: (left, right) => {
+  check: (left, right) => liftOverFacetTypes(left, right, (left, right) => {
     if (NumberFacet.is(left) && NumberFacet.is(right)) {
       const leftUnit = NumberFacet.detail(left)
       const rightUnit = NumberFacet.detail(right)
@@ -114,7 +115,7 @@ const multiply: BinaryOperation = {
     }
 
     return undefined
-  },
+  }),
 
   compute: (left, right) => {
     if (NumberFacet.has(left) && NumberFacet.has(right)) {
@@ -145,7 +146,7 @@ const multiply: BinaryOperation = {
 const divide: BinaryOperation = {
   operator: '/',
 
-  check: (left, right) => {
+  check: (left, right) => liftOverFacetTypes(left, right, (left, right) => {
     if (NumberFacet.is(left) && NumberFacet.is(right)) {
       const leftUnit = NumberFacet.detail(left)
       const rightUnit = NumberFacet.detail(right)
@@ -156,16 +157,16 @@ const divide: BinaryOperation = {
       }
 
       if (rightUnit == null) {
-        return left
+        return NumberFacet.with(leftUnit).type()
       }
     }
 
     if (PatternFacet.is(left) && NumberFacet.with(undefined).is(right)) {
-      return left
+      return PatternFacet.type()
     }
 
     return undefined
-  },
+  }),
 
   compute: (left, right) => {
     if (NumberFacet.has(left) && NumberFacet.has(right)) {

--- a/packages/language/src/compiler/operators/comparison.ts
+++ b/packages/language/src/compiler/operators/comparison.ts
@@ -1,13 +1,26 @@
 import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
-import type { FacetType, Value } from '../../type-system/types.ts'
+import type { FacetType, Type, Value } from '../../type-system/types.ts'
 import { fail } from '../assert.ts'
+import { getTypeAtoms } from './lifting.ts'
 
 /**
  * Returns a boolean indicating whether the two types can be compared for equality.
  */
-export function areTypesEqualityComparable (left: FacetType, right: FacetType): boolean {
+export function areTypesEqualityComparable (left: Type, right: Type): boolean {
+  for (const leftFacet of getTypeAtoms(left)) {
+    for (const rightFacet of getTypeAtoms(right)) {
+      if (!areFacetTypesEqualityComparable(leftFacet, rightFacet)) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+function areFacetTypesEqualityComparable (left: FacetType, right: FacetType): boolean {
   if (NumberFacet.is(left) && NumberFacet.is(right)) {
     const leftUnit = NumberFacet.detail(left)
     const rightUnit = NumberFacet.detail(right)
@@ -51,7 +64,19 @@ export function areValuesEqual (left: Value, right: Value): boolean {
  * Returns a boolean indicating whether the two types can be compared for relational ordering
  * (i.e., less than, greater than, less than or equal to, greater than or equal to).
  */
-export function areTypesRelationallyComparable (left: FacetType, right: FacetType): boolean {
+export function areTypesRelationallyComparable (left: Type, right: Type): boolean {
+  for (const leftFacet of getTypeAtoms(left)) {
+    for (const rightFacet of getTypeAtoms(right)) {
+      if (!areFacetTypesRelationallyComparable(leftFacet, rightFacet)) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+function areFacetTypesRelationallyComparable (left: FacetType, right: FacetType): boolean {
   if (NumberFacet.is(left) && NumberFacet.is(right)) {
     const leftUnit = NumberFacet.detail(left)
     const rightUnit = NumberFacet.detail(right)

--- a/packages/language/src/compiler/operators/lifting.ts
+++ b/packages/language/src/compiler/operators/lifting.ts
@@ -1,0 +1,49 @@
+import { makeUnion } from '../../type-system/factory.ts'
+import { isFacetType } from '../../type-system/guards.ts'
+import type { FacetType, Type } from '../../type-system/types.ts'
+
+type CheckUnary = (type: FacetType) => Type | undefined
+type CheckBinary = (left: FacetType, right: FacetType) => Type | undefined
+
+export function getTypeAtoms (type: Type): readonly FacetType[] {
+  if (isFacetType(type)) {
+    return [type]
+  }
+
+  return type.members
+}
+
+export function liftOverFacetType (operand: Type, check: CheckUnary): Type | undefined {
+  const results: Type[] = []
+
+  for (const member of getTypeAtoms(operand)) {
+    const result = check(member)
+
+    // If the operation is invalid for any member, it is invalid for the entire union.
+    if (result == null) {
+      return undefined
+    }
+
+    results.push(result)
+  }
+
+  return combineTypes(results)
+}
+
+function combineTypes (types: readonly Type[]): Type {
+  const flattened = types.flatMap((type) => getTypeAtoms(type))
+
+  if (flattened.length === 1) {
+    return flattened[0]
+  }
+
+  return makeUnion(...flattened)
+}
+
+export function liftOverFacetTypes (left: Type, right: Type, check: CheckBinary): Type | undefined {
+  return liftOverFacetType(left, (leftFacet) => {
+    return liftOverFacetType(right, (rightFacet) => {
+      return check(leftFacet, rightFacet)
+    })
+  })
+}

--- a/packages/language/src/compiler/operators/unary.ts
+++ b/packages/language/src/compiler/operators/unary.ts
@@ -3,24 +3,37 @@ import type { Numeric, Unit } from '@meyfa/cadence-utility'
 import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import { NumberFacet } from '../../type-system/base/number.ts'
 import { Numbers } from '../../type-system/helpers.ts'
-import type { FacetType, Value } from '../../type-system/types.ts'
+import type { Type, Value } from '../../type-system/types.ts'
+import { liftOverFacetType } from './lifting.ts'
 
 export interface UnaryOperation {
   readonly operator: ast.UnaryOperator
-  readonly check: (operand: FacetType) => FacetType | undefined
+
+  /**
+   * Returns the result type of the operation if the operand type is valid, undefined otherwise.
+   */
+  readonly check: (operand: Type) => Type | undefined
+
+  /**
+   * Returns the result value of the operation. The operand must have been checked beforehand.
+   */
   readonly compute: (operand: Value) => Value
 }
 
 export const unaryOperations: Readonly<Record<ast.UnaryOperator, UnaryOperation>> = {
   '+': {
     operator: '+',
-    check: (operand) => NumberFacet.is(operand) ? operand : undefined,
-    compute: (operand) => operand
+    check: (operand) => checkNumericOperand(operand),
+    compute: (operand) => {
+      // Remove facets other than NumberFacet from the operand.
+      const numeric = NumberFacet.get(operand)
+      return Numbers.of(numeric)
+    }
   },
 
   '-': {
     operator: '-',
-    check: (operand) => NumberFacet.is(operand) ? operand : undefined,
+    check: (operand) => checkNumericOperand(operand),
     compute: (operand) => {
       const { unit, value } = NumberFacet.get(operand)
       return Numbers.of({ unit, value: -(value as number) as Numeric<Unit> })
@@ -35,4 +48,15 @@ export const unaryOperations: Readonly<Record<ast.UnaryOperator, UnaryOperation>
       return BooleanFacet.type().of(!value)
     }
   }
+}
+
+function checkNumericOperand (operand: Type): Type | undefined {
+  return liftOverFacetType(operand, (facetType) => {
+    if (NumberFacet.is(facetType)) {
+      const unit = NumberFacet.detail(facetType)
+      return NumberFacet.with(unit).type()
+    }
+
+    return undefined
+  })
 }

--- a/packages/language/test/compiler/operators/binary.test.ts
+++ b/packages/language/test/compiler/operators/binary.test.ts
@@ -12,6 +12,7 @@ import { PatternFacet } from '../../../src/type-system/domain/pattern.ts'
 import { createSerialPattern } from '@meyfa/cadence-core'
 import { RecordFacet } from '../../../src/type-system/base/record.ts'
 import { FunctionFacet } from '../../../src/type-system/base/function.ts'
+import { makeUnion } from '../../../src/type-system/factory.ts'
 
 describe('compiler/operators/binary.ts', () => {
   it('should be defined for all operators', () => {
@@ -84,6 +85,45 @@ describe('compiler/operators/binary.ts', () => {
       const resultType = binaryOperations['+'].check(leftType, rightType)
       assert.strictEqual(resultType, undefined)
     })
+
+    it('should accept UnionType exactly if both sides are compatible', () => {
+      const testCases = [
+        // operand, expected
+        [
+          makeUnion(NumberFacet.with(undefined).type()),
+          NumberFacet.with(undefined).type()
+        ],
+        [
+          makeUnion(NumberFacet.with('hz').type()),
+          NumberFacet.with('hz').type()
+        ],
+        [
+          makeUnion(StringFacet.type()),
+          StringFacet.type()
+        ],
+        [
+          makeUnion(PatternFacet.type()),
+          PatternFacet.type()
+        ]
+      ]
+
+      for (const [operand, expected] of testCases) {
+        const result = binaryOperations['+'].check(operand, operand)
+        assert.strictEqual(result?.kind, 'FacetType', `Expected operator "+" to accept operands: ${operand.format()}, ${operand.format()}`)
+        assert.deepStrictEqual(result, expected)
+      }
+
+      for (const [left] of testCases) {
+        for (const [right] of testCases) {
+          if (left === right) {
+            continue
+          }
+
+          const result = binaryOperations['+'].check(left, right)
+          assert.strictEqual(result, undefined, `Expected operator "+" to reject operands: ${left.format()}, ${right.format()}`)
+        }
+      }
+    })
   })
 
   describe('operator "-"', () => {
@@ -116,6 +156,41 @@ describe('compiler/operators/binary.ts', () => {
       const rightType = BooleanFacet.type()
       const resultType = binaryOperations['-'].check(leftType, rightType)
       assert.strictEqual(resultType, undefined)
+    })
+
+    it('should accept UnionType exactly if both sides are compatible', () => {
+      const testCases = [
+        // operand, expected
+        [
+          makeUnion(NumberFacet.with(undefined).type()),
+          NumberFacet.with(undefined).type()
+        ],
+        [
+          makeUnion(NumberFacet.with('hz').type()),
+          NumberFacet.with('hz').type()
+        ],
+        [
+          makeUnion(NumberFacet.with('db').type()),
+          NumberFacet.with('db').type()
+        ]
+      ]
+
+      for (const [operand, expected] of testCases) {
+        const result = binaryOperations['-'].check(operand, operand)
+        assert.strictEqual(result?.kind, 'FacetType', `Expected operator "-" to accept operands: ${operand.format()}, ${operand.format()}`)
+        assert.deepStrictEqual(result, expected)
+      }
+
+      for (const [left] of testCases) {
+        for (const [right] of testCases) {
+          if (left === right) {
+            continue
+          }
+
+          const result = binaryOperations['-'].check(left, right)
+          assert.strictEqual(result, undefined, `Expected operator "-" to reject operands: ${left.format()}, ${right.format()}`)
+        }
+      }
     })
   })
 
@@ -180,7 +255,7 @@ describe('compiler/operators/binary.ts', () => {
 
       for (const [leftType, rightType] of testCases) {
         const resultType = binaryOperations['*'].check(leftType, rightType)
-        assert.strictEqual(resultType, undefined)
+        assert.strictEqual(resultType, undefined, `Expected operator "*" to reject operands: ${leftType.format()}, ${rightType.format()}`)
       }
     })
 
@@ -198,7 +273,54 @@ describe('compiler/operators/binary.ts', () => {
 
       for (const [leftType, rightType] of testCases) {
         const resultType = binaryOperations['*'].check(leftType, rightType)
-        assert.strictEqual(resultType, undefined)
+        assert.strictEqual(resultType, undefined, `Expected operator "*" to reject operands: ${leftType.format()}, ${rightType.format()}`)
+      }
+    })
+
+    it('should accept UnionType exactly if all members are valid operands', () => {
+      const validTestCases = [
+        // first, second, expected result
+        [
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          NumberFacet.with(undefined).type(),
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+        ],
+        [
+          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          NumberFacet.with(undefined).type(),
+          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type())
+        ]
+      ] as const
+
+      for (const [first, second, expectedResult] of validTestCases) {
+        for (const [left, right] of [[first, second], [second, first]] as const) {
+          const result = binaryOperations['*'].check(left, right)
+          assert.strictEqual(result?.kind, 'UnionType')
+          assert.deepStrictEqual(result.members, expectedResult.members)
+        }
+      }
+
+      const invalidTestCases = [
+        // first, second
+        [
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          NumberFacet.with('hz').type()
+        ],
+        [
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+        ],
+        [
+          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          NumberFacet.with('hz').type()
+        ]
+      ] as const
+
+      for (const [first, second] of invalidTestCases) {
+        for (const [left, right] of [[first, second], [second, first]] as const) {
+          const result = binaryOperations['*'].check(left, right)
+          assert.strictEqual(result, undefined, `Expected operator "*" to reject operands: ${left.format()}, ${right.format()}`)
+        }
       }
     })
   })
@@ -291,6 +413,54 @@ describe('compiler/operators/binary.ts', () => {
         assert.strictEqual(resultType, undefined)
       }
     })
+
+    it('should accept UnionType exactly if all members are valid operands', () => {
+      const validTestCases = [
+        // left, right, expected result
+        [
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          NumberFacet.with(undefined).type(),
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+        ],
+        [
+          NumberFacet.with('hz').type(),
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnion(NumberFacet.with('hz').type(), NumberFacet.with(undefined).type())
+        ],
+        [
+          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          NumberFacet.with(undefined).type(),
+          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type())
+        ]
+      ] as const
+
+      for (const [left, right, expectedResult] of validTestCases) {
+        const result = binaryOperations['/'].check(left, right)
+        assert.strictEqual(result?.kind, 'UnionType', `Expected operator "/" to accept operands: ${left.format()}, ${right.format()}`)
+        assert.deepStrictEqual(result.members, expectedResult.members)
+      }
+
+      const invalidTestCases = [
+        // left, right
+        [
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          NumberFacet.with('hz').type()
+        ],
+        [
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+        ],
+        [
+          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          NumberFacet.with('hz').type()
+        ]
+      ] as const
+
+      for (const [left, right] of invalidTestCases) {
+        const result = binaryOperations['/'].check(left, right)
+        assert.strictEqual(result, undefined, `Expected operator "/" to reject operands: ${left.format()}, ${right.format()}`)
+      }
+    })
   })
 
   for (const operator of ['==', '!='] as const) {
@@ -341,6 +511,11 @@ describe('compiler/operators/binary.ts', () => {
         const testCases = [
           [Numbers.of(runtimeNumeric('hz', 440)), Numbers.of(runtimeNumeric('hz', 440)), true],
           [Numbers.of(runtimeNumeric('hz', 440)), Numbers.of(runtimeNumeric('hz', 220)), false],
+          [Numbers.of(runtimeNumeric(undefined, Number.NaN)), Numbers.of(runtimeNumeric(undefined, Number.NaN)), false],
+          [Numbers.of(runtimeNumeric(undefined, Infinity)), Numbers.of(runtimeNumeric(undefined, Infinity)), true],
+          [Numbers.of(runtimeNumeric(undefined, -Infinity)), Numbers.of(runtimeNumeric(undefined, -Infinity)), true],
+          [Numbers.of(runtimeNumeric(undefined, Infinity)), Numbers.of(runtimeNumeric(undefined, -Infinity)), false],
+          [Numbers.of(runtimeNumeric('hz', 440)), Numbers.of(runtimeNumeric('hz', 440)), true],
           [StringFacet.type().of('Hello'), StringFacet.type().of('Hello'), true],
           [StringFacet.type().of('Hello'), StringFacet.type().of('World'), false],
           [BooleanFacet.type().of(true), BooleanFacet.type().of(true), true],
@@ -352,6 +527,53 @@ describe('compiler/operators/binary.ts', () => {
 
           const expectedResult = operator === '==' ? expectedEqual : !expectedEqual
           assert.strictEqual(BooleanFacet.get(resultValue), expectedResult)
+        }
+      })
+
+      it('should accept UnionType if all members are comparable to all members of the other operand', () => {
+        const testCases = [
+          // first, second
+          [
+            makeUnion(NumberFacet.with(undefined).type()),
+            makeUnion(NumberFacet.with(undefined).type())
+          ],
+          [
+            makeUnion(StringFacet.type()),
+            makeUnion(StringFacet.type())
+          ],
+          [
+            makeUnion(BooleanFacet.type()),
+            makeUnion(BooleanFacet.type())
+          ]
+        ]
+
+        for (const [first, second] of testCases) {
+          for (const [left, right] of [[first, second], [second, first]] as const) {
+            const result = binaryOperations[operator].check(left, right)
+            assert.strictEqual(result?.kind, 'FacetType')
+            assert.deepStrictEqual([...result.facets.keys()], [BooleanFacet.name])
+          }
+        }
+      })
+
+      it('should reject UnionType if any member is not comparable to any member of the other operand', () => {
+        const testCases = [
+          // first, second
+          [
+            makeUnion(NumberFacet.with(undefined).type(), StringFacet.type()),
+            NumberFacet.with(undefined).type()
+          ],
+          [
+            makeUnion(NumberFacet.with(undefined).type(), StringFacet.type()),
+            makeUnion(NumberFacet.with(undefined).type(), StringFacet.type())
+          ]
+        ]
+
+        for (const [first, second] of testCases) {
+          for (const [left, right] of [[first, second], [second, first]] as const) {
+            const result = binaryOperations[operator].check(left, right)
+            assert.strictEqual(result, undefined)
+          }
         }
       })
     })
@@ -484,78 +706,103 @@ describe('compiler/operators/binary.ts', () => {
           assert.strictEqual(BooleanFacet.get(resultValue), expectedResult, `Failed for operator "${operator}" with left=${testCase.left} and right=${testCase.right}`)
         }
       })
+
+      it('should accept UnionType if all members are comparable to all members of the other operand', () => {
+        const testCases = [
+          // first, second
+          [
+            makeUnion(NumberFacet.with(undefined).type()),
+            makeUnion(NumberFacet.with(undefined).type())
+          ],
+          [
+            makeUnion(NumberFacet.with('hz').type()),
+            makeUnion(NumberFacet.with('hz').type())
+          ]
+        ]
+
+        for (const [first, second] of testCases) {
+          for (const [left, right] of [[first, second], [second, first]] as const) {
+            const result = binaryOperations[operator].check(left, right)
+            assert.strictEqual(result?.kind, 'FacetType')
+            assert.deepStrictEqual([...result.facets.keys()], [BooleanFacet.name])
+          }
+        }
+      })
+
+      it('should reject UnionType if any member is not comparable to any member of the other operand', () => {
+        const testCases = [
+          // first, second
+          [
+            makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+            NumberFacet.with(undefined).type()
+          ],
+          [
+            makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+            makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+          ]
+        ]
+
+        for (const [first, second] of testCases) {
+          for (const [left, right] of [[first, second], [second, first]] as const) {
+            const result = binaryOperations[operator].check(left, right)
+            assert.strictEqual(result, undefined)
+          }
+        }
+      })
     })
   }
 
-  describe('operator "and"', () => {
-    it('should accept boolean FacetType', () => {
-      const result = binaryOperations.and.check(BooleanFacet.type(), BooleanFacet.type())
-      assert.strictEqual(result, BooleanFacet.type())
+  for (const operator of ['and', 'or'] as const) {
+    describe(`operator "${operator}"`, () => {
+      it('should accept boolean FacetType', () => {
+        const result = binaryOperations[operator].check(BooleanFacet.type(), BooleanFacet.type())
+        assert.strictEqual(result, BooleanFacet.type())
+      })
+
+      it('should reject non-boolean FacetType', () => {
+        const operands = [
+          StringFacet.type(),
+          NumberFacet.with(undefined).type()
+        ]
+
+        for (const operand of operands) {
+          const result = binaryOperations[operator].check(operand, operand)
+          assert.strictEqual(result, undefined)
+        }
+      })
+
+      it('should return the logical and value', () => {
+        const truthTable = {
+          and: (a: boolean, b: boolean) => a && b,
+          or: (a: boolean, b: boolean) => a || b
+        }
+
+        for (const left of [false, true]) {
+          for (const right of [false, true]) {
+            const leftValue = BooleanFacet.type().of(left)
+            const rightValue = BooleanFacet.type().of(right)
+
+            const result = binaryOperations[operator].compute(leftValue, rightValue)
+            assert.strictEqual(
+              BooleanFacet.get(result),
+              truthTable[operator](left, right),
+              `Failed for operator "${operator}" with left=${left} and right=${right}`
+            )
+          }
+        }
+      })
+
+      it('should reject UnionType if any member is not boolean', () => {
+        const validOperand = makeUnion(BooleanFacet.type())
+        const invalidOperand = makeUnion(BooleanFacet.type(), StringFacet.type())
+
+        // same operand on both sides
+        assert.strictEqual(binaryOperations[operator].check(invalidOperand, invalidOperand), undefined)
+
+        // valid operand on one side, invalid operand on the other
+        assert.strictEqual(binaryOperations[operator].check(validOperand, invalidOperand), undefined)
+        assert.strictEqual(binaryOperations[operator].check(invalidOperand, validOperand), undefined)
+      })
     })
-
-    it('should reject non-boolean FacetType', () => {
-      const operands = [
-        StringFacet.type(),
-        NumberFacet.with(undefined).type()
-      ]
-
-      for (const operand of operands) {
-        const result = binaryOperations.and.check(operand, operand)
-        assert.strictEqual(result, undefined)
-      }
-    })
-
-    it('should return the logical and value', () => {
-      const testCases = [
-        // left, right, expected
-        [false, false, false],
-        [false, true, false],
-        [true, false, false],
-        [true, true, true]
-      ]
-
-      for (const [left, right, expected] of testCases) {
-        const leftValue = BooleanFacet.type().of(left)
-        const rightValue = BooleanFacet.type().of(right)
-        const result = binaryOperations.and.compute(leftValue, rightValue)
-        assert.strictEqual(BooleanFacet.get(result), expected)
-      }
-    })
-  })
-
-  describe('operator "or"', () => {
-    it('should accept boolean FacetType', () => {
-      const result = binaryOperations.or.check(BooleanFacet.type(), BooleanFacet.type())
-      assert.strictEqual(result, BooleanFacet.type())
-    })
-
-    it('should reject non-boolean FacetType', () => {
-      const operands = [
-        StringFacet.type(),
-        NumberFacet.with(undefined).type()
-      ]
-
-      for (const operand of operands) {
-        const result = binaryOperations.or.check(operand, operand)
-        assert.strictEqual(result, undefined)
-      }
-    })
-
-    it('should return the logical or value', () => {
-      const testCases = [
-        // left, right, expected
-        [false, false, false],
-        [false, true, true],
-        [true, false, true],
-        [true, true, true]
-      ]
-
-      for (const [left, right, expected] of testCases) {
-        const leftValue = BooleanFacet.type().of(left)
-        const rightValue = BooleanFacet.type().of(right)
-        const result = binaryOperations.or.compute(leftValue, rightValue)
-        assert.strictEqual(BooleanFacet.get(result), expected)
-      }
-    })
-  })
+  }
 })

--- a/packages/language/test/compiler/operators/unary.test.ts
+++ b/packages/language/test/compiler/operators/unary.test.ts
@@ -7,6 +7,7 @@ import { BooleanFacet } from '../../../src/type-system/base/boolean.ts'
 import { NumberFacet } from '../../../src/type-system/base/number.ts'
 import { StringFacet } from '../../../src/type-system/base/string.ts'
 import { Numbers } from '../../../src/type-system/helpers.ts'
+import { makeUnion } from '../../../src/type-system/factory.ts'
 
 function createNumericTestCases (operator: ast.UnaryOperator): void {
   it('should accept numeric FacetType', () => {
@@ -33,6 +34,26 @@ function createNumericTestCases (operator: ast.UnaryOperator): void {
       const result = unaryOperations[operator].check(operand)
       assert.strictEqual(result, undefined)
     }
+  })
+
+  it('should accept UnionType exactly if all members are numeric FacetType', () => {
+    const validOperand = makeUnion(
+      NumberFacet.with(undefined).type(),
+      NumberFacet.with('hz').type(),
+      NumberFacet.with('db').type()
+    )
+
+    const result = unaryOperations[operator].check(validOperand)
+    assert.strictEqual(result?.kind, 'UnionType')
+    assert.deepStrictEqual(result.members, validOperand.members)
+
+    const invalidOperand = makeUnion(
+      NumberFacet.with(undefined).type(),
+      NumberFacet.with('hz').type(),
+      StringFacet.type()
+    )
+
+    assert.strictEqual(unaryOperations[operator].check(invalidOperand), undefined)
   })
 }
 
@@ -81,6 +102,24 @@ describe('compiler/operators/unary.ts', () => {
         const result = unaryOperations.not.check(operand)
         assert.strictEqual(result, undefined)
       }
+    })
+
+    it('should accept UnionType exactly if all members are boolean FacetType', () => {
+      const validOperand = makeUnion(
+        BooleanFacet.type(),
+        BooleanFacet.type()
+      )
+
+      const result = unaryOperations.not.check(validOperand)
+      assert.strictEqual(result?.kind, 'FacetType')
+      assert.deepStrictEqual([...result.facets.keys()], [BooleanFacet.name])
+
+      const invalidOperand = makeUnion(
+        BooleanFacet.type(),
+        StringFacet.type()
+      )
+
+      assert.strictEqual(unaryOperations.not.check(invalidOperand), undefined)
     })
 
     it('should return the negated value', () => {


### PR DESCRIPTION
Future features will require broader UnionType support. For example, any optional values (e.g., from optional function parameters) will be represented via a UnionType. To enable this, all parts of the checker must be able to handle UnionType in addition to FacetType.

This patch adds support for UnionType to the unary and binary operators. An operation is valid for a UnionType operand if it is valid for all members of the UnionType. The resulting type is the union of the results of the operation for each member of the UnionType.

Note that UnionType results currently cannot be propagated to the rest of the checker, as other parts still only support FacetType. This will be addressed in future patches. The unit tests cover the new UnionType support for operators.