### PR TITLE
feat: Handle union types throughout the checker

### DIFF
--- a/packages/language/src/compiler/builtins/global.ts
+++ b/packages/language/src/compiler/builtins/global.ts
@@ -7,7 +7,8 @@ import { PatternFacet } from '../../type-system/domain/pattern.ts'
 import { RoutingFacet } from '../../type-system/domain/routing.ts'
 import { Functions } from '../../type-system/helpers.ts'
 import { makeSchema } from '../../type-system/schema.ts'
-import type { FacetType, Value } from '../../type-system/types.ts'
+import { getPossibleTypeAtoms } from '../../type-system/transforms.ts'
+import type { Type, Value } from '../../type-system/types.ts'
 
 const play = Functions.of({
   parameters: makeSchema([
@@ -42,7 +43,7 @@ const automate = Functions.of({
   ]),
   returnType: AutomationFacet.type(),
   capabilities: { mayBlock: false },
-  check: (args: ReadonlyMap<string, FacetType>) => {
+  check: (args: ReadonlyMap<string, Type>) => {
     const errors: ParameterError[] = []
 
     const targetType = args.get('target')
@@ -52,14 +53,19 @@ const automate = Functions.of({
       return errors
     }
 
-    const targetUnit = ParameterFacet.detail(targetType)
-    const curveUnit = CurveFacet.detail(curveType)
-
-    if (targetUnit !== curveUnit) {
-      errors.push({
-        parameter: 'curve',
-        message: `Expected type ${CurveFacet.with(targetUnit).format()} for argument "curve", got ${curveType.format()}`
+    for (const targetAtom of getPossibleTypeAtoms(targetType)) {
+      const targetUnit = ParameterFacet.detail(targetAtom)
+      const match = getPossibleTypeAtoms(curveType).every((curveAtom) => {
+        return CurveFacet.detail(curveAtom) === targetUnit
       })
+
+      if (!match) {
+        errors.push({
+          parameter: 'curve',
+          message: `Expected type ${CurveFacet.with(targetUnit).format()} for argument "curve", got ${curveType.format()}`
+        })
+        break
+      }
     }
 
     return errors

--- a/packages/language/src/compiler/checker/arguments.ts
+++ b/packages/language/src/compiler/checker/arguments.ts
@@ -1,7 +1,7 @@
 import type { ast, SourceRange } from '@meyfa/cadence-ast'
 import type { Capabilities } from '../../type-system/base/function.ts'
 import type { Schema, SchemaItem } from '../../type-system/schema.ts'
-import type { FacetType } from '../../type-system/types.ts'
+import type { Type } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import { checkExpression } from './expressions.ts'
@@ -10,7 +10,7 @@ import type { Scope } from './scopes.ts'
 export interface CheckedArguments {
   readonly errors: readonly CompileError[]
   readonly capabilities: Capabilities
-  readonly types: ReadonlyMap<string, FacetType>
+  readonly types: ReadonlyMap<string, Type>
   readonly ranges: ReadonlyMap<string, SourceRange>
 }
 
@@ -22,7 +22,7 @@ export function checkArguments (
 ): CheckedArguments {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
-  const types = new Map<string, FacetType>()
+  const types = new Map<string, Type>()
   const ranges = new Map<string, SourceRange>()
 
   const seen = new Set<string>()

--- a/packages/language/src/compiler/checker/blocks.ts
+++ b/packages/language/src/compiler/checker/blocks.ts
@@ -5,7 +5,7 @@ import { RecordFacet } from '../../type-system/base/record.ts'
 import { makeFacetType } from '../../type-system/factory.ts'
 import type { Schema } from '../../type-system/schema.ts'
 import { makeSchema } from '../../type-system/schema.ts'
-import type { Facet, FacetType } from '../../type-system/types.ts'
+import type { Facet, FacetType, Type } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
 import { checkArguments } from './arguments.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
@@ -145,7 +145,7 @@ export function createBlockChecker<TBlock extends BlockNode> (schema: BlockSchem
 const emptySchema = makeSchema([])
 
 function makeBlockType (facet: Facet, properties: ReadonlyMap<string, Binding>): FacetType {
-  const fields: Record<string, FacetType> = Object.create(null)
+  const fields: Record<string, Type> = Object.create(null)
   let hasDefiniteProperties = false
 
   for (const [name, binding] of properties) {

--- a/packages/language/src/compiler/checker/emissions.ts
+++ b/packages/language/src/compiler/checker/emissions.ts
@@ -1,7 +1,8 @@
 import type { SourceRange } from '@meyfa/cadence-ast'
 import type { Brand } from '@meyfa/cadence-utility'
 import type { Result } from '../../result/result.ts'
-import type { FacetType, Type } from '../../type-system/types.ts'
+import { intersectTypes } from '../../type-system/transforms.ts'
+import type { Type } from '../../type-system/types.ts'
 import { assert } from '../assert.ts'
 import { CompileError } from '../error.ts'
 
@@ -44,7 +45,7 @@ export interface Emission {
   /**
    * For inferred slots, the type of the emitted value. For typed slots, this field is absent.
    */
-  readonly type?: FacetType
+  readonly type?: Type
 
   /**
    * The minimum amount of emissions into the slot over all conditional branches.
@@ -74,10 +75,10 @@ export function addEmission (target: MutableEmissions, emission: Emission): read
   const { slot } = existing
   assert(slot.type === emission.slot.type, `Slot "${slot.name}" type mismatch when merging emissions`)
 
-  let type: FacetType | undefined
+  let type: Type | undefined
 
   if (slot.type === 'infer') {
-    const intersection = intersectTypes(existing, emission)
+    const intersection = intersectEmissionTypes(existing, emission)
     if (intersection.complete) {
       type = intersection.value
     } else {
@@ -121,12 +122,12 @@ export function validateEmissions (emissions: Emissions, slots: Slots, range: So
   return errors
 }
 
-function intersectTypes (existing: Emission, emission: Emission): Result<FacetType | undefined, CompileError> {
+function intersectEmissionTypes (existing: Emission, emission: Emission): Result<Type | undefined, CompileError> {
   if (existing.type == null || emission.type == null) {
     return { complete: true, value: existing.type ?? emission.type }
   }
 
-  const intersection = existing.type.intersect(emission.type)
+  const intersection = intersectTypes(existing.type, emission.type)
   if (intersection == null) {
     const types = [existing.type.format(), emission.type.format()].join(', ')
     const message = `Incompatible types for slot "${emission.slot.name}": ${types}`

--- a/packages/language/src/compiler/checker/expressions.ts
+++ b/packages/language/src/compiler/checker/expressions.ts
@@ -23,7 +23,6 @@ import { SourceFacet } from '../../type-system/domain/source.ts'
 import { TrackFacet } from '../../type-system/domain/track.ts'
 import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeUnionType } from '../../type-system/factory.ts'
-import { isFacetType } from '../../type-system/guards.ts'
 import type { FacetType, Type } from '../../type-system/types.ts'
 import { nonNull } from '../assert.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
@@ -44,6 +43,7 @@ import type { Binding, Scope } from './scopes.ts'
 import { createLocalScope } from './scopes.ts'
 import type { StatementOptions } from './statements.ts'
 import { checkStatement } from './statements.ts'
+import { computeTypeUnion, getPossibleTypeAtoms } from '../../type-system/transforms.ts'
 
 export interface Checked<TValue> {
   readonly errors: readonly CompileError[]
@@ -51,7 +51,7 @@ export interface Checked<TValue> {
   readonly result?: TValue
 }
 
-export function checkExpression (scope: Scope, expression: ast.Expression): Checked<FacetType> {
+export function checkExpression (scope: Scope, expression: ast.Expression): Checked<Type> {
   switch (expression.type) {
     case 'Identifier':
       return checkIdentifier(scope, expression)
@@ -119,7 +119,7 @@ function expectType (expected: Pick<Type, 'is' | 'format'>, actual: Type, range?
   return []
 }
 
-function checkIdentifier (scope: Scope, expression: ast.Identifier): Checked<FacetType> {
+function checkIdentifier (scope: Scope, expression: ast.Identifier): Checked<Type> {
   const errors: CompileError[] = []
   const capabilities = noCapabilities
 
@@ -139,15 +139,15 @@ function checkIdentifier (scope: Scope, expression: ast.Identifier): Checked<Fac
   return { errors, capabilities, result }
 }
 
-function checkBoolean (scope: Scope, expression: ast.Boolean): Checked<FacetType> {
+function checkBoolean (scope: Scope, expression: ast.Boolean): Checked<Type> {
   return { errors: [], capabilities: noCapabilities, result: BooleanFacet.type() }
 }
 
-function checkNumber (scope: Scope, expression: ast.Number): Checked<FacetType> {
+function checkNumber (scope: Scope, expression: ast.Number): Checked<Type> {
   return { errors: [], capabilities: noCapabilities, result: NumberFacet.with(undefined).type() }
 }
 
-function checkString (scope: Scope, expression: ast.String): Checked<FacetType> {
+function checkString (scope: Scope, expression: ast.String): Checked<Type> {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
 
@@ -168,7 +168,7 @@ function checkString (scope: Scope, expression: ast.String): Checked<FacetType> 
   return { errors, capabilities, result: StringFacet.type() }
 }
 
-function checkPattern (scope: Scope, expression: ast.Pattern): Checked<FacetType> {
+function checkPattern (scope: Scope, expression: ast.Pattern): Checked<Type> {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
 
@@ -217,7 +217,7 @@ interface CurveDetail {
   readonly unit: Unit
 }
 
-function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
+function checkCurve (scope: Scope, expression: ast.Curve): Checked<Type> {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
 
@@ -268,7 +268,9 @@ function checkCurve (scope: Scope, expression: ast.Curve): Checked<FacetType> {
           break
         }
 
-        append(CurveFacet.detail(itemCheck.result), item.range)
+        for (const itemType of getPossibleTypeAtoms(itemCheck.result)) {
+          append(CurveFacet.detail(itemType), item.range)
+        }
         break
       }
     }
@@ -317,7 +319,7 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
     return { errors: [new CompileError(message, expression.range)], capabilities }
   }
 
-  const units: Array<Unit | undefined> = []
+  const units: Array<{ readonly unit: Unit | undefined, readonly range: SourceRange }> = []
 
   for (const point of expression.arguments) {
     const pointCheck = checkExpression(scope, point)
@@ -329,7 +331,9 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
       errors.push(...typeErrors)
 
       if (typeErrors.length === 0) {
-        units.push(NumberFacet.detail(pointCheck.result))
+        for (const pointType of getPossibleTypeAtoms(pointCheck.result)) {
+          units.push({ unit: NumberFacet.detail(pointType), range: point.range })
+        }
       }
     }
   }
@@ -338,11 +342,11 @@ function checkCurveSegment (scope: Scope, expression: ast.CurveSegment, detail?:
     return { errors, capabilities }
   }
 
-  const firstUnit = omittedFirstParameter ? detail?.unit : units[0]
+  const firstUnit = omittedFirstParameter ? detail?.unit : units[0]?.unit
 
   const expected = NumberFacet.with(firstUnit).type()
   for (let i = omittedFirstParameter ? 0 : 1; i < units.length; ++i) {
-    errors.push(...expectType(expected, NumberFacet.with(units[i]).type(), expression.arguments[i].range))
+    errors.push(...expectType(expected, NumberFacet.with(units[i].unit).type(), units[i].range))
   }
 
   const result = { unit: firstUnit }
@@ -364,7 +368,7 @@ const functionStatementOptions: StatementOptions = {
   ]
 }
 
-function checkFunction (scope: Scope, expression: ast.Function): Checked<FacetType> {
+function checkFunction (scope: Scope, expression: ast.Function): Checked<Type> {
   const errors: CompileError[] = []
 
   // Allow blocking calls inside the function. If a blocking call is encountered,
@@ -589,7 +593,7 @@ const checkPart = createBlockChecker<ast.Part>({
   }
 })
 
-function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Checked<FacetType> {
+function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): Checked<Type> {
   const operandCheck = checkExpression(scope, expression.operand)
   const errors = [...operandCheck.errors]
   const capabilities = operandCheck.capabilities
@@ -601,8 +605,7 @@ function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): C
 
   const result = unaryOperations[expression.operator].check(operand)
 
-  // TODO: Support non-FacetType
-  if (result == null || !isFacetType(result)) {
+  if (result == null) {
     errors.push(new CompileError(`Incompatible operand for "${expression.operator}": ${operand.format()}`, expression.range))
     return { errors, capabilities }
   }
@@ -610,7 +613,7 @@ function checkUnaryExpression (scope: Scope, expression: ast.UnaryExpression): C
   return { errors, capabilities, result }
 }
 
-function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression): Checked<FacetType> {
+function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression): Checked<Type> {
   const leftCheck = checkExpression(scope, expression.left)
   const rightCheck = checkExpression(scope, expression.right)
 
@@ -626,8 +629,7 @@ function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression):
 
   const result = binaryOperations[expression.operator].check(left, right)
 
-  // TODO: Support non-FacetType
-  if (result == null || !isFacetType(result)) {
+  if (result == null) {
     errors.push(new CompileError(`Incompatible operands for "${expression.operator}": ${left.format()}, ${right.format()}`, expression.range))
     return { errors, capabilities }
   }
@@ -635,13 +637,13 @@ function checkBinaryExpression (scope: Scope, expression: ast.BinaryExpression):
   return { errors, capabilities, result }
 }
 
-function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Checked<FacetType> {
+function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Checked<Type> {
   const errors: CompileError[] = []
+  let capabilities = noCapabilities
 
   const objectCheck = checkExpression(scope, expression.object)
   errors.push(...objectCheck.errors)
-
-  const capabilities = objectCheck.capabilities
+  capabilities = mergeCapabilities(capabilities, objectCheck.capabilities)
 
   if (objectCheck.result == null) {
     return { errors, capabilities }
@@ -649,6 +651,22 @@ function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Che
 
   const { property } = expression
   const object = objectCheck.result
+
+  const lifted = liftOverFacetType(object, (facetType) => {
+    return checkPropertyAccessWithObjectAtom(facetType, property)
+  })
+  errors.push(...lifted.errors)
+  capabilities = mergeCapabilities(capabilities, lifted.capabilities)
+
+  return { errors, capabilities, result: lifted.result }
+}
+
+function checkPropertyAccessWithObjectAtom (
+  object: FacetType,
+  property: ast.Identifier
+): Checked<Type> {
+  const errors: CompileError[] = []
+  const capabilities = noCapabilities
 
   if (NumberFacet.is(object)) {
     if (!isSyntaxUnit(property.name)) {
@@ -675,15 +693,7 @@ function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Che
   if (RecordFacet.is(object)) {
     const record = RecordFacet.detail(object)
     if (Object.hasOwn(record, property.name)) {
-      const result = record[property.name]
-
-      // TODO: Support non-FacetType
-      if (result != null && !isFacetType(result)) {
-        errors.push(new CompileError(`Property "${property.name}" has non-definite type`, property.range))
-        return { errors, capabilities }
-      }
-
-      return { errors, capabilities, result }
+      return { errors, capabilities, result: record[property.name] }
     }
 
     // Improve error messages for modules
@@ -700,7 +710,7 @@ function checkPropertyAccess (scope: Scope, expression: ast.PropertyAccess): Che
   return { errors, capabilities }
 }
 
-function checkCall (scope: Scope, expression: ast.Call): Checked<FacetType> {
+function checkCall (scope: Scope, expression: ast.Call): Checked<Type> {
   const errors: CompileError[] = []
   let capabilities = noCapabilities
 
@@ -717,6 +727,23 @@ function checkCall (scope: Scope, expression: ast.Call): Checked<FacetType> {
     errors.push(new CompileError(`Cannot call value of type ${callee.format()}`, expression.range))
     return { errors, capabilities }
   }
+
+  const lifted = liftOverFacetType(callee, (facetType) => {
+    return checkCallWithCalleeAtom(scope, expression, facetType)
+  })
+  errors.push(...lifted.errors)
+  capabilities = mergeCapabilities(capabilities, lifted.capabilities)
+
+  return { errors, capabilities, result: lifted.result }
+}
+
+function checkCallWithCalleeAtom (
+  scope: Scope,
+  expression: ast.Call,
+  callee: FacetType
+): Checked<Type> {
+  const errors: CompileError[] = []
+  let capabilities = noCapabilities
 
   const {
     parameters,
@@ -760,4 +787,36 @@ function tryGetFunctionName (callee: ast.Expression): string | undefined {
   }
 
   return undefined
+}
+
+// TODO: De-duplicate this function with the one in operators/lifting.ts
+function liftOverFacetType (
+  type: Type,
+  check: (facetType: FacetType) => Checked<Type>
+): Checked<Type> {
+  const errors: CompileError[] = []
+  let capabilities = noCapabilities
+
+  const atoms = getPossibleTypeAtoms(type)
+  const resultTypes: Type[] = []
+
+  for (const atom of atoms) {
+    const checkResult = check(atom)
+    errors.push(...checkResult.errors)
+    capabilities = mergeCapabilities(capabilities, checkResult.capabilities)
+
+    if (checkResult.result != null) {
+      resultTypes.push(checkResult.result)
+    }
+  }
+
+  // If any of the atoms failed to produce a result, we cannot determine a useful
+  // result type for the union.
+  if (resultTypes.length < atoms.length) {
+    return { errors, capabilities }
+  }
+
+  const result = computeTypeUnion(resultTypes)
+
+  return { errors, capabilities, result }
 }

--- a/packages/language/src/compiler/checker/scopes.ts
+++ b/packages/language/src/compiler/checker/scopes.ts
@@ -1,6 +1,6 @@
 import type { ast, SourceRange } from '@meyfa/cadence-ast'
 import type { Capabilities, FunctionSpec } from '../../type-system/base/function.ts'
-import type { FacetType } from '../../type-system/types.ts'
+import type { Type } from '../../type-system/types.ts'
 
 export interface Scope {
   readonly top: GlobalScope
@@ -21,7 +21,7 @@ export interface MutableScope extends Scope {
 
 export interface Binding {
   readonly name: string
-  readonly type: FacetType
+  readonly type: Type
   readonly definite: boolean
   readonly range?: SourceRange
 }

--- a/packages/language/src/compiler/checker/statements.ts
+++ b/packages/language/src/compiler/checker/statements.ts
@@ -2,7 +2,8 @@ import type { ast, SourceRange } from '@meyfa/cadence-ast'
 import { setAll } from '@meyfa/cadence-utility'
 import { BooleanFacet } from '../../type-system/base/boolean.ts'
 import type { Capabilities } from '../../type-system/base/function.ts'
-import type { FacetType } from '../../type-system/types.ts'
+import { intersectTypes } from '../../type-system/transforms.ts'
+import type { Type } from '../../type-system/types.ts'
 import { CompileError } from '../error.ts'
 import { mergeCapabilities, noCapabilities } from './capabilities.ts'
 import type { Emission, Emissions, MutableEmissions, Slot, SlotName, Slots } from './emissions.ts'
@@ -62,7 +63,7 @@ function checkSimpleStatement (scope: MutableScope, statement: ast.SimpleStateme
   const emissions: MutableEmissions = new Map()
   const properties = new Map<string, Binding>()
 
-  const values: Array<FacetType | undefined> = []
+  const values: Array<Type | undefined> = []
 
   for (const value of statement.values) {
     const valueCheck = checkExpression(scope, value)
@@ -114,7 +115,7 @@ function checkSimpleStatement (scope: MutableScope, statement: ast.SimpleStateme
   return { errors, capabilities, emissions, properties }
 }
 
-function checkEmission (emissions: MutableEmissions, type: FacetType, range: SourceRange, options: StatementOptions): readonly CompileError[] {
+function checkEmission (emissions: MutableEmissions, type: Type, range: SourceRange, options: StatementOptions): readonly CompileError[] {
   const { context, slots = [] } = options
 
   if (slots.length === 0) {
@@ -124,7 +125,7 @@ function checkEmission (emissions: MutableEmissions, type: FacetType, range: Sou
   const slot = slots.find((slot) => slot.type == 'infer' || slot.type.is(type))
   if (slot == null) {
     const expectedTypes = slots
-      .filter((slot): slot is Slot & { type: FacetType } => slot.type != 'infer')
+      .filter((slot): slot is Slot & { type: Type } => slot.type != 'infer')
       .map((slot) => slot.type.format())
       .join(', ')
     return [new CompileError(`Unexpected emitted value of type ${type.format()}; expected one of: ${expectedTypes}`, range)]
@@ -233,11 +234,11 @@ function applyBranchEmissions (
 
     const ranges = emissions.flatMap((item) => item.ranges)
 
-    let type: FacetType | undefined
+    let type: Type | undefined
 
     if (slot.type === 'infer') {
       const types = emissions.map((item) => item.type).filter((item) => item != null)
-      type = intersectTypes(types)
+      type = intersectManyTypes(types)
 
       if (type == null) {
         const typeStrings = types.map((type) => type.format()).join(', ')
@@ -280,7 +281,7 @@ function applyBranchBindings (
     const definite = bindings.every((binding) => binding?.definite === true)
 
     const types = bindings.map((binding) => binding?.type).filter((type) => type != null)
-    const type = intersectTypes(types)
+    const type = intersectManyTypes(types)
 
     const ranges = bindings.map((binding) => binding?.range).filter((range) => range != null)
     const range = ranges.length === 1 ? ranges[0] : undefined
@@ -300,6 +301,6 @@ function applyBranchBindings (
   return errors
 }
 
-function intersectTypes (types: readonly FacetType[]): FacetType | undefined {
-  return types.reduce((acc, type) => acc?.intersect(type), types.at(0))
+function intersectManyTypes (types: readonly Type[]): Type | undefined {
+  return types.reduce((acc, type) => acc == null ? undefined : intersectTypes(acc, type), types.at(0))
 }

--- a/packages/language/src/compiler/checker/type-expressions.ts
+++ b/packages/language/src/compiler/checker/type-expressions.ts
@@ -1,15 +1,15 @@
 import type { ast, SourceRange } from '@meyfa/cadence-ast'
-import type { Facet, FacetType } from '../../type-system/types.ts'
-import { CompileError } from '../error.ts'
-import { RecordFacet } from '../../type-system/base/record.ts'
 import { FunctionFacet } from '../../type-system/base/function.ts'
-import { checkParameters } from './parameters.ts'
+import { RecordFacet } from '../../type-system/base/record.ts'
 import { makeFacetType } from '../../type-system/factory.ts'
+import type { Facet, Type } from '../../type-system/types.ts'
+import { CompileError } from '../error.ts'
+import { checkParameters } from './parameters.ts'
 import { getFacet } from './type-facets.ts'
 
 export interface CheckedType {
   readonly errors: readonly CompileError[]
-  readonly result?: FacetType
+  readonly result?: Type
 }
 
 export function checkType (expression: ast.Type): CheckedType {
@@ -145,7 +145,7 @@ function checkRecordType (expression: ast.RecordType): CheckedFacets {
   const errors: CompileError[] = []
   const facets: FacetWithRange[] = []
 
-  const properties = new Map<string, FacetType>()
+  const properties: Record<string, Type> = Object.create(null)
 
   for (const property of expression.properties) {
     const propertyCheck = checkType(property.propertyType)
@@ -155,15 +155,15 @@ function checkRecordType (expression: ast.RecordType): CheckedFacets {
       continue
     }
 
-    if (properties.has(property.name.name)) {
+    if (Object.hasOwn(properties, property.name.name)) {
       errors.push(new CompileError(`Duplicate property name "${property.name.name}"`, property.name.range))
       continue
     }
 
-    properties.set(property.name.name, propertyCheck.result)
+    properties[property.name.name] = propertyCheck.result
   }
 
-  const facet = RecordFacet.with(Object.fromEntries(properties))
+  const facet = RecordFacet.with(properties)
   facets.push({ facet, range: expression.range })
 
   return { errors, facets }

--- a/packages/language/src/compiler/generator/generator.ts
+++ b/packages/language/src/compiler/generator/generator.ts
@@ -26,7 +26,7 @@ import { VoiceFacet } from '../../type-system/domain/voice.ts'
 import { makeFacetType } from '../../type-system/factory.ts'
 import { Curves, Functions, Numbers, Parameters } from '../../type-system/helpers.ts'
 import type { InferSchema, Schema } from '../../type-system/schema.ts'
-import type { FacetType, Value } from '../../type-system/types.ts'
+import type { Type, Value } from '../../type-system/types.ts'
 import { assert, assertNever, fail, nonNull } from '../assert.ts'
 import { globalBuiltins } from '../builtins/global.ts'
 import { patternBuiltins } from '../builtins/patterns.ts'
@@ -759,7 +759,7 @@ function resolvePropertyAccess (scope: Scope, expression: ast.PropertyAccess): V
 
 function resolveCall (scope: Scope, expression: ast.Call): Value {
   // cast due to context type
-  const func = FunctionFacet.get(resolve(scope, expression.callee)) as Function<Schema, FacetType, GlobalScope>
+  const func = FunctionFacet.get(resolve(scope, expression.callee)) as Function<Schema, Type, GlobalScope>
   const args = resolveArgumentList(scope, expression.arguments, func.parameters)
 
   return func.invoke(scope.top, args)

--- a/packages/language/src/type-system/base/function.ts
+++ b/packages/language/src/type-system/base/function.ts
@@ -1,6 +1,6 @@
 import { makeFacet } from '../factory.ts'
 import type { InferSchema, Schema } from '../schema.ts'
-import type { CustomComparable, FacetType, ValueForType } from '../types.ts'
+import type { CustomComparable, FacetType, Type, ValueForType } from '../types.ts'
 
 export interface Capabilities {
   readonly mayBlock: boolean
@@ -13,7 +13,7 @@ export interface ParameterError {
 
 export interface FunctionSpec<
   S extends Schema = Schema,
-  R extends FacetType = FacetType
+  R extends Type = Type
 > {
   readonly parameters: S
   readonly returnType: R
@@ -25,12 +25,12 @@ export interface FunctionSpec<
    *
    * If an argument is missing from the map, do not report an error; this will already be handled by the schema validation.
    */
-  readonly check?: (args: ReadonlyMap<string, FacetType>) => readonly ParameterError[]
+  readonly check?: (args: ReadonlyMap<string, Type>) => readonly ParameterError[]
 }
 
 export interface FunctionRuntime<
   S extends Schema = Schema,
-  R extends FacetType = FacetType,
+  R extends Type = Type,
   Context = never
 > {
   /**
@@ -44,7 +44,7 @@ export interface FunctionRuntime<
 
 export interface Function<
   S extends Schema = Schema,
-  R extends FacetType = FacetType,
+  R extends Type = Type,
   Context = never
 > extends FunctionSpec<S, R>, FunctionRuntime<S, R, Context> {
 }
@@ -58,7 +58,7 @@ const FACET_NAME = 'function'
 export const FunctionFacet = {
   ...makeFacet<typeof FACET_NAME, Function>(FACET_NAME, {}),
 
-  with: <const S extends Schema, const R extends FacetType> (spec: FunctionSpec<S, R>) => {
+  with: <const S extends Schema, const R extends Type> (spec: FunctionSpec<S, R>) => {
     const generic: FunctionSpecGeneric = {
       value: spec,
 

--- a/packages/language/src/type-system/helpers.ts
+++ b/packages/language/src/type-system/helpers.ts
@@ -10,10 +10,10 @@ import { CurveFacet } from './domain/curve.ts'
 import { ParameterFacet } from './domain/parameter.ts'
 import { makeFacetType } from './factory.ts'
 import type { Schema } from './schema.ts'
-import type { Facet, FacetType, Value } from './types.ts'
+import type { Facet, FacetType, Type, Value } from './types.ts'
 
 export const Functions = {
-  of: <const S extends Schema, const R extends FacetType, const Context> (
+  of: <const S extends Schema, const R extends Type, const Context> (
     spec: FunctionSpec<S, R>,
     runtime: FunctionRuntime<S, R, Context>
   ): Value => {

--- a/packages/language/test/compiler/checker/checker.test.ts
+++ b/packages/language/test/compiler/checker/checker.test.ts
@@ -4,12 +4,19 @@ import { createFixtureTests, fromLineComment } from '@meyfa/cadence-snapshot-tes
 import assert from 'node:assert'
 import { describe, it } from 'node:test'
 import { check } from '../../../src/compiler/checker/checker.ts'
+import { checkExpression } from '../../../src/compiler/checker/expressions.ts'
+import { createGlobalScope, createLocalScope } from '../../../src/compiler/checker/scopes.ts'
+import { checkStatement } from '../../../src/compiler/checker/statements.ts'
 import { CompileError } from '../../../src/compiler/error.ts'
 import { lex } from '../../../src/lexer/lexer.ts'
 import { parse } from '../../../src/parser/parser.ts'
+import { FunctionFacet } from '../../../src/type-system/base/function.ts'
 import { NumberFacet } from '../../../src/type-system/base/number.ts'
+import { RecordFacet } from '../../../src/type-system/base/record.ts'
 import { InstrumentFacet } from '../../../src/type-system/domain/instrument.ts'
+import { makeFacetType, makeUnionType } from '../../../src/type-system/factory.ts'
 import { makeSchema } from '../../../src/type-system/schema.ts'
+import type { Type } from '../../../src/type-system/types.ts'
 import { assertResultComplete } from '../../test-utils.ts'
 
 function checkSource (source: string, fileName?: string): readonly CompileError[] {
@@ -1480,6 +1487,123 @@ describe('compiler/checker/checker.ts', async () => {
       assertErrorMessages(source, [
         'Incompatible types for slot "return" in conditional branches: number.bpm, number.hz'
       ])
+    })
+  })
+
+  describe('union types', () => {
+    const range = getEmptySourceRange()
+
+    const identifier = (name: string) => ast.make('Identifier', range, { name })
+
+    const resolve = (name: string, type: Type) => {
+      return { name, type, definite: true }
+    }
+
+    it('should lift property access over all union members', () => {
+      const valueType = makeUnionType(
+        RecordFacet.with({ value: NumberFacet.with('bpm').type() }).type(),
+        RecordFacet.with({ value: NumberFacet.with('hz').type() }).type()
+      )
+      const scope = createLocalScope(createGlobalScope(new Map([
+        ['item', { name: 'item', type: valueType, definite: true }]
+      ])))
+      const expression = ast.make('PropertyAccess', range, {
+        object: identifier('item'),
+        property: identifier('value')
+      })
+
+      const result = checkExpression(scope, expression)
+
+      assert.deepStrictEqual(result.errors, [])
+      assert.strictEqual(result.result?.format(), '(number.bpm | number.hz)')
+    })
+
+    it('should lift calls over all union members', () => {
+      const functionType = makeUnionType(
+        makeFacetType(FunctionFacet.with({
+          parameters: makeSchema([]),
+          returnType: NumberFacet.with('bpm').type(),
+          capabilities: { mayBlock: false }
+        })),
+        makeFacetType(FunctionFacet.with({
+          parameters: makeSchema([]),
+          returnType: NumberFacet.with('hz').type(),
+          capabilities: { mayBlock: false }
+        }))
+      )
+      const scope = createLocalScope(createGlobalScope(new Map([
+        ['func', { name: 'func', type: functionType, definite: true }]
+      ])))
+      const expression = ast.make('Call', range, {
+        callee: identifier('func'),
+        arguments: []
+      })
+
+      const result = checkExpression(scope, expression)
+
+      assert.deepStrictEqual(result.errors, [])
+      assert.strictEqual(result.result?.format(), '(number.bpm | number.hz)')
+    })
+
+    it('should intersect union types assigned in conditional branches', () => {
+      const scope = createLocalScope(createGlobalScope(new Map([
+        ['left', resolve('left', makeUnionType(
+          NumberFacet.with('bpm').type(),
+          NumberFacet.with('hz').type()
+        ))],
+        ['right', resolve('right', makeUnionType(
+          NumberFacet.with('bpm').type(),
+          NumberFacet.with('db').type()
+        ))]
+      ])))
+      const statement = ast.make('IfStatement', range, {
+        branches: [ast.make('ConditionalBranch', range, {
+          condition: ast.make('Boolean', range, { value: true }),
+          children: [ast.make('SimpleStatement', range, {
+            emit: false,
+            expose: false,
+            name: identifier('result'),
+            values: [identifier('left')]
+          })]
+        })],
+        elseBranch: [ast.make('SimpleStatement', range, {
+          emit: false,
+          expose: false,
+          name: identifier('result'),
+          values: [identifier('right')]
+        })]
+      })
+
+      const result = checkStatement(scope, statement, { context: 'test' })
+
+      assert.deepStrictEqual(result.errors, [])
+      assert.strictEqual(scope.resolutions.get('result')?.type.format(), 'number.bpm')
+    })
+
+    it('should reject curve points with incompatible possible units', () => {
+      const pointType = makeUnionType(
+        NumberFacet.with('bpm').type(),
+        NumberFacet.with('hz').type()
+      )
+      const scope = createLocalScope(createGlobalScope(new Map([
+        ['point', { name: 'point', type: pointType, definite: true }],
+        ['length', { name: 'length', type: NumberFacet.with('beats').type(), definite: true }]
+      ])))
+      const expression = ast.make('Curve', range, {
+        children: [ast.make('CurveSegment', range, {
+          curveType: 'hold',
+          arguments: [identifier('point')],
+          length: identifier('length')
+        })]
+      })
+
+      const result = checkExpression(scope, expression)
+
+      assert.deepStrictEqual(
+        result.errors.map((error) => error.message),
+        ['Expected type number.bpm, got number.hz']
+      )
+      assert.strictEqual(result.result, undefined)
     })
   })
 })

--- a/packages/language/test/compiler/checker/emissions.test.ts
+++ b/packages/language/test/compiler/checker/emissions.test.ts
@@ -5,6 +5,7 @@ import type { Emission, Slot, SlotName, Slots } from '../../../src/compiler/chec
 import { addEmission, validateEmissions } from '../../../src/compiler/checker/emissions.ts'
 import { NumberFacet } from '../../../src/type-system/base/number.ts'
 import { SourceFacet } from '../../../src/type-system/domain/source.ts'
+import { makeUnionType } from '../../../src/type-system/factory.ts'
 
 describe('compiler/checker/emissions.ts', () => {
   describe('addEmission()', () => {
@@ -86,6 +87,39 @@ describe('compiler/checker/emissions.ts', () => {
         maximum: 2,
         ranges: [...original.ranges, ...incompatible.ranges]
       })
+    })
+
+    it('should infer the shared member of compatible union emissions', () => {
+      const target = new Map<SlotName, Emission>()
+      const inferredSlot: Slot = {
+        name: 'inferred' as SlotName,
+        type: 'infer'
+      }
+
+      const first = addEmission(target, {
+        slot: inferredSlot,
+        type: makeUnionType(
+          NumberFacet.with('bpm').type(),
+          NumberFacet.with('hz').type()
+        ),
+        minimum: 1,
+        maximum: 1,
+        ranges: [getEmptySourceRange()]
+      })
+      const second = addEmission(target, {
+        slot: inferredSlot,
+        type: makeUnionType(
+          NumberFacet.with('bpm').type(),
+          NumberFacet.with('db').type()
+        ),
+        minimum: 1,
+        maximum: 1,
+        ranges: [getEmptySourceRange()]
+      })
+
+      assert.deepStrictEqual(first, [])
+      assert.deepStrictEqual(second, [])
+      assert.strictEqual(target.get(inferredSlot.name)?.type?.format(), 'number.bpm')
     })
   })
 


### PR DESCRIPTION
This patch finalizes the handling of union types everywhere in the checker. This will make it possible to use union-typed values in the language once syntax support is added.