### PR TITLE
refactor: Use clearer names for type factories

### DIFF
--- a/packages/language/src/compiler/checker/blocks.ts
+++ b/packages/language/src/compiler/checker/blocks.ts
@@ -2,7 +2,7 @@ import type { ast } from '@meyfa/cadence-ast'
 import { setAll } from '@meyfa/cadence-utility'
 import type { Capabilities } from '../../type-system/base/function.ts'
 import { RecordFacet } from '../../type-system/base/record.ts'
-import { makeType } from '../../type-system/factory.ts'
+import { makeFacetType } from '../../type-system/factory.ts'
 import type { Schema } from '../../type-system/schema.ts'
 import { makeSchema } from '../../type-system/schema.ts'
 import type { Facet, FacetType } from '../../type-system/types.ts'
@@ -165,5 +165,5 @@ function makeBlockType (facet: Facet, properties: ReadonlyMap<string, Binding>):
     return facet.type()
   }
 
-  return makeType(facet, RecordFacet.with(fields))
+  return makeFacetType(facet, RecordFacet.with(fields))
 }

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -22,7 +22,7 @@ import { RoutingFacet } from '../../type-system/domain/routing.ts'
 import { SourceFacet } from '../../type-system/domain/source.ts'
 import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
-import { makeUnion } from '../../type-system/factory.ts'
+import { makeUnionType } from '../../type-system/factory.ts'
 import { isFacetType } from '../../type-system/guards.ts'
 import type { FacetType, Type } from '../../type-system/types.ts'
 import { nonNull } from '../assert.ts'
@@ -283,7 +283,7 @@ function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
   return { errors, capabilities, result }
 }
 
-const curveSegmentLengthType = makeUnion(
+const curveSegmentLengthType = makeUnionType(
   NumberFacet.with('beats').type(),
   NumberFacet.with('s').type()
 )
@@ -514,7 +514,7 @@ const checkBus = createBlockChecker<ast.Bus>({
   slots: [
     {
       name: 'input' as SlotName,
-      type: makeUnion(BusFacet.type(), InstrumentFacet.type())
+      type: makeUnionType(BusFacet.type(), InstrumentFacet.type())
     },
     {
       name: 'effect' as SlotName,

--- a/packages/language/src/compiler/checker/type-expressions.ts
+++ b/packages/language/src/compiler/checker/type-expressions.ts
@@ -4,7 +4,7 @@ import { CompileError } from '../error.ts'
 import { RecordFacet } from '../../type-system/base/record.ts'
 import { FunctionFacet } from '../../type-system/base/function.ts'
 import { checkParameters } from './parameters.ts'
-import { makeType } from '../../type-system/factory.ts'
+import { makeFacetType } from '../../type-system/factory.ts'
 import { getFacet } from './type-facets.ts'
 
 export interface CheckedType {
@@ -44,7 +44,7 @@ export function checkType (expression: ast.Type): CheckedType {
     facets.set(facet.name, facet)
   }
 
-  const result = makeType(...facets.values())
+  const result = makeFacetType(...facets.values())
 
   return { errors, result }
 }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -23,7 +23,7 @@ import { RoutingFacet } from '../../type-system/domain/routing.ts'
 import { SourceFacet } from '../../type-system/domain/source.ts'
 import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
-import { makeType } from '../../type-system/factory.ts'
+import { makeFacetType } from '../../type-system/factory.ts'
 import { Curves, Functions, Numbers, Parameters } from '../../type-system/helpers.ts'
 import type { InferSchema, Schema } from '../../type-system/schema.ts'
 import type { FacetType, Value } from '../../type-system/types.ts'
@@ -439,7 +439,7 @@ function generateInstrument (scope: Scope, expression: ast.Instrument): Value {
   const instrument = scope.top.allocateInstrument({ label, gain: gainParameter, voices })
 
   return !recordBuilder.empty
-    ? makeType(InstrumentFacet, recordBuilder.facet).of(instrument, recordBuilder.record)
+    ? makeFacetType(InstrumentFacet, recordBuilder.facet).of(instrument, recordBuilder.record)
     : InstrumentFacet.type().of(instrument)
 }
 
@@ -548,7 +548,7 @@ function generateMixer (scope: Scope, expression: ast.Mixer): Value {
   const mixer = { buses, routings }
 
   return !recordBuilder.empty
-    ? makeType(MixerFacet, recordBuilder.facet).of(mixer, recordBuilder.record)
+    ? makeFacetType(MixerFacet, recordBuilder.facet).of(mixer, recordBuilder.record)
     : MixerFacet.type().of(mixer)
 }
 
@@ -625,7 +625,7 @@ function generateBus (scope: Scope, expression: ast.Bus): Value {
   }
 
   const bus = scope.top.allocateBus({ label, sources, gain, pan, effects })
-  const value = makeType(BusFacet, recordBuilder.facet).of(bus, recordBuilder.record)
+  const value = makeFacetType(BusFacet, recordBuilder.facet).of(bus, recordBuilder.record)
 
   return value
 }
@@ -671,7 +671,7 @@ function generateTrack (scope: Scope, expression: ast.Track): Value {
   const track = { tempo, parts }
 
   return !recordBuilder.empty
-    ? makeType(TrackFacet, recordBuilder.facet).of(track, recordBuilder.record)
+    ? makeFacetType(TrackFacet, recordBuilder.facet).of(track, recordBuilder.record)
     : TrackFacet.type().of(track)
 }
 
@@ -705,7 +705,7 @@ function generatePart (scope: Scope, expression: ast.Part): Value {
   const part = { label, length: length.value, routings, automations }
 
   return !recordBuilder.empty
-    ? makeType(PartFacet, recordBuilder.facet).of(part, recordBuilder.record)
+    ? makeFacetType(PartFacet, recordBuilder.facet).of(part, recordBuilder.record)
     : PartFacet.type().of(part)
 }
 

--- a/packages/language/src/compiler/operators/lifting.ts
+++ b/packages/language/src/compiler/operators/lifting.ts
@@ -1,4 +1,4 @@
-import { makeUnion } from '../../type-system/factory.ts'
+import { makeUnionType } from '../../type-system/factory.ts'
 import { isFacetType } from '../../type-system/guards.ts'
 import type { FacetType, Type } from '../../type-system/types.ts'
 
@@ -37,7 +37,7 @@ function combineTypes (types: readonly Type[]): Type {
     return flattened[0]
   }
 
-  return makeUnion(...flattened)
+  return makeUnionType(...flattened)
 }
 
 export function liftOverFacetTypes (left: Type, right: Type, check: CheckBinary): Type | undefined {

--- a/packages/language/src/library/modules/effects.ts
+++ b/packages/language/src/library/modules/effects.ts
@@ -5,7 +5,7 @@ import { NumberFacet } from '../../type-system/base/number.ts'
 import { RecordFacet } from '../../type-system/base/record.ts'
 import { EffectFacet } from '../../type-system/domain/effect.ts'
 import { ParameterFacet } from '../../type-system/domain/parameter.ts'
-import { makeType, makeUnion } from '../../type-system/factory.ts'
+import { makeFacetType, makeUnionType } from '../../type-system/factory.ts'
 import { Functions, Modules, Parameters } from '../../type-system/helpers.ts'
 import { makeSchema } from '../../type-system/schema.ts'
 import type { Value } from '../../type-system/types.ts'
@@ -14,31 +14,31 @@ const UNITY_GAIN = 0 as Numeric<'db'>
 
 // types
 
-const GainEffectType = makeType(EffectFacet, RecordFacet.with({
+const GainEffectType = makeFacetType(EffectFacet, RecordFacet.with({
   gain: ParameterFacet.with('db').type()
 }))
 
-const PanEffectType = makeType(EffectFacet, RecordFacet.with({
+const PanEffectType = makeFacetType(EffectFacet, RecordFacet.with({
   pan: ParameterFacet.with(undefined).type()
 }))
 
-const LowpassEffectType = makeType(EffectFacet, RecordFacet.with({
+const LowpassEffectType = makeFacetType(EffectFacet, RecordFacet.with({
   frequency: ParameterFacet.with('hz').type()
 }))
 
-const HighpassEffectType = makeType(EffectFacet, RecordFacet.with({
+const HighpassEffectType = makeFacetType(EffectFacet, RecordFacet.with({
   frequency: ParameterFacet.with('hz').type()
 }))
 
-const WidthEffectType = makeType(EffectFacet)
+const WidthEffectType = makeFacetType(EffectFacet)
 
-const DelayEffectType = makeType(EffectFacet, RecordFacet.with({
+const DelayEffectType = makeFacetType(EffectFacet, RecordFacet.with({
   feedback: ParameterFacet.with(undefined).type()
 }))
 
-const ReverbEffectType = makeType(EffectFacet)
+const ReverbEffectType = makeFacetType(EffectFacet)
 
-const ClipEffectType = makeType(EffectFacet, RecordFacet.with({
+const ClipEffectType = makeFacetType(EffectFacet, RecordFacet.with({
   threshold: ParameterFacet.with('db').type()
 }))
 
@@ -145,7 +145,7 @@ const width = Functions.of({
 const delay = Functions.of({
   parameters: makeSchema([
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
-    { name: 'time', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
+    { name: 'time', type: makeUnionType(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
     { name: 'feedback', type: NumberFacet.with(undefined).type(), required: true },
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
@@ -171,7 +171,7 @@ const delay = Functions.of({
 const reverb = Functions.of({
   parameters: makeSchema([
     { name: 'mix', type: NumberFacet.with(undefined).type(), required: true },
-    { name: 'decay', type: makeUnion(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
+    { name: 'decay', type: makeUnionType(NumberFacet.with('beats').type(), NumberFacet.with('s').type()), required: true },
     { name: 'wet', type: NumberFacet.with('db').type(), required: false }
   ]),
   returnType: ReverbEffectType,

--- a/packages/language/src/library/modules/instruments.ts
+++ b/packages/language/src/library/modules/instruments.ts
@@ -7,7 +7,7 @@ import { RecordFacet } from '../../type-system/base/record.ts'
 import { StringFacet } from '../../type-system/base/string.ts'
 import { InstrumentFacet } from '../../type-system/domain/instrument.ts'
 import { ParameterFacet } from '../../type-system/domain/parameter.ts'
-import { makeType } from '../../type-system/factory.ts'
+import { makeFacetType } from '../../type-system/factory.ts'
 import { Functions, Modules, Parameters } from '../../type-system/helpers.ts'
 import { makeSchema } from '../../type-system/schema.ts'
 import type { Value } from '../../type-system/types.ts'
@@ -25,11 +25,11 @@ const ENVELOPE_DECLICK: Envelope = {
   release: 0.003 as Numeric<'s'>
 }
 
-const SampleInstrumentType = makeType(InstrumentFacet, RecordFacet.with({
+const SampleInstrumentType = makeFacetType(InstrumentFacet, RecordFacet.with({
   gain: ParameterFacet.with('db').type()
 }))
 
-const OscillatorInstrumentType = makeType(InstrumentFacet, RecordFacet.with({
+const OscillatorInstrumentType = makeFacetType(InstrumentFacet, RecordFacet.with({
   gain: ParameterFacet.with('db').type()
 }))
 

--- a/packages/language/src/type-system/factory.ts
+++ b/packages/language/src/type-system/factory.ts
@@ -48,7 +48,7 @@ export function makeFacet<const Name extends string, Data> (
     intersect: options?.intersect ?? ((other: Facet) => intersectFacets(facet, other)),
 
     type: () => {
-      cachedType ??= makeType(facet)
+      cachedType ??= makeFacetType(facet)
       return cachedType
     },
 
@@ -86,7 +86,7 @@ function intersectFacets (facet: Facet, other: Facet): Facet | undefined {
   return undefined
 }
 
-export function makeType<const Facets extends readonly Facet[]> (
+export function makeFacetType<const Facets extends readonly Facet[]> (
   ...facets: Facets
 ): FacetType<Facets> {
   if (facets.length === 0) {
@@ -168,7 +168,7 @@ function mergeFacetTypes (type: FacetType, other: FacetType): FacetType | undefi
     }
   }
 
-  return makeType(...resultFacets)
+  return makeFacetType(...resultFacets)
 }
 
 function intersectFacetTypes (type: FacetType, other: FacetType): FacetType | undefined {
@@ -196,10 +196,10 @@ function intersectFacetTypes (type: FacetType, other: FacetType): FacetType | un
     return undefined
   }
 
-  return makeType(...resultFacets)
+  return makeFacetType(...resultFacets)
 }
 
-export function makeUnion<const Members extends readonly FacetType[]> (
+export function makeUnionType<const Members extends readonly FacetType[]> (
   ...members: Members
 ): UnionType<Members> {
   if (members.length === 0) {

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -8,7 +8,7 @@ import { NumberFacet } from './base/number.ts'
 import { RecordFacet } from './base/record.ts'
 import { CurveFacet } from './domain/curve.ts'
 import { ParameterFacet } from './domain/parameter.ts'
-import { makeType } from './factory.ts'
+import { makeFacetType } from './factory.ts'
 import type { Schema } from './schema.ts'
 import type { Facet, FacetType, Value } from './types.ts'
 
@@ -32,7 +32,7 @@ export const Modules = {
       exportValues[name] = exportValue
     }
 
-    return makeType(
+    return makeFacetType(
       ModuleFacet.with(value),
       RecordFacet.with(exportTypes)
     ).of(

--- a/packages/language/test/compiler/operators/binary.test.ts
+++ b/packages/language/test/compiler/operators/binary.test.ts
@@ -12,7 +12,7 @@ import { PatternFacet } from '../../../src/type-system/domain/pattern.ts'
 import { createSerialPattern } from '@meyfa/cadence-core'
 import { RecordFacet } from '../../../src/type-system/base/record.ts'
 import { FunctionFacet } from '../../../src/type-system/base/function.ts'
-import { makeUnion } from '../../../src/type-system/factory.ts'
+import { makeUnionType } from '../../../src/type-system/factory.ts'
 
 describe('compiler/operators/binary.ts', () => {
   it('should be defined for all operators', () => {
@@ -90,19 +90,19 @@ describe('compiler/operators/binary.ts', () => {
       const testCases = [
         // operand, expected
         [
-          makeUnion(NumberFacet.with(undefined).type()),
+          makeUnionType(NumberFacet.with(undefined).type()),
           NumberFacet.with(undefined).type()
         ],
         [
-          makeUnion(NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with('hz').type()),
           NumberFacet.with('hz').type()
         ],
         [
-          makeUnion(StringFacet.type()),
+          makeUnionType(StringFacet.type()),
           StringFacet.type()
         ],
         [
-          makeUnion(PatternFacet.type()),
+          makeUnionType(PatternFacet.type()),
           PatternFacet.type()
         ]
       ]
@@ -162,15 +162,15 @@ describe('compiler/operators/binary.ts', () => {
       const testCases = [
         // operand, expected
         [
-          makeUnion(NumberFacet.with(undefined).type()),
+          makeUnionType(NumberFacet.with(undefined).type()),
           NumberFacet.with(undefined).type()
         ],
         [
-          makeUnion(NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with('hz').type()),
           NumberFacet.with('hz').type()
         ],
         [
-          makeUnion(NumberFacet.with('db').type()),
+          makeUnionType(NumberFacet.with('db').type()),
           NumberFacet.with('db').type()
         ]
       ]
@@ -281,14 +281,14 @@ describe('compiler/operators/binary.ts', () => {
       const validTestCases = [
         // first, second, expected result
         [
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
           NumberFacet.with(undefined).type(),
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
         ],
         [
-          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          makeUnionType(PatternFacet.type(), NumberFacet.with(undefined).type()),
           NumberFacet.with(undefined).type(),
-          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type())
+          makeUnionType(PatternFacet.type(), NumberFacet.with(undefined).type())
         ]
       ] as const
 
@@ -303,15 +303,15 @@ describe('compiler/operators/binary.ts', () => {
       const invalidTestCases = [
         // first, second
         [
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
           NumberFacet.with('hz').type()
         ],
         [
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
         ],
         [
-          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          makeUnionType(PatternFacet.type(), NumberFacet.with(undefined).type()),
           NumberFacet.with('hz').type()
         ]
       ] as const
@@ -418,19 +418,19 @@ describe('compiler/operators/binary.ts', () => {
       const validTestCases = [
         // left, right, expected result
         [
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
           NumberFacet.with(undefined).type(),
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
         ],
         [
           NumberFacet.with('hz').type(),
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
-          makeUnion(NumberFacet.with('hz').type(), NumberFacet.with(undefined).type())
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with('hz').type(), NumberFacet.with(undefined).type())
         ],
         [
-          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          makeUnionType(PatternFacet.type(), NumberFacet.with(undefined).type()),
           NumberFacet.with(undefined).type(),
-          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type())
+          makeUnionType(PatternFacet.type(), NumberFacet.with(undefined).type())
         ]
       ] as const
 
@@ -443,15 +443,15 @@ describe('compiler/operators/binary.ts', () => {
       const invalidTestCases = [
         // left, right
         [
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
           NumberFacet.with('hz').type()
         ],
         [
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
-          makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+          makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
         ],
         [
-          makeUnion(PatternFacet.type(), NumberFacet.with(undefined).type()),
+          makeUnionType(PatternFacet.type(), NumberFacet.with(undefined).type()),
           NumberFacet.with('hz').type()
         ]
       ] as const
@@ -534,16 +534,16 @@ describe('compiler/operators/binary.ts', () => {
         const testCases = [
           // first, second
           [
-            makeUnion(NumberFacet.with(undefined).type()),
-            makeUnion(NumberFacet.with(undefined).type())
+            makeUnionType(NumberFacet.with(undefined).type()),
+            makeUnionType(NumberFacet.with(undefined).type())
           ],
           [
-            makeUnion(StringFacet.type()),
-            makeUnion(StringFacet.type())
+            makeUnionType(StringFacet.type()),
+            makeUnionType(StringFacet.type())
           ],
           [
-            makeUnion(BooleanFacet.type()),
-            makeUnion(BooleanFacet.type())
+            makeUnionType(BooleanFacet.type()),
+            makeUnionType(BooleanFacet.type())
           ]
         ]
 
@@ -560,12 +560,12 @@ describe('compiler/operators/binary.ts', () => {
         const testCases = [
           // first, second
           [
-            makeUnion(NumberFacet.with(undefined).type(), StringFacet.type()),
+            makeUnionType(NumberFacet.with(undefined).type(), StringFacet.type()),
             NumberFacet.with(undefined).type()
           ],
           [
-            makeUnion(NumberFacet.with(undefined).type(), StringFacet.type()),
-            makeUnion(NumberFacet.with(undefined).type(), StringFacet.type())
+            makeUnionType(NumberFacet.with(undefined).type(), StringFacet.type()),
+            makeUnionType(NumberFacet.with(undefined).type(), StringFacet.type())
           ]
         ]
 
@@ -711,12 +711,12 @@ describe('compiler/operators/binary.ts', () => {
         const testCases = [
           // first, second
           [
-            makeUnion(NumberFacet.with(undefined).type()),
-            makeUnion(NumberFacet.with(undefined).type())
+            makeUnionType(NumberFacet.with(undefined).type()),
+            makeUnionType(NumberFacet.with(undefined).type())
           ],
           [
-            makeUnion(NumberFacet.with('hz').type()),
-            makeUnion(NumberFacet.with('hz').type())
+            makeUnionType(NumberFacet.with('hz').type()),
+            makeUnionType(NumberFacet.with('hz').type())
           ]
         ]
 
@@ -733,12 +733,12 @@ describe('compiler/operators/binary.ts', () => {
         const testCases = [
           // first, second
           [
-            makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+            makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
             NumberFacet.with(undefined).type()
           ],
           [
-            makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
-            makeUnion(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
+            makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type()),
+            makeUnionType(NumberFacet.with(undefined).type(), NumberFacet.with('hz').type())
           ]
         ]
 
@@ -793,8 +793,8 @@ describe('compiler/operators/binary.ts', () => {
       })
 
       it('should reject UnionType if any member is not boolean', () => {
-        const validOperand = makeUnion(BooleanFacet.type())
-        const invalidOperand = makeUnion(BooleanFacet.type(), StringFacet.type())
+        const validOperand = makeUnionType(BooleanFacet.type())
+        const invalidOperand = makeUnionType(BooleanFacet.type(), StringFacet.type())
 
         // same operand on both sides
         assert.strictEqual(binaryOperations[operator].check(invalidOperand, invalidOperand), undefined)

--- a/packages/language/test/compiler/operators/unary.test.ts
+++ b/packages/language/test/compiler/operators/unary.test.ts
@@ -7,7 +7,7 @@ import { BooleanFacet } from '../../../src/type-system/base/boolean.ts'
 import { NumberFacet } from '../../../src/type-system/base/number.ts'
 import { StringFacet } from '../../../src/type-system/base/string.ts'
 import { Numbers } from '../../../src/type-system/helpers.ts'
-import { makeUnion } from '../../../src/type-system/factory.ts'
+import { makeUnionType } from '../../../src/type-system/factory.ts'
 
 function createNumericTestCases (operator: ast.UnaryOperator): void {
   it('should accept numeric FacetType', () => {
@@ -37,7 +37,7 @@ function createNumericTestCases (operator: ast.UnaryOperator): void {
   })
 
   it('should accept UnionType exactly if all members are numeric FacetType', () => {
-    const validOperand = makeUnion(
+    const validOperand = makeUnionType(
       NumberFacet.with(undefined).type(),
       NumberFacet.with('hz').type(),
       NumberFacet.with('db').type()
@@ -47,7 +47,7 @@ function createNumericTestCases (operator: ast.UnaryOperator): void {
     assert.strictEqual(result?.kind, 'UnionType')
     assert.deepStrictEqual(result.members, validOperand.members)
 
-    const invalidOperand = makeUnion(
+    const invalidOperand = makeUnionType(
       NumberFacet.with(undefined).type(),
       NumberFacet.with('hz').type(),
       StringFacet.type()
@@ -105,7 +105,7 @@ describe('compiler/operators/unary.ts', () => {
     })
 
     it('should accept UnionType exactly if all members are boolean FacetType', () => {
-      const validOperand = makeUnion(
+      const validOperand = makeUnionType(
         BooleanFacet.type(),
         BooleanFacet.type()
       )
@@ -114,7 +114,7 @@ describe('compiler/operators/unary.ts', () => {
       assert.strictEqual(result?.kind, 'FacetType')
       assert.deepStrictEqual([...result.facets.keys()], [BooleanFacet.name])
 
-      const invalidOperand = makeUnion(
+      const invalidOperand = makeUnionType(
         BooleanFacet.type(),
         StringFacet.type()
       )

--- a/packages/language/test/type-system/base.test.ts
+++ b/packages/language/test/type-system/base.test.ts
@@ -10,7 +10,7 @@ import { ModuleFacet } from '../../src/type-system/base/module.ts'
 import { NumberFacet } from '../../src/type-system/base/number.ts'
 import { RecordFacet } from '../../src/type-system/base/record.ts'
 import { StringFacet } from '../../src/type-system/base/string.ts'
-import { makeType } from '../../src/type-system/factory.ts'
+import { makeFacetType } from '../../src/type-system/factory.ts'
 import { makeSchema } from '../../src/type-system/schema.ts'
 import type { ValueForType } from '../../src/type-system/types.ts'
 import { expectTypeEquals } from '../test-utils.ts'
@@ -66,7 +66,7 @@ describe('type-system/base', () => {
         parameters: makeSchema([
           { name: 'amount', type: NumberFacet.with('db').type(), required: true }
         ]),
-        returnType: makeType(StringFacet, RecordFacet.with({ gain: NumberFacet.with('db').type() })),
+        returnType: makeFacetType(StringFacet, RecordFacet.with({ gain: NumberFacet.with('db').type() })),
         capabilities: { mayBlock: false }
       })
       assert.strictEqual(

--- a/packages/language/test/type-system/guards.test.ts
+++ b/packages/language/test/type-system/guards.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { NumberFacet } from '../../src/type-system/base/number.ts'
 import { RecordFacet } from '../../src/type-system/base/record.ts'
 import { StringFacet } from '../../src/type-system/base/string.ts'
-import { makeType, makeUnion } from '../../src/type-system/factory.ts'
+import { makeFacetType, makeUnionType } from '../../src/type-system/factory.ts'
 import { isFacet, isType } from '../../src/type-system/guards.ts'
 
 describe('type-system/guards.ts', () => {
@@ -17,16 +17,16 @@ describe('type-system/guards.ts', () => {
 
     it('should return false for Type', () => {
       assert.strictEqual(isFacet(NumberFacet.type()), false)
-      assert.strictEqual(isFacet(makeType(NumberFacet, RecordFacet)), false)
-      assert.strictEqual(isFacet(makeUnion(NumberFacet.type(), RecordFacet.type())), false)
+      assert.strictEqual(isFacet(makeFacetType(NumberFacet, RecordFacet)), false)
+      assert.strictEqual(isFacet(makeUnionType(NumberFacet.type(), RecordFacet.type())), false)
     })
   })
 
   describe('isType', () => {
     it('should return true for Type', () => {
       assert.strictEqual(isType(NumberFacet.type()), true)
-      assert.strictEqual(isType(makeType(NumberFacet, RecordFacet)), true)
-      assert.strictEqual(isType(makeUnion(NumberFacet.type(), RecordFacet.type())), true)
+      assert.strictEqual(isType(makeFacetType(NumberFacet, RecordFacet)), true)
+      assert.strictEqual(isType(makeUnionType(NumberFacet.type(), RecordFacet.type())), true)
     })
 
     it('should return false for Facet', () => {

--- a/packages/language/test/type-system/type-system.test.ts
+++ b/packages/language/test/type-system/type-system.test.ts
@@ -2,7 +2,7 @@ import type { RuntimeNumeric, Unit } from '@meyfa/cadence-utility'
 import { runtimeNumeric } from '@meyfa/cadence-utility'
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
-import { makeFacet, makeType, makeUnion } from '../../src/type-system/factory.ts'
+import { makeFacet, makeFacetType, makeUnionType } from '../../src/type-system/factory.ts'
 import type { DataForFacet, DataForFacets, Value, ValueForType } from '../../src/type-system/types.ts'
 import { expectTypeEquals } from '../test-utils.ts'
 
@@ -16,14 +16,14 @@ const hertzFacet = makeFacet<'numeric', RuntimeNumeric<'hz'>>('numeric', { unit:
   format: () => 'numeric(hz)'
 })
 
-const stringType = makeType(stringFacet)
-const numberType = makeType(numberFacet)
-const stringAndNumberType = makeType(stringFacet, numberFacet)
-const numericType = makeType(numericFacet)
-const decibelType = makeType(decibelFacet)
-const hertzType = makeType(hertzFacet)
+const stringType = makeFacetType(stringFacet)
+const numberType = makeFacetType(numberFacet)
+const stringAndNumberType = makeFacetType(stringFacet, numberFacet)
+const numericType = makeFacetType(numericFacet)
+const decibelType = makeFacetType(decibelFacet)
+const hertzType = makeFacetType(hertzFacet)
 
-const numericUnion = makeUnion(decibelType, hertzType)
+const numericUnion = makeUnionType(decibelType, hertzType)
 
 describe('type-system', () => {
   describe('DataForFacet', () => {
@@ -95,10 +95,10 @@ describe('type-system', () => {
       assert.strictEqual(customComparableFacetA.is(customComparableFacetB), false)
 
       const unionGenericFacetA = makeFacet<'generic', unknown>('generic', {
-        foobar: makeUnion(decibelType, hertzType)
+        foobar: makeUnionType(decibelType, hertzType)
       })
       const unionGenericFacetB = makeFacet<'generic', unknown>('generic', {
-        foobar: makeUnion(decibelType, hertzType)
+        foobar: makeUnionType(decibelType, hertzType)
       })
 
       assert.strictEqual(unionGenericFacetA.is(unionGenericFacetB), true)
@@ -203,7 +203,7 @@ describe('type-system', () => {
 
   describe('FacetType', () => {
     it('should throw if given zero facets', () => {
-      assert.throws(() => makeType(), /Expected at least one facet/)
+      assert.throws(() => makeFacetType(), /Expected at least one facet/)
     })
 
     it('should store facets', () => {
@@ -261,8 +261,8 @@ describe('type-system', () => {
     it('should reject missing or duplicate names', () => {
       const duplicateStringFacet = makeFacet<'string', number>('string', { variant: true })
 
-      assert.throws(() => makeType(stringFacet, duplicateStringFacet), /Duplicate facet names are not allowed in a type/)
-      assert.throws(() => makeType(decibelFacet, hertzFacet), /Duplicate facet names are not allowed in a type/)
+      assert.throws(() => makeFacetType(stringFacet, duplicateStringFacet), /Duplicate facet names are not allowed in a type/)
+      assert.throws(() => makeFacetType(decibelFacet, hertzFacet), /Duplicate facet names are not allowed in a type/)
     })
 
     it('should narrow values through has()', () => {
@@ -307,7 +307,7 @@ describe('type-system', () => {
       const incompatibleIntersect = decibelType.intersect(hertzType)
       assert.strictEqual(incompatibleIntersect, undefined)
 
-      const stringAndDecibelType = makeType(stringFacet, decibelFacet)
+      const stringAndDecibelType = makeFacetType(stringFacet, decibelFacet)
       const intersectedWithDecibel = stringAndDecibelType.intersect(stringAndNumberType)
       assert.ok(intersectedWithDecibel != null)
       assert.deepStrictEqual([...intersectedWithDecibel.facets.keys()], ['string'])
@@ -316,27 +316,27 @@ describe('type-system', () => {
 
   describe('UnionType', () => {
     it('should throw if given zero members', () => {
-      assert.throws(() => makeUnion(), /Expected at least one member/)
+      assert.throws(() => makeUnionType(), /Expected at least one member/)
     })
 
     it('should store members', () => {
-      const primitiveUnion = makeUnion(stringType, numberType)
+      const primitiveUnion = makeUnionType(stringType, numberType)
       assert.deepStrictEqual(primitiveUnion.members, [stringType, numberType])
     })
 
     it('should format based on members', () => {
-      const primitiveUnion = makeUnion(stringType, numberType)
+      const primitiveUnion = makeUnionType(stringType, numberType)
       assert.strictEqual(primitiveUnion.format(), '(string | number)')
       assert.strictEqual(numericUnion.format(), '(numeric(db) | numeric(hz))')
 
-      const singleMemberUnion = makeUnion(stringType)
+      const singleMemberUnion = makeUnionType(stringType)
       assert.strictEqual(singleMemberUnion.format(), 'string')
     })
 
     it('should compare assignability against members and other unions', () => {
-      const primitiveUnion = makeUnion(stringType, numberType)
-      const widerUnion = makeUnion(stringType, numberType, decibelType)
-      const narrowerUnion = makeUnion(stringType)
+      const primitiveUnion = makeUnionType(stringType, numberType)
+      const widerUnion = makeUnionType(stringType, numberType, decibelType)
+      const narrowerUnion = makeUnionType(stringType)
 
       assert.strictEqual(primitiveUnion.is(primitiveUnion), true)
       assert.strictEqual(primitiveUnion.is(stringType), true)
@@ -349,7 +349,7 @@ describe('type-system', () => {
     })
 
     it('should accept values from any compatible member type', () => {
-      const primitiveUnion = makeUnion(stringType, numberType)
+      const primitiveUnion = makeUnionType(stringType, numberType)
       const stringValue = stringType.of('hello')
       const pairValue = stringAndNumberType.of('hello', 42)
       const decibelValue = decibelType.of(runtimeNumeric('db', 42))


### PR DESCRIPTION
Replaces `makeType` with `makeFacetType` to clarify that it returns not just any `Type`, but specifically a `FacetType`. Replaces `makeUnion` with `makeUnionType` to follow the same naming convention.